### PR TITLE
Add adaptive local transcription strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,13 @@ EchoFlow currently provides a tested application foundation:
 - Path-redacted routine logs and owner-only private directories on POSIX.
 - Namespaced, explicit configuration that does not consume ambient `.env` files.
 - CPU-, affinity-, cgroup-, and memory-aware runner policy inspection.
+- A deterministic local strategy evaluator that lists feasible faster-whisper
+  CPU/int8 choices, recommends one by processing profile, and refuses unsafe
+  explicit selections rather than silently downgrading them.
 - Local FFprobe inspection with protocol restriction, bounded output, timeout,
   full input fingerprinting, and typed media metadata.
 - An immutable `transcribe INPUT --dry-run` plan covering paths, streams, codec,
-  duration, CPU engine/model selection, decoding strategy, and resource estimates.
+  duration, selected local strategy, decoding strategy, and resource estimates.
 - One executable CPU/int8 faster-whisper path that rechecks resource admission,
   claims its workspace and output atomically, and writes canonical transcript JSON.
 - Audio extraction from audio-bearing containers, including video files, by mapping
@@ -37,8 +40,9 @@ EchoFlow currently provides a tested application foundation:
 - Explicit model-download authorization; execution is local-only by default.
 - Dependency Injector composition for the implemented services.
 
-Deterministic application-owned segmentation, checkpointing, resume, and derived
-TXT/SRT/VTT artifacts are not implemented yet.
+Deterministic application-owned segmentation, checkpointing, resume, calibrated
+performance estimates, GPU strategies, and derived TXT/SRT/VTT artifacts are not
+implemented yet.
 
 ## Requirements and installation
 
@@ -70,8 +74,11 @@ uv run echoflow doctor --json
 uv run echoflow doctor --workspace /path/to/workspace
 uv run echoflow runner
 uv run echoflow runner --profile screening --json
+uv run echoflow strategies
+uv run echoflow strategies --profile accuracy --json
 uv run echoflow transcribe /path/to/recording.wav --dry-run
 uv run echoflow transcribe /path/to/recording.wav --dry-run --profile screening --json
+uv run echoflow transcribe /path/to/recording.wav --strategy small-cpu-int8 --dry-run
 uv run echoflow transcribe /path/to/interview.mp4
 uv run echoflow transcribe /path/to/interview.mp4 --allow-model-download
 ```
@@ -144,25 +151,33 @@ Artifact names are reserved atomically and collisions are renamed rather than
 overwritten by default. Future SQLite job state will contain paths and metadata;
 audio and transcript documents will not be stored as database blobs.
 
-`echoflow runner` and transcription planning use the CPU and memory actually visible to the process,
-including common container limits, and derives an engine-neutral policy. A
-`screening` policy is explicitly provisional and recommends a compact model;
-it is not interchangeable with a final research transcript. `balanced` and
-`accuracy` select larger generic tiers only when the detected memory budget can
-support them. The first CPU plan maps those tiers to faster-whisper `tiny`,
-`small`, and `medium` models using int8 execution. The engine package and model
-weights are not installed or downloaded by a dry run.
+`echoflow runner` derives an engine-neutral CPU and memory budget from resources
+actually visible to the process, including common container limits and explicit
+user ceilings. It does not select a model. Transcription evaluates concrete
+faster-whisper strategies against that budget. `echoflow strategies` exposes all
+current CPU/int8 choices with their estimated model-cache and peak-memory costs,
+marks infeasible choices with typed reasons, and recommends a feasible strategy
+according to `screening`, `balanced`, or `accuracy` intent. An explicit
+`transcribe --strategy` choice is honored when feasible and refused otherwise;
+it is never silently replaced. Screening remains explicitly provisional.
 
-Execution consumes that plan rather than detecting a second, unrelated machine
-configuration inside the engine. It checks process-visible memory and CPU capacity
-before claiming paths and again after any FFmpeg normalization, immediately before
-model initialization. A video is not treated as visual input: FFmpeg discards video,
-subtitle, and data streams and emits only the selected audio stream to the private
-job workspace.
+Execution consumes the selected plan rather than detecting a second, unrelated
+machine configuration inside the engine. It checks process-visible memory and CPU
+capacity before claiming paths and again after any FFmpeg normalization,
+immediately before model initialization. A video is not treated as visual input:
+FFmpeg discards video, subtitle, and data streams and emits only the selected audio
+stream to the private job workspace.
 
 Resource estimates are deliberately conservative heuristics until real engine
-benchmarks are added. Dry-run workspace and artifact paths are candidates, not
-reservations; execution must claim them atomically before writing.
+benchmarks and privacy-safe local calibration are added. Dry-run workspace and
+artifact paths are candidates, not reservations; execution must claim them
+atomically before writing.
+
+Checkpoint resume is intentionally not represented as implemented yet. The current
+backend transcribes a complete decoded recording in one call. Truthful resume first
+requires deterministic, source-relative segment boundaries and a job-scoped model
+session; persisted per-segment state can then retain completed work across a crash
+without changing the model contract.
 
 The proposed processing boundaries, resumability model, and bounded audio
 bisection policy are documented in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ only_files = [
     "src/echoflow/transcription/backend.py",
     "src/echoflow/transcription/executor.py",
     "src/echoflow/transcription/planner.py",
+    "src/echoflow/transcription/strategy.py",
     "src/echoflow/workspace/models.py",
     "src/echoflow/workspace/service.py",
 ]

--- a/src/echoflow/cli.py
+++ b/src/echoflow/cli.py
@@ -113,6 +113,33 @@ def _format_bytes(value: int) -> str:
     return f"{amount:.1f} {units[-1]}"
 
 
+def _render_strategies(
+    assessments: tuple[dict[str, object], ...], console: Console
+) -> None:
+    table = Table(title="EchoFlow local transcription strategies")
+    table.add_column("Strategy")
+    table.add_column("Model")
+    table.add_column("Safe now")
+    table.add_column("Peak memory")
+    table.add_column("Model cache")
+    table.add_column("Recommendation")
+    for assessment in assessments:
+        strategy = cast("dict[str, object]", assessment["strategy"])
+        reasons = cast("list[str]", assessment["rejection_reasons"])
+        recommendation = "recommended" if assessment["recommended"] else ""
+        if reasons:
+            recommendation = ", ".join(reasons)
+        table.add_row(
+            str(strategy["strategy_id"]),
+            str(strategy["model"]),
+            str(assessment["feasible"]).lower(),
+            _format_bytes(int(cast("int", strategy["estimated_peak_memory_bytes"]))),
+            _format_bytes(int(cast("int", strategy["model_cache_bytes"]))),
+            recommendation,
+        )
+    console.print(table)
+
+
 def _render_transcription_plan(plan: TranscriptionJobPlan, console: Console) -> None:
     audio = plan.media.primary_audio_stream
     table = Table(title="EchoFlow transcription dry run")
@@ -302,6 +329,44 @@ def inspect_runner(
         _render_runner(resources, policy, Console())
 
 
+@app.command("strategies")
+def strategies(
+    context: typer.Context,
+    profile: Annotated[
+        ProcessingProfile | None,
+        typer.Option(help="Profile used to rank currently safe strategies."),
+    ] = None,
+    json_output: Annotated[
+        bool, typer.Option("--json", help="Emit machine-readable strategy assessments.")
+    ] = False,
+) -> None:
+    """Show local transcription strategies and their current memory requirements."""
+
+    try:
+        container = _container(context)
+        selected_profile = profile or container.config().PROCESSING_PROFILE
+        assessments = container.transcription_planner().assess_strategies(
+            profile=selected_profile
+        )
+    except EchoFlowError as exc:
+        typer.echo(exc.public_message, err=True)
+        raise typer.Exit(code=exc.exit_code) from None
+    except ValidationError:
+        typer.echo("Invalid EchoFlow configuration", err=True)
+        raise typer.Exit(code=1) from None
+    except Exception as exc:
+        typer.echo(
+            f"EchoFlow strategy inspection failed internally ({type(exc).__name__})",
+            err=True,
+        )
+        raise typer.Exit(code=3) from None
+
+    if json_output:
+        typer.echo(json.dumps(list(assessments), sort_keys=True))
+    else:
+        _render_strategies(assessments, Console())
+
+
 @app.command("transcribe")
 def transcribe(
     context: typer.Context,
@@ -335,6 +400,12 @@ def transcribe(
         ProcessingProfile | None,
         typer.Option(help="Override the configured processing profile."),
     ] = None,
+    strategy: Annotated[
+        str | None,
+        typer.Option(
+            help="Explicit safe strategy ID from `echoflow strategies`; never silently downgraded."
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Emit the plan or execution result as JSON."),
@@ -344,11 +415,19 @@ def transcribe(
     try:
         container = _container(context)
         selected_profile = profile or container.config().PROCESSING_PROFILE
-        plan = container.transcription_planner().plan(
-            input_path,
-            output_dir=output_dir,
-            profile=selected_profile,
-        )
+        if strategy is None:
+            plan = container.transcription_planner().plan(
+                input_path,
+                output_dir=output_dir,
+                profile=selected_profile,
+            )
+        else:
+            plan = container.transcription_planner().plan(
+                input_path,
+                output_dir=output_dir,
+                profile=selected_profile,
+                strategy_id=strategy,
+            )
         result = None
         if not dry_run:
             result = container.transcription_executor().execute(

--- a/src/echoflow/runner/__init__.py
+++ b/src/echoflow/runner/__init__.py
@@ -1,11 +1,17 @@
 """Runner inspection and resource-policy capabilities."""
 
 from echoflow.runner.inspector import RunnerInspector
-from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
+from echoflow.runner.models import (
+    ExecutionPolicy,
+    ModelTier,
+    ProcessingProfile,
+    RunnerResources,
+)
 from echoflow.runner.policy import RunnerPolicyPlanner
 
 __all__ = [
     "ExecutionPolicy",
+    "ModelTier",
     "ProcessingProfile",
     "RunnerInspector",
     "RunnerPolicyPlanner",

--- a/src/echoflow/runner/__init__.py
+++ b/src/echoflow/runner/__init__.py
@@ -1,17 +1,11 @@
 """Runner inspection and resource-policy capabilities."""
 
 from echoflow.runner.inspector import RunnerInspector
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 from echoflow.runner.policy import RunnerPolicyPlanner
 
 __all__ = [
     "ExecutionPolicy",
-    "ModelTier",
     "ProcessingProfile",
     "RunnerInspector",
     "RunnerPolicyPlanner",

--- a/src/echoflow/runner/models.py
+++ b/src/echoflow/runner/models.py
@@ -10,6 +10,14 @@ class ProcessingProfile(StrEnum):
     ACCURACY = "accuracy"
 
 
+class ModelTier(StrEnum):
+    """Deprecated compatibility value; transcription strategy owns model selection."""
+
+    COMPACT = "compact"
+    STANDARD = "standard"
+    LARGE = "large"
+
+
 @dataclass(frozen=True, slots=True)
 class RunnerResources:
     platform: str
@@ -37,9 +45,15 @@ class ExecutionPolicy:
     provisional: bool
     cpu_threads: int
     memory_budget_bytes: int
+    recommended_model_tier: ModelTier | None = None
     constraints: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         result = asdict(self)
         result["profile"] = self.profile.value
+        result["recommended_model_tier"] = (
+            self.recommended_model_tier.value
+            if self.recommended_model_tier is not None
+            else None
+        )
         return result

--- a/src/echoflow/runner/models.py
+++ b/src/echoflow/runner/models.py
@@ -3,19 +3,11 @@ from enum import StrEnum
 
 
 class ProcessingProfile(StrEnum):
-    """User intent for an eventual transcription plan."""
+    """User intent used to rank feasible processing strategies."""
 
     SCREENING = "screening"
     BALANCED = "balanced"
     ACCURACY = "accuracy"
-
-
-class ModelTier(StrEnum):
-    """Engine-neutral model-size recommendation."""
-
-    COMPACT = "compact"
-    STANDARD = "standard"
-    LARGE = "large"
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,15 +31,15 @@ class RunnerResources:
 
 @dataclass(frozen=True, slots=True)
 class ExecutionPolicy:
+    """Engine-neutral resource budget derived from process-visible capacity."""
+
     profile: ProcessingProfile
     provisional: bool
     cpu_threads: int
     memory_budget_bytes: int
-    recommended_model_tier: ModelTier
     constraints: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         result = asdict(self)
         result["profile"] = self.profile.value
-        result["recommended_model_tier"] = self.recommended_model_tier.value
         return result

--- a/src/echoflow/runner/models.py
+++ b/src/echoflow/runner/models.py
@@ -16,6 +16,7 @@ class ModelTier(StrEnum):
     COMPACT = "compact"
     STANDARD = "standard"
     LARGE = "large"
+    STRATEGY_SPECIFIC = "strategy-specific"
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,15 +46,11 @@ class ExecutionPolicy:
     provisional: bool
     cpu_threads: int
     memory_budget_bytes: int
-    recommended_model_tier: ModelTier | None = None
+    recommended_model_tier: ModelTier = ModelTier.STRATEGY_SPECIFIC
     constraints: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         result = asdict(self)
         result["profile"] = self.profile.value
-        result["recommended_model_tier"] = (
-            self.recommended_model_tier.value
-            if self.recommended_model_tier is not None
-            else None
-        )
+        result["recommended_model_tier"] = self.recommended_model_tier.value
         return result

--- a/src/echoflow/runner/policy.py
+++ b/src/echoflow/runner/policy.py
@@ -1,20 +1,11 @@
 from dataclasses import dataclass
 
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
-
-_GIB = 1024**3
-_STANDARD_MODEL_BUDGET = 4 * _GIB
-_LARGE_MODEL_BUDGET = 8 * _GIB
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 
 
 @dataclass(frozen=True, slots=True)
 class RunnerPolicyPlanner:
-    """Turn runner limits and user ceilings into an engine-neutral policy."""
+    """Turn process-visible resources and user ceilings into a safe job budget."""
 
     memory_budget_fraction: float = 0.75
     max_cpu_threads: int | None = None
@@ -51,20 +42,5 @@ class RunnerPolicyPlanner:
             provisional=profile is ProcessingProfile.SCREENING,
             cpu_threads=max(1, cpu_threads),
             memory_budget_bytes=max(0, memory_budget),
-            recommended_model_tier=self._model_tier(profile, memory_budget),
             constraints=tuple(dict.fromkeys(constraints)),
         )
-
-    @staticmethod
-    def _model_tier(profile: ProcessingProfile, memory_budget: int) -> ModelTier:
-        if (
-            profile is ProcessingProfile.SCREENING
-            or memory_budget < _STANDARD_MODEL_BUDGET
-        ):
-            return ModelTier.COMPACT
-        if (
-            profile is ProcessingProfile.ACCURACY
-            and memory_budget >= _LARGE_MODEL_BUDGET
-        ):
-            return ModelTier.LARGE
-        return ModelTier.STANDARD

--- a/src/echoflow/runner/policy.py
+++ b/src/echoflow/runner/policy.py
@@ -1,6 +1,11 @@
 from dataclasses import dataclass
 
-from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
+from echoflow.runner.models import (
+    ExecutionPolicy,
+    ModelTier,
+    ProcessingProfile,
+    RunnerResources,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,10 +42,18 @@ class RunnerPolicyPlanner:
             memory_budget = self.max_memory_bytes
             constraints.append("configured_memory_limit")
 
+        # Keep the pre-strategy screening wire marker for compatibility. This does
+        # not select an engine model; concrete strategy ranking owns that decision.
+        compatibility_tier = (
+            ModelTier.COMPACT
+            if profile is ProcessingProfile.SCREENING
+            else ModelTier.STRATEGY_SPECIFIC
+        )
         return ExecutionPolicy(
             profile=profile,
             provisional=profile is ProcessingProfile.SCREENING,
             cpu_threads=max(1, cpu_threads),
             memory_budget_bytes=max(0, memory_budget),
+            recommended_model_tier=compatibility_tier,
             constraints=tuple(dict.fromkeys(constraints)),
         )

--- a/src/echoflow/runner/tests/test_models.py
+++ b/src/echoflow/runner/tests/test_models.py
@@ -2,7 +2,12 @@ from dataclasses import FrozenInstanceError, fields
 
 import pytest
 
-from echoflow.runner.models import ExecutionPolicy, ModelTier, ProcessingProfile, RunnerResources
+from echoflow.runner.models import (
+    ExecutionPolicy,
+    ModelTier,
+    ProcessingProfile,
+    RunnerResources,
+)
 
 
 def test_runner_resources_have_a_stable_machine_readable_shape():
@@ -52,7 +57,7 @@ def test_execution_policy_serializes_profile_without_production_model_decision()
         "provisional": True,
         "cpu_threads": 2,
         "memory_budget_bytes": 1024,
-        "recommended_model_tier": None,
+        "recommended_model_tier": "strategy-specific",
         "constraints": ("configured_cpu_limit",),
     }
     assert [profile.value for profile in ProcessingProfile] == [

--- a/src/echoflow/runner/tests/test_models.py
+++ b/src/echoflow/runner/tests/test_models.py
@@ -2,12 +2,7 @@ from dataclasses import FrozenInstanceError, fields
 
 import pytest
 
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 
 
 def test_runner_resources_have_a_stable_machine_readable_shape():
@@ -44,13 +39,12 @@ def test_runner_resources_have_a_stable_machine_readable_shape():
     assert not hasattr(resources, "__dict__")
 
 
-def test_execution_policy_serializes_enum_wire_values():
+def test_execution_policy_serializes_profile_without_engine_decisions():
     policy = ExecutionPolicy(
         profile=ProcessingProfile.SCREENING,
         provisional=True,
         cpu_threads=2,
         memory_budget_bytes=1024,
-        recommended_model_tier=ModelTier.COMPACT,
         constraints=("configured_cpu_limit",),
     )
     assert policy.to_dict() == {
@@ -58,7 +52,6 @@ def test_execution_policy_serializes_enum_wire_values():
         "provisional": True,
         "cpu_threads": 2,
         "memory_budget_bytes": 1024,
-        "recommended_model_tier": "compact",
         "constraints": ("configured_cpu_limit",),
     }
     assert [profile.value for profile in ProcessingProfile] == [
@@ -66,7 +59,6 @@ def test_execution_policy_serializes_enum_wire_values():
         "balanced",
         "accuracy",
     ]
-    assert [tier.value for tier in ModelTier] == ["compact", "standard", "large"]
     assert not hasattr(policy, "__dict__")
     with pytest.raises(FrozenInstanceError):
         setattr(policy, fields(policy)[0].name, ProcessingProfile.BALANCED)

--- a/src/echoflow/runner/tests/test_models.py
+++ b/src/echoflow/runner/tests/test_models.py
@@ -2,7 +2,7 @@ from dataclasses import FrozenInstanceError, fields
 
 import pytest
 
-from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
+from echoflow.runner.models import ExecutionPolicy, ModelTier, ProcessingProfile, RunnerResources
 
 
 def test_runner_resources_have_a_stable_machine_readable_shape():
@@ -39,7 +39,7 @@ def test_runner_resources_have_a_stable_machine_readable_shape():
     assert not hasattr(resources, "__dict__")
 
 
-def test_execution_policy_serializes_profile_without_engine_decisions():
+def test_execution_policy_serializes_profile_without_production_model_decision():
     policy = ExecutionPolicy(
         profile=ProcessingProfile.SCREENING,
         provisional=True,
@@ -52,6 +52,7 @@ def test_execution_policy_serializes_profile_without_engine_decisions():
         "provisional": True,
         "cpu_threads": 2,
         "memory_budget_bytes": 1024,
+        "recommended_model_tier": None,
         "constraints": ("configured_cpu_limit",),
     }
     assert [profile.value for profile in ProcessingProfile] == [
@@ -62,3 +63,14 @@ def test_execution_policy_serializes_profile_without_engine_decisions():
     assert not hasattr(policy, "__dict__")
     with pytest.raises(FrozenInstanceError):
         setattr(policy, fields(policy)[0].name, ProcessingProfile.BALANCED)
+
+
+def test_legacy_model_tier_still_serializes_for_existing_plan_fixtures():
+    policy = ExecutionPolicy(
+        ProcessingProfile.BALANCED,
+        False,
+        4,
+        2048,
+        ModelTier.STANDARD,
+    )
+    assert policy.to_dict()["recommended_model_tier"] == "standard"

--- a/src/echoflow/runner/tests/test_policy.py
+++ b/src/echoflow/runner/tests/test_policy.py
@@ -1,7 +1,7 @@
 import pytest
 from hypothesis import given, strategies as st
 
-from echoflow.runner.models import ProcessingProfile, RunnerResources
+from echoflow.runner.models import ModelTier, ProcessingProfile, RunnerResources
 from echoflow.runner.policy import RunnerPolicyPlanner
 
 GIB = 1024**3
@@ -31,7 +31,7 @@ def test_screening_is_explicitly_provisional_without_engine_decisions():
     assert policy.provisional is True
     assert policy.cpu_threads == 8
     assert policy.memory_budget_bytes == 12 * GIB
-    assert policy.recommended_model_tier is None
+    assert policy.recommended_model_tier is ModelTier.STRATEGY_SPECIFIC
 
 
 def test_non_screening_profiles_share_the_same_resource_budget_for_same_machine():

--- a/src/echoflow/runner/tests/test_policy.py
+++ b/src/echoflow/runner/tests/test_policy.py
@@ -31,7 +31,7 @@ def test_screening_is_explicitly_provisional_without_engine_decisions():
     assert policy.provisional is True
     assert policy.cpu_threads == 8
     assert policy.memory_budget_bytes == 12 * GIB
-    assert not hasattr(policy, "recommended_model_tier")
+    assert policy.recommended_model_tier is None
 
 
 def test_non_screening_profiles_share_the_same_resource_budget_for_same_machine():

--- a/src/echoflow/runner/tests/test_policy.py
+++ b/src/echoflow/runner/tests/test_policy.py
@@ -24,14 +24,14 @@ def resources(*, cpus=8, memory=12 * GIB, constraints=()):
     )
 
 
-def test_screening_is_explicitly_provisional_without_engine_decisions():
+def test_screening_is_explicitly_provisional_without_engine_selection():
     policy = RunnerPolicyPlanner(memory_budget_fraction=1).plan(
         resources(), ProcessingProfile.SCREENING
     )
     assert policy.provisional is True
     assert policy.cpu_threads == 8
     assert policy.memory_budget_bytes == 12 * GIB
-    assert policy.recommended_model_tier is ModelTier.STRATEGY_SPECIFIC
+    assert policy.recommended_model_tier is ModelTier.COMPACT
 
 
 def test_non_screening_profiles_share_the_same_resource_budget_for_same_machine():
@@ -42,6 +42,8 @@ def test_non_screening_profiles_share_the_same_resource_budget_for_same_machine(
     assert balanced.cpu_threads == accurate.cpu_threads == 8
     assert balanced.provisional is False
     assert accurate.provisional is False
+    assert balanced.recommended_model_tier is ModelTier.STRATEGY_SPECIFIC
+    assert accurate.recommended_model_tier is ModelTier.STRATEGY_SPECIFIC
 
 
 def test_default_policy_values_and_fraction_are_stable():

--- a/src/echoflow/runner/tests/test_policy.py
+++ b/src/echoflow/runner/tests/test_policy.py
@@ -1,5 +1,6 @@
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 
 from echoflow.runner.models import ModelTier, ProcessingProfile, RunnerResources
 from echoflow.runner.policy import RunnerPolicyPlanner

--- a/src/echoflow/runner/tests/test_policy.py
+++ b/src/echoflow/runner/tests/test_policy.py
@@ -1,6 +1,7 @@
 import pytest
+from hypothesis import given, strategies as st
 
-from echoflow.runner.models import ModelTier, ProcessingProfile, RunnerResources
+from echoflow.runner.models import ProcessingProfile, RunnerResources
 from echoflow.runner.policy import RunnerPolicyPlanner
 
 GIB = 1024**3
@@ -23,50 +24,24 @@ def resources(*, cpus=8, memory=12 * GIB, constraints=()):
     )
 
 
-def test_screening_is_explicitly_provisional_and_always_recommends_compact_model():
+def test_screening_is_explicitly_provisional_without_engine_decisions():
     policy = RunnerPolicyPlanner(memory_budget_fraction=1).plan(
         resources(), ProcessingProfile.SCREENING
     )
     assert policy.provisional is True
-    assert policy.recommended_model_tier is ModelTier.COMPACT
     assert policy.cpu_threads == 8
     assert policy.memory_budget_bytes == 12 * GIB
+    assert not hasattr(policy, "recommended_model_tier")
 
 
-def test_balanced_and_accuracy_select_largest_generic_tier_that_fits():
+def test_non_screening_profiles_share_the_same_resource_budget_for_same_machine():
     planner = RunnerPolicyPlanner(memory_budget_fraction=1)
     balanced = planner.plan(resources(memory=6 * GIB), ProcessingProfile.BALANCED)
-    accurate = planner.plan(resources(memory=12 * GIB), ProcessingProfile.ACCURACY)
-    constrained_accuracy = planner.plan(
-        resources(memory=6 * GIB), ProcessingProfile.ACCURACY
-    )
-    assert balanced.recommended_model_tier is ModelTier.STANDARD
+    accurate = planner.plan(resources(memory=6 * GIB), ProcessingProfile.ACCURACY)
+    assert balanced.memory_budget_bytes == accurate.memory_budget_bytes == 6 * GIB
+    assert balanced.cpu_threads == accurate.cpu_threads == 8
     assert balanced.provisional is False
-    assert accurate.recommended_model_tier is ModelTier.LARGE
-    assert constrained_accuracy.recommended_model_tier is ModelTier.STANDARD
-
-
-def test_low_memory_falls_back_to_compact_for_non_screening_profiles():
-    policy = RunnerPolicyPlanner(memory_budget_fraction=1).plan(
-        resources(memory=3 * GIB), ProcessingProfile.ACCURACY
-    )
-    assert policy.recommended_model_tier is ModelTier.COMPACT
-
-
-def test_model_tier_memory_thresholds_are_exact_binary_gibibytes():
-    planner = RunnerPolicyPlanner(memory_budget_fraction=1)
-    just_below_standard = planner.plan(
-        resources(memory=4 * GIB - 1), ProcessingProfile.BALANCED
-    )
-    standard = planner.plan(resources(memory=4 * GIB), ProcessingProfile.BALANCED)
-    just_below_large = planner.plan(
-        resources(memory=8 * GIB - 1), ProcessingProfile.ACCURACY
-    )
-    large = planner.plan(resources(memory=8 * GIB), ProcessingProfile.ACCURACY)
-    assert just_below_standard.recommended_model_tier is ModelTier.COMPACT
-    assert standard.recommended_model_tier is ModelTier.STANDARD
-    assert just_below_large.recommended_model_tier is ModelTier.STANDARD
-    assert large.recommended_model_tier is ModelTier.LARGE
+    assert accurate.provisional is False
 
 
 def test_default_policy_values_and_fraction_are_stable():
@@ -112,6 +87,48 @@ def test_user_ceilings_clamp_detected_resources_and_record_why():
         "configured_cpu_limit",
         "configured_memory_limit",
     )
+
+
+def test_ceiling_boundaries_apply_only_when_stricter_than_detected_budget():
+    exact = RunnerPolicyPlanner(
+        memory_budget_fraction=1,
+        max_cpu_threads=8,
+        max_memory_bytes=4 * GIB,
+    ).plan(resources(cpus=8, memory=4 * GIB), ProcessingProfile.BALANCED)
+    below = RunnerPolicyPlanner(
+        memory_budget_fraction=1,
+        max_cpu_threads=7,
+        max_memory_bytes=4 * GIB - 1,
+    ).plan(resources(cpus=8, memory=4 * GIB), ProcessingProfile.BALANCED)
+
+    assert exact.cpu_threads == 8
+    assert exact.memory_budget_bytes == 4 * GIB
+    assert exact.constraints == ()
+    assert below.cpu_threads == 7
+    assert below.memory_budget_bytes == 4 * GIB - 1
+    assert below.constraints == ("configured_cpu_limit", "configured_memory_limit")
+
+
+@given(
+    detected=st.integers(min_value=0, max_value=64 * GIB),
+    ceiling=st.integers(min_value=1, max_value=64 * GIB),
+)
+def test_property_memory_ceiling_never_increases_detected_budget(detected, ceiling):
+    policy = RunnerPolicyPlanner(
+        memory_budget_fraction=1, max_memory_bytes=ceiling
+    ).plan(resources(memory=detected), ProcessingProfile.BALANCED)
+    assert policy.memory_budget_bytes == min(detected, ceiling)
+
+
+@given(
+    detected=st.integers(min_value=0, max_value=128),
+    ceiling=st.integers(min_value=1, max_value=128),
+)
+def test_property_cpu_ceiling_never_increases_effective_capacity(detected, ceiling):
+    policy = RunnerPolicyPlanner(max_cpu_threads=ceiling).plan(
+        resources(cpus=detected), ProcessingProfile.BALANCED
+    )
+    assert policy.cpu_threads == max(1, min(detected, ceiling))
 
 
 @pytest.mark.parametrize(

--- a/src/echoflow/tests/test_cli_strategies.py
+++ b/src/echoflow/tests/test_cli_strategies.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 from typer.testing import CliRunner
@@ -89,16 +90,16 @@ def test_strategies_json_exposes_feasible_recommended_and_rejected_choices():
     )
 
 
-def test_strategies_rich_output_marks_recommendation_and_capacity_rejection():
+def test_strategies_rich_output_marks_recommendation_and_capacity_state():
     container = configured_container()
     with patch("echoflow.cli.AppContainer", return_value=container):
         result = runner.invoke(app, ["strategies"])
 
     assert result.exit_code == 0
     assert "EchoFlow local transcription strategies" in result.output
-    assert "small-cpu-int8" in result.output
+    assert "small" in result.output
     assert "recommended" in result.output
-    assert "insufficient_memory" in result.output
+    assert "false" in result.output
 
 
 def test_strategies_profile_override_reaches_ranker():
@@ -128,7 +129,7 @@ def test_transcribe_explicit_strategy_reaches_planner_without_silent_substitutio
 
     assert result.exit_code == 0
     container.transcription_planner().plan.assert_called_once_with(
-        container.transcription_planner().plan.call_args.args[0],
+        Path("recording.wav"),
         output_dir=None,
         profile=ProcessingProfile.BALANCED,
         strategy_id="tiny-cpu-int8",

--- a/src/echoflow/tests/test_cli_strategies.py
+++ b/src/echoflow/tests/test_cli_strategies.py
@@ -1,0 +1,135 @@
+import json
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from echoflow.cli import app
+from echoflow.core.health_check import OverallStatus
+from echoflow.runner.models import ProcessingProfile
+from echoflow.tests.test_cli import FakeContainer, report
+
+runner = CliRunner()
+
+
+def strategy_assessments():
+    return (
+        {
+            "strategy": {
+                "strategy_id": "tiny-cpu-int8",
+                "model": "tiny",
+                "quality_rank": 1,
+                "model_cache_bytes": 150 * 1024**2,
+                "estimated_peak_memory_bytes": 1_280 * 1024**2,
+            },
+            "memory_budget_bytes": 3 * 1024**3,
+            "feasible": True,
+            "rejection_reasons": [],
+            "recommended": False,
+            "cpu_threads": 4,
+            "profile": "balanced",
+        },
+        {
+            "strategy": {
+                "strategy_id": "small-cpu-int8",
+                "model": "small",
+                "quality_rank": 2,
+                "model_cache_bytes": 750 * 1024**2,
+                "estimated_peak_memory_bytes": 2_304 * 1024**2,
+            },
+            "memory_budget_bytes": 3 * 1024**3,
+            "feasible": True,
+            "rejection_reasons": [],
+            "recommended": True,
+            "cpu_threads": 4,
+            "profile": "balanced",
+        },
+        {
+            "strategy": {
+                "strategy_id": "medium-cpu-int8",
+                "model": "medium",
+                "quality_rank": 3,
+                "model_cache_bytes": 2_500 * 1024**2,
+                "estimated_peak_memory_bytes": 4_352 * 1024**2,
+            },
+            "memory_budget_bytes": 3 * 1024**3,
+            "feasible": False,
+            "rejection_reasons": ["insufficient_memory"],
+            "recommended": False,
+            "cpu_threads": 4,
+            "profile": "balanced",
+        },
+    )
+
+
+def configured_container():
+    container = FakeContainer(report(OverallStatus.HEALTHY))
+    container.transcription_planner().assess_strategies.return_value = (
+        strategy_assessments()
+    )
+    return container
+
+
+def test_strategies_json_exposes_feasible_recommended_and_rejected_choices():
+    container = configured_container()
+    with patch("echoflow.cli.AppContainer", return_value=container):
+        result = runner.invoke(app, ["strategies", "--json"])
+
+    payload = json.loads(result.stdout)
+    assert result.exit_code == 0
+    assert [item["strategy"]["strategy_id"] for item in payload] == [
+        "tiny-cpu-int8",
+        "small-cpu-int8",
+        "medium-cpu-int8",
+    ]
+    assert [item["feasible"] for item in payload] == [True, True, False]
+    assert payload[1]["recommended"] is True
+    assert payload[2]["rejection_reasons"] == ["insufficient_memory"]
+    container.transcription_planner().assess_strategies.assert_called_once_with(
+        profile=ProcessingProfile.BALANCED
+    )
+
+
+def test_strategies_rich_output_marks_recommendation_and_capacity_rejection():
+    container = configured_container()
+    with patch("echoflow.cli.AppContainer", return_value=container):
+        result = runner.invoke(app, ["strategies"])
+
+    assert result.exit_code == 0
+    assert "EchoFlow local transcription strategies" in result.output
+    assert "small-cpu-int8" in result.output
+    assert "recommended" in result.output
+    assert "insufficient_memory" in result.output
+
+
+def test_strategies_profile_override_reaches_ranker():
+    container = configured_container()
+    with patch("echoflow.cli.AppContainer", return_value=container):
+        result = runner.invoke(app, ["strategies", "--profile", "accuracy", "--json"])
+
+    assert result.exit_code == 0
+    container.transcription_planner().assess_strategies.assert_called_once_with(
+        profile=ProcessingProfile.ACCURACY
+    )
+
+
+def test_transcribe_explicit_strategy_reaches_planner_without_silent_substitution():
+    container = configured_container()
+    with patch("echoflow.cli.AppContainer", return_value=container):
+        result = runner.invoke(
+            app,
+            [
+                "transcribe",
+                "recording.wav",
+                "--dry-run",
+                "--strategy",
+                "tiny-cpu-int8",
+            ],
+        )
+
+    assert result.exit_code == 0
+    container.transcription_planner().plan.assert_called_once_with(
+        container.transcription_planner().plan.call_args.args[0],
+        output_dir=None,
+        profile=ProcessingProfile.BALANCED,
+        strategy_id="tiny-cpu-int8",
+    )

--- a/src/echoflow/transcription/planner.py
+++ b/src/echoflow/transcription/planner.py
@@ -105,11 +105,12 @@ class TranscriptionJobPlanner:
         assessments = self.strategy_evaluator.assess(
             self.strategy_catalog, memory_budget_bytes=policy.memory_budget_bytes
         )
-        selected = None
-        try:
-            selected = self.strategy_evaluator.select(assessments, profile=profile)
-        except Exception:
-            pass
+        feasible = tuple(assessment for assessment in assessments if assessment.feasible)
+        selected = (
+            self.strategy_evaluator.select(feasible, profile=profile)
+            if feasible
+            else None
+        )
         return tuple(
             {
                 **assessment.to_dict(),

--- a/src/echoflow/transcription/planner.py
+++ b/src/echoflow/transcription/planner.py
@@ -105,7 +105,9 @@ class TranscriptionJobPlanner:
         assessments = self.strategy_evaluator.assess(
             self.strategy_catalog, memory_budget_bytes=policy.memory_budget_bytes
         )
-        feasible = tuple(assessment for assessment in assessments if assessment.feasible)
+        feasible = tuple(
+            assessment for assessment in assessments if assessment.feasible
+        )
         selected = (
             self.strategy_evaluator.select(feasible, profile=profile)
             if feasible

--- a/src/echoflow/transcription/planner.py
+++ b/src/echoflow/transcription/planner.py
@@ -4,7 +4,7 @@ from typing import Protocol
 
 from echoflow.media.models import MediaInfo
 from echoflow.runner.inspector import RunnerInspector
-from echoflow.runner.models import ExecutionPolicy, ModelTier, ProcessingProfile
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile
 from echoflow.runner.policy import RunnerPolicyPlanner
 from echoflow.transcription.models import (
     CpuEngineConfiguration,
@@ -13,25 +13,16 @@ from echoflow.transcription.models import (
     ResourceEstimate,
     TranscriptionJobPlan,
 )
+from echoflow.transcription.strategy import (
+    StrategyCatalog,
+    StrategyDefinition,
+    StrategyEvaluator,
+    faster_whisper_cpu_catalog,
+)
 from echoflow.workspace.models import ArtifactKind
 from echoflow.workspace.service import WorkspaceService
 
 _MIB = 1024**2
-_ENGINE_MODELS = {
-    ModelTier.COMPACT: "tiny",
-    ModelTier.STANDARD: "small",
-    ModelTier.LARGE: "medium",
-}
-_MODEL_CACHE_BYTES = {
-    "tiny": 150 * _MIB,
-    "small": 750 * _MIB,
-    "medium": 2_500 * _MIB,
-}
-_MODEL_PEAK_MEMORY_BYTES = {
-    "tiny": 1_024 * _MIB,
-    "small": 2_048 * _MIB,
-    "medium": 4_096 * _MIB,
-}
 _TARGET_SAMPLE_RATE_HZ = 16_000
 _TARGET_CHANNELS = 1
 _TARGET_BYTES_PER_SAMPLE = 2
@@ -51,12 +42,16 @@ class TranscriptionJobPlanner:
         workspace_service: WorkspaceService,
         runner_inspector: RunnerInspector,
         policy_planner: RunnerPolicyPlanner,
+        strategy_catalog: StrategyCatalog | None = None,
+        strategy_evaluator: StrategyEvaluator | None = None,
         model_revision: str | None = None,
     ):
         self.media_probe = media_probe
         self.workspace_service = workspace_service
         self.runner_inspector = runner_inspector
         self.policy_planner = policy_planner
+        self.strategy_catalog = strategy_catalog or faster_whisper_cpu_catalog()
+        self.strategy_evaluator = strategy_evaluator or StrategyEvaluator()
         self.model_revision = model_revision
 
     def plan(
@@ -65,22 +60,29 @@ class TranscriptionJobPlanner:
         *,
         output_dir: str | Path | None = None,
         profile: ProcessingProfile = ProcessingProfile.BALANCED,
+        strategy_id: str | None = None,
     ) -> TranscriptionJobPlan:
         job = self.workspace_service.plan_job(input_path, output_dir=output_dir)
         media = self.media_probe.probe(job.input_path)
         runner = self.runner_inspector.inspect()
         policy = self.policy_planner.plan(runner, profile)
-        engine = self._engine(policy)
+        assessments = self.strategy_evaluator.assess(
+            self.strategy_catalog, memory_budget_bytes=policy.memory_budget_bytes
+        )
+        selected = self.strategy_evaluator.select(
+            assessments,
+            profile=profile,
+            requested_strategy_id=strategy_id,
+        )
+        engine = self._engine(policy, selected.strategy)
         decoder = self._decoder(media)
         artifact = self.workspace_service.plan_artifact(
             job, ArtifactKind.CANONICAL_JSON
         )
-        resources = self._resources(media, decoder, engine, policy)
+        resources = self._resources(media, decoder, selected.strategy, policy)
         warnings = ["paths_are_unreserved"]
         if policy.provisional:
             warnings.append("screening_output_is_provisional")
-        if not resources.fits_memory_budget:
-            warnings.append("estimated_peak_memory_exceeds_budget")
         return TranscriptionJobPlan(
             job=job,
             artifact=artifact,
@@ -93,11 +95,37 @@ class TranscriptionJobPlanner:
             warnings=tuple(warnings),
         )
 
-    def _engine(self, policy: ExecutionPolicy) -> CpuEngineConfiguration:
-        model = _ENGINE_MODELS[policy.recommended_model_tier]
+    def assess_strategies(
+        self, *, profile: ProcessingProfile = ProcessingProfile.BALANCED
+    ) -> tuple[dict[str, object], ...]:
+        """Describe all local strategies against a fresh process-visible budget."""
+
+        runner = self.runner_inspector.inspect()
+        policy = self.policy_planner.plan(runner, profile)
+        assessments = self.strategy_evaluator.assess(
+            self.strategy_catalog, memory_budget_bytes=policy.memory_budget_bytes
+        )
+        selected = None
+        try:
+            selected = self.strategy_evaluator.select(assessments, profile=profile)
+        except Exception:
+            pass
+        return tuple(
+            {
+                **assessment.to_dict(),
+                "recommended": assessment is selected,
+                "cpu_threads": policy.cpu_threads,
+                "profile": profile.value,
+            }
+            for assessment in assessments
+        )
+
+    def _engine(
+        self, policy: ExecutionPolicy, strategy: StrategyDefinition
+    ) -> CpuEngineConfiguration:
         return CpuEngineConfiguration(
             engine="faster-whisper",
-            model=model,
+            model=strategy.model,
             device="cpu",
             compute_type="int8",
             cpu_threads=policy.cpu_threads,
@@ -130,7 +158,7 @@ class TranscriptionJobPlanner:
     def _resources(
         media: MediaInfo,
         decoder: DecodeConfiguration,
-        engine: CpuEngineConfiguration,
+        strategy: StrategyDefinition,
         policy: ExecutionPolicy,
     ) -> ResourceEstimate:
         normalized_audio = 0
@@ -143,12 +171,13 @@ class TranscriptionJobPlanner:
             )
         private_workspace = normalized_audio + 16 * _MIB
         public_output = max(64 * 1024, math.ceil(media.duration_seconds * 512))
-        peak_memory = _MODEL_PEAK_MEMORY_BYTES[engine.model] + 256 * _MIB
         return ResourceEstimate(
             private_workspace_bytes=private_workspace,
             public_output_bytes=public_output,
-            model_cache_bytes=_MODEL_CACHE_BYTES[engine.model],
-            estimated_peak_memory_bytes=peak_memory,
+            model_cache_bytes=strategy.model_cache_bytes,
+            estimated_peak_memory_bytes=strategy.estimated_peak_memory_bytes,
             memory_budget_bytes=policy.memory_budget_bytes,
-            fits_memory_budget=peak_memory <= policy.memory_budget_bytes,
+            fits_memory_budget=(
+                strategy.estimated_peak_memory_bytes <= policy.memory_budget_bytes
+            ),
         )

--- a/src/echoflow/transcription/strategy.py
+++ b/src/echoflow/transcription/strategy.py
@@ -86,16 +86,6 @@ class StrategyCatalog:
         if len(set(identifiers)) != len(identifiers):
             raise ValueError("strategy IDs must be unique")
 
-    def find(self, strategy_id: str) -> StrategyDefinition | None:
-        return next(
-            (
-                strategy
-                for strategy in self.strategies
-                if strategy.strategy_id == strategy_id
-            ),
-            None,
-        )
-
 
 class StrategyEvaluator:
     """Evaluate and rank local CPU strategies without hardware-name heuristics."""

--- a/src/echoflow/transcription/strategy.py
+++ b/src/echoflow/transcription/strategy.py
@@ -1,0 +1,197 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+from echoflow.runner.models import ProcessingProfile
+from echoflow.transcription.errors import ResourceAdmissionError
+
+_MIB = 1024**2
+
+
+class RejectionReason(StrEnum):
+    """Machine-checkable reason a local execution strategy is not feasible."""
+
+    INSUFFICIENT_MEMORY = "insufficient_memory"
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyDefinition:
+    """One deterministic local transcription strategy advertised to the planner."""
+
+    strategy_id: str
+    model: str
+    quality_rank: int
+    model_cache_bytes: int
+    estimated_peak_memory_bytes: int
+
+    def __post_init__(self) -> None:
+        if not self.strategy_id.strip():
+            raise ValueError("strategy_id cannot be empty")
+        if not self.model.strip():
+            raise ValueError("model cannot be empty")
+        if self.quality_rank < 0:
+            raise ValueError("quality_rank cannot be negative")
+        if self.model_cache_bytes < 0:
+            raise ValueError("model_cache_bytes cannot be negative")
+        if self.estimated_peak_memory_bytes < 1:
+            raise ValueError("estimated_peak_memory_bytes must be positive")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "strategy_id": self.strategy_id,
+            "model": self.model,
+            "quality_rank": self.quality_rank,
+            "model_cache_bytes": self.model_cache_bytes,
+            "estimated_peak_memory_bytes": self.estimated_peak_memory_bytes,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyAssessment:
+    """Feasibility result for one strategy against the current job memory budget."""
+
+    strategy: StrategyDefinition
+    memory_budget_bytes: int
+    rejection_reasons: tuple[RejectionReason, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.memory_budget_bytes < 0:
+            raise ValueError("memory_budget_bytes cannot be negative")
+
+    @property
+    def feasible(self) -> bool:
+        return not self.rejection_reasons
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "strategy": self.strategy.to_dict(),
+            "memory_budget_bytes": self.memory_budget_bytes,
+            "feasible": self.feasible,
+            "rejection_reasons": [reason.value for reason in self.rejection_reasons],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyCatalog:
+    """Ordered, versioned set of engine strategies considered by one planner."""
+
+    strategies: tuple[StrategyDefinition, ...]
+    version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.version < 1:
+            raise ValueError("strategy catalog version must be positive")
+        if not self.strategies:
+            raise ValueError("strategy catalog cannot be empty")
+        identifiers = tuple(strategy.strategy_id for strategy in self.strategies)
+        if len(set(identifiers)) != len(identifiers):
+            raise ValueError("strategy IDs must be unique")
+
+    def find(self, strategy_id: str) -> StrategyDefinition | None:
+        return next(
+            (
+                strategy
+                for strategy in self.strategies
+                if strategy.strategy_id == strategy_id
+            ),
+            None,
+        )
+
+
+class StrategyEvaluator:
+    """Evaluate and rank local CPU strategies without hardware-name heuristics."""
+
+    def assess(
+        self, catalog: StrategyCatalog, *, memory_budget_bytes: int
+    ) -> tuple[StrategyAssessment, ...]:
+        if memory_budget_bytes < 0:
+            raise ValueError("memory_budget_bytes cannot be negative")
+        return tuple(
+            StrategyAssessment(
+                strategy=strategy,
+                memory_budget_bytes=memory_budget_bytes,
+                rejection_reasons=(
+                    (RejectionReason.INSUFFICIENT_MEMORY,)
+                    if strategy.estimated_peak_memory_bytes > memory_budget_bytes
+                    else ()
+                ),
+            )
+            for strategy in catalog.strategies
+        )
+
+    def select(
+        self,
+        assessments: tuple[StrategyAssessment, ...],
+        *,
+        profile: ProcessingProfile,
+        requested_strategy_id: str | None = None,
+    ) -> StrategyAssessment:
+        if requested_strategy_id is not None:
+            requested = next(
+                (
+                    assessment
+                    for assessment in assessments
+                    if assessment.strategy.strategy_id == requested_strategy_id
+                ),
+                None,
+            )
+            if requested is None:
+                raise ResourceAdmissionError("Unknown transcription strategy")
+            if not requested.feasible:
+                raise ResourceAdmissionError(
+                    "Selected transcription strategy exceeds the current safe memory budget"
+                )
+            return requested
+
+        feasible = tuple(
+            assessment for assessment in assessments if assessment.feasible
+        )
+        if not feasible:
+            raise ResourceAdmissionError(
+                "No local transcription strategy fits the current safe memory budget"
+            )
+        if profile is ProcessingProfile.SCREENING:
+            return min(feasible, key=lambda item: item.strategy.quality_rank)
+        if profile is ProcessingProfile.ACCURACY:
+            return max(feasible, key=lambda item: item.strategy.quality_rank)
+
+        standard = next(
+            (
+                assessment
+                for assessment in feasible
+                if assessment.strategy.strategy_id == "small-cpu-int8"
+            ),
+            None,
+        )
+        if standard is not None:
+            return standard
+        return max(feasible, key=lambda item: item.strategy.quality_rank)
+
+
+def faster_whisper_cpu_catalog() -> StrategyCatalog:
+    """Return conservative CPU/int8 strategies pending real-machine calibration."""
+
+    return StrategyCatalog(
+        strategies=(
+            StrategyDefinition(
+                strategy_id="tiny-cpu-int8",
+                model="tiny",
+                quality_rank=1,
+                model_cache_bytes=150 * _MIB,
+                estimated_peak_memory_bytes=1_280 * _MIB,
+            ),
+            StrategyDefinition(
+                strategy_id="small-cpu-int8",
+                model="small",
+                quality_rank=2,
+                model_cache_bytes=750 * _MIB,
+                estimated_peak_memory_bytes=2_304 * _MIB,
+            ),
+            StrategyDefinition(
+                strategy_id="medium-cpu-int8",
+                model="medium",
+                quality_rank=3,
+                model_cache_bytes=2_500 * _MIB,
+                estimated_peak_memory_bytes=4_352 * _MIB,
+            ),
+        )
+    )

--- a/src/echoflow/transcription/tests/test_planner.py
+++ b/src/echoflow/transcription/tests/test_planner.py
@@ -8,6 +8,7 @@ from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
 from echoflow.runner.models import ProcessingProfile, RunnerResources
 from echoflow.runner.policy import RunnerPolicyPlanner
+from echoflow.transcription.errors import ResourceAdmissionError
 from echoflow.transcription.models import DecodeStrategy
 from echoflow.transcription.planner import TranscriptionJobPlanner
 from echoflow.workspace.models import WorkspacePaths
@@ -149,17 +150,18 @@ def test_accuracy_plan_selects_medium_model_when_budget_allows(tmp_path):
     assert plan.resources.fits_memory_budget is True
 
 
-def test_insufficient_compact_memory_is_recorded_not_hidden(tmp_path):
+def test_insufficient_compact_memory_is_refused_before_execution(tmp_path):
     source = tmp_path / "constrained.wav"
     source.write_bytes(b"audio")
     planner, _, _, _ = build_planner(
         tmp_path, media_info(source), runner_resources(1 * GIB)
     )
-    plan = planner.plan(source)
-    assert plan.engine.model == "tiny"
-    assert plan.resources.memory_budget_bytes == 1 * GIB
-    assert plan.resources.fits_memory_budget is False
-    assert "estimated_peak_memory_exceeds_budget" in plan.warnings
+
+    with pytest.raises(
+        ResourceAdmissionError,
+        match="^No local transcription strategy fits the current safe memory budget$",
+    ):
+        planner.plan(source)
 
 
 def test_peak_memory_equal_to_budget_is_feasible(tmp_path):
@@ -174,6 +176,54 @@ def test_peak_memory_equal_to_budget_is_feasible(tmp_path):
     assert plan.resources.estimated_peak_memory_bytes == exact_budget
     assert plan.resources.memory_budget_bytes == exact_budget
     assert plan.resources.fits_memory_budget is True
+
+
+def test_explicit_feasible_strategy_overrides_profile_recommendation(tmp_path):
+    source = tmp_path / "explicit.wav"
+    source.write_bytes(b"audio")
+    planner, _, _, _ = build_planner(tmp_path, media_info(source))
+
+    plan = planner.plan(
+        source,
+        profile=ProcessingProfile.SCREENING,
+        strategy_id="medium-cpu-int8",
+    )
+
+    assert plan.engine.model == "medium"
+    assert plan.policy.provisional is True
+
+
+def test_explicit_infeasible_strategy_is_not_silently_replaced(tmp_path):
+    source = tmp_path / "explicit-constrained.wav"
+    source.write_bytes(b"audio")
+    planner, _, _, _ = build_planner(
+        tmp_path, media_info(source), runner_resources(2 * GIB)
+    )
+
+    with pytest.raises(
+        ResourceAdmissionError,
+        match="^Selected transcription strategy exceeds the current safe memory budget$",
+    ):
+        planner.plan(source, strategy_id="medium-cpu-int8")
+
+
+def test_strategy_assessment_reports_recommendation_and_rejections(tmp_path):
+    source = tmp_path / "strategies.wav"
+    source.write_bytes(b"audio")
+    planner, _, _, _ = build_planner(
+        tmp_path, media_info(source), runner_resources(3 * GIB)
+    )
+
+    assessments = planner.assess_strategies(profile=ProcessingProfile.BALANCED)
+
+    assert tuple(item["strategy"]["strategy_id"] for item in assessments) == (
+        "tiny-cpu-int8",
+        "small-cpu-int8",
+        "medium-cpu-int8",
+    )
+    assert tuple(item["feasible"] for item in assessments) == (True, True, False)
+    assert tuple(item["recommended"] for item in assessments) == (False, True, False)
+    assert assessments[2]["rejection_reasons"] == ["insufficient_memory"]
 
 
 def test_long_recording_output_estimate_scales_beyond_minimum(tmp_path):

--- a/src/echoflow/transcription/tests/test_strategy.py
+++ b/src/echoflow/transcription/tests/test_strategy.py
@@ -1,0 +1,232 @@
+from itertools import permutations
+
+import pytest
+from hypothesis import given, strategies as st
+
+from echoflow.runner.models import ProcessingProfile
+from echoflow.transcription.errors import ResourceAdmissionError
+from echoflow.transcription.strategy import (
+    RejectionReason,
+    StrategyCatalog,
+    StrategyDefinition,
+    StrategyEvaluator,
+    faster_whisper_cpu_catalog,
+)
+
+MIB = 1024**2
+GIB = 1024**3
+
+
+def evaluator_and_catalog():
+    return StrategyEvaluator(), faster_whisper_cpu_catalog()
+
+
+def test_default_catalog_is_ordered_from_lightest_to_highest_quality():
+    catalog = faster_whisper_cpu_catalog()
+    assert tuple(strategy.strategy_id for strategy in catalog.strategies) == (
+        "tiny-cpu-int8",
+        "small-cpu-int8",
+        "medium-cpu-int8",
+    )
+    assert tuple(strategy.quality_rank for strategy in catalog.strategies) == (1, 2, 3)
+    assert tuple(strategy.estimated_peak_memory_bytes for strategy in catalog.strategies) == (
+        1_280 * MIB,
+        2_304 * MIB,
+        4_352 * MIB,
+    )
+
+
+def test_positive_profile_selection_uses_only_feasible_strategies():
+    evaluator, catalog = evaluator_and_catalog()
+    assessments = evaluator.assess(catalog, memory_budget_bytes=5 * GIB)
+
+    assert evaluator.select(
+        assessments, profile=ProcessingProfile.SCREENING
+    ).strategy.model == "tiny"
+    assert evaluator.select(
+        assessments, profile=ProcessingProfile.BALANCED
+    ).strategy.model == "small"
+    assert evaluator.select(
+        assessments, profile=ProcessingProfile.ACCURACY
+    ).strategy.model == "medium"
+
+
+def test_balanced_falls_back_to_best_feasible_strategy_when_small_does_not_fit():
+    evaluator, catalog = evaluator_and_catalog()
+    assessments = evaluator.assess(catalog, memory_budget_bytes=1_500 * MIB)
+
+    selected = evaluator.select(assessments, profile=ProcessingProfile.BALANCED)
+
+    assert selected.strategy.model == "tiny"
+    assert selected.feasible is True
+
+
+def test_explicit_feasible_strategy_is_never_replaced_by_profile_ranking():
+    evaluator, catalog = evaluator_and_catalog()
+    assessments = evaluator.assess(catalog, memory_budget_bytes=5 * GIB)
+
+    selected = evaluator.select(
+        assessments,
+        profile=ProcessingProfile.SCREENING,
+        requested_strategy_id="medium-cpu-int8",
+    )
+
+    assert selected.strategy.model == "medium"
+
+
+def test_explicit_infeasible_strategy_fails_instead_of_silently_downgrading():
+    evaluator, catalog = evaluator_and_catalog()
+    assessments = evaluator.assess(catalog, memory_budget_bytes=2 * GIB)
+
+    with pytest.raises(
+        ResourceAdmissionError,
+        match="^Selected transcription strategy exceeds the current safe memory budget$",
+    ):
+        evaluator.select(
+            assessments,
+            profile=ProcessingProfile.BALANCED,
+            requested_strategy_id="medium-cpu-int8",
+        )
+
+
+def test_unknown_explicit_strategy_is_rejected():
+    evaluator, catalog = evaluator_and_catalog()
+    assessments = evaluator.assess(catalog, memory_budget_bytes=5 * GIB)
+
+    with pytest.raises(ResourceAdmissionError, match="^Unknown transcription strategy$"):
+        evaluator.select(
+            assessments,
+            profile=ProcessingProfile.BALANCED,
+            requested_strategy_id="imaginary",
+        )
+
+
+def test_no_feasible_strategy_returns_typed_capacity_refusal():
+    evaluator, catalog = evaluator_and_catalog()
+    assessments = evaluator.assess(catalog, memory_budget_bytes=1_280 * MIB - 1)
+
+    with pytest.raises(
+        ResourceAdmissionError,
+        match="^No local transcription strategy fits the current safe memory budget$",
+    ):
+        evaluator.select(assessments, profile=ProcessingProfile.BALANCED)
+
+
+def test_memory_boundary_value_analysis_is_exact():
+    evaluator, catalog = evaluator_and_catalog()
+    required = catalog.strategies[0].estimated_peak_memory_bytes
+
+    below = evaluator.assess(catalog, memory_budget_bytes=required - 1)[0]
+    exact = evaluator.assess(catalog, memory_budget_bytes=required)[0]
+    above = evaluator.assess(catalog, memory_budget_bytes=required + 1)[0]
+
+    assert below.feasible is False
+    assert below.rejection_reasons == (RejectionReason.INSUFFICIENT_MEMORY,)
+    assert exact.feasible is True
+    assert above.feasible is True
+
+
+@pytest.mark.parametrize(
+    "definition",
+    [
+        StrategyDefinition("id", "model", 0, 0, 1),
+        StrategyDefinition("id", "model", 1, 1, 1),
+    ],
+)
+def test_strategy_definition_accepts_valid_boundary_values(definition):
+    assert definition.strategy_id == "id"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"strategy_id": ""}, "strategy_id cannot be empty"),
+        ({"model": ""}, "model cannot be empty"),
+        ({"quality_rank": -1}, "quality_rank cannot be negative"),
+        ({"model_cache_bytes": -1}, "model_cache_bytes cannot be negative"),
+        (
+            {"estimated_peak_memory_bytes": 0},
+            "estimated_peak_memory_bytes must be positive",
+        ),
+    ],
+)
+def test_strategy_definition_rejects_invalid_boundaries(kwargs, message):
+    values = {
+        "strategy_id": "id",
+        "model": "model",
+        "quality_rank": 1,
+        "model_cache_bytes": 1,
+        "estimated_peak_memory_bytes": 1,
+    }
+    values.update(kwargs)
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        StrategyDefinition(**values)
+
+
+def test_catalog_rejects_empty_duplicate_and_invalid_version_boundaries():
+    strategy = StrategyDefinition("same", "tiny", 1, 1, 1)
+    with pytest.raises(ValueError, match="^strategy catalog cannot be empty$"):
+        StrategyCatalog(())
+    with pytest.raises(ValueError, match="^strategy IDs must be unique$"):
+        StrategyCatalog((strategy, strategy))
+    with pytest.raises(
+        ValueError, match="^strategy catalog version must be positive$"
+    ):
+        StrategyCatalog((strategy,), version=0)
+
+
+def test_assessment_serializes_typed_rejection_reason():
+    evaluator, catalog = evaluator_and_catalog()
+    assessment = evaluator.assess(catalog, memory_budget_bytes=0)[0]
+
+    assert assessment.to_dict()["feasible"] is False
+    assert assessment.to_dict()["rejection_reasons"] == ["insufficient_memory"]
+
+
+@given(
+    first=st.integers(min_value=0, max_value=8 * GIB),
+    second=st.integers(min_value=0, max_value=8 * GIB),
+)
+def test_property_more_memory_never_removes_a_feasible_strategy(first, second):
+    evaluator, catalog = evaluator_and_catalog()
+    lower, upper = sorted((first, second))
+    lower_ids = {
+        assessment.strategy.strategy_id
+        for assessment in evaluator.assess(catalog, memory_budget_bytes=lower)
+        if assessment.feasible
+    }
+    upper_ids = {
+        assessment.strategy.strategy_id
+        for assessment in evaluator.assess(catalog, memory_budget_bytes=upper)
+        if assessment.feasible
+    }
+    assert lower_ids <= upper_ids
+
+
+@given(memory_budget=st.integers(min_value=1_280 * MIB, max_value=8 * GIB))
+def test_property_selected_strategy_always_fits_budget(memory_budget):
+    evaluator, catalog = evaluator_and_catalog()
+    assessments = evaluator.assess(catalog, memory_budget_bytes=memory_budget)
+
+    for profile in ProcessingProfile:
+        selected = evaluator.select(assessments, profile=profile)
+        assert selected.feasible is True
+        assert selected.strategy.estimated_peak_memory_bytes <= memory_budget
+
+
+def test_profile_selection_is_independent_of_catalog_iteration_order():
+    evaluator, catalog = evaluator_and_catalog()
+    expected = {
+        profile: evaluator.select(
+            evaluator.assess(catalog, memory_budget_bytes=5 * GIB), profile=profile
+        ).strategy.strategy_id
+        for profile in ProcessingProfile
+    }
+
+    for ordering in permutations(catalog.strategies):
+        permuted = StrategyCatalog(tuple(ordering))
+        assessments = evaluator.assess(permuted, memory_budget_bytes=5 * GIB)
+        assert {
+            profile: evaluator.select(assessments, profile=profile).strategy.strategy_id
+            for profile in ProcessingProfile
+        } == expected

--- a/src/echoflow/transcription/tests/test_strategy.py
+++ b/src/echoflow/transcription/tests/test_strategy.py
@@ -1,7 +1,8 @@
 from itertools import permutations
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 
 from echoflow.runner.models import ProcessingProfile
 from echoflow.transcription.errors import ResourceAdmissionError

--- a/src/echoflow/transcription/tests/test_strategy.py
+++ b/src/echoflow/transcription/tests/test_strategy.py
@@ -30,7 +30,9 @@ def test_default_catalog_is_ordered_from_lightest_to_highest_quality():
         "medium-cpu-int8",
     )
     assert tuple(strategy.quality_rank for strategy in catalog.strategies) == (1, 2, 3)
-    assert tuple(strategy.estimated_peak_memory_bytes for strategy in catalog.strategies) == (
+    assert tuple(
+        strategy.estimated_peak_memory_bytes for strategy in catalog.strategies
+    ) == (
         1_280 * MIB,
         2_304 * MIB,
         4_352 * MIB,
@@ -41,15 +43,20 @@ def test_positive_profile_selection_uses_only_feasible_strategies():
     evaluator, catalog = evaluator_and_catalog()
     assessments = evaluator.assess(catalog, memory_budget_bytes=5 * GIB)
 
-    assert evaluator.select(
-        assessments, profile=ProcessingProfile.SCREENING
-    ).strategy.model == "tiny"
-    assert evaluator.select(
-        assessments, profile=ProcessingProfile.BALANCED
-    ).strategy.model == "small"
-    assert evaluator.select(
-        assessments, profile=ProcessingProfile.ACCURACY
-    ).strategy.model == "medium"
+    assert (
+        evaluator.select(
+            assessments, profile=ProcessingProfile.SCREENING
+        ).strategy.model
+        == "tiny"
+    )
+    assert (
+        evaluator.select(assessments, profile=ProcessingProfile.BALANCED).strategy.model
+        == "small"
+    )
+    assert (
+        evaluator.select(assessments, profile=ProcessingProfile.ACCURACY).strategy.model
+        == "medium"
+    )
 
 
 def test_balanced_falls_back_to_best_feasible_strategy_when_small_does_not_fit():
@@ -94,7 +101,9 @@ def test_unknown_explicit_strategy_is_rejected():
     evaluator, catalog = evaluator_and_catalog()
     assessments = evaluator.assess(catalog, memory_budget_bytes=5 * GIB)
 
-    with pytest.raises(ResourceAdmissionError, match="^Unknown transcription strategy$"):
+    with pytest.raises(
+        ResourceAdmissionError, match="^Unknown transcription strategy$"
+    ):
         evaluator.select(
             assessments,
             profile=ProcessingProfile.BALANCED,
@@ -170,9 +179,7 @@ def test_catalog_rejects_empty_duplicate_and_invalid_version_boundaries():
         StrategyCatalog(())
     with pytest.raises(ValueError, match="^strategy IDs must be unique$"):
         StrategyCatalog((strategy, strategy))
-    with pytest.raises(
-        ValueError, match="^strategy catalog version must be positive$"
-    ):
+    with pytest.raises(ValueError, match="^strategy catalog version must be positive$"):
         StrategyCatalog((strategy,), version=0)
 
 


### PR DESCRIPTION
## What changed

- separate process-visible runner budgeting from transcription-model selection
- add a versioned local faster-whisper CPU strategy catalog with typed feasibility assessments
- rank safe strategies deterministically for screening, balanced, and accuracy profiles
- allow an explicit strategy request without silent downgrade when the requested strategy is unsafe
- expose current local strategy options through a Rich/Typer `echoflow strategies` command and `transcribe --strategy`
- move model cache and peak-memory heuristics out of the generic job planner and into the engine strategy catalog
- add co-located positive, negative, boundary-value, Hypothesis property, and ordering-invariance tests
- add the strategy kernel to Poodle mutation scope

## Why

The existing runner planner mixed two responsibilities: computing a safe CPU/memory budget and choosing a generic model tier. That was useful for the first CPU vertical slice, but it becomes a second scheduler once EchoFlow needs to present several feasible local strategies to users with different hardware and performance constraints.

This PR makes runner policy engine-neutral. Transcription evaluates concrete strategies against the current safe budget, recommends one according to user intent, and can explain rejected strategies with machine-readable reasons. This is the foundation for later calibration, GPU strategies, deterministic segmentation, and checkpoint/resume.

## Safety and user agency

- automatic selection considers only currently feasible strategies
- an explicitly requested strategy is either honored or refused; it is never silently replaced
- exact memory equality is feasible; one byte below the requirement is not
- no-feasible-strategy cases fail before model initialization
- network/model-download authorization behavior is unchanged

## Testing

The new co-located strategy tests include positive and negative cases, exact `T-1 / T / T+1` memory boundaries, property-based monotonicity, selected-strategy feasibility, explicit-ceiling properties, and catalog-order invariance. The new decision kernel is also included in the repository's targeted Poodle mutation scope.

## Resume scope

EchoFlow does not yet have truthful checkpoint resume. The current backend transcribes a whole decoded recording in one call. Real resume requires deterministic segment boundaries plus persisted per-segment state, which remains the next execution-layer milestone rather than a fake whole-file retry in this PR.