### PR TITLE
Add continuous dependency security audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,53 @@
+name: Security
+
+on:
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-audit
+  cancel-in-progress: true
+
+jobs:
+  dependency-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.33"
+          enable-cache: true
+
+      - name: Check lockfile
+        run: uv lock --check
+
+      - name: Export locked runtime and transcription dependencies
+        run: >-
+          uv export
+          --locked
+          --no-dev
+          --extra transcription
+          --no-emit-project
+          --no-hashes
+          --format requirements-txt
+          --output-file ${{ runner.temp }}/echoflow-runtime-requirements.txt
+
+      - name: Audit runtime dependencies
+        run: >-
+          uvx --from pip-audit==2.10.1 pip-audit
+          --requirement ${{ runner.temp }}/echoflow-runtime-requirements.txt
+          --progress-spinner off


### PR DESCRIPTION
## What changed

- Add a dedicated `Security` GitHub Actions workflow.
- Audit the locked runtime and optional transcription dependency graph once per day and on manual dispatch.
- Reuse the same pinned GitHub Actions and `pip-audit` version as the existing quality workflow.
- Keep workflow permissions read-only and avoid running the full test/build matrix for a dependency-only security check.

## Why

The existing quality workflow audits dependencies only on pushes and pull requests. A newly published advisory can therefore affect the already-merged lockfile without causing EchoFlow's CI to run again. The scheduled audit closes that detection gap while keeping the repository's existing locked-dependency and least-privilege model.

## Scope

This PR does not change application code, dependency versions, or the transcription roadmap. It adds continuous detection only; concrete dependency remediation remains an explicit lockfile change when an audit reports a vulnerable package.

## Validation

- Workflow uses the repository's existing Python 3.12, uv 0.11.33, and pip-audit 2.10.1 toolchain.
- Runtime export matches the existing quality workflow: locked, no dev dependencies, with the optional transcription extra included.
- GitHub Actions are pinned to the same commit SHAs already used by the passing quality workflow.
- Workflow permissions are `contents: read` only.