### PR TITLE
Harden cross-platform private storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ transcription GUI. EchoFlow keeps the orchestration core small, treats engines
 and model payloads as optional capabilities, and derives plans from the CPU and
 memory actually available to a laptop, workstation, container, or CI runner.
 
+EchoFlow is intended to remain useful without mandatory hosted transcription
+fees or a cloud account. Durability, reliability, performance on ordinary
+hardware, storage/resource awareness, and portable user-owned artifacts are
+first-class design constraints. The current direction and research candidates
+are documented in [`ROADMAP.md`](ROADMAP.md).
+
 ## Project status
 
 EchoFlow currently provides a tested application foundation:
@@ -23,7 +29,7 @@ EchoFlow currently provides a tested application foundation:
 - Human-readable Rich tables and stable JSON diagnostic output.
 - Atomic local file operations with typed errors.
 - Structured logging and monotonic operation timing.
-- Path-redacted routine logs and owner-only private directories on POSIX.
+- Path-redacted routine logs and platform-specific private-storage enforcement.
 - Namespaced, explicit configuration that does not consume ambient `.env` files.
 - CPU-, affinity-, cgroup-, and memory-aware runner policy inspection.
 - A deterministic local strategy evaluator that lists feasible faster-whisper
@@ -153,10 +159,11 @@ uv run python scripts/verify_distribution.py dist
 ```
 
 The distribution verifier inspects the built wheel for its console entry point,
-transcription extra, and accidental test leakage. It then creates a temporary
-virtual environment outside the repository, disables user-site and source-path
-imports, installs `echoflow[transcription]` from that wheel, and exercises the
-installed CLI. CI runs that contract on Linux, macOS, and Windows.
+transcription extra, license metadata, packaged license file, and accidental test
+leakage. It then creates a temporary virtual environment outside the repository,
+disables user-site and source-path imports, installs `echoflow[transcription]` from
+that wheel, and exercises the installed CLI. CI runs that contract on Linux,
+macOS, and Windows.
 
 The enforced budgets are:
 
@@ -182,7 +189,7 @@ EchoFlow keeps user artifacts as normal files in a user-selected output
 directory. Private state and model caches are separate internal concerns.
 Artifact names are reserved atomically and collisions are renamed rather than
 overwritten by default. Durable checkpoint state is stored as private per-job
-files; a future SQLite job index, if added, should contain metadata rather than
+files; a future local job index, if added, should contain metadata rather than
 audio or transcript blobs.
 
 `echoflow runner` derives an engine-neutral CPU and memory budget from resources
@@ -241,4 +248,6 @@ Security boundaries, residual risks, and disclosure instructions are in
 
 ## License
 
-EchoFlow is licensed under the [Apache License 2.0](LICENSE).
+EchoFlow is licensed under the [GNU Affero General Public License v3.0 only](LICENSE).
+See [`LICENSING.md`](LICENSING.md) for the transition from earlier Apache-2.0
+versions.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,67 @@
+# EchoFlow roadmap
+
+EchoFlow is being built as a local-first, privacy-conscious, resource-aware audio
+processing application. The goal is not to compete with speech-recognition engines
+on model quality. EchoFlow should make local processing dependable on the hardware
+people already own and keep useful artifacts portable, inspectable, and recoverable.
+
+The project is intended to remain useful without mandatory hosted transcription
+fees or a cloud account. Cost awareness means respecting CPU, memory, disk, and
+model-storage constraints rather than assuming a high-end GPU. Privacy-first means
+local execution by default, explicit network authorization where a capability
+requires model retrieval, minimized sensitive metadata, and clearly separated
+private recovery state and public user artifacts.
+
+The primary engineering priorities are:
+
+- **Durability and recovery.** Long-running work should survive ordinary process or
+  system failure without silently changing the execution contract.
+- **Performance and resource awareness.** Plans should fit the CPU, memory, and
+  storage actually available to the process, including modest consumer machines.
+- **Reproducibility and provenance.** Canonical artifacts should preserve enough
+  source and execution identity to explain how they were produced.
+- **Privacy boundaries.** Sensitive recordings, transcript fragments, paths, model
+  state, and public exports should have explicit and testable handling rules.
+- **Small mandatory surface area.** Heavier capabilities should remain optional so a
+  user who only needs transcription does not inherit unrelated analysis machinery.
+
+## Near-term direction
+
+The next development sequence is intentionally evidence-driven:
+
+1. Harden private local storage consistently across supported operating systems.
+2. Evolve the canonical transcript contract so future speaker, language, confidence,
+   and timestamp enrichment has stable optional fields without changing today's
+   transcription behavior.
+3. Separate ASR execution from optional capabilities such as alignment, diarization,
+   and language identification without creating a general plugin platform.
+4. Calibrate real execution on representative Windows, macOS, and Linux hardware,
+   including peak memory, CPU behavior, decode overhead, checkpoint overhead, and
+   interruption/resume.
+5. Add TXT, SRT, and WebVTT as deterministic views derived from canonical transcript
+   data rather than additional sources of truth.
+6. Research optional local speaker diarization and the resource/privacy implications
+   of candidate engines.
+7. Research a rebuildable local transcript library and search index. DuckDB is a
+   candidate for this analytical/search layer; canonical transcript files would
+   remain authoritative so the index can be deleted and rebuilt.
+
+## Research candidates
+
+These are directions to investigate, not committed release promises:
+
+- multilingual and code-switching behavior with language attribution below the job
+  level;
+- multiple local ASR engine adapters when they provide a meaningful hardware,
+  accuracy, or deployment advantage;
+- anonymous speaker diarization and timestamped speaker turns without silently
+  creating a biometric identity database;
+- local lexical and metadata search across transcript collections;
+- optional semantic embeddings and hybrid lexical/semantic retrieval;
+- cross-transcript relationship discovery, clustering, and other research-oriented
+  corpus analysis.
+
+The order can change when benchmarks, security review, implementation complexity, or
+actual user needs contradict an assumption. The stable direction is narrower:
+sensitive local transcription should be dependable, inspectable, portable, and
+usable on ordinary hardware.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,10 +18,21 @@ Public failure messages omit input and artifact paths. Human and JSON job-plan
 output includes paths because producing that plan is the explicit command
 result; callers are responsible for where they store or forward it.
 
-Private state, cache, model, and per-job directories are owner-only on POSIX.
-Public transcript artifacts remain ordinary user files. EchoFlow does not
-currently encrypt artifacts at rest; storage encryption is an operating-system
-or volume responsibility.
+Private state, cache, model, and per-job directories use a platform-specific
+private-storage policy. On POSIX, private directories are tightened and verified
+as `0700`, and private file writes are tightened and verified as `0600`. On
+Windows, EchoFlow uses the operating system's built-in `whoami.exe` and
+`icacls.exe` utilities to resolve the current user SID, reset the path DACL,
+remove inherited access, grant that SID full control, and verify the resulting
+ACL structure. A private operation fails rather than silently continuing when
+the current SID or required ACL utility cannot be established.
+
+These controls limit ordinary access through the current operating-system user
+boundary; they are not application-level encryption. A local administrator,
+process with equivalent privileges, compromised user session, backup product, or
+storage snapshot may still access private state. Public transcript artifacts
+remain ordinary user files. EchoFlow does not currently encrypt artifacts at
+rest; storage encryption is an operating-system or volume responsibility.
 
 ## Supported versions
 
@@ -56,7 +67,7 @@ For media that is not already canonical mono 16 kHz PCM audio, EchoFlow invokes
 FFmpeg without a shell or stdin, restricts input protocols to `file`, explicitly
 maps the audio stream selected by FFprobe, discards video/subtitle/data streams,
 suppresses native diagnostic output from public failures, and enforces a
-configurable process timeout. Normalized audio exists only in the owner-private job
+configurable process timeout. Normalized audio exists only in the private job
 workspace and is removed after the attempt. Filesystem deletion is not secure
 erasure.
 
@@ -88,8 +99,8 @@ They bind the work to the input SHA-256 and media identity, engine/model/revisio
 decode configuration, segmentation schema, and exact PCM frame windows. Completed
 segment payloads contain the recognized transcript text required to resume exactly;
 that text is not masked because masking would change the recovered transcript.
-Checkpoint files are atomic private writes and are owner-only (`0600`) on POSIX,
-with private checkpoint directories tightened to `0700`.
+Checkpoint files are atomic private writes. Their private file/directory protection
+is enforced through the same POSIX-mode or Windows-DACL policy described above.
 
 Resume accepts only a contiguous prefix of completed segments whose manifest,
 window identity, and payload integrity checks match the current transcription
@@ -103,15 +114,16 @@ status fields, and exception types. They do not contain transcript text or sourc
 paths. After the final canonical transcript is published successfully, EchoFlow
 removes checkpoint payloads on a best-effort basis. Interrupted jobs retain them so
 that recovery remains possible. Deletion is ordinary filesystem deletion, not
-secure erasure; backups, snapshots, swap, SSD remapping, and same-user processes
-remain outside this guarantee.
+secure erasure; backups, snapshots, swap, SSD remapping, privileged local actors,
+and same-user processes remain outside this guarantee.
 
 ## Processing risks still outside the implemented boundary
 
 FFmpeg and the transcription engine still execute in the EchoFlow process/user
 security context rather than an operating-system sandbox. Model signatures,
 process-wide network egress enforcement, hard CPU limits, adversarial-media test
-corpora, encryption, and secure deletion are not implemented. Memory admission is
-a conservative preflight check, not a hard runtime memory cage. Windows ACL
-semantics are not equivalent to POSIX mode bits and require native hardening before
-a stable security claim. These properties must not be inferred from local-first.
+corpora, application-level encryption, and secure deletion are not implemented.
+Memory admission is a conservative preflight check, not a hard runtime memory cage.
+Private-storage ACLs and mode bits do not protect against a compromised user account,
+local administrators, or equivalent privileged processes. These properties must not
+be inferred from local-first.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ only_files = [
     "src/echoflow/core/performance_tracker.py",
     "src/echoflow/core/privacy.py",
     "src/echoflow/interfaces/local_file_manager.py",
+    "src/echoflow/interfaces/private_storage.py",
     "src/echoflow/media/models.py",
     "src/echoflow/media/probe.py",
     "src/echoflow/runner/inspector.py",

--- a/src/echoflow/interfaces/local_file_manager.py
+++ b/src/echoflow/interfaces/local_file_manager.py
@@ -10,6 +10,10 @@ from echoflow.core.errors import (
     StoragePermissionError,
 )
 from echoflow.interfaces.base_file_manager import FileMetadata
+from echoflow.interfaces.private_storage import (
+    PrivateStoragePolicy,
+    default_private_storage_policy,
+)
 
 _WINDOWS_RESERVED_NAMES = {
     "CON",
@@ -24,6 +28,9 @@ _WINDOWS_RESERVED_NAMES = {
 class LocalFileManager:
     """Logger-free adapter for local filesystem behavior."""
 
+    def __init__(self, private_storage: PrivateStoragePolicy | None = None) -> None:
+        self.private_storage = private_storage or default_private_storage_policy()
+
     def save_file(
         self, content: bytes, file_path: str | Path, *, private: bool = False
     ) -> None:
@@ -34,14 +41,14 @@ class LocalFileManager:
                 mode="wb", delete=False, dir=destination.parent
             ) as temporary_file:
                 temporary_path = Path(temporary_file.name)
-                if private and os.name != "nt":
-                    os.chmod(temporary_path, 0o600)
+                if private:
+                    self.private_storage.protect_file(temporary_path)
                 temporary_file.write(content)
                 temporary_file.flush()
                 os.fsync(temporary_file.fileno())
             os.replace(temporary_path, destination)
-            if private and os.name != "nt":
-                destination.chmod(0o600)
+            if private:
+                self.private_storage.protect_file(destination)
         except Exception as exc:
             if temporary_path is not None:
                 temporary_path.unlink(missing_ok=True)
@@ -91,8 +98,8 @@ class LocalFileManager:
         path = Path(directory_path)
         try:
             path.mkdir(mode=0o700 if private else 0o777, parents=True, exist_ok=True)
-            if private and os.name != "nt":
-                path.chmod(0o700)
+            if private:
+                self.private_storage.protect_directory(path)
         except Exception as exc:
             raise self._error("create directory", path, exc) from exc
 
@@ -102,6 +109,8 @@ class LocalFileManager:
         path = Path(directory_path)
         try:
             path.mkdir(mode=0o700 if private else 0o777)
+            if private:
+                self.private_storage.protect_directory(path)
         except Exception as exc:
             raise self._error("reserve directory", path, exc) from exc
 

--- a/src/echoflow/interfaces/private_storage.py
+++ b/src/echoflow/interfaces/private_storage.py
@@ -56,9 +56,7 @@ class WindowsPrivateStoragePolicy:
         self._run([icacls, str(path), "/reset", "/Q"])
         self._run([icacls, str(path), "/inheritance:r", "/Q"])
         inheritance = "(OI)(CI)" if inherit_to_children else ""
-        self._run(
-            [icacls, str(path), "/grant:r", f"*{sid}:{inheritance}F", "/Q"]
-        )
+        self._run([icacls, str(path), "/grant:r", f"*{sid}:{inheritance}F", "/Q"])
         self._run([icacls, str(path), "/verify", "/Q"])
 
     def _current_user_sid(self) -> str:

--- a/src/echoflow/interfaces/private_storage.py
+++ b/src/echoflow/interfaces/private_storage.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import csv
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+from typing import Protocol
+
+_PRIVATE_DIRECTORY_MODE = 0o700
+_PRIVATE_FILE_MODE = 0o600
+_WINDOWS_ACL_TIMEOUT_SECONDS = 10.0
+_SID_PATTERN = re.compile(r"S-\d-\d+(?:-\d+)+\Z")
+
+
+class PrivateStoragePolicy(Protocol):
+    """Platform-specific enforcement behind one private-storage contract."""
+
+    def protect_directory(self, path: Path) -> None: ...
+    def protect_file(self, path: Path) -> None: ...
+
+
+class PosixPrivateStoragePolicy:
+    """Enforce and verify owner-only POSIX mode bits."""
+
+    def protect_directory(self, path: Path) -> None:
+        self._protect(path, _PRIVATE_DIRECTORY_MODE)
+
+    def protect_file(self, path: Path) -> None:
+        self._protect(path, _PRIVATE_FILE_MODE)
+
+    @staticmethod
+    def _protect(path: Path, expected_mode: int) -> None:
+        path.chmod(expected_mode)
+        actual_mode = stat.S_IMODE(path.stat().st_mode)
+        if actual_mode != expected_mode:
+            raise PermissionError("Private POSIX permissions could not be verified")
+
+
+class WindowsPrivateStoragePolicy:
+    """Protect private paths with a DACL scoped to the current user SID."""
+
+    def __init__(self) -> None:
+        self._user_sid: str | None = None
+
+    def protect_directory(self, path: Path) -> None:
+        self._protect(path, inherit_to_children=True)
+
+    def protect_file(self, path: Path) -> None:
+        self._protect(path, inherit_to_children=False)
+
+    def _protect(self, path: Path, *, inherit_to_children: bool) -> None:
+        sid = self._current_user_sid()
+        icacls = self._system_executable("icacls.exe")
+        self._run([icacls, str(path), "/reset", "/Q"])
+        self._run([icacls, str(path), "/inheritance:r", "/Q"])
+        inheritance = "(OI)(CI)" if inherit_to_children else ""
+        self._run(
+            [icacls, str(path), "/grant:r", f"*{sid}:{inheritance}F", "/Q"]
+        )
+        self._run([icacls, str(path), "/verify", "/Q"])
+
+    def _current_user_sid(self) -> str:
+        if self._user_sid is not None:
+            return self._user_sid
+
+        whoami = self._system_executable("whoami.exe")
+        completed = self._run([whoami, "/user", "/fo", "csv", "/nh"])
+        row = next(csv.reader([completed.stdout.strip()]), [])
+        if len(row) < 2 or _SID_PATTERN.fullmatch(row[1].strip()) is None:
+            raise PermissionError("Windows user SID could not be verified")
+        self._user_sid = row[1].strip()
+        return self._user_sid
+
+    @staticmethod
+    def _system_executable(name: str) -> str:
+        system_root = os.environ.get("SystemRoot", r"C:\Windows")
+        executable = Path(system_root) / "System32" / name
+        if not executable.is_file():
+            raise PermissionError("Required Windows ACL utility is unavailable")
+        return str(executable)
+
+    @staticmethod
+    def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(  # noqa: S603
+                command,
+                capture_output=True,
+                check=True,
+                text=True,
+                timeout=_WINDOWS_ACL_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.SubprocessError, UnicodeError) as exc:
+            raise PermissionError("Windows private ACL enforcement failed") from exc
+
+
+def default_private_storage_policy() -> PrivateStoragePolicy:
+    if os.name == "nt":
+        return WindowsPrivateStoragePolicy()
+    return PosixPrivateStoragePolicy()

--- a/src/echoflow/interfaces/private_storage.py
+++ b/src/echoflow/interfaces/private_storage.py
@@ -75,7 +75,7 @@ class WindowsPrivateStoragePolicy:
 
     @staticmethod
     def _system_executable(name: str) -> str:
-        system_root = os.environ.get("SystemRoot", r"C:\Windows")
+        system_root = os.environ.get("SYSTEMROOT", r"C:\Windows")
         executable = Path(system_root) / "System32" / name
         if not executable.is_file():
             raise PermissionError("Required Windows ACL utility is unavailable")

--- a/src/echoflow/interfaces/tests/test_local_file_manager.py
+++ b/src/echoflow/interfaces/tests/test_local_file_manager.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from hypothesis import given
@@ -10,6 +10,7 @@ from echoflow.core.errors import (
     StorageAlreadyExistsError,
     StorageError,
     StorageNotFoundError,
+    StoragePermissionError,
 )
 from echoflow.interfaces.base_file_manager import FileManager
 from echoflow.interfaces.local_file_manager import LocalFileManager
@@ -61,6 +62,38 @@ def test_private_directories_are_created_and_tightened_to_owner_only(manager, tm
     reserved = private / "job"
     manager.reserve_directory(reserved, private=True)
     assert reserved.stat().st_mode & 0o777 == 0o700
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+def test_private_file_writes_are_owner_only(manager, tmp_path):
+    destination = tmp_path / "checkpoint.json"
+
+    manager.save_file(b"sensitive", destination, private=True)
+
+    assert destination.stat().st_mode & 0o777 == 0o600
+
+
+def test_private_operations_delegate_to_platform_policy(tmp_path):
+    policy = Mock()
+    manager = LocalFileManager(private_storage=policy)
+    directory = tmp_path / "private"
+    destination = directory / "checkpoint.json"
+
+    manager.ensure_directory_exists(directory, private=True)
+    manager.save_file(b"sensitive", destination, private=True)
+
+    policy.protect_directory.assert_called_once_with(directory)
+    assert policy.protect_file.call_count == 2
+    assert policy.protect_file.call_args_list[-1].args == (destination.absolute(),)
+
+
+def test_private_policy_failure_is_typed_permission_error(tmp_path):
+    policy = Mock()
+    policy.protect_directory.side_effect = PermissionError("ACL failure")
+    manager = LocalFileManager(private_storage=policy)
+
+    with pytest.raises(StoragePermissionError):
+        manager.ensure_directory_exists(tmp_path / "private", private=True)
 
 
 def test_directory_and_file_reservations_are_exclusive(manager, tmp_path):

--- a/src/echoflow/interfaces/tests/test_private_storage.py
+++ b/src/echoflow/interfaces/tests/test_private_storage.py
@@ -60,9 +60,10 @@ def test_windows_policy_removes_inheritance_and_grants_current_sid(
     policy.protect_file(file_path)
 
     commands = [call[0] for call in calls]
-    assert commands.count(
-        [str(system32 / "whoami.exe"), "/user", "/fo", "csv", "/nh"]
-    ) == 1
+    assert (
+        commands.count([str(system32 / "whoami.exe"), "/user", "/fo", "csv", "/nh"])
+        == 1
+    )
     assert [
         str(system32 / "icacls.exe"),
         str(directory),

--- a/src/echoflow/interfaces/tests/test_private_storage.py
+++ b/src/echoflow/interfaces/tests/test_private_storage.py
@@ -1,0 +1,131 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from echoflow.interfaces.private_storage import (
+    PosixPrivateStoragePolicy,
+    WindowsPrivateStoragePolicy,
+)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+def test_posix_policy_tightens_and_verifies_private_paths(tmp_path):
+    directory = tmp_path / "private"
+    directory.mkdir(mode=0o755)
+    file_path = directory / "checkpoint.json"
+    file_path.write_text("sensitive")
+    file_path.chmod(0o644)
+
+    policy = PosixPrivateStoragePolicy()
+    policy.protect_directory(directory)
+    policy.protect_file(file_path)
+
+    assert directory.stat().st_mode & 0o777 == 0o700
+    assert file_path.stat().st_mode & 0o777 == 0o600
+
+
+def _fake_windows_system_root(tmp_path, monkeypatch):
+    system32 = tmp_path / "Windows" / "System32"
+    system32.mkdir(parents=True)
+    (system32 / "whoami.exe").write_bytes(b"")
+    (system32 / "icacls.exe").write_bytes(b"")
+    monkeypatch.setenv("SystemRoot", str(system32.parent))
+    return system32
+
+
+def test_windows_policy_removes_inheritance_and_grants_current_sid(
+    tmp_path, monkeypatch
+):
+    system32 = _fake_windows_system_root(tmp_path, monkeypatch)
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        stdout = (
+            '"desktop\\researcher","S-1-5-21-1000"\n'
+            if command[0] == str(system32 / "whoami.exe")
+            else ""
+        )
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("echoflow.interfaces.private_storage.subprocess.run", run)
+    policy = WindowsPrivateStoragePolicy()
+    directory = tmp_path / "private"
+    directory.mkdir()
+    file_path = directory / "checkpoint.json"
+    file_path.write_text("sensitive")
+
+    policy.protect_directory(directory)
+    policy.protect_file(file_path)
+
+    commands = [call[0] for call in calls]
+    assert commands.count(
+        [str(system32 / "whoami.exe"), "/user", "/fo", "csv", "/nh"]
+    ) == 1
+    assert [
+        str(system32 / "icacls.exe"),
+        str(directory),
+        "/inheritance:r",
+        "/Q",
+    ] in commands
+    assert [
+        str(system32 / "icacls.exe"),
+        str(directory),
+        "/grant:r",
+        "*S-1-5-21-1000:(OI)(CI)F",
+        "/Q",
+    ] in commands
+    assert [
+        str(system32 / "icacls.exe"),
+        str(file_path),
+        "/grant:r",
+        "*S-1-5-21-1000:F",
+        "/Q",
+    ] in commands
+    assert all(call[1]["check"] is True for call in calls)
+    assert all(call[1]["timeout"] == 10.0 for call in calls)
+
+
+def test_windows_policy_refuses_unverified_user_sid(tmp_path, monkeypatch):
+    system32 = _fake_windows_system_root(tmp_path, monkeypatch)
+
+    def run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout='"desktop\\researcher","not-a-sid"\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr("echoflow.interfaces.private_storage.subprocess.run", run)
+    path = tmp_path / "private"
+    path.mkdir()
+
+    with pytest.raises(PermissionError, match="SID"):
+        WindowsPrivateStoragePolicy().protect_directory(path)
+
+    assert (system32 / "whoami.exe").is_file()
+
+
+def test_windows_policy_refuses_missing_acl_utility(tmp_path, monkeypatch):
+    system32 = tmp_path / "Windows" / "System32"
+    system32.mkdir(parents=True)
+    (system32 / "whoami.exe").write_bytes(b"")
+    monkeypatch.setenv("SystemRoot", str(system32.parent))
+
+    def run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout='"desktop\\researcher","S-1-5-21-1000"\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr("echoflow.interfaces.private_storage.subprocess.run", run)
+    path = tmp_path / "private"
+    path.mkdir()
+
+    with pytest.raises(PermissionError, match="utility"):
+        WindowsPrivateStoragePolicy().protect_directory(path)

--- a/src/echoflow/interfaces/tests/test_private_storage.py
+++ b/src/echoflow/interfaces/tests/test_private_storage.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from pathlib import Path
 
 import pytest
 
@@ -31,7 +30,7 @@ def _fake_windows_system_root(tmp_path, monkeypatch):
     system32.mkdir(parents=True)
     (system32 / "whoami.exe").write_bytes(b"")
     (system32 / "icacls.exe").write_bytes(b"")
-    monkeypatch.setenv("SystemRoot", str(system32.parent))
+    monkeypatch.setenv("SYSTEMROOT", str(system32.parent))
     return system32
 
 
@@ -113,7 +112,7 @@ def test_windows_policy_refuses_missing_acl_utility(tmp_path, monkeypatch):
     system32 = tmp_path / "Windows" / "System32"
     system32.mkdir(parents=True)
     (system32 / "whoami.exe").write_bytes(b"")
-    monkeypatch.setenv("SystemRoot", str(system32.parent))
+    monkeypatch.setenv("SYSTEMROOT", str(system32.parent))
 
     def run(command, **_kwargs):
         return subprocess.CompletedProcess(


### PR DESCRIPTION
## What changed

- Added a platform-neutral private-storage policy behind the existing `private=True` filesystem boundary.
- POSIX private directories/files are tightened and verified as `0700`/`0600`.
- Windows private paths now use built-in `whoami.exe` and `icacls.exe` to resolve the current user SID, reset the DACL, remove inherited access, grant that SID full control, and verify the ACL structure.
- Private storage operations fail closed with the existing typed permission error when the platform privacy policy cannot be established.
- `LocalFileManager` applies the same policy to private directory creation/reservation and atomic private file writes without exposing OS permission mechanics to transcription/workspace code.
- Added direct POSIX and mocked Windows policy tests plus storage-boundary failure/delegation tests.
- Added the new policy module to targeted mutation scope.
- Updated `SECURITY.md` to state the implemented Windows/POSIX boundary and retain explicit exclusions for privileged actors, encryption, secure deletion, backups/snapshots, and same-user compromise.
- Added `ROADMAP.md` describing EchoFlow's cost-conscious, privacy-first, performance/resource-aware, durable direction and research candidates including transcript semantics, engine/capability separation, real-device calibration, derived exports, diarization, DuckDB-backed rebuildable local search, multilingual/code-switching, and optional semantic retrieval.
- Updated the README to link the roadmap, clarify the intended no-mandatory-cloud-fee/ordinary-hardware direction, and correct the stale Apache license text to AGPL-3.0-only.

## Why

PR #37 made sensitive resumable transcript fragments durable, but POSIX mode bits did not provide an equivalent privacy control on Windows. This PR makes the existing private-storage abstraction truthful across supported desktop operating systems without adding application encryption or a new dependency.

The roadmap documentation also records the intended product direction before adding higher-level features: EchoFlow should optimize for durability, reliability, privacy boundaries, resource/storage constraints, reproducibility, and user-owned artifacts rather than becoming a model-specific transcription GUI or requiring paid hosted transcription.

## Security boundary

Windows DACL hardening is an operating-system access-control boundary, not encryption. Local administrators, equivalent privileged processes, compromised user sessions, backups/snapshots, and same-user hostile processes remain outside the guarantee. The implementation does not claim HIPAA or other regulatory compliance.

## Validation

CI should run the locked dependency audit, Ruff lint/format, strict mypy, Vulture, Radon, branch-aware coverage, source tests on Linux/macOS/Windows, distribution builds, and clean-wheel verification. Windows source tests will exercise the real private-storage path through existing workspace/checkpoint tests; policy command-shape and failure cases are also covered without requiring Windows for branch coverage.