### PR TITLE
Add empirical execution benchmark harness

### DIFF
--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -1,0 +1,157 @@
+# Empirical benchmarking and calibration
+
+EchoFlow's resource estimates are intentionally conservative heuristics until they
+can be compared with measured execution. The benchmarking subsystem is a local-only
+measurement harness for collecting that evidence without turning normal
+transcription into a separate benchmark implementation.
+
+The current development interface is:
+
+```bash
+uv run python -m echoflow.benchmarking /path/to/recording.wav
+uv run python -m echoflow.benchmarking /path/to/recording.wav --allow-model-download
+uv run python -m echoflow.benchmarking /path/to/recording.wav --json
+```
+
+An interrupted job can be measured as a separate resumed attempt:
+
+```bash
+uv run python -m echoflow.benchmarking /path/to/recording.wav --resume JOB_ID
+```
+
+The harness is deliberately experimental. Once its schema and behavior have been
+validated on real devices it can be promoted into the primary `echoflow` command
+surface.
+
+## What is measured
+
+A benchmark report records one execution attempt. It currently contains:
+
+- EchoFlow and Python versions;
+- path-minimized source provenance: SHA-256, size, modification timestamp,
+  container, duration, and audio stream index;
+- the process-visible runner resources and selected execution policy;
+- the path-free engine/model, decoder, segmentation, and resource-estimate
+  contract;
+- planning, execution, and total wall-clock duration;
+- whole-run and execution-only real-time factors;
+- sampled RSS and CPU use for the EchoFlow process and its current descendants;
+- aggregate named execution-stage durations and failure counts;
+- segment totals, restored counts, and completed counts where available;
+- the canonical transcript artifact size after successful publication; and
+- the ratio between observed peak process-tree RSS and the planner's current
+  peak-memory estimate.
+
+Repeated stages are represented as named aggregates rather than fixed benchmark
+columns. A future capability can therefore add measurements such as
+`diarization`, `alignment`, `language.identification`, `embedding.index`,
+`search.index`, `gpu.transfer`, or `pause.checkpoint` without requiring a new
+benchmark architecture.
+
+CPU percentages are the sum of sampled process-tree CPU percentages and can exceed
+100% on multi-core machines. RSS is summed across the process tree and can
+conservatively double-count shared pages. These measurements are useful comparative
+evidence, not operating-system accounting.
+
+## Privacy boundary
+
+Benchmarking does not transmit results and EchoFlow has no benchmark telemetry.
+Reports are ordinary user-owned JSON files in the selected public output directory.
+
+The report intentionally omits the source filesystem path, source filename, model
+cache path, transcript text, and exception messages. It still contains the source
+SHA-256 and other provenance needed to compare equivalent runs. A source digest can
+itself be linkable when another party possesses the same recording, so a benchmark
+report for a sensitive recording should not be treated as anonymous or published
+casually.
+
+Public benchmark sharing should use a known redistributable or synthetic benchmark
+corpus, or a future explicitly shareable report format with an appropriately
+reduced provenance contract.
+
+## Interruption and resume
+
+Ctrl+C and ordinary Python-level failures persist a partial benchmark report before
+the benchmark command exits. The report identifies the attempt as `interrupted` or
+`failed`, includes only the exception type, and preserves any measurements recorded
+before the failure.
+
+The transcription checkpoint contract remains authoritative for recovery. Completed
+segments are checkpointed before they are considered complete, so a later
+`--resume JOB_ID` benchmark measures the resumed attempt without redefining resume
+semantics.
+
+A hard process kill, power loss, kernel termination, or machine crash cannot execute
+benchmark-finalization code, so no final benchmark report is promised for those
+failures. Durable transcription checkpoints remain the recovery mechanism. A future
+job-lifecycle layer can persist progress observations incrementally if real-world
+evidence justifies that additional write path.
+
+## How calibration should be tested
+
+Calibration needs three different evidence layers. They answer different questions
+and should not be collapsed into one CI number.
+
+### 1. Deterministic unit and contract tests
+
+These validate the measurement system itself:
+
+- ordinary transcription uses a no-op observer and retains its existing semantics;
+- repeated stage measurements aggregate correctly;
+- failed stages are recorded without swallowing the original error;
+- benchmark reports omit sensitive paths and transcript content;
+- interruption and failure produce partial reports;
+- process-tree sampling tolerates disappearing child processes;
+- resume continues to use the checkpointed execution contract; and
+- report/schema validation fails closed on invalid values.
+
+These tests should remain deterministic and fast.
+
+### 2. Cross-platform CI
+
+Linux, macOS, and Windows GitHub Actions runners should execute source tests, build
+the distribution, and exercise the clean-wheel contract. CI is useful for proving
+that psutil sampling, packaging, observer injection, file handling, and CLI behavior
+work on each supported operating system.
+
+Hosted-runner timing is **not calibration truth**. Runner generations, neighboring
+workloads, virtualization, CPU frequency policy, caches, and GitHub infrastructure
+change outside EchoFlow's control. CI timing can detect catastrophic regressions,
+but product resource heuristics should not be fitted to a single hosted-runner
+measurement.
+
+### 3. Representative real-device runs
+
+The planner should eventually be calibrated from repeated runs on hardware people
+actually own. A useful initial matrix is:
+
+- an 8 GB Windows consumer machine;
+- a 16 GB commodity Windows or Linux machine;
+- an Apple Silicon Mac; and
+- a larger 32/64 GB workstation for comparison.
+
+For comparisons, keep the input bytes, EchoFlow version, engine/model revision,
+profile/strategy, and relevant configuration identical. Record whether the model was
+already cached. Run each condition multiple times and compare medians and spread,
+not a single fastest result. Cold-cache/model-download behavior should be measured
+separately from warm local inference.
+
+Thermal throttling, battery/power mode, other active applications, storage speed,
+and operating-system updates are legitimate parts of real consumer behavior. They
+should be recorded as experimental context when intentionally contributed, not
+silently inferred or uploaded by EchoFlow.
+
+## How the evidence should change the planner
+
+The first purpose of this harness is **measurement, not self-tuning**. Do not make a
+single benchmark overwrite the planner's conservative resource constants.
+
+Once a sufficient matrix exists, compare predicted and observed peak memory,
+real-time factor, model initialization, decode cost, checkpoint cost, and segment
+processing across hardware classes. Only then should a separate change propose
+calibrated constants, safety margins, hardware classes, or privacy-safe local
+calibration behavior.
+
+This separation keeps the evidence auditable: the benchmark says what happened; a
+later policy change explains how those observations alter admission and strategy
+selection.

--- a/src/echoflow/app/app_container.py
+++ b/src/echoflow/app/app_container.py
@@ -1,5 +1,6 @@
 from dependency_injector import containers, providers
 
+from echoflow.benchmarking.runner import BenchmarkRunner
 from echoflow.core.config import AppConfig
 from echoflow.core.file_manager_facade import FileManagerFacade
 from echoflow.core.health_check import HealthCheck
@@ -130,6 +131,11 @@ class AppContainer(containers.DeclarativeContainer):
         transcript_assembler=transcript_assembler,
         checkpoint_store=checkpoint_store,
         logger=logger,
+    )
+    benchmark_runner = providers.Factory(
+        BenchmarkRunner,
+        file_manager=file_manager,
+        workspace_service=workspace_service,
     )
     health_check = providers.Factory(
         _create_health_check, config=config, runner_inspector=runner_inspector

--- a/src/echoflow/benchmarking/__init__.py
+++ b/src/echoflow/benchmarking/__init__.py
@@ -1,0 +1,1 @@
+"""Empirical, local-only calibration support for EchoFlow execution."""

--- a/src/echoflow/benchmarking/__main__.py
+++ b/src/echoflow/benchmarking/__main__.py
@@ -1,5 +1,4 @@
 from echoflow.benchmarking.cli import main
 
-
 if __name__ == "__main__":
     main()

--- a/src/echoflow/benchmarking/__main__.py
+++ b/src/echoflow/benchmarking/__main__.py
@@ -1,0 +1,5 @@
+from echoflow.benchmarking.cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/src/echoflow/benchmarking/cli.py
+++ b/src/echoflow/benchmarking/cli.py
@@ -1,0 +1,247 @@
+import json
+from pathlib import Path
+from time import perf_counter
+from typing import Annotated
+
+import typer
+from pydantic import ValidationError
+from rich.console import Console
+from rich.table import Table
+
+from echoflow.app.app_container import AppContainer
+from echoflow.benchmarking.models import BenchmarkRunError, BenchmarkRunResult
+from echoflow.core.config import AppConfig
+from echoflow.core.errors import EchoFlowError
+from echoflow.core.measurements import ExecutionObserver
+from echoflow.runner.models import ProcessingProfile
+from echoflow.transcription.models import (
+    TranscriptionExecutionResult,
+    TranscriptionJobPlan,
+)
+from echoflow.workspace.models import JobId
+
+
+app = typer.Typer(
+    name="echoflow-benchmark",
+    help="Run privacy-minimized empirical EchoFlow calibration.",
+    invoke_without_command=True,
+)
+
+
+def _container(config_file: Path | None) -> AppContainer:
+    container = AppContainer()
+    if config_file is not None:
+        container.config.override(AppConfig.load(config_file))
+    return container
+
+
+def _plan(
+    container: AppContainer,
+    input_path: Path,
+    *,
+    output_dir: Path | None,
+    profile: ProcessingProfile | None,
+    strategy: str | None,
+    resume: str | None,
+) -> TranscriptionJobPlan:
+    planner = container.transcription_planner()
+    if resume is not None:
+        if profile is not None or strategy is not None:
+            raise typer.BadParameter(
+                "--resume restores the original profile and strategy; "
+                "do not override them"
+            )
+        return planner.plan_resume(
+            input_path,
+            output_dir=output_dir,
+            job_id=JobId(resume),
+        )
+
+    selected_profile = profile or container.config().PROCESSING_PROFILE
+    if strategy is None:
+        return planner.plan(
+            input_path,
+            output_dir=output_dir,
+            profile=selected_profile,
+        )
+    return planner.plan(
+        input_path,
+        output_dir=output_dir,
+        profile=selected_profile,
+        strategy_id=strategy,
+    )
+
+
+def _execute(
+    container: AppContainer,
+    plan: TranscriptionJobPlan,
+    observer: ExecutionObserver,
+    *,
+    allow_model_download: bool,
+    resume: bool,
+) -> TranscriptionExecutionResult:
+    executor = container.transcription_executor(observer=observer)
+    if resume:
+        return executor.execute(
+            plan,
+            allow_model_download=allow_model_download,
+            resume=True,
+        )
+    return executor.execute(plan, allow_model_download=allow_model_download)
+
+
+def _format_bytes(value: int) -> str:
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    amount = float(value)
+    for unit in units[:-1]:
+        if amount < 1024:
+            return f"{amount:.1f} {unit}"
+        amount /= 1024
+    return f"{amount:.1f} {units[-1]}"
+
+
+def _render(result: BenchmarkRunResult) -> None:
+    report = result.report
+    table = Table(title="EchoFlow empirical benchmark")
+    table.add_column("Measurement")
+    table.add_column("Value")
+    rows = (
+        ("Status", report.status.value),
+        ("Job ID", report.job_id),
+        ("Real-time factor", f"{report.real_time_factor:.3f}x"),
+        ("Total wall time", f"{report.total_wall_seconds:.3f} seconds"),
+        ("Planning", f"{report.planning_wall_seconds:.3f} seconds"),
+        ("Execution", f"{report.execution_wall_seconds:.3f} seconds"),
+        ("Peak process-tree RSS", _format_bytes(report.process_tree.peak_rss_bytes)),
+        ("Peak sampled CPU", f"{report.process_tree.peak_cpu_percent:.1f}%"),
+        ("Benchmark report", str(result.report_path)),
+        ("Transcript artifact", str(result.transcription.artifact.path)),
+    )
+    for name, value in rows:
+        table.add_row(name, value)
+    Console().print(table)
+
+
+@app.callback()
+def benchmark(
+    input_path: Annotated[
+        Path,
+        typer.Argument(
+            metavar="INPUT",
+            help="Local audio-bearing recording to benchmark with real transcription.",
+        ),
+    ],
+    config_file: Annotated[
+        Path | None,
+        typer.Option(
+            "--config",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            resolve_path=True,
+            help="Explicit EchoFlow dotenv configuration file.",
+        ),
+    ] = None,
+    allow_model_download: Annotated[
+        bool,
+        typer.Option(
+            "--allow-model-download",
+            help="Authorize retrieval of the selected model if absent.",
+        ),
+    ] = False,
+    output_dir: Annotated[
+        Path | None,
+        typer.Option(
+            help="Consumer directory for transcript and benchmark artifacts.",
+            file_okay=False,
+            resolve_path=True,
+        ),
+    ] = None,
+    profile: Annotated[
+        ProcessingProfile | None,
+        typer.Option(help="Override the configured processing profile."),
+    ] = None,
+    strategy: Annotated[
+        str | None,
+        typer.Option(help="Explicit safe strategy ID from `echoflow strategies`."),
+    ] = None,
+    resume: Annotated[
+        str | None,
+        typer.Option(
+            "--resume",
+            metavar="JOB_ID",
+            help="Measure a validated resume of an interrupted job.",
+        ),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit the benchmark result as JSON."),
+    ] = False,
+) -> None:
+    """Run a local transcription and persist privacy-minimized empirical metrics."""
+    try:
+        container = _container(config_file)
+        planning_started = perf_counter()
+        plan = _plan(
+            container,
+            input_path,
+            output_dir=output_dir,
+            profile=profile,
+            strategy=strategy,
+            resume=resume,
+        )
+        planning_wall_seconds = perf_counter() - planning_started
+        if resume is None:
+            typer.echo(f"EchoFlow job ID: {plan.job.job_id.value}", err=True)
+        result = container.benchmark_runner().run(
+            plan,
+            execute=lambda observer: _execute(
+                container,
+                plan,
+                observer,
+                allow_model_download=allow_model_download,
+                resume=resume is not None,
+            ),
+            resume=resume is not None,
+            planning_wall_seconds=planning_wall_seconds,
+        )
+    except typer.BadParameter:
+        raise
+    except BenchmarkRunError as exc:
+        typer.echo(f"EchoFlow benchmark report: {exc.report_path}", err=True)
+        if isinstance(exc.cause, KeyboardInterrupt):
+            typer.echo(
+                "EchoFlow benchmark interrupted; completed checkpoints were retained.",
+                err=True,
+            )
+            raise typer.Exit(code=130) from None
+        if isinstance(exc.cause, EchoFlowError):
+            typer.echo(exc.cause.public_message, err=True)
+            raise typer.Exit(code=exc.cause.exit_code) from None
+        typer.echo(
+            f"EchoFlow benchmark failed internally ({type(exc.cause).__name__})",
+            err=True,
+        )
+        raise typer.Exit(code=3) from None
+    except EchoFlowError as exc:
+        typer.echo(exc.public_message, err=True)
+        raise typer.Exit(code=exc.exit_code) from None
+    except ValidationError:
+        typer.echo("Invalid EchoFlow configuration", err=True)
+        raise typer.Exit(code=1) from None
+    except Exception as exc:
+        typer.echo(
+            f"EchoFlow benchmark failed internally ({type(exc).__name__})",
+            err=True,
+        )
+        raise typer.Exit(code=3) from None
+
+    if json_output:
+        typer.echo(json.dumps(result.to_dict(), sort_keys=True))
+    else:
+        _render(result)
+
+
+def main() -> None:
+    app()

--- a/src/echoflow/benchmarking/cli.py
+++ b/src/echoflow/benchmarking/cli.py
@@ -9,7 +9,10 @@ from rich.console import Console
 from rich.table import Table
 
 from echoflow.app.app_container import AppContainer
-from echoflow.benchmarking.models import BenchmarkRunError, BenchmarkRunResult
+from echoflow.benchmarking.models import (
+    BenchmarkRunError,
+    BenchmarkRunResult,
+)
 from echoflow.core.config import AppConfig
 from echoflow.core.errors import EchoFlowError
 from echoflow.core.measurements import ExecutionObserver
@@ -20,11 +23,9 @@ from echoflow.transcription.models import (
 )
 from echoflow.workspace.models import JobId
 
-
 app = typer.Typer(
     name="echoflow-benchmark",
     help="Run privacy-minimized empirical EchoFlow calibration.",
-    invoke_without_command=True,
 )
 
 
@@ -122,7 +123,7 @@ def _render(result: BenchmarkRunResult) -> None:
     Console().print(table)
 
 
-@app.callback()
+@app.command()
 def benchmark(
     input_path: Annotated[
         Path,

--- a/src/echoflow/benchmarking/models.py
+++ b/src/echoflow/benchmarking/models.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from echoflow.core.measurements import StageMeasurement
+from echoflow.transcription.models import (
+    TranscriptionExecutionResult,
+    TranscriptionJobPlan,
+    TranscriptSource,
+)
+
+from .resources import ProcessTreeObservation
+
+
+class BenchmarkStatus(StrEnum):
+    COMPLETED = "completed"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkReport:
+    """Path-minimized benchmark evidence for one execution attempt."""
+
+    benchmark_id: str
+    job_id: str
+    status: BenchmarkStatus
+    resume: bool
+    echoflow_version: str
+    python_version: str
+    source: TranscriptSource
+    plan: TranscriptionJobPlan
+    planning_wall_seconds: float
+    execution_wall_seconds: float
+    process_tree: ProcessTreeObservation
+    stages: tuple[StageMeasurement, ...]
+    values: dict[str, int | float]
+    canonical_artifact_bytes: int | None = None
+    error_type: str | None = None
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("unsupported benchmark schema version")
+        if not self.benchmark_id or not self.job_id:
+            raise ValueError("benchmark and job IDs cannot be empty")
+        if self.planning_wall_seconds < 0 or self.execution_wall_seconds < 0:
+            raise ValueError("benchmark wall-clock durations cannot be negative")
+        if self.canonical_artifact_bytes is not None and self.canonical_artifact_bytes < 0:
+            raise ValueError("canonical_artifact_bytes cannot be negative")
+        if self.status is BenchmarkStatus.COMPLETED and self.error_type is not None:
+            raise ValueError("completed benchmark cannot carry an error type")
+        if self.status is not BenchmarkStatus.COMPLETED and not self.error_type:
+            raise ValueError("incomplete benchmark must carry an error type")
+
+    @property
+    def total_wall_seconds(self) -> float:
+        return self.planning_wall_seconds + self.execution_wall_seconds
+
+    @property
+    def real_time_factor(self) -> float:
+        return self.total_wall_seconds / self.source.duration_seconds
+
+    @property
+    def execution_real_time_factor(self) -> float:
+        return self.execution_wall_seconds / self.source.duration_seconds
+
+    @property
+    def peak_rss_to_estimate_ratio(self) -> float | None:
+        estimate = self.plan.resources.estimated_peak_memory_bytes
+        if estimate <= 0:
+            return None
+        return self.process_tree.peak_rss_bytes / estimate
+
+    def to_dict(self) -> dict[str, object]:
+        engine = self.plan.engine
+        return {
+            "schema_version": self.schema_version,
+            "benchmark_id": self.benchmark_id,
+            "job_id": self.job_id,
+            "status": self.status.value,
+            "resume": self.resume,
+            "environment": {
+                "echoflow_version": self.echoflow_version,
+                "python_version": self.python_version,
+            },
+            "source": self.source.to_dict(),
+            "runner": self.plan.runner.to_dict(),
+            "policy": self.plan.policy.to_dict(),
+            "execution_contract": {
+                "engine": {
+                    "engine": engine.engine,
+                    "model": engine.model,
+                    "device": engine.device,
+                    "compute_type": engine.compute_type,
+                    "cpu_threads": engine.cpu_threads,
+                    "beam_size": engine.beam_size,
+                    "language": engine.language,
+                    "model_revision": engine.model_revision,
+                },
+                "decoder": self.plan.decoder.to_dict(),
+                "segmentation": self.plan.segmentation.to_dict(),
+                "resource_estimate": self.plan.resources.to_dict(),
+            },
+            "observed": {
+                "planning_wall_seconds": self.planning_wall_seconds,
+                "execution_wall_seconds": self.execution_wall_seconds,
+                "total_wall_seconds": self.total_wall_seconds,
+                "real_time_factor": self.real_time_factor,
+                "execution_real_time_factor": self.execution_real_time_factor,
+                "process_tree": self.process_tree.to_dict(),
+                "stages": [stage.to_dict() for stage in self.stages],
+                "values": dict(sorted(self.values.items())),
+                "canonical_artifact_bytes": self.canonical_artifact_bytes,
+                "peak_rss_to_estimate_ratio": self.peak_rss_to_estimate_ratio,
+            },
+            "error_type": self.error_type,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkRunResult:
+    report_path: Path
+    report: BenchmarkReport
+    transcription: TranscriptionExecutionResult
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "benchmark_report_path": str(self.report_path),
+            "transcript_artifact_path": str(self.transcription.artifact.path),
+            "report": self.report.to_dict(),
+        }
+
+
+class BenchmarkRunError(Exception):
+    """Execution failed or was interrupted after a partial report was persisted."""
+
+    def __init__(
+        self,
+        report_path: Path,
+        status: BenchmarkStatus,
+        cause: BaseException,
+    ):
+        self.report_path = report_path
+        self.status = status
+        self.cause = cause
+        super().__init__(f"benchmark {status.value}")

--- a/src/echoflow/benchmarking/models.py
+++ b/src/echoflow/benchmarking/models.py
@@ -48,7 +48,10 @@ class BenchmarkReport:
             raise ValueError("benchmark and job IDs cannot be empty")
         if self.planning_wall_seconds < 0 or self.execution_wall_seconds < 0:
             raise ValueError("benchmark wall-clock durations cannot be negative")
-        if self.canonical_artifact_bytes is not None and self.canonical_artifact_bytes < 0:
+        if (
+            self.canonical_artifact_bytes is not None
+            and self.canonical_artifact_bytes < 0
+        ):
             raise ValueError("canonical_artifact_bytes cannot be negative")
         if self.status is BenchmarkStatus.COMPLETED and self.error_type is not None:
             raise ValueError("completed benchmark cannot carry an error type")

--- a/src/echoflow/benchmarking/resources.py
+++ b/src/echoflow/benchmarking/resources.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Event, Thread
+
+import psutil
+
+_DEFAULT_SAMPLE_INTERVAL_SECONDS = 0.25
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessTreeObservation:
+    """Sampled resource use for the EchoFlow process and current descendants."""
+
+    sample_interval_seconds: float
+    sample_count: int
+    baseline_rss_bytes: int
+    peak_rss_bytes: int
+    mean_rss_bytes: float
+    peak_cpu_percent: float
+    mean_cpu_percent: float
+
+    @property
+    def peak_incremental_rss_bytes(self) -> int:
+        return max(0, self.peak_rss_bytes - self.baseline_rss_bytes)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "sample_interval_seconds": self.sample_interval_seconds,
+            "sample_count": self.sample_count,
+            "baseline_rss_bytes": self.baseline_rss_bytes,
+            "peak_rss_bytes": self.peak_rss_bytes,
+            "peak_incremental_rss_bytes": self.peak_incremental_rss_bytes,
+            "mean_rss_bytes": self.mean_rss_bytes,
+            "peak_cpu_percent": self.peak_cpu_percent,
+            "mean_cpu_percent": self.mean_cpu_percent,
+            "cpu_percent_basis": "process_tree_sum",
+            "rss_basis": "process_tree_rss_sum",
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _Sample:
+    rss_bytes: int
+    cpu_percent: float
+
+
+class ProcessTreeSampler:
+    """Periodically sample the current process tree without transmitting data."""
+
+    def __init__(
+        self,
+        sample_interval_seconds: float = _DEFAULT_SAMPLE_INTERVAL_SECONDS,
+        process: psutil.Process | None = None,
+    ):
+        if sample_interval_seconds <= 0:
+            raise ValueError("sample_interval_seconds must be positive")
+        self.sample_interval_seconds = sample_interval_seconds
+        self.process = process or psutil.Process()
+        self._samples: list[_Sample] = []
+        self._stop_event = Event()
+        self._thread: Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("process sampler is already running")
+        self._stop_event.clear()
+        self._prime_cpu()
+        self._append_sample()
+        self._thread = Thread(target=self._run, name="echoflow-benchmark", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> ProcessTreeObservation:
+        if self._thread is None:
+            raise RuntimeError("process sampler is not running")
+        self._stop_event.set()
+        self._thread.join()
+        self._thread = None
+        self._append_sample()
+        return self._observation()
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self.sample_interval_seconds):
+            self._append_sample()
+
+    def _prime_cpu(self) -> None:
+        for process in self._processes():
+            try:
+                process.cpu_percent(interval=None)
+            except psutil.Error:
+                continue
+
+    def _append_sample(self) -> None:
+        rss_bytes = 0
+        cpu_percent = 0.0
+        observed = False
+        for process in self._processes():
+            try:
+                rss_bytes += process.memory_info().rss
+                cpu_percent += max(0.0, process.cpu_percent(interval=None))
+                observed = True
+            except psutil.Error:
+                continue
+        if observed:
+            self._samples.append(_Sample(rss_bytes, cpu_percent))
+
+    def _processes(self) -> list[psutil.Process]:
+        try:
+            return [self.process, *self.process.children(recursive=True)]
+        except psutil.Error:
+            return [self.process]
+
+    def _observation(self) -> ProcessTreeObservation:
+        if not self._samples:
+            return ProcessTreeObservation(
+                sample_interval_seconds=self.sample_interval_seconds,
+                sample_count=0,
+                baseline_rss_bytes=0,
+                peak_rss_bytes=0,
+                mean_rss_bytes=0.0,
+                peak_cpu_percent=0.0,
+                mean_cpu_percent=0.0,
+            )
+        rss_values = [sample.rss_bytes for sample in self._samples]
+        cpu_values = [sample.cpu_percent for sample in self._samples]
+        return ProcessTreeObservation(
+            sample_interval_seconds=self.sample_interval_seconds,
+            sample_count=len(self._samples),
+            baseline_rss_bytes=rss_values[0],
+            peak_rss_bytes=max(rss_values),
+            mean_rss_bytes=sum(rss_values) / len(rss_values),
+            peak_cpu_percent=max(cpu_values),
+            mean_cpu_percent=sum(cpu_values) / len(cpu_values),
+        )

--- a/src/echoflow/benchmarking/runner.py
+++ b/src/echoflow/benchmarking/runner.py
@@ -118,7 +118,9 @@ class BenchmarkRunner:
         if error is not None:
             raise BenchmarkRunError(report_path, status, error) from error
         if result is None:
-            raise RuntimeError("completed benchmark did not produce a transcription result")
+            raise RuntimeError(
+                "completed benchmark did not produce a transcription result"
+            )
         return BenchmarkRunResult(report_path, report, result)
 
     def _reserve_report(self, plan: TranscriptionJobPlan, benchmark_id: str) -> Path:
@@ -129,9 +131,7 @@ class BenchmarkRunner:
         self.file_manager.reserve_file(report_path)
         return report_path
 
-    def _artifact_size(
-        self, result: TranscriptionExecutionResult | None
-    ) -> int | None:
+    def _artifact_size(self, result: TranscriptionExecutionResult | None) -> int | None:
         if result is None or not self.file_manager.file_exists(result.artifact.path):
             return None
         return int(self.file_manager.get_file_metadata(result.artifact.path)["size"])

--- a/src/echoflow/benchmarking/runner.py
+++ b/src/echoflow/benchmarking/runner.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import platform
+from collections.abc import Callable
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from time import perf_counter
+from typing import Protocol
+from uuid import uuid4
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.core.measurements import ExecutionObserver, MeasurementRecorder
+from echoflow.transcription.models import (
+    TranscriptionExecutionResult,
+    TranscriptionJobPlan,
+    TranscriptSource,
+)
+from echoflow.workspace.service import WorkspaceService
+
+from .models import (
+    BenchmarkReport,
+    BenchmarkRunError,
+    BenchmarkRunResult,
+    BenchmarkStatus,
+)
+from .resources import ProcessTreeObservation, ProcessTreeSampler
+
+
+class ResourceSampler(Protocol):
+    def start(self) -> None: ...
+    def stop(self) -> ProcessTreeObservation: ...
+
+
+def _echoflow_version() -> str:
+    try:
+        return version("echoflow")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+def _benchmark_id() -> str:
+    return uuid4().hex
+
+
+class BenchmarkRunner:
+    """Run one real transcription attempt while collecting local benchmark evidence."""
+
+    def __init__(
+        self,
+        *,
+        file_manager: FileManagerFacade,
+        workspace_service: WorkspaceService,
+        sampler_factory: Callable[[], ResourceSampler] = ProcessTreeSampler,
+        clock: Callable[[], float] = perf_counter,
+        id_factory: Callable[[], str] = _benchmark_id,
+        version_factory: Callable[[], str] = _echoflow_version,
+        python_version_factory: Callable[[], str] = platform.python_version,
+    ):
+        self.file_manager = file_manager
+        self.workspace_service = workspace_service
+        self.sampler_factory = sampler_factory
+        self.clock = clock
+        self.id_factory = id_factory
+        self.version_factory = version_factory
+        self.python_version_factory = python_version_factory
+
+    def run(
+        self,
+        plan: TranscriptionJobPlan,
+        *,
+        execute: Callable[[ExecutionObserver], TranscriptionExecutionResult],
+        resume: bool = False,
+        planning_wall_seconds: float = 0.0,
+    ) -> BenchmarkRunResult:
+        if planning_wall_seconds < 0:
+            raise ValueError("planning_wall_seconds cannot be negative")
+        benchmark_id = self.id_factory()
+        report_path = self._reserve_report(plan, benchmark_id)
+        recorder = MeasurementRecorder(clock=self.clock)
+        sampler = self.sampler_factory()
+        started = self.clock()
+        sampler.start()
+
+        result: TranscriptionExecutionResult | None = None
+        error: BaseException | None = None
+        status = BenchmarkStatus.COMPLETED
+        try:
+            result = execute(recorder)
+        except KeyboardInterrupt as exc:
+            status = BenchmarkStatus.INTERRUPTED
+            error = exc
+        except BaseException as exc:
+            status = BenchmarkStatus.FAILED
+            error = exc
+
+        process_tree = sampler.stop()
+        execution_wall_seconds = max(0.0, self.clock() - started)
+        report = BenchmarkReport(
+            benchmark_id=benchmark_id,
+            job_id=plan.job.job_id.value,
+            status=status,
+            resume=resume,
+            echoflow_version=self.version_factory(),
+            python_version=self.python_version_factory(),
+            source=self._source(plan),
+            plan=plan,
+            planning_wall_seconds=planning_wall_seconds,
+            execution_wall_seconds=execution_wall_seconds,
+            process_tree=process_tree,
+            stages=recorder.stages(),
+            values=recorder.values(),
+            canonical_artifact_bytes=self._artifact_size(result),
+            error_type=None if error is None else type(error).__name__,
+        )
+        self._write_report(report_path, report)
+
+        if error is not None:
+            raise BenchmarkRunError(report_path, status, error) from error
+        if result is None:
+            raise RuntimeError("completed benchmark did not produce a transcription result")
+        return BenchmarkRunResult(report_path, report, result)
+
+    def _reserve_report(self, plan: TranscriptionJobPlan, benchmark_id: str) -> Path:
+        self.workspace_service.initialize(plan.job.output_dir)
+        report_path = (
+            plan.job.output_dir / f"echoflow-benchmark-{benchmark_id}.json"
+        ).resolve(strict=False)
+        self.file_manager.reserve_file(report_path)
+        return report_path
+
+    def _artifact_size(
+        self, result: TranscriptionExecutionResult | None
+    ) -> int | None:
+        if result is None or not self.file_manager.file_exists(result.artifact.path):
+            return None
+        return int(self.file_manager.get_file_metadata(result.artifact.path)["size"])
+
+    def _write_report(self, path: Path, report: BenchmarkReport) -> None:
+        document = json.dumps(
+            report.to_dict(),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        self.file_manager.save_file(f"{document}\n".encode(), path)
+
+    @staticmethod
+    def _source(plan: TranscriptionJobPlan) -> TranscriptSource:
+        return TranscriptSource.from_media(plan.media)

--- a/src/echoflow/benchmarking/tests/__init__.py
+++ b/src/echoflow/benchmarking/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the empirical benchmarking subsystem."""

--- a/src/echoflow/benchmarking/tests/test_cli.py
+++ b/src/echoflow/benchmarking/tests/test_cli.py
@@ -28,7 +28,9 @@ class Provider:
 
 class FakeContainer:
     def __init__(self):
-        self.config = Provider(SimpleNamespace(PROCESSING_PROFILE=ProcessingProfile.BALANCED))
+        self.config = Provider(
+            SimpleNamespace(PROCESSING_PROFILE=ProcessingProfile.BALANCED)
+        )
         planner = Mock()
         planner.plan.return_value = transcription_plan()
         planner.plan_resume.return_value = planner.plan.return_value
@@ -41,7 +43,7 @@ class FakeContainer:
         benchmark_runner = Mock()
 
         def run(plan, *, execute, resume=False, planning_wall_seconds=0.0):
-            execution = execute(NoOpExecutionObserver())
+            execute(NoOpExecutionObserver())
             report = SimpleNamespace(
                 status=BenchmarkStatus.COMPLETED,
                 job_id=plan.job.job_id.value,

--- a/src/echoflow/benchmarking/tests/test_cli.py
+++ b/src/echoflow/benchmarking/tests/test_cli.py
@@ -18,8 +18,10 @@ runner = CliRunner()
 class Provider:
     def __init__(self, value):
         self.value = value
+        self.calls = []
 
-    def __call__(self, **_kwargs):
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
         return self.value
 
     def override(self, value):
@@ -87,9 +89,9 @@ def test_fresh_benchmark_plans_executes_with_observer_and_emits_json():
         output_dir=None,
         profile=ProcessingProfile.BALANCED,
     )
-    kwargs = container.transcription_executor.value.call_args.kwargs
-    assert isinstance(kwargs["observer"], NoOpExecutionObserver)
-    container.transcription_executor.value.return_value.execute.assert_called_once_with(
+    observer = container.transcription_executor.calls[-1]["observer"]
+    assert isinstance(observer, NoOpExecutionObserver)
+    container.transcription_executor.value.execute.assert_called_once_with(
         container.transcription_planner().plan.return_value,
         allow_model_download=False,
     )
@@ -107,7 +109,7 @@ def test_resume_uses_authoritative_resume_plan_and_explicit_resume_execution():
     assert result.exit_code == 0
     assert "EchoFlow job ID" not in result.stderr
     container.transcription_planner().plan_resume.assert_called_once()
-    container.transcription_executor.value.return_value.execute.assert_called_once_with(
+    container.transcription_executor.value.execute.assert_called_once_with(
         container.transcription_planner().plan_resume.return_value,
         allow_model_download=False,
         resume=True,

--- a/src/echoflow/benchmarking/tests/test_cli.py
+++ b/src/echoflow/benchmarking/tests/test_cli.py
@@ -1,0 +1,163 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from echoflow.benchmarking.cli import app
+from echoflow.benchmarking.models import BenchmarkRunError, BenchmarkStatus
+from echoflow.core.measurements import NoOpExecutionObserver
+from echoflow.runner.models import ProcessingProfile
+from echoflow.tests.test_cli import transcription_plan
+
+runner = CliRunner()
+
+
+class Provider:
+    def __init__(self, value):
+        self.value = value
+
+    def __call__(self, **_kwargs):
+        return self.value
+
+    def override(self, value):
+        self.value = value
+
+
+class FakeContainer:
+    def __init__(self):
+        self.config = Provider(SimpleNamespace(PROCESSING_PROFILE=ProcessingProfile.BALANCED))
+        planner = Mock()
+        planner.plan.return_value = transcription_plan()
+        planner.plan_resume.return_value = planner.plan.return_value
+        self.transcription_planner = Provider(planner)
+
+        executor = Mock()
+        executor.execute.return_value = Mock()
+        self.transcription_executor = Provider(executor)
+
+        benchmark_runner = Mock()
+
+        def run(plan, *, execute, resume=False, planning_wall_seconds=0.0):
+            execution = execute(NoOpExecutionObserver())
+            report = SimpleNamespace(
+                status=BenchmarkStatus.COMPLETED,
+                job_id=plan.job.job_id.value,
+                real_time_factor=0.5,
+                total_wall_seconds=1.0,
+                planning_wall_seconds=planning_wall_seconds,
+                execution_wall_seconds=0.9,
+                process_tree=SimpleNamespace(
+                    peak_rss_bytes=1024,
+                    peak_cpu_percent=50.0,
+                ),
+            )
+            return SimpleNamespace(
+                report=report,
+                report_path=Path("benchmark.json"),
+                transcription=SimpleNamespace(
+                    artifact=SimpleNamespace(path=Path("transcript.json"))
+                ),
+                to_dict=lambda: {
+                    "benchmark_report_path": "benchmark.json",
+                    "report": {"status": "completed", "resume": resume},
+                },
+            )
+
+        benchmark_runner.run.side_effect = run
+        self.benchmark_runner = Provider(benchmark_runner)
+
+
+def test_fresh_benchmark_plans_executes_with_observer_and_emits_json():
+    container = FakeContainer()
+
+    with patch("echoflow.benchmarking.cli.AppContainer", return_value=container):
+        result = runner.invoke(app, ["recording.wav", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["report"]["status"] == "completed"
+    assert "EchoFlow job ID: job-1" in result.stderr
+    container.transcription_planner().plan.assert_called_once_with(
+        Path("recording.wav"),
+        output_dir=None,
+        profile=ProcessingProfile.BALANCED,
+    )
+    kwargs = container.transcription_executor.value.call_args.kwargs
+    assert isinstance(kwargs["observer"], NoOpExecutionObserver)
+    container.transcription_executor.value.return_value.execute.assert_called_once_with(
+        container.transcription_planner().plan.return_value,
+        allow_model_download=False,
+    )
+
+
+def test_resume_uses_authoritative_resume_plan_and_explicit_resume_execution():
+    container = FakeContainer()
+
+    with patch("echoflow.benchmarking.cli.AppContainer", return_value=container):
+        result = runner.invoke(
+            app,
+            ["recording.wav", "--resume", "job-1", "--json"],
+        )
+
+    assert result.exit_code == 0
+    assert "EchoFlow job ID" not in result.stderr
+    container.transcription_planner().plan_resume.assert_called_once()
+    container.transcription_executor.value.return_value.execute.assert_called_once_with(
+        container.transcription_planner().plan_resume.return_value,
+        allow_model_download=False,
+        resume=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        ["--strategy", "small-cpu-int8"],
+        ["--profile", "accuracy"],
+    ],
+)
+def test_resume_refuses_profile_or_strategy_override(override):
+    container = FakeContainer()
+
+    with patch("echoflow.benchmarking.cli.AppContainer", return_value=container):
+        result = runner.invoke(
+            app,
+            ["recording.wav", "--resume", "job-1", *override],
+        )
+
+    assert result.exit_code == 2
+    assert "restores the original profile and strategy" in result.output
+    container.benchmark_runner().run.assert_not_called()
+
+
+def test_interrupted_benchmark_reports_path_and_exit_130():
+    container = FakeContainer()
+    container.benchmark_runner().run.side_effect = BenchmarkRunError(
+        Path("partial.json"), BenchmarkStatus.INTERRUPTED, KeyboardInterrupt()
+    )
+
+    with patch("echoflow.benchmarking.cli.AppContainer", return_value=container):
+        result = runner.invoke(app, ["recording.wav"])
+
+    assert result.exit_code == 130
+    assert "partial.json" in result.stderr
+    assert "completed checkpoints were retained" in result.stderr
+
+
+def test_internal_failure_reports_type_without_secret_exception_message():
+    container = FakeContainer()
+    container.benchmark_runner().run.side_effect = BenchmarkRunError(
+        Path("partial.json"),
+        BenchmarkStatus.FAILED,
+        RuntimeError("participant-secret-name"),
+    )
+
+    with patch("echoflow.benchmarking.cli.AppContainer", return_value=container):
+        result = runner.invoke(app, ["recording.wav"])
+
+    assert result.exit_code == 3
+    assert "RuntimeError" in result.stderr
+    assert "participant-secret-name" not in result.output

--- a/src/echoflow/benchmarking/tests/test_resources.py
+++ b/src/echoflow/benchmarking/tests/test_resources.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+
+import psutil
+import pytest
+
+from echoflow.benchmarking.resources import ProcessTreeSampler
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        rss: int,
+        cpu_values: list[float],
+        children: list["FakeProcess"] | None = None,
+        *,
+        fail_children: bool = False,
+        fail_sample: bool = False,
+    ) -> None:
+        self.rss = rss
+        self.cpu_values = list(cpu_values)
+        self._children = children or []
+        self.fail_children = fail_children
+        self.fail_sample = fail_sample
+
+    def children(self, *, recursive: bool) -> list["FakeProcess"]:
+        assert recursive is True
+        if self.fail_children:
+            raise psutil.AccessDenied(pid=1)
+        return self._children
+
+    def memory_info(self):
+        if self.fail_sample:
+            raise psutil.NoSuchProcess(pid=2)
+        return SimpleNamespace(rss=self.rss)
+
+    def cpu_percent(self, interval=None) -> float:
+        assert interval is None
+        if self.fail_sample:
+            raise psutil.NoSuchProcess(pid=2)
+        if self.cpu_values:
+            return self.cpu_values.pop(0)
+        return 0.0
+
+
+def test_sampler_collects_process_tree_rss_and_cpu_without_external_io():
+    child = FakeProcess(300, [0.0, 25.0, 30.0])
+    root = FakeProcess(700, [0.0, 50.0, 60.0], [child])
+    sampler = ProcessTreeSampler(sample_interval_seconds=10.0, process=root)
+
+    sampler.start()
+    observation = sampler.stop()
+
+    assert observation.sample_count == 2
+    assert observation.baseline_rss_bytes == 1000
+    assert observation.peak_rss_bytes == 1000
+    assert observation.peak_incremental_rss_bytes == 0
+    assert observation.mean_rss_bytes == 1000
+    assert observation.peak_cpu_percent == 90.0
+    assert observation.mean_cpu_percent == 82.5
+    assert observation.to_dict()["cpu_percent_basis"] == "process_tree_sum"
+
+
+def test_sampler_ignores_disappearing_children_and_child_enumeration_failure():
+    disappearing = FakeProcess(100, [0.0], fail_sample=True)
+    root = FakeProcess(500, [0.0, 10.0, 20.0], [disappearing])
+    sampler = ProcessTreeSampler(sample_interval_seconds=10.0, process=root)
+
+    sampler.start()
+    observation = sampler.stop()
+
+    assert observation.peak_rss_bytes == 500
+
+    root.fail_children = True
+    sampler = ProcessTreeSampler(sample_interval_seconds=10.0, process=root)
+    sampler.start()
+    fallback = sampler.stop()
+    assert fallback.peak_rss_bytes == 500
+
+
+def test_sampler_state_and_interval_are_validated():
+    with pytest.raises(ValueError, match="positive"):
+        ProcessTreeSampler(sample_interval_seconds=0)
+
+    root = FakeProcess(1, [0.0, 0.0, 0.0])
+    sampler = ProcessTreeSampler(sample_interval_seconds=10.0, process=root)
+    with pytest.raises(RuntimeError, match="not running"):
+        sampler.stop()
+
+    sampler.start()
+    with pytest.raises(RuntimeError, match="already running"):
+        sampler.start()
+    sampler.stop()

--- a/src/echoflow/benchmarking/tests/test_runner.py
+++ b/src/echoflow/benchmarking/tests/test_runner.py
@@ -1,0 +1,268 @@
+import json
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from echoflow.benchmarking.models import BenchmarkRunError, BenchmarkStatus
+from echoflow.benchmarking.resources import ProcessTreeObservation
+from echoflow.benchmarking.runner import BenchmarkRunner, _echoflow_version
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.core.performance_tracker import PerformanceTracker
+from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
+from echoflow.runner.models import (
+    ExecutionPolicy,
+    ModelTier,
+    ProcessingProfile,
+    RunnerResources,
+)
+from echoflow.transcription.models import (
+    CanonicalTranscript,
+    CpuEngineConfiguration,
+    DecodeConfiguration,
+    DecodeStrategy,
+    EngineProvenance,
+    RecognizedSegment,
+    ResourceEstimate,
+    TranscriptionExecutionResult,
+    TranscriptionJobPlan,
+    TranscriptSource,
+)
+from echoflow.workspace.models import Artifact, ArtifactKind, Job, JobId, WorkspacePaths
+from echoflow.workspace.service import WorkspaceService
+
+MIB = 1024**2
+GIB = 1024**3
+
+
+class StepClock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        self.value += 1.0
+        return self.value
+
+
+class FakeSampler:
+    def __init__(self) -> None:
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> ProcessTreeObservation:
+        assert self.started
+        return ProcessTreeObservation(
+            sample_interval_seconds=0.25,
+            sample_count=4,
+            baseline_rss_bytes=100 * MIB,
+            peak_rss_bytes=500 * MIB,
+            mean_rss_bytes=300 * MIB,
+            peak_cpu_percent=250.0,
+            mean_cpu_percent=150.0,
+        )
+
+
+def _plan(tmp_path: Path) -> tuple[TranscriptionJobPlan, WorkspacePaths]:
+    source = tmp_path / "participant-secret-name.wav"
+    source.write_bytes(b"private-audio")
+    paths = WorkspacePaths(
+        tmp_path / "state",
+        tmp_path / "cache",
+        tmp_path / "cache" / "models",
+        tmp_path / "output",
+    )
+    job = Job(JobId("job-1"), source, paths.jobs_dir / "job-1", paths.output_dir)
+    media = MediaInfo(
+        InputIdentity(
+            source.resolve(),
+            source.stat().st_size,
+            source.stat().st_mtime_ns,
+            "a" * 64,
+        ),
+        "wav",
+        10.0,
+        (MediaStream(0, StreamKind.AUDIO, "pcm_s16le", 10.0, 16_000, 1),),
+        0,
+    )
+    runner = RunnerResources(
+        platform="TestOS",
+        machine="x86_64",
+        logical_cpus=8,
+        physical_cpus=4,
+        affinity_cpus=4,
+        cpu_quota_cores=None,
+        effective_cpus=4,
+        memory_total_bytes=8 * GIB,
+        memory_available_bytes=6 * GIB,
+        memory_limit_bytes=None,
+        effective_memory_available_bytes=6 * GIB,
+    )
+    policy = ExecutionPolicy(
+        ProcessingProfile.BALANCED,
+        False,
+        4,
+        4 * GIB,
+        ModelTier.STANDARD,
+    )
+    engine = CpuEngineConfiguration(
+        "faster-whisper",
+        "small",
+        "cpu",
+        "int8",
+        4,
+        5,
+        None,
+        paths.model_dir / "faster-whisper" / "small",
+        "revision-1",
+    )
+    artifact = Artifact(
+        job.job_id,
+        ArtifactKind.CANONICAL_JSON,
+        paths.output_dir / "participant-secret-name.json",
+    )
+    estimate = ResourceEstimate(
+        private_workspace_bytes=16 * MIB,
+        public_output_bytes=64 * 1024,
+        model_cache_bytes=750 * MIB,
+        estimated_peak_memory_bytes=2_304 * MIB,
+        memory_budget_bytes=4 * GIB,
+        fits_memory_budget=True,
+    )
+    return (
+        TranscriptionJobPlan(
+            job=job,
+            artifact=artifact,
+            media=media,
+            runner=runner,
+            policy=policy,
+            engine=engine,
+            decoder=DecodeConfiguration(
+                DecodeStrategy.DIRECT,
+                "pcm_s16le",
+                16_000,
+                1,
+            ),
+            resources=estimate,
+            warnings=("paths_are_unreserved",),
+        ),
+        paths,
+    )
+
+
+def _result(plan: TranscriptionJobPlan, artifact: Artifact) -> TranscriptionExecutionResult:
+    transcript = CanonicalTranscript(
+        job_id=plan.job.job_id.value,
+        source=TranscriptSource.from_media(plan.media),
+        profile=plan.policy.profile,
+        provisional=plan.policy.provisional,
+        decode_strategy=plan.decoder.strategy,
+        engine=EngineProvenance.from_engine(plan.engine, "1.2.1"),
+        detected_language="en",
+        language_probability=0.99,
+        segments=(RecognizedSegment(0, 0.0, 10.0, "Synthetic transcript."),),
+    )
+    return TranscriptionExecutionResult(plan.job, artifact, transcript)
+
+
+def _runner(
+    paths: WorkspacePaths,
+) -> tuple[BenchmarkRunner, FileManagerFacade, WorkspaceService]:
+    facade = FileManagerFacade(LocalFileManager(), Mock(), PerformanceTracker())
+    workspace = WorkspaceService(paths, facade, id_factory=lambda: "unused")
+    runner = BenchmarkRunner(
+        file_manager=facade,
+        workspace_service=workspace,
+        sampler_factory=FakeSampler,
+        clock=StepClock(),
+        id_factory=lambda: "benchmark-1",
+        version_factory=lambda: "0.1.0",
+        python_version_factory=lambda: "3.12.0",
+    )
+    return runner, facade, workspace
+
+
+def test_completed_run_persists_path_minimized_extensible_report(tmp_path):
+    plan, paths = _plan(tmp_path)
+    runner, facade, workspace = _runner(paths)
+
+    def execute(observer):
+        job = workspace.create_job(
+            plan.job.input_path,
+            output_dir=plan.job.output_dir,
+            job_id=plan.job.job_id,
+        )
+        artifact = workspace.reserve_artifact(job, ArtifactKind.CANONICAL_JSON)
+        with observer.span("segment.transcribe"):
+            observer.record_value("segments.total", 1)
+            observer.record_value("segments.completed", 1)
+        facade.save_file(b'{"transcript":true}\n', artifact.path)
+        return _result(plan, artifact)
+
+    result = runner.run(plan, execute=execute, planning_wall_seconds=0.5)
+
+    assert result.report.status is BenchmarkStatus.COMPLETED
+    assert result.report.source.sha256 == "a" * 64
+    assert result.report.process_tree.peak_rss_bytes == 500 * MIB
+    assert result.report.canonical_artifact_bytes == len(b'{"transcript":true}\n')
+    assert result.report.values == {"segments.completed": 1, "segments.total": 1}
+    assert result.report.stages[0].name == "segment.transcribe"
+    assert result.report.to_dict()["execution_contract"]["engine"]["model"] == "small"
+
+    serialized = result.report_path.read_text()
+    assert str(plan.job.input_path) not in serialized
+    assert plan.job.input_path.name not in serialized
+    assert str(plan.engine.model_cache_path) not in serialized
+    assert "model_cache_path" not in serialized
+    assert json.loads(serialized)["source"]["sha256"] == "a" * 64
+    assert result.to_dict()["benchmark_report_path"] == str(result.report_path)
+
+
+def test_keyboard_interrupt_persists_partial_report_and_retains_error_type(tmp_path):
+    plan, paths = _plan(tmp_path)
+    runner, _, _ = _runner(paths)
+
+    def execute(observer):
+        with observer.span("segment.transcribe"):
+            observer.record_value("segments.completed", 1)
+            raise KeyboardInterrupt()
+
+    with pytest.raises(BenchmarkRunError) as raised:
+        runner.run(plan, execute=execute)
+
+    error = raised.value
+    assert error.status is BenchmarkStatus.INTERRUPTED
+    document = json.loads(error.report_path.read_text())
+    assert document["status"] == "interrupted"
+    assert document["error_type"] == "KeyboardInterrupt"
+    assert document["observed"]["values"]["segments.completed"] == 1
+    assert document["observed"]["stages"][0]["failed_count"] == 1
+
+
+def test_failed_run_persists_type_without_exception_message(tmp_path):
+    plan, paths = _plan(tmp_path)
+    runner, _, _ = _runner(paths)
+
+    def execute(_observer):
+        raise RuntimeError("private participant name leaked here")
+
+    with pytest.raises(BenchmarkRunError) as raised:
+        runner.run(plan, execute=execute, resume=True)
+
+    document = raised.value.report_path.read_text()
+    parsed = json.loads(document)
+    assert parsed["status"] == "failed"
+    assert parsed["resume"] is True
+    assert parsed["error_type"] == "RuntimeError"
+    assert "private participant name leaked here" not in document
+
+
+def test_uninstalled_package_version_has_safe_fallback():
+    with patch(
+        "echoflow.benchmarking.runner.version",
+        side_effect=PackageNotFoundError("echoflow"),
+    ):
+        assert _echoflow_version() == "0+unknown"

--- a/src/echoflow/benchmarking/tests/test_runner.py
+++ b/src/echoflow/benchmarking/tests/test_runner.py
@@ -153,7 +153,9 @@ def _plan(tmp_path: Path) -> tuple[TranscriptionJobPlan, WorkspacePaths]:
     )
 
 
-def _result(plan: TranscriptionJobPlan, artifact: Artifact) -> TranscriptionExecutionResult:
+def _result(
+    plan: TranscriptionJobPlan, artifact: Artifact
+) -> TranscriptionExecutionResult:
     transcript = CanonicalTranscript(
         job_id=plan.job.job_id.value,
         source=TranscriptSource.from_media(plan.media),

--- a/src/echoflow/core/measurements.py
+++ b/src/echoflow/core/measurements.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass
+from threading import Lock
+from time import perf_counter
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class StageMeasurement:
+    """Aggregate repeated observations of one execution stage."""
+
+    name: str
+    count: int
+    failed_count: int
+    total_seconds: float
+    max_seconds: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "count": self.count,
+            "failed_count": self.failed_count,
+            "total_seconds": self.total_seconds,
+            "max_seconds": self.max_seconds,
+        }
+
+
+class ExecutionObserver(Protocol):
+    """Small measurement seam shared by current and future execution pipelines."""
+
+    def span(self, name: str) -> AbstractContextManager[None]: ...
+    def record_value(self, name: str, value: int | float) -> None: ...
+
+
+class NoOpExecutionObserver:
+    """Default observer for ordinary execution."""
+
+    @contextmanager
+    def span(self, name: str) -> Iterator[None]:
+        del name
+        yield
+
+    def record_value(self, name: str, value: int | float) -> None:
+        del name, value
+
+
+@dataclass(slots=True)
+class _MutableStage:
+    count: int = 0
+    failed_count: int = 0
+    total_seconds: float = 0.0
+    max_seconds: float = 0.0
+
+
+class MeasurementRecorder:
+    """Thread-safe aggregate recorder suitable for sequential or future parallel work."""
+
+    def __init__(self, clock: Callable[[], float] = perf_counter):
+        self.clock = clock
+        self._stages: dict[str, _MutableStage] = {}
+        self._values: dict[str, int | float] = {}
+        self._lock = Lock()
+
+    @contextmanager
+    def span(self, name: str) -> Iterator[None]:
+        started = self.clock()
+        failed = False
+        try:
+            yield
+        except BaseException:
+            failed = True
+            raise
+        finally:
+            duration = max(0.0, self.clock() - started)
+            with self._lock:
+                stage = self._stages.setdefault(name, _MutableStage())
+                stage.count += 1
+                stage.failed_count += int(failed)
+                stage.total_seconds += duration
+                stage.max_seconds = max(stage.max_seconds, duration)
+
+    def record_value(self, name: str, value: int | float) -> None:
+        with self._lock:
+            self._values[name] = value
+
+    def stages(self) -> tuple[StageMeasurement, ...]:
+        with self._lock:
+            return tuple(
+                StageMeasurement(
+                    name=name,
+                    count=stage.count,
+                    failed_count=stage.failed_count,
+                    total_seconds=stage.total_seconds,
+                    max_seconds=stage.max_seconds,
+                )
+                for name, stage in sorted(self._stages.items())
+            )
+
+    def values(self) -> dict[str, int | float]:
+        with self._lock:
+            return dict(sorted(self._values.items()))

--- a/src/echoflow/core/tests/test_measurements.py
+++ b/src/echoflow/core/tests/test_measurements.py
@@ -1,0 +1,48 @@
+import pytest
+
+from echoflow.core.measurements import MeasurementRecorder, NoOpExecutionObserver
+
+
+class StepClock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        self.value += 1.0
+        return self.value
+
+
+def test_noop_observer_preserves_execution_and_accepts_values():
+    observer = NoOpExecutionObserver()
+    with observer.span("decode"):
+        observer.record_value("segments.total", 2)
+
+
+def test_recorder_aggregates_repeated_stages_and_latest_values():
+    recorder = MeasurementRecorder(clock=StepClock())
+
+    with recorder.span("segment.transcribe"):
+        pass
+    with recorder.span("segment.transcribe"):
+        recorder.record_value("segments.completed", 2)
+
+    stage = recorder.stages()[0]
+    assert stage.name == "segment.transcribe"
+    assert stage.count == 2
+    assert stage.failed_count == 0
+    assert stage.total_seconds == 2.0
+    assert stage.max_seconds == 1.0
+    assert recorder.values() == {"segments.completed": 2}
+
+
+def test_recorder_marks_failed_span_without_swallowing_exception():
+    recorder = MeasurementRecorder(clock=StepClock())
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with recorder.span("engine.open"):
+            raise RuntimeError("boom")
+
+    stage = recorder.stages()[0]
+    assert stage.count == 1
+    assert stage.failed_count == 1
+    assert stage.total_seconds == 1.0

--- a/src/echoflow/core/tests/test_measurements.py
+++ b/src/echoflow/core/tests/test_measurements.py
@@ -38,9 +38,8 @@ def test_recorder_aggregates_repeated_stages_and_latest_values():
 def test_recorder_marks_failed_span_without_swallowing_exception():
     recorder = MeasurementRecorder(clock=StepClock())
 
-    with pytest.raises(RuntimeError, match="boom"):
-        with recorder.span("engine.open"):
-            raise RuntimeError("boom")
+    with pytest.raises(RuntimeError, match="boom"), recorder.span("engine.open"):
+        raise RuntimeError("boom")
 
     stage = recorder.stages()[0]
     assert stage.count == 1

--- a/src/echoflow/transcription/executor.py
+++ b/src/echoflow/transcription/executor.py
@@ -5,6 +5,7 @@ from typing import Protocol
 
 from echoflow.core.file_manager_facade import FileManagerFacade
 from echoflow.core.ilogger import ILogger
+from echoflow.core.measurements import ExecutionObserver, NoOpExecutionObserver
 from echoflow.media.errors import InputChangedError
 from echoflow.media.models import MediaInfo
 from echoflow.runner.inspector import RunnerInspector
@@ -162,6 +163,7 @@ class TranscriptionExecutor:
         transcript_assembler: SegmentTranscriptAssembler,
         logger: ILogger,
         checkpoint_store: SegmentCheckpointStore | None = None,
+        observer: ExecutionObserver | None = None,
     ):
         self.media_probe = media_probe
         self.workspace_service = workspace_service
@@ -174,6 +176,7 @@ class TranscriptionExecutor:
         self.transcript_assembler = transcript_assembler
         self.logger = logger
         self.checkpoint_store = checkpoint_store or _NoCheckpointStore()
+        self.observer = observer or NoOpExecutionObserver()
 
     def execute(
         self,
@@ -182,38 +185,38 @@ class TranscriptionExecutor:
         allow_model_download: bool = False,
         resume: bool = False,
     ) -> TranscriptionExecutionResult:
-        self._admit(plan)
-        verified_media = self.media_probe.probe(plan.job.input_path)
+        with self.observer.span("admission.initial"):
+            self._admit(plan)
+        with self.observer.span("media.verify"):
+            verified_media = self.media_probe.probe(plan.job.input_path)
         if verified_media.input != plan.media.input:
             raise InputChangedError(
                 "Input changed between transcription planning and execution"
             )
 
-        if resume:
-            job = self.workspace_service.resume_job(
-                plan.job.input_path,
-                output_dir=plan.job.output_dir,
-                job_id=plan.job.job_id,
+        with self.observer.span("workspace.claim"):
+            job = self._claim_job(plan, resume=resume)
+            artifact = self.workspace_service.reserve_artifact(
+                job, ArtifactKind.CANONICAL_JSON
             )
-        else:
-            job = self.workspace_service.create_job(
-                plan.job.input_path,
-                output_dir=plan.job.output_dir,
-                job_id=plan.job.job_id,
-            )
-        artifact = self.workspace_service.reserve_artifact(
-            job, ArtifactKind.CANONICAL_JSON
-        )
+
         decoded: DecodedAudio | None = None
         try:
-            decoded = self.audio_decoder.decode(
-                plan.media, plan.decoder, job.workspace_dir
-            )
-            windows = self.audio_segmenter.plan(
-                decoded.path, plan.decoder, plan.segmentation
-            )
-            restored = self._checkpoint_state(job, plan, windows, resume=resume)
-            self._admit(plan)
+            with self.observer.span("decode"):
+                decoded = self.audio_decoder.decode(
+                    plan.media, plan.decoder, job.workspace_dir
+                )
+            with self.observer.span("segmentation.plan"):
+                windows = self.audio_segmenter.plan(
+                    decoded.path, plan.decoder, plan.segmentation
+                )
+            self.observer.record_value("segments.total", len(windows))
+            with self.observer.span("checkpoint.prepare"):
+                restored = self._checkpoint_state(job, plan, windows, resume=resume)
+            self.observer.record_value("segments.restored", len(restored.completed))
+            self.observer.record_value("segments.completed", len(restored.completed))
+            with self.observer.span("admission.pre_model"):
+                self._admit(plan)
             engine_result = self._transcribe_segments(
                 plan,
                 decoded,
@@ -222,22 +225,39 @@ class TranscriptionExecutor:
                 restored,
                 allow_model_download=allow_model_download,
             )
-            transcript = self._transcript(plan, engine_result)
-            document = json.dumps(
-                transcript.to_dict(),
-                ensure_ascii=False,
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            self.file_manager.save_file(f"{document}\n".encode(), artifact.path)
-            self._clear_completed_checkpoints(job)
+            with self.observer.span("transcript.canonicalize"):
+                transcript = self._transcript(plan, engine_result)
+                document = json.dumps(
+                    transcript.to_dict(),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            with self.observer.span("artifact.write"):
+                self.file_manager.save_file(f"{document}\n".encode(), artifact.path)
+            with self.observer.span("checkpoint.cleanup"):
+                self._clear_completed_checkpoints(job)
         except BaseException:
             self._release_failed_artifact(artifact)
             raise
         finally:
             if decoded is not None:
-                self.audio_decoder.cleanup(decoded)
+                with self.observer.span("decode.cleanup"):
+                    self.audio_decoder.cleanup(decoded)
         return TranscriptionExecutionResult(job, artifact, transcript)
+
+    def _claim_job(self, plan: TranscriptionJobPlan, *, resume: bool) -> Job:
+        if resume:
+            return self.workspace_service.resume_job(
+                plan.job.input_path,
+                output_dir=plan.job.output_dir,
+                job_id=plan.job.job_id,
+            )
+        return self.workspace_service.create_job(
+            plan.job.input_path,
+            output_dir=plan.job.output_dir,
+            job_id=plan.job.job_id,
+        )
 
     def _checkpoint_state(
         self,
@@ -275,19 +295,15 @@ class TranscriptionExecutor:
                 "transcription_resume_recognition_complete",
                 segment_count=len(windows),
             )
-            return self.transcript_assembler.assemble(results)
+            with self.observer.span("transcript.assemble"):
+                return self.transcript_assembler.assemble(results)
 
         allowed_download = allow_model_download and completed_count == 0
-        if restored.detected_language is None:
-            session = self.transcriber.open_session(
-                plan.engine,
+        with self.observer.span("engine.open"):
+            session = self._open_session(
+                plan,
+                restored,
                 allow_model_download=allowed_download,
-            )
-        else:
-            session = self.transcriber.open_session(
-                plan.engine,
-                allow_model_download=allowed_download,
-                detected_language=restored.detected_language,
             )
         if (
             restored.engine_version is not None
@@ -305,18 +321,23 @@ class TranscriptionExecutor:
                 segment_index=window.index,
                 segment_count=len(windows),
             )
-            materialized = self.audio_segmenter.materialize(
-                decoded.path,
-                window,
-                plan.decoder,
-                job.workspace_dir,
-            )
+            with self.observer.span("segment.materialize"):
+                materialized = self.audio_segmenter.materialize(
+                    decoded.path,
+                    window,
+                    plan.decoder,
+                    job.workspace_dir,
+                )
             try:
-                result = session.transcribe(materialized.path)
+                with self.observer.span("segment.transcribe"):
+                    result = session.transcribe(materialized.path)
             finally:
-                self.audio_segmenter.cleanup(materialized)
-            self.checkpoint_store.save_segment(job, plan, windows, window, result)
+                with self.observer.span("segment.cleanup"):
+                    self.audio_segmenter.cleanup(materialized)
+            with self.observer.span("checkpoint.write"):
+                self.checkpoint_store.save_segment(job, plan, windows, window, result)
             results.append((window, result))
+            self.observer.record_value("segments.completed", len(results))
             job_logger.info(
                 "transcription_segment_completed",
                 segment_id=window.segment_id,
@@ -324,7 +345,26 @@ class TranscriptionExecutor:
                 segment_count=len(windows),
                 checkpointed=True,
             )
-        return self.transcript_assembler.assemble(results)
+        with self.observer.span("transcript.assemble"):
+            return self.transcript_assembler.assemble(results)
+
+    def _open_session(
+        self,
+        plan: TranscriptionJobPlan,
+        restored: RestoredCheckpoint,
+        *,
+        allow_model_download: bool,
+    ) -> TranscriptionSession:
+        if restored.detected_language is None:
+            return self.transcriber.open_session(
+                plan.engine,
+                allow_model_download=allow_model_download,
+            )
+        return self.transcriber.open_session(
+            plan.engine,
+            allow_model_download=allow_model_download,
+            detected_language=restored.detected_language,
+        )
 
     def _clear_completed_checkpoints(self, job: Job) -> None:
         try:


### PR DESCRIPTION
## What changed

- Added a generic execution-observer contract with a no-op default so ordinary transcription keeps the same execution semantics when benchmarking is disabled.
- Instrumented orchestration boundaries including admission, media verification, workspace claim, decode, segmentation planning, checkpoint preparation/writes/cleanup, engine initialization, per-segment materialization/transcription/cleanup, transcript assembly/canonicalization, and artifact publication.
- Repeated stages aggregate count, failure count, total duration, and maximum duration; numeric observations such as total/restored/completed segments remain extensible named values rather than fixed benchmark columns.
- Added a local process-tree sampler using psutil for sampled RSS and CPU usage across EchoFlow and its current child processes.
- Added benchmark report schema v1 with planning/execution/total wall time, end-to-end and execution-only real-time factor, observed-versus-estimated peak-memory ratio, stage aggregates, process-tree resource measurements, execution contract, and successful artifact size.
- Benchmark reports omit source paths, source filenames, model-cache paths, transcript text, and exception messages while retaining source fingerprint/provenance needed for equivalent-run comparison.
- Added an experimental local benchmark command via `python -m echoflow.benchmarking INPUT`, including explicit model-download authorization and validated `--resume JOB_ID` measurement.
- Ctrl+C and ordinary Python-level failures persist a partial benchmark report before exit; durable transcription checkpoints remain the authority for resume. Hard process/system termination is explicitly not claimed to finalize a report.
- Added deterministic tests for stage aggregation, failed spans, process-tree sampling, report privacy, completed/failed/interrupted runs, and fresh/resumed CLI behavior.
- Added `docs/development/benchmarking.md` describing the calibration protocol and the distinction between deterministic tests, cross-platform CI, and repeated representative real-device measurements.

## Why

EchoFlow currently makes deliberately conservative heuristic CPU/memory decisions. Before changing those heuristics or adding heavier capabilities, the project needs an empirical measurement substrate that can survive future engine, diarization, alignment, embedding, GPU, indexing, and lifecycle work without inventing a new metrics system for every feature.

This PR collects evidence; it does **not** make a single benchmark self-tune the planner. A later policy change should explain how a sufficiently broad benchmark matrix changes safety margins or strategy selection.

## Calibration strategy

GitHub Actions is used to prove portability and measurement-contract behavior across Linux, macOS, and Windows. Hosted-runner timing is intentionally not treated as product calibration truth because the hardware, virtualization, neighboring load, frequency policy, and runner generations are outside EchoFlow's control.

Representative calibration should use the same known non-sensitive/synthetic input bytes, EchoFlow version, engine/model revision, profile/strategy, and relevant configuration across real devices. Each condition should be repeated and evaluated using medians/spread, with warm-cache and cold-cache/model-retrieval behavior separated. Initial device classes should include an 8 GB Windows consumer machine, a 16 GB commodity machine, Apple Silicon, and a larger workstation.

## Privacy and durability boundary

Benchmarking has no telemetry and does not upload reports. Reports are ordinary user-owned output JSON. They retain source SHA-256, which can itself be linkable if another party possesses the same recording, so reports from sensitive recordings should not be published casually.

Interruption measurement does not introduce a second resume implementation. The existing segment checkpoint contract remains authoritative; a resumed benchmark is a separate measured attempt of that same validated job contract.

## Validation

CI should run the existing locked dependency audit, Ruff lint/format, strict mypy, Vulture, Radon, branch-aware coverage, native macOS/Windows source suites, distribution builds, and clean-wheel verification. The new deterministic tests exercise benchmark aggregation/privacy/interruption behavior without relying on wall-clock performance thresholds.