### PR TITLE
Implement resource-aware CPU transcription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ ECHOFLOW_LOG_PATHS=redact
 ECHOFLOW_PROCESSING_PROFILE=balanced
 ECHOFLOW_MEMORY_BUDGET_FRACTION=0.75
 ECHOFLOW_FFPROBE_TIMEOUT_SECONDS=30
+ECHOFLOW_FFMPEG_PROCESS_TIMEOUT_SECONDS=3600
+
+# Optional model revision. Set a commit SHA for immutable model retrieval.
+# ECHOFLOW_FASTER_WHISPER_MODEL_REVISION=commit-sha
 
 # Optional user ceilings. Leave unset to use process-visible runner limits.
 # ECHOFLOW_MAX_CPU_THREADS=4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,16 +33,20 @@ jobs:
           enable-cache: true
 
       - name: Install locked dependencies
-        run: uv sync --locked --all-groups
+        run: uv sync --locked --all-groups --extra transcription
+
+      - name: Import optional CPU engine
+        run: uv run python -c "import faster_whisper; print(faster_whisper.__version__)"
 
       - name: Check lockfile
         run: uv lock --check
 
-      - name: Export locked runtime dependencies
+      - name: Export locked runtime and transcription dependencies
         run: >-
           uv export
           --locked
           --no-dev
+          --extra transcription
           --no-emit-project
           --no-hashes
           --format requirements-txt
@@ -106,7 +110,10 @@ jobs:
           enable-cache: true
 
       - name: Install locked dependencies
-        run: uv sync --locked --all-groups
+        run: uv sync --locked --all-groups --extra transcription
+
+      - name: Import optional CPU engine
+        run: uv run python -c "import faster_whisper; print(faster_whisper.__version__)"
 
       - name: Run tests
         run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -30,10 +30,15 @@ EchoFlow currently provides a tested application foundation:
   full input fingerprinting, and typed media metadata.
 - An immutable `transcribe INPUT --dry-run` plan covering paths, streams, codec,
   duration, CPU engine/model selection, decoding strategy, and resource estimates.
+- One executable CPU/int8 faster-whisper path that rechecks resource admission,
+  claims its workspace and output atomically, and writes canonical transcript JSON.
+- Audio extraction from audio-bearing containers, including video files, by mapping
+  only the selected audio stream into a private canonical WAV.
+- Explicit model-download authorization; execution is local-only by default.
 - Dependency Injector composition for the implemented services.
 
-Audio decoding and transcription execution are not implemented yet. The next
-product slice is one working CPU transcription path consuming the dry-run plan.
+Deterministic application-owned segmentation, checkpointing, resume, and derived
+TXT/SRT/VTT artifacts are not implemented yet.
 
 ## Requirements and installation
 
@@ -44,6 +49,13 @@ product slice is one working CPU transcription path consuming the dry-run plan.
 git clone https://github.com/SSD1805/EchoFlow.git
 cd EchoFlow
 uv sync --locked
+```
+
+The small default installation can inspect and plan recordings. Install the
+optional CPU engine for transcription execution:
+
+```bash
+uv sync --locked --extra transcription
 ```
 
 Run the CLI and diagnostics:
@@ -60,7 +72,14 @@ uv run echoflow runner
 uv run echoflow runner --profile screening --json
 uv run echoflow transcribe /path/to/recording.wav --dry-run
 uv run echoflow transcribe /path/to/recording.wav --dry-run --profile screening --json
+uv run echoflow transcribe /path/to/interview.mp4
+uv run echoflow transcribe /path/to/interview.mp4 --allow-model-download
 ```
+
+Without `--allow-model-download`, EchoFlow asks faster-whisper to use only model
+files already present in EchoFlow's private model cache. The flag authorizes the
+selected model retrieval for that invocation; it does not authorize uploading the
+recording.
 
 Configuration uses `ECHOFLOW_*` environment variables, including
 `ECHOFLOW_STATE_DIR`, `ECHOFLOW_CACHE_DIR`, `ECHOFLOW_MODEL_DIR`, and
@@ -133,6 +152,13 @@ it is not interchangeable with a final research transcript. `balanced` and
 support them. The first CPU plan maps those tiers to faster-whisper `tiny`,
 `small`, and `medium` models using int8 execution. The engine package and model
 weights are not installed or downloaded by a dry run.
+
+Execution consumes that plan rather than detecting a second, unrelated machine
+configuration inside the engine. It checks process-visible memory and CPU capacity
+before claiming paths and again after any FFmpeg normalization, immediately before
+model initialization. A video is not treated as visual input: FFmpeg discards video,
+subtitle, and data streams and emits only the selected audio stream to the private
+job workspace.
 
 Resource estimates are deliberately conservative heuristics until real engine
 benchmarks are added. Dry-run workspace and artifact paths are candidates, not

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,13 @@
 
 ## Current boundary
 
-EchoFlow is a local-first application. The current release foundation has no
-network client, cloud integration, telemetry, transcription engine, or model
-downloader. It does execute a locally resolved `ffprobe` process for explicit
-dry-run media inspection. Local-first describes where EchoFlow performs its
-work; it is not a claim that the host operating system, selected storage,
-future third-party engines, or external executables are trusted.
+EchoFlow is a local-first application. It has no cloud transcription integration
+or application telemetry. It executes locally resolved FFprobe for inspection,
+FFmpeg when audio extraction or normalization is required, and the optional
+faster-whisper/CTranslate2 engine for CPU transcription. Local-first describes
+where EchoFlow performs its work; it is not a claim that the host operating
+system, selected storage, third-party engine, model files, or external executables
+are trusted.
 
 The application treats recording names and local paths as potentially
 sensitive. Routine logs redact paths by default. Full path logging requires the
@@ -49,10 +50,36 @@ The output limit is checked after the child process exits, so it bounds JSON
 parsing but not the memory already consumed by `subprocess.run`. FFprobe remains
 native media-parsing code operating on user-selected input.
 
+## Decode and transcription boundary
+
+For media that is not already canonical mono 16 kHz PCM audio, EchoFlow invokes
+FFmpeg without a shell or stdin, restricts input protocols to `file`, explicitly
+maps the audio stream selected by FFprobe, discards video/subtitle/data streams,
+suppresses native diagnostic output from public failures, and enforces a
+configurable process timeout. Normalized audio exists only in the owner-private job
+workspace and is removed after the attempt. Filesystem deletion is not secure
+erasure.
+
+The faster-whisper package and model weights remain optional. The backend uses CPU
+int8 execution with the thread count selected by the runner policy and one model
+worker to avoid hidden memory multiplication. It uses local model files by default.
+`--allow-model-download` explicitly authorizes the engine's Hugging Face retrieval
+for that command; it does not authorize recording upload. EchoFlow records the
+engine package version, model name, requested revision, compute type, thread count,
+beam size, and language setting in canonical output. Unless an immutable model
+revision is configured, model provenance identifies the request but does not prove
+immutable model content.
+
+Canonical transcript JSON omits the source path, source filename, and model-cache
+path. It retains the input SHA-256, size, modification timestamp, container, audio
+stream index, and media duration for provenance. Command result envelopes include
+job and artifact paths because those paths are an explicit result of the command.
+
 ## Processing risks still outside the implemented boundary
 
-Before EchoFlow decodes or transcribes untrusted media, its FFmpeg and
-transcription-engine boundary still needs explicit version policy, time and
-resource limits, model provenance, failure isolation, and adversarial-media
-testing. Encryption, secure deletion, and process-wide network egress
-enforcement are not implemented and must not be inferred from local-first.
+FFmpeg and the transcription engine still execute in the EchoFlow process/user
+security context rather than an operating-system sandbox. Model signatures,
+process-wide network egress enforcement, hard CPU limits, adversarial-media test
+corpora, encryption, and secure deletion are not implemented. Memory admission is
+a conservative preflight check, not a hard runtime memory cage. These properties
+must not be inferred from local-first.

--- a/docs/architecture/processing-capabilities.md
+++ b/docs/architecture/processing-capabilities.md
@@ -20,9 +20,15 @@ decisions required to reproduce that work elsewhere.
 
 The implemented checkpoint now covers input validation, SHA-256 fingerprinting,
 FFprobe metadata, side-effect-free path resolution, CPU engine/model selection,
-decode strategy, resource estimates, and immutable JSON/Rich dry-run output.
-It does not yet decode audio, download a model, execute transcription, or write
-a transcript artifact.
+decode strategy, resource estimates, immutable JSON/Rich dry-run output, local
+FFmpeg audio normalization, one CPU/int8 faster-whisper backend, resource
+readmission, and canonical transcript JSON. Model download is disabled unless the
+invocation explicitly authorizes it.
+
+Video is not a downstream capability. An audio-bearing video container is accepted
+at the media boundary, its selected audio stream is extracted, and all video,
+subtitle, attachment, and data streams are discarded. Everything after decode sees
+the same canonical audio input used for other noncanonical recordings.
 
 ## First vertical slice
 
@@ -131,6 +137,7 @@ guarantees.
 2. Implement media probing and a `transcribe --dry-run` planning command.
    **Implemented.**
 3. Implement one CPU transcription engine for one supported input path.
+   **Implemented for direct canonical audio and FFmpeg-normalized audio-bearing media.**
 4. Add deterministic segmentation and assembly.
 5. Add JSON and TXT output, then SRT and VTT.
 6. Add SQLite checkpoints and resume.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ dependencies = [
     "rich>=14,<15",
 ]
 
+[project.optional-dependencies]
+transcription = [
+    "faster-whisper>=1.2.1,<2",
+]
+
 [dependency-groups]
 dev = [
     "hypothesis>=6.135,<7",
@@ -112,6 +117,9 @@ only_files = [
     "src/echoflow/runner/models.py",
     "src/echoflow/runner/policy.py",
     "src/echoflow/transcription/models.py",
+    "src/echoflow/transcription/audio.py",
+    "src/echoflow/transcription/backend.py",
+    "src/echoflow/transcription/executor.py",
     "src/echoflow/transcription/planner.py",
     "src/echoflow/workspace/models.py",
     "src/echoflow/workspace/service.py",

--- a/src/echoflow/app/app_container.py
+++ b/src/echoflow/app/app_container.py
@@ -16,6 +16,9 @@ from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.media.probe import FfprobeMediaProbe
 from echoflow.runner.inspector import RunnerInspector
 from echoflow.runner.policy import RunnerPolicyPlanner
+from echoflow.transcription.audio import FfmpegAudioDecoder
+from echoflow.transcription.backend import FasterWhisperTranscriber
+from echoflow.transcription.executor import TranscriptionExecutor
 from echoflow.transcription.planner import TranscriptionJobPlanner
 from echoflow.workspace.models import WorkspacePaths
 from echoflow.workspace.service import WorkspaceService
@@ -64,6 +67,10 @@ def _create_media_probe(config: AppConfig) -> FfprobeMediaProbe:
     return FfprobeMediaProbe(timeout_seconds=config.FFPROBE_TIMEOUT_SECONDS)
 
 
+def _create_audio_decoder(config: AppConfig) -> FfmpegAudioDecoder:
+    return FfmpegAudioDecoder(timeout_seconds=config.FFMPEG_PROCESS_TIMEOUT_SECONDS)
+
+
 class AppContainer(containers.DeclarativeContainer):
     """
     Dependency Injection container for managing application services.
@@ -97,6 +104,19 @@ class AppContainer(containers.DeclarativeContainer):
         workspace_service=workspace_service,
         runner_inspector=runner_inspector,
         policy_planner=runner_policy_planner,
+        model_revision=config.provided.FASTER_WHISPER_MODEL_REVISION,
+    )
+    audio_decoder = providers.Factory(_create_audio_decoder, config=config)
+    transcriber = providers.Factory(FasterWhisperTranscriber)
+    transcription_executor = providers.Factory(
+        TranscriptionExecutor,
+        media_probe=media_probe,
+        workspace_service=workspace_service,
+        file_manager=file_manager,
+        runner_inspector=runner_inspector,
+        policy_planner=runner_policy_planner,
+        audio_decoder=audio_decoder,
+        transcriber=transcriber,
     )
     health_check = providers.Factory(
         _create_health_check, config=config, runner_inspector=runner_inspector

--- a/src/echoflow/app/tests/test_app_container.py
+++ b/src/echoflow/app/tests/test_app_container.py
@@ -5,6 +5,9 @@ from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.media.probe import FfprobeMediaProbe
 from echoflow.runner.inspector import RunnerInspector
 from echoflow.runner.policy import RunnerPolicyPlanner
+from echoflow.transcription.audio import FfmpegAudioDecoder
+from echoflow.transcription.backend import FasterWhisperTranscriber
+from echoflow.transcription.executor import TranscriptionExecutor
 from echoflow.transcription.planner import TranscriptionJobPlanner
 from echoflow.workspace.service import WorkspaceService
 
@@ -56,3 +59,16 @@ def test_container_composes_media_probe_and_transcription_planner():
     assert planner.workspace_service is container.workspace_service()
     assert planner.runner_inspector is container.runner_inspector()
     assert planner.policy_planner is container.runner_policy_planner()
+
+
+def test_container_composes_per_execution_audio_and_engine_services():
+    container = AppContainer()
+    first = container.transcription_executor()
+    second = container.transcription_executor()
+    assert isinstance(first, TranscriptionExecutor)
+    assert isinstance(first.audio_decoder, FfmpegAudioDecoder)
+    assert isinstance(first.transcriber, FasterWhisperTranscriber)
+    assert first is not second
+    assert first.transcriber is not second.transcriber
+    assert first.workspace_service is container.workspace_service()
+    assert first.file_manager is container.file_manager()

--- a/src/echoflow/app/tests/test_app_container_integration.py
+++ b/src/echoflow/app/tests/test_app_container_integration.py
@@ -5,6 +5,7 @@ from echoflow.core.ilogger import ILogger
 from echoflow.core.privacy import PathDisclosure
 from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.media.probe import FfprobeMediaProbe
+from echoflow.transcription.audio import FfmpegAudioDecoder
 
 
 def _test_config(tmp_path, **overrides) -> AppConfig:
@@ -75,3 +76,18 @@ def test_container_applies_configured_media_probe_timeout(tmp_path):
     probe = container.media_probe()
     assert isinstance(probe, FfprobeMediaProbe)
     assert probe.timeout_seconds == 7.5
+
+
+def test_container_applies_execution_timeout_and_model_revision(tmp_path):
+    container = AppContainer()
+    container.config.override(
+        _test_config(
+            tmp_path,
+            FFMPEG_PROCESS_TIMEOUT_SECONDS=123.0,
+            FASTER_WHISPER_MODEL_REVISION="revision-1",
+        )
+    )
+    executor = container.transcription_executor()
+    assert isinstance(executor.audio_decoder, FfmpegAudioDecoder)
+    assert executor.audio_decoder.timeout_seconds == 123.0
+    assert container.transcription_planner().model_revision == "revision-1"

--- a/src/echoflow/cli.py
+++ b/src/echoflow/cli.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, cast
 
 import typer
 from pydantic import ValidationError
@@ -13,7 +13,10 @@ from echoflow.core.config import AppConfig
 from echoflow.core.errors import EchoFlowError
 from echoflow.core.health_check import HealthReport
 from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
-from echoflow.transcription.models import TranscriptionJobPlan
+from echoflow.transcription.models import (
+    TranscriptionExecutionResult,
+    TranscriptionJobPlan,
+)
 from echoflow.workspace.models import WorkspacePaths
 
 app = typer.Typer(
@@ -139,6 +142,29 @@ def _render_transcription_plan(plan: TranscriptionJobPlan, console: Console) -> 
         ),
         ("Fits memory budget", str(plan.resources.fits_memory_budget).lower()),
         ("Warnings", ", ".join(plan.warnings) or "none"),
+    )
+    for setting, value in rows:
+        table.add_row(setting, value)
+    console.print(table)
+
+
+def _render_transcription_result(
+    result: TranscriptionExecutionResult, console: Console
+) -> None:
+    transcript = result.transcript
+    table = Table(title="EchoFlow transcription complete")
+    table.add_column("Setting")
+    table.add_column("Value")
+    rows = (
+        ("Job ID", result.job.job_id.value),
+        ("Canonical output", str(result.artifact.path)),
+        ("Profile", transcript.profile.value),
+        ("Provisional", str(transcript.provisional).lower()),
+        ("Engine", f"{transcript.engine.name} {transcript.engine.package_version}"),
+        ("Model", transcript.engine.model),
+        ("Decode", transcript.decode_strategy.value),
+        ("Detected language", transcript.detected_language or "unknown"),
+        ("Segments", str(len(transcript.segments))),
     )
     for setting, value in rows:
         table.add_row(setting, value)
@@ -283,17 +309,24 @@ def transcribe(
         Path,
         typer.Argument(
             metavar="INPUT",
-            help="Local recording to inspect and plan.",
+            help="Local audio-bearing recording to transcribe.",
         ),
     ],
     dry_run: Annotated[
         bool,
         typer.Option("--dry-run", help="Plan without creating files or transcribing."),
     ] = False,
+    allow_model_download: Annotated[
+        bool,
+        typer.Option(
+            "--allow-model-download",
+            help="Authorize network access to obtain the selected model if absent.",
+        ),
+    ] = False,
     output_dir: Annotated[
         Path | None,
         typer.Option(
-            help="Consumer directory for eventual transcript artifacts.",
+            help="Consumer directory for transcript artifacts.",
             file_okay=False,
             resolve_path=True,
         ),
@@ -303,16 +336,11 @@ def transcribe(
         typer.Option(help="Override the configured processing profile."),
     ] = None,
     json_output: Annotated[
-        bool, typer.Option("--json", help="Emit the immutable plan as JSON.")
+        bool,
+        typer.Option("--json", help="Emit the plan or execution result as JSON."),
     ] = False,
 ) -> None:
-    """Inspect a recording and produce a resource-aware transcription plan."""
-    if not dry_run:
-        typer.echo(
-            "Transcription execution is not implemented; use --dry-run",
-            err=True,
-        )
-        raise typer.Exit(code=2)
+    """Transcribe the audio stream from a local recording or inspect its plan."""
     try:
         container = _container(context)
         selected_profile = profile or container.config().PROCESSING_PROFILE
@@ -321,6 +349,11 @@ def transcribe(
             output_dir=output_dir,
             profile=selected_profile,
         )
+        result = None
+        if not dry_run:
+            result = container.transcription_executor().execute(
+                plan, allow_model_download=allow_model_download
+            )
     except EchoFlowError as exc:
         typer.echo(exc.public_message, err=True)
         raise typer.Exit(code=exc.exit_code) from None
@@ -329,15 +362,22 @@ def transcribe(
         raise typer.Exit(code=1) from None
     except Exception as exc:
         typer.echo(
-            f"EchoFlow transcription planning failed internally ({type(exc).__name__})",
+            f"EchoFlow transcription failed internally ({type(exc).__name__})",
             err=True,
         )
         raise typer.Exit(code=3) from None
 
-    if json_output:
+    if dry_run and json_output:
         typer.echo(json.dumps(plan.to_dict(), sort_keys=True))
-    else:
+    elif dry_run:
         _render_transcription_plan(plan, Console())
+    elif json_output:
+        execution_result = cast("TranscriptionExecutionResult", result)
+        typer.echo(json.dumps(execution_result.to_dict(), sort_keys=True))
+    else:
+        _render_transcription_result(
+            cast("TranscriptionExecutionResult", result), Console()
+        )
 
 
 def main() -> None:

--- a/src/echoflow/core/config.py
+++ b/src/echoflow/core/config.py
@@ -109,6 +109,16 @@ class AppConfig(BaseSettings):
         gt=0,
         description="Maximum time allowed for dry-run media inspection",
     )
+    FFMPEG_PROCESS_TIMEOUT_SECONDS: float = Field(
+        default=3_600.0,
+        gt=0,
+        description="Maximum time allowed for one audio normalization process",
+    )
+    FASTER_WHISPER_MODEL_REVISION: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Optional immutable model revision requested from the model hub",
+    )
 
     @field_validator("LOG_LEVEL")
     def validate_log_level(cls, value: str) -> str:

--- a/src/echoflow/core/errors.py
+++ b/src/echoflow/core/errors.py
@@ -16,6 +16,11 @@ class ErrorCode(StrEnum):
     MEDIA_PROBE = "media_probe_failed"
     UNSUPPORTED_MEDIA = "unsupported_media"
     INPUT_CHANGED = "input_changed"
+    AUDIO_DECODE = "audio_decode_failed"
+    RESOURCE_ADMISSION = "resource_admission_failed"
+    TRANSCRIPTION_DEPENDENCY = "transcription_dependency_unavailable"
+    MODEL_UNAVAILABLE = "transcription_model_unavailable"
+    TRANSCRIPTION = "transcription_failed"
 
 
 class EchoFlowError(Exception):

--- a/src/echoflow/core/tests/test_config.py
+++ b/src/echoflow/core/tests/test_config.py
@@ -22,6 +22,8 @@ def test_local_defaults_are_valid():
     assert config.WARN_FREE_DISK_BYTES == 2 * 1024 * 1024 * 1024
     assert config.FFMPEG_TIMEOUT_SECONDS == 2.0
     assert config.FFPROBE_TIMEOUT_SECONDS == 30.0
+    assert config.FFMPEG_PROCESS_TIMEOUT_SECONDS == 3_600.0
+    assert config.FASTER_WHISPER_MODEL_REVISION is None
     platform_paths = PlatformDirs("EchoFlow", appauthor=False)
     assert platform_paths.user_state_path == config.STATE_DIR
     assert platform_paths.user_cache_path == config.CACHE_DIR
@@ -43,6 +45,8 @@ def test_environment_overrides_local_settings(monkeypatch, tmp_path):
     monkeypatch.setenv("ECHOFLOW_MAX_MEMORY_BYTES", "4096")
     monkeypatch.setenv("ECHOFLOW_MEMORY_BUDGET_FRACTION", "0.5")
     monkeypatch.setenv("ECHOFLOW_FFPROBE_TIMEOUT_SECONDS", "45")
+    monkeypatch.setenv("ECHOFLOW_FFMPEG_PROCESS_TIMEOUT_SECONDS", "900")
+    monkeypatch.setenv("ECHOFLOW_FASTER_WHISPER_MODEL_REVISION", "abc123")
     monkeypatch.setenv("ECHOFLOW_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("ECHOFLOW_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setenv("ECHOFLOW_MODEL_DIR", str(tmp_path / "cache" / "models"))
@@ -57,6 +61,8 @@ def test_environment_overrides_local_settings(monkeypatch, tmp_path):
     assert config.MAX_MEMORY_BYTES == 4096
     assert config.MEMORY_BUDGET_FRACTION == 0.5
     assert config.FFPROBE_TIMEOUT_SECONDS == 45.0
+    assert config.FFMPEG_PROCESS_TIMEOUT_SECONDS == 900.0
+    assert config.FASTER_WHISPER_MODEL_REVISION == "abc123"
     assert tmp_path / "state" == config.STATE_DIR
     assert tmp_path / "cache" == config.CACHE_DIR
     assert tmp_path / "cache" / "models" == config.MODEL_DIR
@@ -184,6 +190,7 @@ def test_resource_and_diagnostic_lower_boundaries_are_exact():
         WARN_FREE_DISK_BYTES=0,
         FFMPEG_TIMEOUT_SECONDS=0.001,
         FFPROBE_TIMEOUT_SECONDS=0.001,
+        FFMPEG_PROCESS_TIMEOUT_SECONDS=0.001,
         _env_file=None,
     )
     assert config.MAX_CPU_THREADS == 1
@@ -192,12 +199,15 @@ def test_resource_and_diagnostic_lower_boundaries_are_exact():
     assert config.WARN_FREE_DISK_BYTES == 0
     assert config.FFMPEG_TIMEOUT_SECONDS == 0.001
     assert config.FFPROBE_TIMEOUT_SECONDS == 0.001
+    assert config.FFMPEG_PROCESS_TIMEOUT_SECONDS == 0.001
 
     for invalid in (
         {"MIN_FREE_DISK_BYTES": -1},
         {"WARN_FREE_DISK_BYTES": -1, "MIN_FREE_DISK_BYTES": 0},
         {"FFMPEG_TIMEOUT_SECONDS": -0.5},
         {"FFPROBE_TIMEOUT_SECONDS": 0},
+        {"FFMPEG_PROCESS_TIMEOUT_SECONDS": 0},
+        {"FASTER_WHISPER_MODEL_REVISION": ""},
     ):
         with pytest.raises(ValidationError):
             AppConfig(**invalid, _env_file=None)
@@ -242,5 +252,11 @@ def test_configuration_field_descriptions_are_stable_public_schema():
         "FFMPEG_TIMEOUT_SECONDS": None,
         "FFPROBE_TIMEOUT_SECONDS": (
             "Maximum time allowed for dry-run media inspection"
+        ),
+        "FFMPEG_PROCESS_TIMEOUT_SECONDS": (
+            "Maximum time allowed for one audio normalization process"
+        ),
+        "FASTER_WHISPER_MODEL_REVISION": (
+            "Optional immutable model revision requested from the model hub"
         ),
     }

--- a/src/echoflow/media/errors.py
+++ b/src/echoflow/media/errors.py
@@ -19,3 +19,8 @@ class UnsupportedMediaError(EchoFlowError):
 class InputChangedError(EchoFlowError):
     code = ErrorCode.INPUT_CHANGED
     exit_code = 2
+
+
+class AudioDecodeError(EchoFlowError):
+    code = ErrorCode.AUDIO_DECODE
+    exit_code = 2

--- a/src/echoflow/tests/test_cli.py
+++ b/src/echoflow/tests/test_cli.py
@@ -22,11 +22,16 @@ from echoflow.runner.models import (
 )
 from echoflow.runner.policy import RunnerPolicyPlanner
 from echoflow.transcription.models import (
+    CanonicalTranscript,
     CpuEngineConfiguration,
     DecodeConfiguration,
     DecodeStrategy,
+    EngineProvenance,
+    RecognizedSegment,
     ResourceEstimate,
+    TranscriptionExecutionResult,
     TranscriptionJobPlan,
+    TranscriptSource,
 )
 from echoflow.workspace.errors import InvalidInputError, UnsafePathError
 from echoflow.workspace.models import (
@@ -117,6 +122,11 @@ class FakeContainer:
         transcription_planner = Mock()
         transcription_planner.plan.return_value = transcription_plan()
         self.transcription_planner = Provider(transcription_planner)
+        transcription_executor = Mock()
+        transcription_executor.execute.return_value = transcription_result(
+            transcription_planner.plan.return_value
+        )
+        self.transcription_executor = Provider(transcription_executor)
 
 
 def transcription_plan() -> TranscriptionJobPlan:
@@ -174,6 +184,21 @@ def transcription_plan() -> TranscriptionJobPlan:
         ResourceEstimate(1, 2, 3, 4, 5, True),
         ("paths_are_unreserved",),
     )
+
+
+def transcription_result(plan: TranscriptionJobPlan) -> TranscriptionExecutionResult:
+    transcript = CanonicalTranscript(
+        job_id=plan.job.job_id.value,
+        source=TranscriptSource.from_media(plan.media),
+        profile=plan.policy.profile,
+        provisional=plan.policy.provisional,
+        decode_strategy=plan.decoder.strategy,
+        engine=EngineProvenance.from_engine(plan.engine, "1.2.1"),
+        detected_language="en",
+        language_probability=0.99,
+        segments=(RecognizedSegment(0, 0, 1.25, "Test transcript."),),
+    )
+    return TranscriptionExecutionResult(plan.job, plan.artifact, transcript)
 
 
 def invoke_doctor(status: OverallStatus, *arguments: str):
@@ -316,12 +341,39 @@ def test_explicit_configuration_file_is_loaded_only_when_selected(tmp_path):
     assert json.loads(result.stdout)["policy"]["profile"] == "screening"
 
 
-def test_transcribe_requires_explicit_dry_run_without_constructing_application():
-    with patch("echoflow.cli.AppContainer") as container:
+def test_transcribe_executes_planned_job_without_download_authorization():
+    container = FakeContainer(report(OverallStatus.HEALTHY))
+    with patch("echoflow.cli.AppContainer", return_value=container):
         result = runner.invoke(app, ["transcribe", "recording.wav"])
-    assert result.exit_code == 2
-    assert "use --dry-run" in result.stderr
-    container.assert_not_called()
+    assert result.exit_code == 0
+    assert "transcription complete" in result.output
+    container.transcription_executor().execute.assert_called_once_with(
+        container.transcription_planner().plan.return_value,
+        allow_model_download=False,
+    )
+
+
+def test_transcribe_json_emits_execution_result_and_authorizes_download():
+    container = FakeContainer(report(OverallStatus.HEALTHY))
+    with patch("echoflow.cli.AppContainer", return_value=container):
+        result = runner.invoke(
+            app,
+            [
+                "transcribe",
+                "recording.mp4",
+                "--allow-model-download",
+                "--json",
+            ],
+        )
+    document = json.loads(result.stdout)
+    assert result.exit_code == 0
+    assert document["dry_run"] is False
+    assert document["paths_reserved"] is True
+    assert document["transcript"]["text"] == "Test transcript."
+    container.transcription_executor().execute.assert_called_once_with(
+        container.transcription_planner().plan.return_value,
+        allow_model_download=True,
+    )
 
 
 def test_transcribe_dry_run_json_emits_complete_machine_readable_plan():

--- a/src/echoflow/transcription/__init__.py
+++ b/src/echoflow/transcription/__init__.py
@@ -1,19 +1,38 @@
-"""Transcription planning capability."""
+"""Resource-aware local transcription capability."""
 
+from echoflow.transcription.audio import DecodedAudio, FfmpegAudioDecoder
+from echoflow.transcription.backend import FasterWhisperTranscriber
+from echoflow.transcription.executor import TranscriptionExecutor
 from echoflow.transcription.models import (
+    CanonicalTranscript,
     CpuEngineConfiguration,
     DecodeConfiguration,
     DecodeStrategy,
+    EngineProvenance,
+    EngineTranscript,
+    RecognizedSegment,
     ResourceEstimate,
+    TranscriptionExecutionResult,
     TranscriptionJobPlan,
+    TranscriptSource,
 )
 from echoflow.transcription.planner import TranscriptionJobPlanner
 
 __all__ = [
+    "CanonicalTranscript",
     "CpuEngineConfiguration",
+    "DecodedAudio",
     "DecodeConfiguration",
     "DecodeStrategy",
+    "EngineProvenance",
+    "EngineTranscript",
+    "FasterWhisperTranscriber",
+    "FfmpegAudioDecoder",
+    "RecognizedSegment",
     "ResourceEstimate",
+    "TranscriptSource",
+    "TranscriptionExecutionResult",
+    "TranscriptionExecutor",
     "TranscriptionJobPlan",
     "TranscriptionJobPlanner",
 ]

--- a/src/echoflow/transcription/audio.py
+++ b/src/echoflow/transcription/audio.py
@@ -1,0 +1,103 @@
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from echoflow.media.errors import AudioDecodeError, MediaToolUnavailableError
+from echoflow.media.models import MediaInfo
+from echoflow.transcription.models import DecodeConfiguration, DecodeStrategy
+
+
+@dataclass(frozen=True, slots=True)
+class DecodedAudio:
+    path: Path
+    temporary: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", self.path.expanduser().resolve(strict=False))
+
+
+class FfmpegAudioDecoder:
+    """Expose one canonical audio input while discarding all non-audio streams."""
+
+    def __init__(self, timeout_seconds: float = 3_600.0):
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self.timeout_seconds = timeout_seconds
+
+    def decode(
+        self,
+        media: MediaInfo,
+        configuration: DecodeConfiguration,
+        workspace_dir: Path,
+    ) -> DecodedAudio:
+        if configuration.strategy is DecodeStrategy.DIRECT:
+            return DecodedAudio(media.input.path, temporary=False)
+
+        executable = shutil.which("ffmpeg")
+        if executable is None:
+            raise MediaToolUnavailableError(
+                "FFmpeg is required to extract and normalize this recording's audio"
+            )
+        destination = (workspace_dir / "normalized.wav").resolve(strict=False)
+        command = [
+            executable,
+            "-nostdin",
+            "-v",
+            "error",
+            "-protocol_whitelist",
+            "file",
+            "-i",
+            str(media.input.path),
+            "-map",
+            f"0:{media.primary_audio_stream_index}",
+            "-vn",
+            "-sn",
+            "-dn",
+            "-ac",
+            str(configuration.channels),
+            "-ar",
+            str(configuration.sample_rate_hz),
+            "-c:a",
+            configuration.output_codec,
+            "-f",
+            "wav",
+            "-n",
+            str(destination),
+        ]
+        try:
+            completed = subprocess.run(  # noqa: S603
+                command,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=self.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            destination.unlink(missing_ok=True)
+            raise AudioDecodeError("Audio extraction timed out", cause=exc) from exc
+        except OSError as exc:
+            destination.unlink(missing_ok=True)
+            raise MediaToolUnavailableError(
+                "FFmpeg could not be executed", cause=exc
+            ) from exc
+        if completed.returncode != 0:
+            destination.unlink(missing_ok=True)
+            raise AudioDecodeError("The selected audio stream could not be normalized")
+        try:
+            size = destination.stat().st_size
+        except OSError as exc:
+            destination.unlink(missing_ok=True)
+            raise AudioDecodeError(
+                "Normalized audio could not be validated", cause=exc
+            ) from exc
+        if size <= 44:
+            destination.unlink(missing_ok=True)
+            raise AudioDecodeError("Normalized audio contains no usable samples")
+        return DecodedAudio(destination, temporary=True)
+
+    @staticmethod
+    def cleanup(audio: DecodedAudio) -> None:
+        if audio.temporary:
+            audio.path.unlink(missing_ok=True)

--- a/src/echoflow/transcription/backend.py
+++ b/src/echoflow/transcription/backend.py
@@ -1,0 +1,154 @@
+from collections.abc import Callable, Iterable
+from importlib import import_module, metadata
+from pathlib import Path
+from typing import Any
+
+from echoflow.transcription.errors import (
+    ModelUnavailableError,
+    TranscriptionDependencyError,
+    TranscriptionError,
+)
+from echoflow.transcription.models import (
+    CpuEngineConfiguration,
+    EngineTranscript,
+    RecognizedSegment,
+)
+
+
+class FasterWhisperTranscriber:
+    """Load one CPU model per job and return engine-neutral segment values."""
+
+    def __init__(
+        self,
+        *,
+        module_loader: Callable[[str], Any] = import_module,
+        version_reader: Callable[[str], str] = metadata.version,
+    ):
+        self.module_loader = module_loader
+        self.version_reader = version_reader
+
+    def transcribe(
+        self,
+        audio_path: Path,
+        configuration: CpuEngineConfiguration,
+        *,
+        allow_model_download: bool,
+    ) -> EngineTranscript:
+        module, version = self._dependency()
+        model = self._model(module, configuration, allow_model_download)
+        try:
+            raw_segments, info = model.transcribe(
+                str(audio_path),
+                beam_size=configuration.beam_size,
+                language=configuration.language,
+                word_timestamps=False,
+                vad_filter=False,
+                log_progress=False,
+            )
+            segments = self._segments(raw_segments)
+            language = self._optional_text(getattr(info, "language", None))
+            language_probability = self._optional_float(
+                getattr(info, "language_probability", None)
+            )
+            return EngineTranscript(
+                segments=segments,
+                language=language,
+                language_probability=language_probability,
+                engine_version=version,
+            )
+        except TranscriptionError:
+            raise
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as exc:
+            raise TranscriptionError(
+                "The transcription engine failed while processing audio", cause=exc
+            ) from exc
+
+    def _dependency(self) -> tuple[Any, str]:
+        try:
+            module = self.module_loader("faster_whisper")
+            version = self.version_reader("faster-whisper")
+        except (ImportError, metadata.PackageNotFoundError) as exc:
+            raise TranscriptionDependencyError(
+                "CPU transcription support is not installed; install EchoFlow's "
+                "transcription extra",
+                cause=exc,
+            ) from exc
+        return module, version
+
+    @staticmethod
+    def _model(
+        module: Any,
+        configuration: CpuEngineConfiguration,
+        allow_model_download: bool,
+    ) -> Any:
+        try:
+            return module.WhisperModel(
+                configuration.model,
+                device=configuration.device,
+                compute_type=configuration.compute_type,
+                cpu_threads=configuration.cpu_threads,
+                num_workers=1,
+                download_root=str(configuration.model_cache_path),
+                local_files_only=not allow_model_download,
+                revision=configuration.model_revision,
+            )
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as exc:
+            if not allow_model_download:
+                raise ModelUnavailableError(
+                    "The selected model is not available locally; rerun with "
+                    "--allow-model-download to authorize network access",
+                    cause=exc,
+                ) from exc
+            raise TranscriptionError(
+                "The selected model could not be downloaded or initialized", cause=exc
+            ) from exc
+
+    @classmethod
+    def _segments(cls, raw_segments: Iterable[Any]) -> tuple[RecognizedSegment, ...]:
+        recognized: list[RecognizedSegment] = []
+        for raw in raw_segments:
+            text = str(getattr(raw, "text", "")).strip()
+            if not text:
+                continue
+            try:
+                recognized.append(
+                    RecognizedSegment(
+                        index=len(recognized),
+                        start_seconds=float(raw.start),
+                        end_seconds=float(raw.end),
+                        text=text,
+                        average_log_probability=cls._optional_float(
+                            getattr(raw, "avg_logprob", None)
+                        ),
+                        no_speech_probability=cls._optional_float(
+                            getattr(raw, "no_speech_prob", None)
+                        ),
+                    )
+                )
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise TranscriptionError(
+                    "The transcription engine returned invalid segment data", cause=exc
+                ) from exc
+        return tuple(recognized)
+
+    @staticmethod
+    def _optional_text(value: object) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _optional_float(value: object) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(str(value))
+        except (TypeError, ValueError) as exc:
+            raise TranscriptionError(
+                "The transcription engine returned invalid probability data", cause=exc
+            ) from exc

--- a/src/echoflow/transcription/errors.py
+++ b/src/echoflow/transcription/errors.py
@@ -1,0 +1,21 @@
+from echoflow.core.errors import EchoFlowError, ErrorCode
+
+
+class ResourceAdmissionError(EchoFlowError):
+    code = ErrorCode.RESOURCE_ADMISSION
+    exit_code = 2
+
+
+class TranscriptionDependencyError(EchoFlowError):
+    code = ErrorCode.TRANSCRIPTION_DEPENDENCY
+    exit_code = 2
+
+
+class ModelUnavailableError(EchoFlowError):
+    code = ErrorCode.MODEL_UNAVAILABLE
+    exit_code = 2
+
+
+class TranscriptionError(EchoFlowError):
+    code = ErrorCode.TRANSCRIPTION
+    exit_code = 2

--- a/src/echoflow/transcription/executor.py
+++ b/src/echoflow/transcription/executor.py
@@ -1,0 +1,158 @@
+import json
+from contextlib import suppress
+from pathlib import Path
+from typing import Protocol
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.media.errors import InputChangedError
+from echoflow.media.models import MediaInfo
+from echoflow.runner.inspector import RunnerInspector
+from echoflow.runner.policy import RunnerPolicyPlanner
+from echoflow.transcription.audio import DecodedAudio
+from echoflow.transcription.errors import ResourceAdmissionError
+from echoflow.transcription.models import (
+    CanonicalTranscript,
+    CpuEngineConfiguration,
+    DecodeConfiguration,
+    EngineProvenance,
+    EngineTranscript,
+    TranscriptionExecutionResult,
+    TranscriptionJobPlan,
+    TranscriptSource,
+)
+from echoflow.workspace.models import Artifact, ArtifactKind
+from echoflow.workspace.service import WorkspaceService
+
+
+class MediaProbe(Protocol):
+    def probe(self, input_path: str | Path) -> MediaInfo: ...
+
+
+class AudioDecoder(Protocol):
+    def decode(
+        self,
+        media: MediaInfo,
+        configuration: DecodeConfiguration,
+        workspace_dir: Path,
+    ) -> DecodedAudio: ...
+
+    def cleanup(self, audio: DecodedAudio) -> None: ...
+
+
+class Transcriber(Protocol):
+    def transcribe(
+        self,
+        audio_path: Path,
+        configuration: CpuEngineConfiguration,
+        *,
+        allow_model_download: bool,
+    ) -> EngineTranscript: ...
+
+
+class TranscriptionExecutor:
+    """Claim a plan, normalize its audio, transcribe it, and publish JSON."""
+
+    def __init__(
+        self,
+        *,
+        media_probe: MediaProbe,
+        workspace_service: WorkspaceService,
+        file_manager: FileManagerFacade,
+        runner_inspector: RunnerInspector,
+        policy_planner: RunnerPolicyPlanner,
+        audio_decoder: AudioDecoder,
+        transcriber: Transcriber,
+    ):
+        self.media_probe = media_probe
+        self.workspace_service = workspace_service
+        self.file_manager = file_manager
+        self.runner_inspector = runner_inspector
+        self.policy_planner = policy_planner
+        self.audio_decoder = audio_decoder
+        self.transcriber = transcriber
+
+    def execute(
+        self,
+        plan: TranscriptionJobPlan,
+        *,
+        allow_model_download: bool = False,
+    ) -> TranscriptionExecutionResult:
+        self._admit(plan)
+        verified_media = self.media_probe.probe(plan.job.input_path)
+        if verified_media.input != plan.media.input:
+            raise InputChangedError(
+                "Input changed between transcription planning and execution"
+            )
+
+        job = self.workspace_service.create_job(
+            plan.job.input_path,
+            output_dir=plan.job.output_dir,
+            job_id=plan.job.job_id,
+        )
+        artifact = self.workspace_service.reserve_artifact(
+            job, ArtifactKind.CANONICAL_JSON
+        )
+        decoded: DecodedAudio | None = None
+        try:
+            decoded = self.audio_decoder.decode(
+                plan.media, plan.decoder, job.workspace_dir
+            )
+            self._admit(plan)
+            engine_result = self.transcriber.transcribe(
+                decoded.path,
+                plan.engine,
+                allow_model_download=allow_model_download,
+            )
+            transcript = self._transcript(plan, engine_result)
+            document = json.dumps(
+                transcript.to_dict(),
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            self.file_manager.save_file(f"{document}\n".encode(), artifact.path)
+        except BaseException:
+            self._release_failed_artifact(artifact)
+            raise
+        finally:
+            if decoded is not None:
+                self.audio_decoder.cleanup(decoded)
+        return TranscriptionExecutionResult(job, artifact, transcript)
+
+    def _admit(self, plan: TranscriptionJobPlan) -> None:
+        current_resources = self.runner_inspector.inspect()
+        current_policy = self.policy_planner.plan(
+            current_resources, plan.policy.profile
+        )
+        if (
+            not plan.resources.fits_memory_budget
+            or plan.resources.estimated_peak_memory_bytes
+            > current_policy.memory_budget_bytes
+        ):
+            raise ResourceAdmissionError(
+                "Available memory is below the selected model's safe execution budget"
+            )
+        if plan.engine.cpu_threads > current_policy.cpu_threads:
+            raise ResourceAdmissionError(
+                "Available CPU capacity changed; create a new transcription plan"
+            )
+
+    def _release_failed_artifact(self, artifact: Artifact) -> None:
+        with suppress(Exception):
+            self.file_manager.delete_file(artifact.path)
+
+    @staticmethod
+    def _transcript(
+        plan: TranscriptionJobPlan, result: EngineTranscript
+    ) -> CanonicalTranscript:
+        return CanonicalTranscript(
+            job_id=plan.job.job_id.value,
+            source=TranscriptSource.from_media(plan.media),
+            profile=plan.policy.profile,
+            provisional=plan.policy.provisional,
+            decode_strategy=plan.decoder.strategy,
+            engine=EngineProvenance.from_engine(plan.engine, result.engine_version),
+            detected_language=result.language,
+            language_probability=result.language_probability,
+            segments=result.segments,
+        )

--- a/src/echoflow/transcription/models.py
+++ b/src/echoflow/transcription/models.py
@@ -1,9 +1,10 @@
+import math
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
 from echoflow.media.models import MediaInfo
-from echoflow.runner.models import ExecutionPolicy, RunnerResources
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 from echoflow.workspace.models import Artifact, Job
 
 
@@ -46,6 +47,7 @@ class CpuEngineConfiguration:
     beam_size: int
     language: str | None
     model_cache_path: Path
+    model_revision: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -60,6 +62,8 @@ class CpuEngineConfiguration:
             raise ValueError("cpu_threads must be positive")
         if self.beam_size < 1:
             raise ValueError("beam_size must be positive")
+        if self.model_revision is not None and not self.model_revision.strip():
+            raise ValueError("model_revision cannot be empty")
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -71,6 +75,7 @@ class CpuEngineConfiguration:
             "beam_size": self.beam_size,
             "language": self.language,
             "model_cache_path": str(self.model_cache_path),
+            "model_revision": self.model_revision,
         }
 
 
@@ -154,4 +159,244 @@ class TranscriptionJobPlan:
             "decoder": self.decoder.to_dict(),
             "resources": self.resources.to_dict(),
             "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RecognizedSegment:
+    index: int
+    start_seconds: float
+    end_seconds: float
+    text: str
+    average_log_probability: float | None = None
+    no_speech_probability: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.index < 0:
+            raise ValueError("segment index cannot be negative")
+        if (
+            not math.isfinite(self.start_seconds)
+            or not math.isfinite(self.end_seconds)
+            or self.start_seconds < 0
+            or self.end_seconds < self.start_seconds
+        ):
+            raise ValueError("segment timestamps must be finite and ordered")
+        if not self.text.strip():
+            raise ValueError("segment text cannot be empty")
+        if self.average_log_probability is not None and not math.isfinite(
+            self.average_log_probability
+        ):
+            raise ValueError("average_log_probability must be finite")
+        if self.no_speech_probability is not None and not (
+            math.isfinite(self.no_speech_probability)
+            and 0 <= self.no_speech_probability <= 1
+        ):
+            raise ValueError("no_speech_probability must be between 0 and 1")
+
+    @property
+    def segment_id(self) -> str:
+        return f"segment-{self.index:06d}"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "segment_id": self.segment_id,
+            "index": self.index,
+            "start_seconds": self.start_seconds,
+            "end_seconds": self.end_seconds,
+            "text": self.text,
+            "average_log_probability": self.average_log_probability,
+            "no_speech_probability": self.no_speech_probability,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EngineTranscript:
+    segments: tuple[RecognizedSegment, ...]
+    language: str | None
+    language_probability: float | None
+    engine_version: str
+
+    def __post_init__(self) -> None:
+        if self.language is not None and not self.language.strip():
+            raise ValueError("language cannot be empty")
+        if self.language_probability is not None and not (
+            math.isfinite(self.language_probability)
+            and 0 <= self.language_probability <= 1
+        ):
+            raise ValueError("language_probability must be between 0 and 1")
+        if not self.engine_version:
+            raise ValueError("engine_version cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptSource:
+    sha256: str
+    size_bytes: int
+    modified_ns: int
+    container_format: str
+    duration_seconds: float
+    audio_stream_index: int
+
+    def __post_init__(self) -> None:
+        if len(self.sha256) != 64 or any(
+            character not in "0123456789abcdef" for character in self.sha256
+        ):
+            raise ValueError("source sha256 must be a lowercase 64-character digest")
+        if self.size_bytes < 1:
+            raise ValueError("source size_bytes must be positive")
+        if self.modified_ns < 0:
+            raise ValueError("source modified_ns cannot be negative")
+        if not self.container_format:
+            raise ValueError("source container_format cannot be empty")
+        if not math.isfinite(self.duration_seconds) or self.duration_seconds <= 0:
+            raise ValueError("source duration_seconds must be finite and positive")
+        if self.audio_stream_index < 0:
+            raise ValueError("source audio_stream_index cannot be negative")
+
+    @classmethod
+    def from_media(cls, media: MediaInfo) -> "TranscriptSource":
+        return cls(
+            sha256=media.input.sha256,
+            size_bytes=media.input.size_bytes,
+            modified_ns=media.input.modified_ns,
+            container_format=media.container_format,
+            duration_seconds=media.duration_seconds,
+            audio_stream_index=media.primary_audio_stream_index,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "sha256": self.sha256,
+            "size_bytes": self.size_bytes,
+            "modified_ns": self.modified_ns,
+            "container_format": self.container_format,
+            "duration_seconds": self.duration_seconds,
+            "audio_stream_index": self.audio_stream_index,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EngineProvenance:
+    name: str
+    package_version: str
+    model: str
+    model_revision: str | None
+    device: str
+    compute_type: str
+    cpu_threads: int
+    beam_size: int
+    requested_language: str | None
+
+    def __post_init__(self) -> None:
+        for name in ("name", "package_version", "model", "device", "compute_type"):
+            if not getattr(self, name):
+                raise ValueError(f"{name} cannot be empty")
+        if self.model_revision is not None and not self.model_revision.strip():
+            raise ValueError("model_revision cannot be empty")
+        if self.cpu_threads < 1:
+            raise ValueError("cpu_threads must be positive")
+        if self.beam_size < 1:
+            raise ValueError("beam_size must be positive")
+
+    @classmethod
+    def from_engine(
+        cls, configuration: CpuEngineConfiguration, package_version: str
+    ) -> "EngineProvenance":
+        return cls(
+            name=configuration.engine,
+            package_version=package_version,
+            model=configuration.model,
+            model_revision=configuration.model_revision,
+            device=configuration.device,
+            compute_type=configuration.compute_type,
+            cpu_threads=configuration.cpu_threads,
+            beam_size=configuration.beam_size,
+            requested_language=configuration.language,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "package_version": self.package_version,
+            "model": self.model,
+            "model_revision": self.model_revision,
+            "device": self.device,
+            "compute_type": self.compute_type,
+            "cpu_threads": self.cpu_threads,
+            "beam_size": self.beam_size,
+            "requested_language": self.requested_language,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalTranscript:
+    job_id: str
+    source: TranscriptSource
+    profile: ProcessingProfile
+    provisional: bool
+    decode_strategy: DecodeStrategy
+    engine: EngineProvenance
+    detected_language: str | None
+    language_probability: float | None
+    segments: tuple[RecognizedSegment, ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("unsupported transcript schema version")
+        if not self.job_id:
+            raise ValueError("job_id cannot be empty")
+        if self.provisional != (self.profile is ProcessingProfile.SCREENING):
+            raise ValueError("provisional flag must match the processing profile")
+        if self.detected_language is not None and not self.detected_language.strip():
+            raise ValueError("detected_language cannot be empty")
+        if self.language_probability is not None and not (
+            math.isfinite(self.language_probability)
+            and 0 <= self.language_probability <= 1
+        ):
+            raise ValueError("language_probability must be between 0 and 1")
+        if tuple(segment.index for segment in self.segments) != tuple(
+            range(len(self.segments))
+        ):
+            raise ValueError("segment indices must be contiguous and zero-based")
+
+    @property
+    def text(self) -> str:
+        return " ".join(segment.text.strip() for segment in self.segments)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "job_id": self.job_id,
+            "source": self.source.to_dict(),
+            "profile": self.profile.value,
+            "provisional": self.provisional,
+            "decode_strategy": self.decode_strategy.value,
+            "engine": self.engine.to_dict(),
+            "detected_language": self.detected_language,
+            "language_probability": self.language_probability,
+            "text": self.text,
+            "segments": [segment.to_dict() for segment in self.segments],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptionExecutionResult:
+    job: Job
+    artifact: Artifact
+    transcript: CanonicalTranscript
+
+    def __post_init__(self) -> None:
+        if self.job.job_id != self.artifact.job_id:
+            raise ValueError("job and artifact IDs must match")
+        if self.job.job_id.value != self.transcript.job_id:
+            raise ValueError("job and transcript IDs must match")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "dry_run": False,
+            "paths_reserved": True,
+            "job": self.job.to_dict(),
+            "artifact": self.artifact.to_dict(),
+            "transcript": self.transcript.to_dict(),
         }

--- a/src/echoflow/transcription/planner.py
+++ b/src/echoflow/transcription/planner.py
@@ -51,11 +51,13 @@ class TranscriptionJobPlanner:
         workspace_service: WorkspaceService,
         runner_inspector: RunnerInspector,
         policy_planner: RunnerPolicyPlanner,
+        model_revision: str | None = None,
     ):
         self.media_probe = media_probe
         self.workspace_service = workspace_service
         self.runner_inspector = runner_inspector
         self.policy_planner = policy_planner
+        self.model_revision = model_revision
 
     def plan(
         self,
@@ -102,8 +104,9 @@ class TranscriptionJobPlanner:
             beam_size=1 if policy.provisional else 5,
             language=None,
             model_cache_path=(
-                self.workspace_service.paths.model_dir / "faster-whisper" / model
+                self.workspace_service.paths.model_dir / "faster-whisper"
             ),
+            model_revision=self.model_revision,
         )
 
     @staticmethod

--- a/src/echoflow/transcription/tests/test_audio.py
+++ b/src/echoflow/transcription/tests/test_audio.py
@@ -1,0 +1,219 @@
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from echoflow.media.errors import AudioDecodeError, MediaToolUnavailableError
+from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
+from echoflow.transcription.audio import DecodedAudio, FfmpegAudioDecoder
+from echoflow.transcription.models import DecodeConfiguration, DecodeStrategy
+
+
+def media(source: Path, *, stream_index: int = 2) -> MediaInfo:
+    return MediaInfo(
+        InputIdentity(
+            source,
+            source.stat().st_size,
+            source.stat().st_mtime_ns,
+            "0" * 64,
+        ),
+        "mov,mp4,m4a,3gp,3g2,mj2",
+        2.0,
+        (
+            MediaStream(0, StreamKind.VIDEO, "h264", 2.0),
+            MediaStream(stream_index, StreamKind.AUDIO, "aac", 2.0, 48_000, 2),
+        ),
+        stream_index,
+    )
+
+
+def normalized() -> DecodeConfiguration:
+    return DecodeConfiguration(DecodeStrategy.FFMPEG_NORMALIZE, "pcm_s16le", 16_000, 1)
+
+
+def test_direct_audio_returns_original_without_resolving_ffmpeg(tmp_path):
+    source = tmp_path / "ready.wav"
+    source.write_bytes(b"RIFFaudio")
+    decoder = FfmpegAudioDecoder()
+    with patch("echoflow.transcription.audio.shutil.which") as which:
+        result = decoder.decode(
+            media(source),
+            DecodeConfiguration(DecodeStrategy.DIRECT, "pcm_s16le", 16_000, 1),
+            tmp_path / "workspace",
+        )
+    assert result == DecodedAudio(source.resolve(), temporary=False)
+    which.assert_not_called()
+    decoder.cleanup(result)
+    assert source.exists()
+
+
+def test_video_container_maps_only_selected_audio_to_private_wav(tmp_path):
+    source = tmp_path / "interview.mp4"
+    source.write_bytes(b"video-and-audio")
+    workspace = tmp_path / "private-job"
+    workspace.mkdir()
+
+    def run(command, **kwargs):
+        Path(command[-1]).write_bytes(b"RIFF" + b"\0" * 64)
+        return SimpleNamespace(returncode=0)
+
+    with (
+        patch("echoflow.transcription.audio.shutil.which", return_value="ffmpeg"),
+        patch("echoflow.transcription.audio.subprocess.run", side_effect=run) as call,
+    ):
+        result = FfmpegAudioDecoder(timeout_seconds=12.5).decode(
+            media(source, stream_index=2), normalized(), workspace
+        )
+
+    assert result.path == workspace / "normalized.wav"
+    assert result.temporary is True
+    command = call.call_args.args[0]
+    assert command == [
+        "ffmpeg",
+        "-nostdin",
+        "-v",
+        "error",
+        "-protocol_whitelist",
+        "file",
+        "-i",
+        str(source.resolve()),
+        "-map",
+        "0:2",
+        "-vn",
+        "-sn",
+        "-dn",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-c:a",
+        "pcm_s16le",
+        "-f",
+        "wav",
+        "-n",
+        str(workspace / "normalized.wav"),
+    ]
+    assert call.call_args.kwargs == {
+        "check": False,
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "timeout": 12.5,
+    }
+    FfmpegAudioDecoder.cleanup(result)
+    assert not result.path.exists()
+
+
+def test_decoder_requires_positive_timeout():
+    with pytest.raises(ValueError, match="^timeout_seconds must be positive$"):
+        FfmpegAudioDecoder(0)
+
+
+def test_normalization_requires_ffmpeg(tmp_path):
+    source = tmp_path / "audio.m4a"
+    source.write_bytes(b"audio")
+    with (
+        patch("echoflow.transcription.audio.shutil.which", return_value=None),
+        pytest.raises(MediaToolUnavailableError, match="^FFmpeg is required"),
+    ):
+        FfmpegAudioDecoder().decode(media(source), normalized(), tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("effect", "error_type", "message"),
+    [
+        (
+            subprocess.TimeoutExpired("ffmpeg", 1),
+            AudioDecodeError,
+            "Audio extraction timed out",
+        ),
+        (OSError("missing dll"), MediaToolUnavailableError, "FFmpeg could not"),
+    ],
+)
+def test_native_process_failures_are_typed_and_remove_partial_output(
+    tmp_path, effect, error_type, message
+):
+    source = tmp_path / "audio.m4a"
+    source.write_bytes(b"audio")
+    partial = tmp_path / "normalized.wav"
+
+    def run(*_args, **_kwargs):
+        partial.write_bytes(b"partial")
+        raise effect
+
+    with (
+        patch("echoflow.transcription.audio.shutil.which", return_value="ffmpeg"),
+        patch("echoflow.transcription.audio.subprocess.run", side_effect=run),
+        pytest.raises(error_type, match=f"^{message}"),
+    ):
+        FfmpegAudioDecoder().decode(media(source), normalized(), tmp_path)
+    assert not partial.exists()
+
+
+@pytest.mark.parametrize("returncode", [1, 255])
+def test_nonzero_ffmpeg_exit_removes_output_and_hides_native_details(
+    tmp_path, returncode
+):
+    source = tmp_path / "audio.m4a"
+    source.write_bytes(b"audio")
+    destination = tmp_path / "normalized.wav"
+
+    def run(*_args, **_kwargs):
+        destination.write_bytes(b"partial")
+        return SimpleNamespace(returncode=returncode)
+
+    with (
+        patch("echoflow.transcription.audio.shutil.which", return_value="ffmpeg"),
+        patch("echoflow.transcription.audio.subprocess.run", side_effect=run),
+        pytest.raises(
+            AudioDecodeError,
+            match="^The selected audio stream could not be normalized$",
+        ),
+    ):
+        FfmpegAudioDecoder().decode(media(source), normalized(), tmp_path)
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize("payload", [b"", b"RIFF" + b"\0" * 40])
+def test_header_only_or_empty_normalized_audio_is_rejected(tmp_path, payload):
+    source = tmp_path / "audio.m4a"
+    source.write_bytes(b"audio")
+    destination = tmp_path / "normalized.wav"
+
+    def run(*_args, **_kwargs):
+        destination.write_bytes(payload)
+        return SimpleNamespace(returncode=0)
+
+    with (
+        patch("echoflow.transcription.audio.shutil.which", return_value="ffmpeg"),
+        patch("echoflow.transcription.audio.subprocess.run", side_effect=run),
+        pytest.raises(
+            AudioDecodeError, match="^Normalized audio contains no usable samples$"
+        ),
+    ):
+        FfmpegAudioDecoder().decode(media(source), normalized(), tmp_path)
+    assert not destination.exists()
+
+
+def test_missing_normalized_output_is_typed(tmp_path):
+    source = tmp_path / "audio.m4a"
+    source.write_bytes(b"audio")
+    with (
+        patch("echoflow.transcription.audio.shutil.which", return_value="ffmpeg"),
+        patch(
+            "echoflow.transcription.audio.subprocess.run",
+            return_value=SimpleNamespace(returncode=0),
+        ),
+        pytest.raises(
+            AudioDecodeError, match="^Normalized audio could not be validated$"
+        ),
+    ):
+        FfmpegAudioDecoder().decode(media(source), normalized(), tmp_path)
+
+
+def test_decoded_audio_normalizes_path_and_is_slotted(tmp_path):
+    audio = DecodedAudio(tmp_path / "nested/../audio.wav", True)
+    assert audio.path == (tmp_path / "audio.wav").resolve()
+    assert not hasattr(audio, "__dict__")

--- a/src/echoflow/transcription/tests/test_backend.py
+++ b/src/echoflow/transcription/tests/test_backend.py
@@ -1,0 +1,268 @@
+from importlib import metadata
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from echoflow.transcription.backend import FasterWhisperTranscriber
+from echoflow.transcription.errors import (
+    ModelUnavailableError,
+    TranscriptionDependencyError,
+    TranscriptionError,
+)
+from echoflow.transcription.models import CpuEngineConfiguration
+
+
+def configuration(tmp_path, *, revision=None):
+    return CpuEngineConfiguration(
+        engine="faster-whisper",
+        model="tiny",
+        device="cpu",
+        compute_type="int8",
+        cpu_threads=2,
+        beam_size=1,
+        language=None,
+        model_cache_path=tmp_path / "models/faster-whisper",
+        model_revision=revision,
+    )
+
+
+def segment(start=0.0, end=1.0, text=" hello ", avg=-0.2, no_speech=0.1):
+    return SimpleNamespace(
+        start=start,
+        end=end,
+        text=text,
+        avg_logprob=avg,
+        no_speech_prob=no_speech,
+    )
+
+
+def backend(model_class, *, version_reader=lambda _name: "1.2.1"):
+    module = SimpleNamespace(WhisperModel=model_class)
+    return FasterWhisperTranscriber(
+        module_loader=lambda name: module,
+        version_reader=version_reader,
+    )
+
+
+def test_local_cpu_transcription_uses_exact_plan_and_consumes_generator(tmp_path):
+    calls = []
+
+    class Model:
+        def __init__(self, model, **kwargs):
+            calls.append((model, kwargs))
+
+        def transcribe(self, path, **kwargs):
+            calls.append((path, kwargs))
+
+            def generated():
+                calls.append("iterated")
+                yield segment()
+                yield segment(1.0, 1.5, "   ")
+                yield segment(1.5, 2.0, "world", -0.4, 0.2)
+
+            return generated(), SimpleNamespace(
+                language=" en ", language_probability="0.95"
+            )
+
+    config = configuration(tmp_path, revision="immutable-revision")
+    result = backend(Model).transcribe(
+        tmp_path / "audio.wav", config, allow_model_download=False
+    )
+
+    assert calls[0] == (
+        "tiny",
+        {
+            "device": "cpu",
+            "compute_type": "int8",
+            "cpu_threads": 2,
+            "num_workers": 1,
+            "download_root": str(config.model_cache_path),
+            "local_files_only": True,
+            "revision": "immutable-revision",
+        },
+    )
+    assert calls[1] == (
+        (str(tmp_path / "audio.wav")),
+        {
+            "beam_size": 1,
+            "language": None,
+            "word_timestamps": False,
+            "vad_filter": False,
+            "log_progress": False,
+        },
+    )
+    assert calls[2] == "iterated"
+    assert [item.text for item in result.segments] == ["hello", "world"]
+    assert [item.index for item in result.segments] == [0, 1]
+    assert result.segments[0].average_log_probability == -0.2
+    assert result.segments[1].no_speech_probability == 0.2
+    assert result.language == "en"
+    assert result.language_probability == 0.95
+    assert result.engine_version == "1.2.1"
+
+
+def test_explicit_download_authorization_disables_local_only_mode(tmp_path):
+    model = Mock()
+    model.transcribe.return_value = (
+        iter(()),
+        SimpleNamespace(language=None, language_probability=None),
+    )
+    factory = Mock(return_value=model)
+    result = backend(factory).transcribe(
+        tmp_path / "audio.wav",
+        configuration(tmp_path),
+        allow_model_download=True,
+    )
+    assert factory.call_args.kwargs["local_files_only"] is False
+    assert result.segments == ()
+    assert result.language is None
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [ModuleNotFoundError("faster_whisper"), ImportError("native dependency")],
+)
+def test_missing_optional_engine_dependency_has_install_instruction(tmp_path, failure):
+    transcriber = FasterWhisperTranscriber(
+        module_loader=Mock(side_effect=failure), version_reader=Mock()
+    )
+    with pytest.raises(
+        TranscriptionDependencyError,
+        match="^CPU transcription support is not installed; install EchoFlow's transcription extra$",
+    ):
+        transcriber.transcribe(
+            tmp_path / "audio.wav",
+            configuration(tmp_path),
+            allow_model_download=False,
+        )
+
+
+def test_missing_package_metadata_is_a_dependency_failure(tmp_path):
+    transcriber = FasterWhisperTranscriber(
+        module_loader=lambda _name: SimpleNamespace(),
+        version_reader=Mock(side_effect=metadata.PackageNotFoundError("missing")),
+    )
+    with pytest.raises(TranscriptionDependencyError):
+        transcriber.transcribe(
+            tmp_path / "audio.wav",
+            configuration(tmp_path),
+            allow_model_download=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("allowed", "error_type", "message"),
+    [
+        (
+            False,
+            ModelUnavailableError,
+            "The selected model is not available locally",
+        ),
+        (
+            True,
+            TranscriptionError,
+            "The selected model could not be downloaded or initialized",
+        ),
+    ],
+)
+def test_model_initialization_failure_reflects_download_authorization(
+    tmp_path, allowed, error_type, message
+):
+    class Model:
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError("private hub detail")
+
+    with pytest.raises(error_type, match=f"^{message}") as error:
+        backend(Model).transcribe(
+            tmp_path / "audio.wav",
+            configuration(tmp_path),
+            allow_model_download=allowed,
+        )
+    assert "private hub detail" not in str(error.value)
+
+
+def test_engine_iteration_failure_is_redacted(tmp_path):
+    class Model:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def transcribe(self, *_args, **_kwargs):
+            def generated():
+                raise RuntimeError("sensitive decoder detail")
+                yield
+
+            return generated(), SimpleNamespace(language="en", language_probability=1.0)
+
+    with pytest.raises(
+        TranscriptionError,
+        match="^The transcription engine failed while processing audio$",
+    ) as error:
+        backend(Model).transcribe(
+            tmp_path / "audio.wav",
+            configuration(tmp_path),
+            allow_model_download=False,
+        )
+    assert "sensitive decoder detail" not in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "bad_segment",
+    [
+        SimpleNamespace(text="words", start="bad", end=1),
+        SimpleNamespace(text="words", start=2, end=1),
+    ],
+)
+def test_invalid_engine_segment_values_are_typed(tmp_path, bad_segment):
+    class Model:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def transcribe(self, *_args, **_kwargs):
+            return iter((bad_segment,)), SimpleNamespace(
+                language="en", language_probability=1.0
+            )
+
+    with pytest.raises(
+        TranscriptionError,
+        match="^The transcription engine returned invalid segment data$",
+    ):
+        backend(Model).transcribe(
+            tmp_path / "audio.wav",
+            configuration(tmp_path),
+            allow_model_download=False,
+        )
+
+
+def test_invalid_language_probability_is_typed_without_native_detail(tmp_path):
+    class Model:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def transcribe(self, *_args, **_kwargs):
+            return iter(()), SimpleNamespace(
+                language="en", language_probability="not-a-number"
+            )
+
+    with pytest.raises(
+        TranscriptionError,
+        match="^The transcription engine returned invalid probability data$",
+    ):
+        backend(Model).transcribe(
+            tmp_path / "audio.wav",
+            configuration(tmp_path),
+            allow_model_download=False,
+        )
+
+
+def test_keyboard_interrupt_is_not_wrapped_during_model_loading(tmp_path):
+    class Model:
+        def __init__(self, *_args, **_kwargs):
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        backend(Model).transcribe(
+            tmp_path / "audio.wav",
+            configuration(tmp_path),
+            allow_model_download=False,
+        )

--- a/src/echoflow/transcription/tests/test_executor.py
+++ b/src/echoflow/transcription/tests/test_executor.py
@@ -1,0 +1,356 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.core.performance_tracker import PerformanceTracker
+from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.media.errors import InputChangedError
+from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
+from echoflow.runner.models import (
+    ExecutionPolicy,
+    ModelTier,
+    ProcessingProfile,
+    RunnerResources,
+)
+from echoflow.runner.policy import RunnerPolicyPlanner
+from echoflow.transcription.audio import DecodedAudio
+from echoflow.transcription.errors import ResourceAdmissionError, TranscriptionError
+from echoflow.transcription.executor import TranscriptionExecutor
+from echoflow.transcription.models import (
+    CpuEngineConfiguration,
+    DecodeConfiguration,
+    DecodeStrategy,
+    EngineTranscript,
+    RecognizedSegment,
+    ResourceEstimate,
+    TranscriptionJobPlan,
+)
+from echoflow.workspace.models import Artifact, ArtifactKind, Job, JobId, WorkspacePaths
+from echoflow.workspace.service import WorkspaceService
+
+MIB = 1024**2
+GIB = 1024**3
+
+
+def resources(*, memory=8 * GIB, cpus=4):
+    return RunnerResources(
+        platform="TestOS",
+        machine="x86_64",
+        logical_cpus=cpus,
+        physical_cpus=cpus,
+        affinity_cpus=cpus,
+        cpu_quota_cores=None,
+        effective_cpus=cpus,
+        memory_total_bytes=memory,
+        memory_available_bytes=memory,
+        memory_limit_bytes=None,
+        effective_memory_available_bytes=memory,
+    )
+
+
+def plan(tmp_path, *, decode=DecodeStrategy.DIRECT, fits=True):
+    source = tmp_path / "private participant video.mp4"
+    source.write_bytes(b"recording")
+    paths = WorkspacePaths(
+        tmp_path / "state",
+        tmp_path / "cache",
+        tmp_path / "cache/models",
+        tmp_path / "output",
+    )
+    job = Job(JobId("job-1"), source, paths.jobs_dir / "job-1", paths.output_dir)
+    media = MediaInfo(
+        InputIdentity(
+            source.resolve(),
+            source.stat().st_size,
+            source.stat().st_mtime_ns,
+            "0" * 64,
+        ),
+        "mov,mp4,m4a,3gp,3g2,mj2",
+        2.0,
+        (
+            MediaStream(0, StreamKind.VIDEO, "h264", 2.0),
+            MediaStream(1, StreamKind.AUDIO, "aac", 2.0, 48_000, 2),
+        ),
+        1,
+    )
+    artifact = Artifact(
+        job.job_id,
+        ArtifactKind.CANONICAL_JSON,
+        paths.output_dir / "private participant video.json",
+    )
+    runner = resources()
+    policy = ExecutionPolicy(
+        ProcessingProfile.BALANCED,
+        False,
+        4,
+        8 * GIB,
+        ModelTier.STANDARD,
+    )
+    engine = CpuEngineConfiguration(
+        "faster-whisper",
+        "small",
+        "cpu",
+        "int8",
+        4,
+        5,
+        None,
+        paths.model_dir / "faster-whisper",
+        "revision-1",
+    )
+    decoder = DecodeConfiguration(decode, "pcm_s16le", 16_000, 1)
+    estimate = ResourceEstimate(
+        16 * MIB,
+        64 * 1024,
+        750 * MIB,
+        2_304 * MIB,
+        8 * GIB,
+        fits,
+    )
+    return (
+        TranscriptionJobPlan(
+            job,
+            artifact,
+            media,
+            runner,
+            policy,
+            engine,
+            decoder,
+            estimate,
+            ("paths_are_unreserved",),
+        ),
+        paths,
+    )
+
+
+def executor(tmp_path, planned, paths, *, available=None):
+    facade = FileManagerFacade(LocalFileManager(), Mock(), PerformanceTracker())
+    workspace = WorkspaceService(paths, facade, id_factory=lambda: "unused")
+    probe = Mock()
+    probe.probe.return_value = planned.media
+    inspector = Mock()
+    inspector.inspect.return_value = available or resources()
+    decoder = Mock()
+    decoder.decode.return_value = DecodedAudio(planned.job.input_path, False)
+    transcriber = Mock()
+    transcriber.transcribe.return_value = EngineTranscript(
+        (
+            RecognizedSegment(0, 0.0, 1.0, "Hello", -0.2, 0.1),
+            RecognizedSegment(1, 1.0, 2.0, "world.", -0.3, 0.2),
+        ),
+        "en",
+        0.98,
+        "1.2.1",
+    )
+    service = TranscriptionExecutor(
+        media_probe=probe,
+        workspace_service=workspace,
+        file_manager=facade,
+        runner_inspector=inspector,
+        policy_planner=RunnerPolicyPlanner(memory_budget_fraction=1),
+        audio_decoder=decoder,
+        transcriber=transcriber,
+    )
+    return service, probe, inspector, decoder, transcriber
+
+
+def test_execution_claims_paths_transcribes_audio_and_writes_private_safe_json(
+    tmp_path,
+):
+    planned, paths = plan(tmp_path, decode=DecodeStrategy.FFMPEG_NORMALIZE)
+    service, probe, inspector, decoder, transcriber = executor(tmp_path, planned, paths)
+    normalized = planned.job.workspace_dir / "normalized.wav"
+    decoder.decode.return_value = DecodedAudio(normalized, True)
+
+    result = service.execute(planned, allow_model_download=True)
+
+    assert result.job.workspace_dir.is_dir()
+    assert result.artifact.path.is_file()
+    document = json.loads(result.artifact.path.read_text())
+    assert document["schema_version"] == 1
+    assert document["job_id"] == "job-1"
+    assert document["source"]["sha256"] == "0" * 64
+    assert "path" not in document["source"]
+    assert document["decode_strategy"] == "ffmpeg_normalize"
+    assert document["engine"] == {
+        "name": "faster-whisper",
+        "package_version": "1.2.1",
+        "model": "small",
+        "model_revision": "revision-1",
+        "device": "cpu",
+        "compute_type": "int8",
+        "cpu_threads": 4,
+        "beam_size": 5,
+        "requested_language": None,
+    }
+    assert document["detected_language"] == "en"
+    assert document["language_probability"] == 0.98
+    assert document["text"] == "Hello world."
+    assert [item["segment_id"] for item in document["segments"]] == [
+        "segment-000000",
+        "segment-000001",
+    ]
+    assert str(planned.job.input_path) not in result.artifact.path.read_text()
+    assert str(planned.engine.model_cache_path) not in result.artifact.path.read_text()
+    probe.probe.assert_called_once_with(planned.job.input_path)
+    assert inspector.inspect.call_count == 2
+    decoder.decode.assert_called_once_with(
+        planned.media, planned.decoder, result.job.workspace_dir
+    )
+    decoder.cleanup.assert_called_once_with(DecodedAudio(normalized, True))
+    transcriber.transcribe.assert_called_once_with(
+        normalized,
+        planned.engine,
+        allow_model_download=True,
+    )
+    assert result.to_dict()["paths_reserved"] is True
+    assert result.to_dict()["dry_run"] is False
+
+
+def test_artifact_collision_is_resolved_at_reservation_not_assumed_from_plan(tmp_path):
+    planned, paths = plan(tmp_path)
+    paths.output_dir.mkdir(parents=True)
+    planned.artifact.path.write_text("existing")
+    service, *_ = executor(tmp_path, planned, paths)
+
+    result = service.execute(planned)
+
+    assert planned.artifact.path.read_text() == "existing"
+    assert result.artifact.path.name == "private participant video-2.json"
+
+
+def test_input_identity_change_is_rejected_before_workspace_creation(tmp_path):
+    planned, paths = plan(tmp_path)
+    service, probe, *_ = executor(tmp_path, planned, paths)
+    changed = MediaInfo(
+        InputIdentity(
+            planned.job.input_path,
+            planned.media.input.size_bytes,
+            planned.media.input.modified_ns,
+            "1" * 64,
+        ),
+        planned.media.container_format,
+        planned.media.duration_seconds,
+        planned.media.streams,
+        planned.media.primary_audio_stream_index,
+    )
+    probe.probe.return_value = changed
+
+    with pytest.raises(
+        InputChangedError,
+        match="^Input changed between transcription planning and execution$",
+    ):
+        service.execute(planned)
+    assert not paths.state_dir.exists()
+    assert not paths.output_dir.exists()
+
+
+@pytest.mark.parametrize(
+    ("planned_fits", "available_memory"),
+    [(False, 8 * GIB), (True, 2_303 * MIB)],
+)
+def test_insufficient_memory_is_rejected_before_input_is_reprobed(
+    tmp_path, planned_fits, available_memory
+):
+    planned, paths = plan(tmp_path, fits=planned_fits)
+    service, probe, inspector, decoder, transcriber = executor(
+        tmp_path,
+        planned,
+        paths,
+        available=resources(memory=available_memory),
+    )
+    with pytest.raises(
+        ResourceAdmissionError,
+        match="^Available memory is below the selected model's safe execution budget$",
+    ):
+        service.execute(planned)
+    inspector.inspect.assert_called_once_with()
+    probe.probe.assert_not_called()
+    decoder.decode.assert_not_called()
+    transcriber.transcribe.assert_not_called()
+
+
+def test_reduced_cpu_capacity_requires_a_fresh_plan(tmp_path):
+    planned, paths = plan(tmp_path)
+    service, probe, _, _, _ = executor(
+        tmp_path, planned, paths, available=resources(cpus=3)
+    )
+    with pytest.raises(
+        ResourceAdmissionError,
+        match="^Available CPU capacity changed; create a new transcription plan$",
+    ):
+        service.execute(planned)
+    probe.probe.assert_not_called()
+
+
+def test_resources_are_rechecked_after_normalization_before_model_load(tmp_path):
+    planned, paths = plan(tmp_path, decode=DecodeStrategy.FFMPEG_NORMALIZE)
+    service, _, inspector, decoder, transcriber = executor(tmp_path, planned, paths)
+    inspector.inspect.side_effect = [resources(), resources(memory=2_303 * MIB)]
+
+    with pytest.raises(ResourceAdmissionError):
+        service.execute(planned)
+
+    assert inspector.inspect.call_count == 2
+    decoder.cleanup.assert_called_once_with(decoder.decode.return_value)
+    transcriber.transcribe.assert_not_called()
+    assert not planned.artifact.path.exists()
+
+
+def test_transcription_failure_releases_placeholder_and_cleans_audio(tmp_path):
+    planned, paths = plan(tmp_path)
+    service, _, _, decoder, transcriber = executor(tmp_path, planned, paths)
+    transcriber.transcribe.side_effect = TranscriptionError("engine failed")
+
+    with pytest.raises(TranscriptionError, match="^engine failed$"):
+        service.execute(planned)
+
+    assert not planned.artifact.path.exists()
+    decoder.cleanup.assert_called_once_with(decoder.decode.return_value)
+
+
+def test_cleanup_failure_does_not_replace_successful_transcript(tmp_path):
+    planned, paths = plan(tmp_path)
+    service, _, _, decoder, _ = executor(tmp_path, planned, paths)
+    decoder.cleanup.side_effect = OSError("cleanup failure")
+
+    with pytest.raises(OSError, match="cleanup failure"):
+        service.execute(planned)
+
+    assert planned.artifact.path.exists()
+
+
+def test_failed_artifact_cleanup_error_does_not_mask_engine_failure(tmp_path):
+    planned, paths = plan(tmp_path)
+    service, _, _, _, transcriber = executor(tmp_path, planned, paths)
+    transcriber.transcribe.side_effect = TranscriptionError("engine failed")
+    service.file_manager.delete_file = Mock(side_effect=OSError("cleanup failed"))
+
+    with pytest.raises(TranscriptionError, match="^engine failed$"):
+        service.execute(planned)
+    service.file_manager.delete_file.assert_called_once_with(planned.artifact.path)
+
+
+def test_execution_result_rejects_mismatched_job_artifact_or_transcript(tmp_path):
+    planned, paths = plan(tmp_path)
+    service, *_ = executor(tmp_path, planned, paths)
+    result = service.execute(planned)
+    wrong_artifact = Artifact(
+        JobId("other"), result.artifact.kind, result.artifact.path
+    )
+    with pytest.raises(ValueError, match="^job and artifact IDs must match$"):
+        type(result)(result.job, wrong_artifact, result.transcript)
+    wrong_transcript = type(result.transcript)(
+        job_id="other",
+        source=result.transcript.source,
+        profile=result.transcript.profile,
+        provisional=result.transcript.provisional,
+        decode_strategy=result.transcript.decode_strategy,
+        engine=result.transcript.engine,
+        detected_language=result.transcript.detected_language,
+        language_probability=result.transcript.language_probability,
+        segments=result.transcript.segments,
+    )
+    with pytest.raises(ValueError, match="^job and transcript IDs must match$"):
+        type(result)(result.job, result.artifact, wrong_transcript)

--- a/src/echoflow/transcription/tests/test_models.py
+++ b/src/echoflow/transcription/tests/test_models.py
@@ -11,11 +11,16 @@ from echoflow.runner.models import (
     RunnerResources,
 )
 from echoflow.transcription.models import (
+    CanonicalTranscript,
     CpuEngineConfiguration,
     DecodeConfiguration,
     DecodeStrategy,
+    EngineProvenance,
+    EngineTranscript,
+    RecognizedSegment,
     ResourceEstimate,
     TranscriptionJobPlan,
+    TranscriptSource,
 )
 from echoflow.workspace.models import Artifact, ArtifactKind, Job, JobId
 
@@ -124,6 +129,7 @@ def test_decode_and_engine_configuration_serialize_stable_wire_values(tmp_path):
         "model_cache_path": str(
             (tmp_path / "cache/models/faster-whisper/small").resolve()
         ),
+        "model_revision": None,
     }
     assert [strategy.value for strategy in DecodeStrategy] == [
         "direct",
@@ -146,6 +152,7 @@ def test_execution_configuration_positive_lower_boundaries_are_valid(tmp_path):
     assert decoder.channels == 1
     assert engine.cpu_threads == 1
     assert engine.beam_size == 1
+    assert engine.model_revision is None
 
 
 @pytest.mark.parametrize(
@@ -294,4 +301,243 @@ def test_job_plan_rejects_reserved_wrong_version_or_inconsistent_values(tmp_path
             decoder,
             resources,
             (),
+        )
+
+
+def test_recognized_segment_is_stable_slotted_and_json_safe():
+    segment = RecognizedSegment(7, 1.25, 2.5, "spoken words", -0.4, 0.15)
+    assert segment.segment_id == "segment-000007"
+    assert segment.to_dict() == {
+        "segment_id": "segment-000007",
+        "index": 7,
+        "start_seconds": 1.25,
+        "end_seconds": 2.5,
+        "text": "spoken words",
+        "average_log_probability": -0.4,
+        "no_speech_probability": 0.15,
+    }
+    assert not hasattr(segment, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        segment.text = "changed"
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        ((-1, 0, 1, "text"), "segment index cannot be negative"),
+        ((0, -1, 1, "text"), "segment timestamps must be finite and ordered"),
+        ((0, 2, 1, "text"), "segment timestamps must be finite and ordered"),
+        ((0, float("inf"), 1, "text"), "segment timestamps must be finite and ordered"),
+        ((0, 0, 1, " "), "segment text cannot be empty"),
+        (
+            (0, 0, 1, "text", float("nan")),
+            "average_log_probability must be finite",
+        ),
+        (
+            (0, 0, 1, "text", None, -0.1),
+            "no_speech_probability must be between 0 and 1",
+        ),
+        (
+            (0, 0, 1, "text", None, 1.1),
+            "no_speech_probability must be between 0 and 1",
+        ),
+    ],
+)
+def test_recognized_segment_rejects_invalid_values(args, message):
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        RecognizedSegment(*args)
+
+
+def test_engine_transcript_validates_language_probability_and_version():
+    segment = RecognizedSegment(0, 0, 1, "text")
+    result = EngineTranscript((segment,), "en", 0.0, "1.2.1")
+    assert result.segments == (segment,)
+    assert not hasattr(result, "__dict__")
+    assert EngineTranscript((), None, 1.0, "1.2.1").segments == ()
+    for arguments, message in (
+        (((), " ", None, "1"), "language cannot be empty"),
+        (((), "en", -0.1, "1"), "language_probability must be between 0 and 1"),
+        (((), "en", 1.1, "1"), "language_probability must be between 0 and 1"),
+        (((), "en", float("nan"), "1"), "language_probability must be between 0 and 1"),
+        (((), "en", 1.0, ""), "engine_version cannot be empty"),
+    ):
+        with pytest.raises(ValueError, match=f"^{message}$"):
+            EngineTranscript(*arguments)
+
+
+def test_transcript_source_derives_media_identity_without_disclosing_path(tmp_path):
+    *_, media, _, _, _, _, _ = values(tmp_path)
+    source = TranscriptSource.from_media(media)
+    document = source.to_dict()
+    assert document == {
+        "sha256": "0" * 64,
+        "size_bytes": 100,
+        "modified_ns": 200,
+        "container_format": "wav",
+        "duration_seconds": 2.0,
+        "audio_stream_index": 0,
+    }
+    assert "path" not in document
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"sha256": "A" * 64}, "source sha256 must be a lowercase 64-character digest"),
+        ({"size_bytes": 0}, "source size_bytes must be positive"),
+        ({"modified_ns": -1}, "source modified_ns cannot be negative"),
+        ({"container_format": ""}, "source container_format cannot be empty"),
+        (
+            {"duration_seconds": 0},
+            "source duration_seconds must be finite and positive",
+        ),
+        (
+            {"duration_seconds": float("inf")},
+            "source duration_seconds must be finite and positive",
+        ),
+        ({"audio_stream_index": -1}, "source audio_stream_index cannot be negative"),
+    ],
+)
+def test_transcript_source_rejects_invalid_values(overrides, message):
+    fields = {
+        "sha256": "0" * 64,
+        "size_bytes": 1,
+        "modified_ns": 0,
+        "container_format": "wav",
+        "duration_seconds": 1.0,
+        "audio_stream_index": 0,
+    }
+    fields.update(overrides)
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        TranscriptSource(**fields)
+
+
+def test_engine_provenance_records_plan_without_cache_path(tmp_path):
+    *_, engine, _, _ = values(tmp_path)
+    provenance = EngineProvenance.from_engine(engine, "1.2.1")
+    assert provenance.to_dict() == {
+        "name": "faster-whisper",
+        "package_version": "1.2.1",
+        "model": "small",
+        "model_revision": None,
+        "device": "cpu",
+        "compute_type": "int8",
+        "cpu_threads": 4,
+        "beam_size": 5,
+        "requested_language": None,
+    }
+    assert "cache" not in provenance.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"name": ""}, "name cannot be empty"),
+        ({"package_version": ""}, "package_version cannot be empty"),
+        ({"model": ""}, "model cannot be empty"),
+        ({"model_revision": " "}, "model_revision cannot be empty"),
+        ({"device": ""}, "device cannot be empty"),
+        ({"compute_type": ""}, "compute_type cannot be empty"),
+        ({"cpu_threads": 0}, "cpu_threads must be positive"),
+        ({"beam_size": 0}, "beam_size must be positive"),
+    ],
+)
+def test_engine_provenance_rejects_invalid_values(overrides, message):
+    fields = {
+        "name": "engine",
+        "package_version": "1",
+        "model": "tiny",
+        "model_revision": None,
+        "device": "cpu",
+        "compute_type": "int8",
+        "cpu_threads": 1,
+        "beam_size": 1,
+        "requested_language": None,
+    }
+    fields.update(overrides)
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        EngineProvenance(**fields)
+
+
+def canonical(tmp_path, **overrides):
+    *_, media, _, policy, engine, decoder, _ = values(tmp_path)
+    fields = {
+        "job_id": "job-1",
+        "source": TranscriptSource.from_media(media),
+        "profile": policy.profile,
+        "provisional": policy.provisional,
+        "decode_strategy": decoder.strategy,
+        "engine": EngineProvenance.from_engine(engine, "1.2.1"),
+        "detected_language": "en",
+        "language_probability": 0.9,
+        "segments": (
+            RecognizedSegment(0, 0, 1, "Hello"),
+            RecognizedSegment(1, 1, 2, "world."),
+        ),
+    }
+    fields.update(overrides)
+    return CanonicalTranscript(**fields)
+
+
+def test_canonical_transcript_is_complete_and_does_not_embed_private_paths(tmp_path):
+    transcript = canonical(tmp_path)
+    document = transcript.to_dict()
+    assert document["schema_version"] == 1
+    assert document["job_id"] == "job-1"
+    assert document["profile"] == "balanced"
+    assert document["provisional"] is False
+    assert document["decode_strategy"] == "direct"
+    assert document["detected_language"] == "en"
+    assert document["language_probability"] == 0.9
+    assert document["text"] == "Hello world."
+    assert len(document["segments"]) == 2
+    assert "path" not in str(document)
+    assert not hasattr(transcript, "__dict__")
+
+
+def test_screening_canonical_transcript_must_remain_provisional(tmp_path):
+    transcript = canonical(
+        tmp_path, profile=ProcessingProfile.SCREENING, provisional=True
+    )
+    assert transcript.provisional is True
+    with pytest.raises(
+        ValueError, match="^provisional flag must match the processing profile$"
+    ):
+        canonical(tmp_path, profile=ProcessingProfile.SCREENING, provisional=False)
+    with pytest.raises(
+        ValueError, match="^provisional flag must match the processing profile$"
+    ):
+        canonical(tmp_path, profile=ProcessingProfile.BALANCED, provisional=True)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"job_id": ""}, "job_id cannot be empty"),
+        ({"schema_version": 2}, "unsupported transcript schema version"),
+        ({"detected_language": " "}, "detected_language cannot be empty"),
+        (
+            {"language_probability": -0.1},
+            "language_probability must be between 0 and 1",
+        ),
+        ({"language_probability": 1.1}, "language_probability must be between 0 and 1"),
+        (
+            {"language_probability": float("nan")},
+            "language_probability must be between 0 and 1",
+        ),
+        (
+            {"segments": (RecognizedSegment(1, 0, 1, "wrong index"),)},
+            "segment indices must be contiguous and zero-based",
+        ),
+    ],
+)
+def test_canonical_transcript_rejects_invalid_values(tmp_path, overrides, message):
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        canonical(tmp_path, **overrides)
+
+
+def test_engine_configuration_rejects_empty_model_revision(tmp_path):
+    with pytest.raises(ValueError, match="^model_revision cannot be empty$"):
+        CpuEngineConfiguration(
+            "engine", "model", "cpu", "int8", 1, 1, None, tmp_path, " "
         )

--- a/src/echoflow/transcription/tests/test_planner.py
+++ b/src/echoflow/transcription/tests/test_planner.py
@@ -101,7 +101,8 @@ def test_balanced_plan_composes_real_paths_media_cpu_engine_and_estimates(tmp_pa
     assert plan.engine.compute_type == "int8"
     assert plan.engine.beam_size == 5
     assert plan.engine.language is None
-    assert plan.engine.model_cache_path == paths.model_dir / "faster-whisper/small"
+    assert plan.engine.model_cache_path == paths.model_dir / "faster-whisper"
+    assert plan.engine.model_revision is None
     assert plan.decoder.strategy is DecodeStrategy.FFMPEG_NORMALIZE
     assert plan.decoder.output_codec == "pcm_s16le"
     assert plan.resources.private_workspace_bytes == 16 * MIB + 320_000

--- a/uv.lock
+++ b/uv.lock
@@ -21,12 +21,51 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "av"
+version = "18.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a4/570a5a35c8638aba01e739925846c35fdd6b0756a15526766d0a4dd3b7df/av-18.0.0.tar.gz", hash = "sha256:4ef7e72c3d3a872584a1215173b16e0226811037f40dcdbf75992631098df1ba", size = 4340222, upload-time = "2026-07-02T06:37:58.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/4a/9e3463df030e063d757fa12f0f39be6541b45b06b5bad48c2ce361b924bf/av-18.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:149289d40e732a6e49c9530bc245b49d9964cfd1c8c9e06778703b7d5bba6b25", size = 22499354, upload-time = "2026-07-02T06:36:58.751Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b3/2576a44b4f39c7462ced4c17fec04c756f7b0f3c5cb940d124173e417d6a/av-18.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:35274c20d2ad3b4774fe632bcef2e34af79858ddf899352339cc3babbc13a484", size = 18175248, upload-time = "2026-07-02T06:37:01.741Z" },
+    { url = "https://files.pythonhosted.org/packages/84/74/6732f17b96dc23fd23b876b2805435855abdc8a3b397142be4e581165de8/av-18.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4d683b7747a0ba9222b8a5f81e41db5f796e7f64473454ec4fe2548e083c2fa0", size = 33387843, upload-time = "2026-07-02T06:37:05.097Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/7708c43fed7ae28b4a1bad060b4221e3334cd827cec24f7165902a6ac1f4/av-18.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ae56b40b6f8b067a8ad2dac664fbfbabac7f7a55b9a7bb031eb99289252bc017", size = 35536910, upload-time = "2026-07-02T06:37:08.806Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/94/eba99691d184f6a395a242d54dc370e2fd2265e95bbc98e2963a0fdbdd6c/av-18.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:ea2e8ebbce521f21b55df9400e00d721623c9020ef158f5a188a96130be0743f", size = 38984619, upload-time = "2026-07-02T06:37:11.861Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/0d7aee07fe16aa9ffdf96043c14bed5485a52c0dea4259de87aa306ecab4/av-18.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef96dabb3e50dac249913145dff5424b302b257fd95dcb64be3c7b7a8aef16d1", size = 34451176, upload-time = "2026-07-02T06:37:15.154Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/810da80b12680d4c4fe235bd1b4003289be9213ac7f114b77b8ecf0e3b3e/av-18.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0f65518a184613e41536f29e8758c8e3d8293e46bf5bef108f04f925bbfa3f44", size = 36619869, upload-time = "2026-07-02T06:37:18.495Z" },
+    { url = "https://files.pythonhosted.org/packages/11/85/0f121ff43dc5a70696676c98a8f1674e2fa787614c2abaacb15fa1a9bc99/av-18.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:aaf4d354d2beaa6651e4f92e54409a578bde64f79c0beef9a30b388d06f7c629", size = 27556236, upload-time = "2026-07-02T06:37:21.388Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f6/2509754d4d2356abc6fc0ea3d57c12ade29bac23a1fb7fc215a53ca518fb/av-18.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:adac2b3833b6cb9bd6cb52664a522b94db453615b3675b1dbb26e13fe1c80da6", size = 20221133, upload-time = "2026-07-02T06:37:23.88Z" },
+]
+
+[[package]]
 name = "bracex"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -84,6 +123,23 @@ wheels = [
 ]
 
 [[package]]
+name = "ctranslate2"
+version = "4.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/09/9a50eeab00db68aeac08f6ab7f98b5c36abd26b89cbd707ea39e70656500/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9de0dddd91ae68da0a7323441e90708d14b31d31cd443004dda0e1198b5bf11e", size = 1270522, upload-time = "2026-07-03T12:39:13.368Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/6c41c4d3ae539ec76b1943c362184677befd7c1d5290d2ec361182cdb1e0/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:82e0e6eb7d4301fd79a714495c8faf34242e09542cef04c9e9794c3fe90014a1", size = 11930367, upload-time = "2026-07-03T12:39:14.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d4/03428106134a0a58922461074f8942f92c5ed0bb3a8d018677ad64a9c476/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5ca144b93035b9f53e6d67b7cdf5802c3fffca9aa0247940eecbd4592c68ce2f", size = 16882768, upload-time = "2026-07-03T12:39:17.425Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c9/976a565398a03fb2973cbe5edd5ca03c4332d86b634799e0ee562420d3bc/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dacc408f716ebc73b3b3c6ddd937700e776c4c68b6d9c81862990150ff0f6af6", size = 39529060, upload-time = "2026-07-03T12:39:20.468Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/82/0a5f7f2b03b4e10aacb3146715724e1b96bb993cc7d199be28c9825aa120/ctranslate2-4.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:49f96e861b57301f0b76a082109bde2cac8204a6b4fedc870883008271e82251", size = 19220789, upload-time = "2026-07-03T12:39:23.356Z" },
+]
+
+[[package]]
 name = "dependency-injector"
 version = "4.49.1"
 source = { registry = "https://pypi.org/simple" }
@@ -125,6 +181,11 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+transcription = [
+    { name = "faster-whisper" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "hypothesis" },
@@ -143,6 +204,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dependency-injector", specifier = ">=4.48,<5" },
+    { name = "faster-whisper", marker = "extra == 'transcription'", specifier = ">=1.2.1,<2" },
     { name = "platformdirs", specifier = ">=4.10.1,<5" },
     { name = "psutil", specifier = ">=7,<8" },
     { name = "pydantic", specifier = ">=2.10,<3" },
@@ -151,6 +213,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25,<26" },
     { name = "typer", specifier = ">=0.16,<1" },
 ]
+provides-extras = ["transcription"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -168,12 +231,118 @@ dev = [
 ]
 
 [[package]]
+name = "faster-whisper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "ctranslate2" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.32.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/39/67be8d71f900d9a55761b6022821d6679fb56c64f1b6063d5af2c2606727/hf_xet-1.5.2.tar.gz", hash = "sha256:73044bd31bae33c984af832d19c752a0dffb67518fee9ddbd91d616e1101cf47", size = 903674, upload-time = "2026-07-16T17:29:56.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/ba/2b70603c7552db82baeb2623e2336898304a17328845151be4fe1f48d420/hf_xet-1.5.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f922b8f5fb84f1dd3d7ab7a1316354a1bca9b1c73ecfc19c76e51a2a49d29799", size = 4033760, upload-time = "2026-07-16T17:29:43.884Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/b097a86a1e4a6098f3a79382643ab09d5733d87ccc864877ad1e12b49b70/hf_xet-1.5.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:045f84440c55cdeb659cf1a1dd48c77bcd0d2e93632e2fea8f2c3bdee79f38ed", size = 3841438, upload-time = "2026-07-16T17:29:45.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/35/db860aa3a0780660324a506ad4b3d322ddc6ecbba4b9340aed0942cbf21c/hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db78c39c83d6279daddc98e2238f373ab8980685556d42472b4ec51abcf03e8c", size = 4428006, upload-time = "2026-07-16T17:29:46.996Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/832dd980af4b0c3ae0660e309285f2ffcdff2faa38129390dbb47aa4a3f9/hf_xet-1.5.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7db73c810500c54c6760be8c39d4b2e476974de85424c50063efc22fdda13025", size = 4221099, upload-time = "2026-07-16T17:29:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/ae50f0d34e3254e6c3e208beb2519f6b8673016fc4b3643badaf6450d186/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6395cfe3c9cbead4f16b31808b0e67eac428b66c656f856e99636adaddea878f", size = 4420766, upload-time = "2026-07-16T17:29:50.092Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/c050bc2743a2bcd68928bfee157b08681667a164a24ec95fbfcfcd717e08/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cde8cd167126bb6109b2ceb19b844433a4988643e8f3e01dd9dd0e4a34535097", size = 4636716, upload-time = "2026-07-16T17:29:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/68b01c5c2edb56ac9a67b3d076ffddcb90867abaee923923eb34e7a14e76/hf_xet-1.5.2-cp38-abi3-win_amd64.whl", hash = "sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65", size = 3988373, upload-time = "2026-07-16T17:29:53.395Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/988383e9dc17294d536fcbcd6fd16eed882e411ad16c954984a53e47b09c/hf_xet-1.5.2-cp38-abi3-win_arm64.whl", hash = "sha256:1da28519496eb7c8094c11e4d25509b4a468457a0302d58136099db2fd9a671d", size = 3816957, upload-time = "2026-07-16T17:29:54.991Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/db/3582597f8be0d34bd6881365a26d390854f12893eabdd62dd36de9df5a47/huggingface_hub-1.26.0.tar.gz", hash = "sha256:c8cd4e2df1ba9402f77fce9b509ec1d52debb502551789473f34016acc14e361", size = 936665, upload-time = "2026-07-30T14:12:04.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/bb/63a644c75b545f3ff394b822e9bd1c4a9586489c618b77a4d8a44a33a23b/huggingface_hub-1.26.0-py3-none-any.whl", hash = "sha256:e8cca670caa5d8dfa7e45bf45e86b466698198cd8150c021bcdb4a86b9252364", size = 780357, upload-time = "2026-07-30T14:12:01.998Z" },
 ]
 
 [[package]]
@@ -214,6 +383,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -360,6 +538,43 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3b/986ca67c274932ba9ac5332fb10de56f643dfd433c74e33f8ae8f847cf24/onnxruntime-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:c35064f9b3c43c81c5d5d282091401d0f1ff22796d93ccade4ea2ece5e137ab8", size = 13755036, upload-time = "2026-07-25T01:22:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/46/059dba81d46c6ba88e0c2d1c64321ac8098847d678423300a183d42ecbd6/onnxruntime-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:e02feeb0165c5f13b4cc954738078d59b90128516ac12b671ee24a530242bf02", size = 13454462, upload-time = "2026-07-25T01:22:17.38Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -424,6 +639,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -643,6 +873,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -676,6 +915,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- adds an optional `faster-whisper` CPU transcription backend without enlarging the default EchoFlow installation
- consumes the immutable dry-run plan for model, compute type, thread, beam, and language decisions
- rechecks currently available resources before model initialization so constrained machines fail cleanly instead of overcommitting memory
- extracts only the selected audio stream from audio-bearing containers, discarding video, subtitle, and data streams
- normalizes noncanonical media to private mono 16 kHz PCM WAV before transcription
- writes one canonical, provenance-bearing transcript JSON artifact atomically
- preserves machine-pure JSON output and redacted public errors
- updates configuration, security documentation, CI, and optional dependency auditing

## Why

The dry-run established EchoFlow's privacy and runner-aware execution contract but stopped before producing a transcript. This PR completes the first vertical transcription path:

`audio-bearing media → probe → plan → reserve → normalize if needed → transcribe → canonical JSON`

The executor uses process-visible available memory and CPU rather than installed capacity. That keeps the path viable on constrained systems, including low-memory Windows machines, and rejects a stale or no-longer-affordable plan before loading native model weights.

## User and developer impact

The default package remains lightweight. Users opt into transcription dependencies explicitly, and real execution does not silently download a model unless configuration permits it. Video inputs are treated only as audio-bearing containers; EchoFlow performs no frame analysis.

The backend, normalizer, and executor are injected behind narrow consumer-side contracts so the concrete path can evolve without a general pipeline framework or DI rewrite.

## Validation

- 426 tests passed locally
- 97.93% branch-aware coverage
- Ruff and strict mypy passed locally
- clean working tree and exact Git tree verification before publication
- all 28 uploaded GitHub blobs matched their local Git blob hashes
- remote GitHub tree `ccf36606204f9c928473517a5e902219714ab811` exactly matches the tested local tree
- GitHub CI installs and imports the optional engine on Ubuntu, Windows, and macOS; that native matrix is pending on this draft PR
