### PR TITLE
Add deterministic transcript exports

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Import optional CPU engine
         run: uv run python -c "import faster_whisper; print(faster_whisper.__version__)"
 
+      - name: Install native media tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ffmpeg
+
       - name: Verify native media tools
         run: >-
           uv run python -c "import shutil;
@@ -123,6 +128,14 @@ jobs:
 
       - name: Import optional CPU engine
         run: uv run python -c "import faster_whisper; print(faster_whisper.__version__)"
+
+      - name: Install native media tools (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ffmpeg
+
+      - name: Install native media tools (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ffmpeg --yes --no-progress
 
       - name: Verify native media tools
         run: >-

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Import optional CPU engine
         run: uv run python -c "import faster_whisper; print(faster_whisper.__version__)"
 
+      - name: Verify native media tools
+        run: >-
+          uv run python -c "import shutil;
+          missing=[name for name in ('ffmpeg','ffprobe') if shutil.which(name) is None];
+          assert not missing, f'Missing native media tools: {missing}'"
+
       - name: Check lockfile
         run: uv lock --check
 
@@ -117,6 +123,12 @@ jobs:
 
       - name: Import optional CPU engine
         run: uv run python -c "import faster_whisper; print(faster_whisper.__version__)"
+
+      - name: Verify native media tools
+        run: >-
+          uv run python -c "import shutil;
+          missing=[name for name in ('ffmpeg','ffprobe') if shutil.which(name) is None];
+          assert not missing, f'Missing native media tools: {missing}'"
 
       - name: Run tests
         run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -52,14 +52,19 @@ EchoFlow currently provides a tested application foundation:
 - Durable private per-segment checkpoints and `transcribe INPUT --resume JOB_ID`
   recovery that restores the original execution contract and skips only validated
   completed work.
+- Deterministic opt-in TXT, SRT, and WebVTT views derived from the completed
+  canonical transcript without rerunning speech recognition.
+- Native-media acceptance coverage that exercises real FFprobe, FFmpeg audio
+  extraction/normalization, canonical WAV validation, segmentation, and cleanup on
+  Linux, macOS, and Windows CI.
 - Explicit model-download authorization; execution is local-only by default.
 - Dependency Injector composition for the implemented services.
 - A distribution contract that builds the wheel and verifies a clean install of
   the packaged CLI and transcription extra outside the source checkout on Linux,
   macOS, and Windows CI.
 
-Calibrated performance estimates, GPU strategies, derived TXT/SRT/VTT artifacts,
-and standalone end-user installers are not implemented yet.
+Calibrated performance estimates, GPU strategies, and standalone end-user
+installers are not implemented yet.
 
 ## Requirements and installation
 
@@ -101,8 +106,16 @@ uv run echoflow transcribe /path/to/recording.wav --dry-run --profile screening 
 uv run echoflow transcribe /path/to/recording.wav --strategy small-cpu-int8 --dry-run
 uv run echoflow transcribe /path/to/interview.mp4
 uv run echoflow transcribe /path/to/interview.mp4 --allow-model-download
-uv run echoflow transcribe /path/to/interview.mp4 --resume JOB_ID
+uv run echoflow transcribe /path/to/interview.mp4 --export txt
+uv run echoflow transcribe /path/to/interview.mp4 --export srt --export vtt
+uv run echoflow transcribe /path/to/interview.mp4 --resume JOB_ID --export txt
 ```
+
+TXT, SRT, and WebVTT are derived views of the completed canonical transcript.
+Selecting an export does not invoke the recognition engine again. Canonical JSON
+remains the authoritative artifact with execution provenance; derived files can be
+removed or regenerated without becoming part of checkpoint or recognition state.
+Derived exports are opt-in for now.
 
 Without `--allow-model-download`, EchoFlow asks faster-whisper to use only model
 files already present in EchoFlow's private model cache. The flag authorizes the
@@ -163,7 +176,10 @@ transcription extra, license metadata, packaged license file, and accidental tes
 leakage. It then creates a temporary virtual environment outside the repository,
 disables user-site and source-path imports, installs `echoflow[transcription]` from
 that wheel, and exercises the installed CLI. CI runs that contract on Linux,
-macOS, and Windows.
+macOS, and Windows. CI also provisions FFmpeg/FFprobe explicitly and exercises a
+small generated MP4 through the production probe, decode, WAV, segmentation, and
+cleanup path on all three operating systems; this is a functional media-boundary
+check, not a performance benchmark or real-model accuracy test.
 
 The enforced budgets are:
 
@@ -177,8 +193,8 @@ The enforced budgets are:
 Radon reports complexity and maintainability trends; Ruff provides the hard
 complexity gate. Targeted Poodle mutation runs are used for changed decision
 logic because its broad runner currently has a process-timeout cleanup defect.
-The segmentation, assembly, and checkpoint modules are included in that targeted
-mutation scope.
+The segmentation, assembly, checkpoint, and transcript-export modules are included
+in that targeted mutation scope.
 
 The full feedback ladder and Git bisect procedure are documented in
 [`docs/development/testing-and-bisect.md`](docs/development/testing-and-bisect.md).
@@ -215,6 +231,13 @@ Only one segment is materialized at a time with bounded reads. A faster-whisper
 model is initialized once for the job and reused across each segment. Engine-local
 timestamps are then rebased onto one source-relative timeline and validated before
 the canonical transcript is written.
+
+TXT, SRT, and WebVTT publication occurs only after canonical transcript completion.
+The renderers consume canonical source-relative segment times; application-owned
+segmentation therefore does not reset subtitle clocks. Derived files are rendered
+before path reservation and published through the same atomic local-file boundary.
+If derived publication fails, EchoFlow rolls back that derived set while preserving
+the already-completed canonical JSON artifact.
 
 This sequential contract is intentionally conservative. It creates a stable,
 reproducible unit of completed work without assuming that parallelism improves

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ only_files = [
     "src/echoflow/transcription/backend.py",
     "src/echoflow/transcription/checkpoint.py",
     "src/echoflow/transcription/executor.py",
+    "src/echoflow/transcription/export.py",
     "src/echoflow/transcription/planner.py",
     "src/echoflow/transcription/segmentation.py",
     "src/echoflow/transcription/strategy.py",

--- a/src/echoflow/app/app_container.py
+++ b/src/echoflow/app/app_container.py
@@ -22,6 +22,7 @@ from echoflow.transcription.audio import FfmpegAudioDecoder
 from echoflow.transcription.backend import FasterWhisperTranscriber
 from echoflow.transcription.checkpoint import LocalCheckpointStore
 from echoflow.transcription.executor import TranscriptionExecutor
+from echoflow.transcription.export import TranscriptExporter
 from echoflow.transcription.planner import TranscriptionJobPlanner
 from echoflow.transcription.segmentation import WaveAudioSegmenter
 from echoflow.workspace.models import WorkspacePaths
@@ -131,6 +132,11 @@ class AppContainer(containers.DeclarativeContainer):
         transcript_assembler=transcript_assembler,
         checkpoint_store=checkpoint_store,
         logger=logger,
+    )
+    transcript_exporter = providers.Factory(
+        TranscriptExporter,
+        workspace_service=workspace_service,
+        file_manager=file_manager,
     )
     benchmark_runner = providers.Factory(
         BenchmarkRunner,

--- a/src/echoflow/app/tests/test_export_container.py
+++ b/src/echoflow/app/tests/test_export_container.py
@@ -1,0 +1,13 @@
+from echoflow.app.app_container import AppContainer
+from echoflow.transcription.export import TranscriptExporter
+
+
+def test_container_composes_transcript_exporter_from_public_workspace_graph():
+    container = AppContainer()
+    first = container.transcript_exporter()
+    second = container.transcript_exporter()
+
+    assert isinstance(first, TranscriptExporter)
+    assert first is not second
+    assert first.workspace_service is container.workspace_service()
+    assert first.file_manager is container.file_manager()

--- a/src/echoflow/cli.py
+++ b/src/echoflow/cli.py
@@ -13,6 +13,7 @@ from echoflow.core.config import AppConfig
 from echoflow.core.errors import EchoFlowError
 from echoflow.core.health_check import HealthReport
 from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
+from echoflow.transcription.export import TranscriptExportFormat, TranscriptExportResult
 from echoflow.transcription.models import (
     TranscriptionExecutionResult,
     TranscriptionJobPlan,
@@ -176,13 +177,15 @@ def _render_transcription_plan(plan: TranscriptionJobPlan, console: Console) -> 
 
 
 def _render_transcription_result(
-    result: TranscriptionExecutionResult, console: Console
+    result: TranscriptionExecutionResult,
+    exports: TranscriptExportResult,
+    console: Console,
 ) -> None:
     transcript = result.transcript
     table = Table(title="EchoFlow transcription complete")
     table.add_column("Setting")
     table.add_column("Value")
-    rows = (
+    rows = [
         ("Job ID", result.job.job_id.value),
         ("Canonical output", str(result.artifact.path)),
         ("Profile", transcript.profile.value),
@@ -192,6 +195,10 @@ def _render_transcription_result(
         ("Decode", transcript.decode_strategy.value),
         ("Detected language", transcript.detected_language or "unknown"),
         ("Segments", str(len(transcript.segments))),
+    ]
+    rows.extend(
+        (f"{artifact.kind.value.upper()} export", str(artifact.path))
+        for artifact in exports.artifacts
     )
     for setting, value in rows:
         table.add_row(setting, value)
@@ -373,6 +380,7 @@ def _validate_resume_options(
     resume: str | None,
     profile: ProcessingProfile | None,
     strategy: str | None,
+    export_formats: list[TranscriptExportFormat] | None,
 ) -> None:
     if dry_run and resume is not None:
         raise typer.BadParameter("--resume cannot be combined with --dry-run")
@@ -380,6 +388,8 @@ def _validate_resume_options(
         raise typer.BadParameter(
             "--resume restores the original profile and strategy; do not override them"
         )
+    if dry_run and export_formats:
+        raise typer.BadParameter("--export cannot be combined with --dry-run")
 
 
 def _plan_transcription(
@@ -430,9 +440,24 @@ def _execute_transcription(
     return executor.execute(plan, allow_model_download=allow_model_download)
 
 
+def _publish_exports(
+    container: AppContainer,
+    result: TranscriptionExecutionResult,
+    formats: list[TranscriptExportFormat] | None,
+) -> TranscriptExportResult:
+    if not formats:
+        return TranscriptExportResult(())
+    return container.transcript_exporter().publish(
+        result.job,
+        result.transcript,
+        tuple(formats),
+    )
+
+
 def _render_transcription_command_output(
     plan: TranscriptionJobPlan,
     result: TranscriptionExecutionResult | None,
+    exports: TranscriptExportResult,
     *,
     dry_run: bool,
     json_output: bool,
@@ -445,9 +470,11 @@ def _render_transcription_command_output(
         return
     execution_result = cast("TranscriptionExecutionResult", result)
     if json_output:
-        typer.echo(json.dumps(execution_result.to_dict(), sort_keys=True))
+        document = execution_result.to_dict()
+        document["exports"] = exports.to_dict()
+        typer.echo(json.dumps(document, sort_keys=True))
     else:
-        _render_transcription_result(execution_result, Console())
+        _render_transcription_result(execution_result, exports, Console())
 
 
 @app.command("transcribe")
@@ -497,6 +524,13 @@ def transcribe(
             help="Resume a compatible interrupted job from private local checkpoints.",
         ),
     ] = None,
+    export_formats: Annotated[
+        list[TranscriptExportFormat] | None,
+        typer.Option(
+            "--export",
+            help="Derived transcript format to publish; repeat for TXT, SRT, or VTT.",
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Emit the plan or execution result as JSON."),
@@ -509,6 +543,7 @@ def transcribe(
             resume=resume,
             profile=profile,
             strategy=strategy,
+            export_formats=export_formats,
         )
         container = _container(context)
         plan = _plan_transcription(
@@ -520,6 +555,7 @@ def transcribe(
             resume=resume,
         )
         result = None
+        exports = TranscriptExportResult(())
         if not dry_run:
             if resume is None:
                 typer.echo(f"EchoFlow job ID: {plan.job.job_id.value}", err=True)
@@ -529,6 +565,7 @@ def transcribe(
                 allow_model_download=allow_model_download,
                 resume=resume is not None,
             )
+            exports = _publish_exports(container, result, export_formats)
     except typer.BadParameter:
         raise
     except EchoFlowError as exc:
@@ -547,6 +584,7 @@ def transcribe(
     _render_transcription_command_output(
         plan,
         result,
+        exports,
         dry_run=dry_run,
         json_output=json_output,
     )

--- a/src/echoflow/tests/test_cli_exports.py
+++ b/src/echoflow/tests/test_cli_exports.py
@@ -1,0 +1,87 @@
+import json
+from unittest.mock import Mock, patch
+
+from typer.testing import CliRunner
+
+from echoflow.cli import app
+from echoflow.core.health_check import OverallStatus
+from echoflow.tests.test_cli import FakeContainer, Provider, report
+from echoflow.transcription.export import TranscriptExportResult
+from echoflow.workspace.models import Artifact, ArtifactKind
+
+runner = CliRunner()
+
+
+def _container_with_exporter() -> tuple[FakeContainer, Mock]:
+    container = FakeContainer(report(OverallStatus.HEALTHY))
+    exporter = Mock()
+    result = container.transcription_executor().execute.return_value
+    exporter.publish.return_value = TranscriptExportResult(
+        (
+            Artifact(
+                result.job.job_id,
+                ArtifactKind.TEXT,
+                result.job.output_dir / "input.txt",
+            ),
+            Artifact(
+                result.job.job_id,
+                ArtifactKind.WEBVTT,
+                result.job.output_dir / "input.vtt",
+            ),
+        )
+    )
+    container.transcript_exporter = Provider(exporter)
+    return container, exporter
+
+
+def test_transcribe_can_publish_repeatable_derived_exports():
+    container, exporter = _container_with_exporter()
+    with patch("echoflow.cli.AppContainer", return_value=container):
+        result = runner.invoke(
+            app,
+            [
+                "transcribe",
+                "recording.wav",
+                "--export",
+                "txt",
+                "--export",
+                "vtt",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "TXT export" in result.output
+    assert "VTT export" in result.output
+    execution = container.transcription_executor().execute.return_value
+    exporter.publish.assert_called_once()
+    assert exporter.publish.call_args.args[:2] == (execution.job, execution.transcript)
+    assert tuple(value.value for value in exporter.publish.call_args.args[2]) == (
+        "txt",
+        "vtt",
+    )
+
+
+def test_transcribe_json_includes_derived_artifact_metadata():
+    container, _ = _container_with_exporter()
+    with patch("echoflow.cli.AppContainer", return_value=container):
+        result = runner.invoke(
+            app,
+            ["transcribe", "recording.wav", "--export", "txt", "--json"],
+        )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["transcript"]["text"] == "Test transcript."
+    assert [artifact["kind"] for artifact in payload["exports"]] == ["txt", "vtt"]
+
+
+def test_export_is_refused_for_dry_run_before_application_construction():
+    with patch("echoflow.cli.AppContainer") as container:
+        result = runner.invoke(
+            app,
+            ["transcribe", "recording.wav", "--dry-run", "--export", "srt"],
+        )
+
+    assert result.exit_code == 2
+    assert "--export cannot be combined with --dry-run" in result.output
+    container.assert_not_called()

--- a/src/echoflow/tests/test_cli_exports.py
+++ b/src/echoflow/tests/test_cli_exports.py
@@ -83,5 +83,6 @@ def test_export_is_refused_for_dry_run_before_application_construction():
         )
 
     assert result.exit_code == 2
-    assert "--export cannot be combined with --dry-run" in result.output
+    assert "cannot be combined with" in result.output
+    assert "--dry-run" in result.output
     container.assert_not_called()

--- a/src/echoflow/tests/test_cli_exports.py
+++ b/src/echoflow/tests/test_cli_exports.py
@@ -84,5 +84,4 @@ def test_export_is_refused_for_dry_run_before_application_construction():
 
     assert result.exit_code == 2
     assert "cannot be combined with" in result.output
-    assert "--dry-run" in result.output
     container.assert_not_called()

--- a/src/echoflow/transcription/export.py
+++ b/src/echoflow/transcription/export.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR
+from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal
 from enum import StrEnum
 
 from echoflow.core.file_manager_facade import FileManagerFacade
@@ -66,7 +66,7 @@ def _cue_text(segment: RecognizedSegment) -> str:
 
 
 def render_text(transcript: CanonicalTranscript) -> bytes:
-    return f"{transcript.text}\n".encode("utf-8")
+    return f"{transcript.text}\n".encode()
 
 
 def render_subrip(transcript: CanonicalTranscript) -> bytes:
@@ -76,7 +76,7 @@ def render_subrip(transcript: CanonicalTranscript) -> bytes:
         end = _timestamp(segment.end_seconds, separator=",", end=True)
         blocks.append(f"{cue_number}\n{start} --> {end}\n{_cue_text(segment)}")
     document = "\n\n".join(blocks)
-    return (f"{document}\n\n" if document else "").encode("utf-8")
+    return (f"{document}\n\n" if document else "").encode()
 
 
 def render_webvtt(transcript: CanonicalTranscript) -> bytes:
@@ -88,7 +88,7 @@ def render_webvtt(transcript: CanonicalTranscript) -> bytes:
             f"{segment.segment_id}\n{start} --> {end}\n{_cue_text(segment)}"
         )
     body = "\n\n".join(blocks)
-    return ("WEBVTT\n\n" + (f"{body}\n\n" if body else "")).encode("utf-8")
+    return ("WEBVTT\n\n" + (f"{body}\n\n" if body else "")).encode()
 
 
 def render_transcript(

--- a/src/echoflow/transcription/export.py
+++ b/src/echoflow/transcription/export.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR
+from enum import StrEnum
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.transcription.errors import TranscriptionError
+from echoflow.transcription.models import CanonicalTranscript, RecognizedSegment
+from echoflow.workspace.models import Artifact, ArtifactKind, Job
+from echoflow.workspace.service import WorkspaceService
+
+
+class TranscriptExportError(TranscriptionError):
+    """A canonical transcript could not be rendered or published safely."""
+
+
+class TranscriptExportFormat(StrEnum):
+    TEXT = "txt"
+    SUBRIP = "srt"
+    WEBVTT = "vtt"
+
+    @property
+    def artifact_kind(self) -> ArtifactKind:
+        return {
+            TranscriptExportFormat.TEXT: ArtifactKind.TEXT,
+            TranscriptExportFormat.SUBRIP: ArtifactKind.SUBRIP,
+            TranscriptExportFormat.WEBVTT: ArtifactKind.WEBVTT,
+        }[self]
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptExportResult:
+    artifacts: tuple[Artifact, ...]
+
+    def to_dict(self) -> list[dict[str, str]]:
+        return [artifact.to_dict() for artifact in self.artifacts]
+
+
+def _milliseconds(seconds: float, *, end: bool) -> int:
+    value = Decimal(str(seconds)) * 1000
+    rounding = ROUND_CEILING if end else ROUND_FLOOR
+    return int(value.to_integral_value(rounding=rounding))
+
+
+def _timestamp(seconds: float, *, separator: str, end: bool) -> str:
+    total_ms = _milliseconds(seconds, end=end)
+    hours, remainder = divmod(total_ms, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    whole_seconds, milliseconds = divmod(remainder, 1000)
+    return (
+        f"{hours:02d}:{minutes:02d}:{whole_seconds:02d}"
+        f"{separator}{milliseconds:03d}"
+    )
+
+
+def _cue_text(segment: RecognizedSegment) -> str:
+    if "\x00" in segment.text:
+        raise TranscriptExportError("Transcript contains text that cannot be exported")
+    normalized = segment.text.replace("\r\n", "\n").replace("\r", "\n")
+    lines = [line.strip() for line in normalized.split("\n") if line.strip()]
+    if not lines:
+        raise TranscriptExportError("Transcript contains an empty subtitle cue")
+    return " ".join(lines)
+
+
+def render_text(transcript: CanonicalTranscript) -> bytes:
+    return f"{transcript.text}\n".encode("utf-8")
+
+
+def render_subrip(transcript: CanonicalTranscript) -> bytes:
+    blocks: list[str] = []
+    for cue_number, segment in enumerate(transcript.segments, start=1):
+        start = _timestamp(segment.start_seconds, separator=",", end=False)
+        end = _timestamp(segment.end_seconds, separator=",", end=True)
+        blocks.append(f"{cue_number}\n{start} --> {end}\n{_cue_text(segment)}")
+    document = "\n\n".join(blocks)
+    return (f"{document}\n\n" if document else "").encode("utf-8")
+
+
+def render_webvtt(transcript: CanonicalTranscript) -> bytes:
+    blocks: list[str] = []
+    for segment in transcript.segments:
+        start = _timestamp(segment.start_seconds, separator=".", end=False)
+        end = _timestamp(segment.end_seconds, separator=".", end=True)
+        blocks.append(
+            f"{segment.segment_id}\n{start} --> {end}\n{_cue_text(segment)}"
+        )
+    body = "\n\n".join(blocks)
+    return ("WEBVTT\n\n" + (f"{body}\n\n" if body else "")).encode("utf-8")
+
+
+def render_transcript(
+    transcript: CanonicalTranscript, export_format: TranscriptExportFormat
+) -> bytes:
+    renderers = {
+        TranscriptExportFormat.TEXT: render_text,
+        TranscriptExportFormat.SUBRIP: render_subrip,
+        TranscriptExportFormat.WEBVTT: render_webvtt,
+    }
+    return renderers[export_format](transcript)
+
+
+class TranscriptExporter:
+    """Publish deterministic views without making them transcript authorities."""
+
+    def __init__(
+        self,
+        *,
+        workspace_service: WorkspaceService,
+        file_manager: FileManagerFacade,
+    ):
+        self.workspace_service = workspace_service
+        self.file_manager = file_manager
+
+    def publish(
+        self,
+        job: Job,
+        transcript: CanonicalTranscript,
+        formats: tuple[TranscriptExportFormat, ...],
+    ) -> TranscriptExportResult:
+        selected = tuple(dict.fromkeys(formats))
+        payloads = tuple(
+            (export_format, render_transcript(transcript, export_format))
+            for export_format in selected
+        )
+        reserved: list[tuple[Artifact, bytes]] = []
+        try:
+            for export_format, payload in payloads:
+                artifact = self.workspace_service.reserve_artifact(
+                    job, export_format.artifact_kind
+                )
+                reserved.append((artifact, payload))
+            for artifact, payload in reserved:
+                self.file_manager.save_file(payload, artifact.path)
+        except BaseException:
+            for artifact, _ in reserved:
+                with suppress(Exception):
+                    self.file_manager.delete_file(artifact.path)
+            raise
+        return TranscriptExportResult(tuple(artifact for artifact, _ in reserved))

--- a/src/echoflow/transcription/export.py
+++ b/src/echoflow/transcription/export.py
@@ -49,10 +49,7 @@ def _timestamp(seconds: float, *, separator: str, end: bool) -> str:
     hours, remainder = divmod(total_ms, 3_600_000)
     minutes, remainder = divmod(remainder, 60_000)
     whole_seconds, milliseconds = divmod(remainder, 1000)
-    return (
-        f"{hours:02d}:{minutes:02d}:{whole_seconds:02d}"
-        f"{separator}{milliseconds:03d}"
-    )
+    return f"{hours:02d}:{minutes:02d}:{whole_seconds:02d}{separator}{milliseconds:03d}"
 
 
 def _cue_text(segment: RecognizedSegment) -> str:
@@ -84,9 +81,7 @@ def render_webvtt(transcript: CanonicalTranscript) -> bytes:
     for segment in transcript.segments:
         start = _timestamp(segment.start_seconds, separator=".", end=False)
         end = _timestamp(segment.end_seconds, separator=".", end=True)
-        blocks.append(
-            f"{segment.segment_id}\n{start} --> {end}\n{_cue_text(segment)}"
-        )
+        blocks.append(f"{segment.segment_id}\n{start} --> {end}\n{_cue_text(segment)}")
     body = "\n\n".join(blocks)
     return ("WEBVTT\n\n" + (f"{body}\n\n" if body else "")).encode()
 

--- a/src/echoflow/transcription/tests/test_export.py
+++ b/src/echoflow/transcription/tests/test_export.py
@@ -94,7 +94,8 @@ def test_webvtt_keeps_stable_canonical_segment_ids():
 def test_subtitle_export_rejects_nul_instead_of_writing_invalid_cue():
     value = transcript(RecognizedSegment(0, 0, 1, "unsafe\x00text"))
     with pytest.raises(
-        TranscriptExportError, match="^Transcript contains text that cannot be exported$"
+        TranscriptExportError,
+        match="^Transcript contains text that cannot be exported$",
     ):
         render_webvtt(value)
 
@@ -115,10 +116,16 @@ def test_exporter_renders_before_reserving_and_deduplicates_formats(tmp_path):
         tmp_path / "state/jobs/job-1",
         tmp_path / "output",
     )
-    text_artifact = Artifact(job.job_id, ArtifactKind.TEXT, tmp_path / "output/input.txt")
-    srt_artifact = Artifact(job.job_id, ArtifactKind.SUBRIP, tmp_path / "output/input.srt")
+    text_artifact = Artifact(
+        job.job_id, ArtifactKind.TEXT, tmp_path / "output/input.txt"
+    )
+    srt_artifact = Artifact(
+        job.job_id, ArtifactKind.SUBRIP, tmp_path / "output/input.srt"
+    )
     workspace.reserve_artifact.side_effect = [text_artifact, srt_artifact]
-    exporter = TranscriptExporter(workspace_service=workspace, file_manager=file_manager)
+    exporter = TranscriptExporter(
+        workspace_service=workspace, file_manager=file_manager
+    )
 
     result = exporter.publish(
         job,
@@ -145,11 +152,17 @@ def test_exporter_rolls_back_entire_derived_set_without_touching_canonical(tmp_p
         tmp_path / "state/jobs/job-1",
         tmp_path / "output",
     )
-    text_artifact = Artifact(job.job_id, ArtifactKind.TEXT, tmp_path / "output/input.txt")
-    vtt_artifact = Artifact(job.job_id, ArtifactKind.WEBVTT, tmp_path / "output/input.vtt")
+    text_artifact = Artifact(
+        job.job_id, ArtifactKind.TEXT, tmp_path / "output/input.txt"
+    )
+    vtt_artifact = Artifact(
+        job.job_id, ArtifactKind.WEBVTT, tmp_path / "output/input.vtt"
+    )
     workspace.reserve_artifact.side_effect = [text_artifact, vtt_artifact]
     file_manager.save_file.side_effect = [None, OSError("disk full")]
-    exporter = TranscriptExporter(workspace_service=workspace, file_manager=file_manager)
+    exporter = TranscriptExporter(
+        workspace_service=workspace, file_manager=file_manager
+    )
 
     with pytest.raises(OSError, match="disk full"):
         exporter.publish(

--- a/src/echoflow/transcription/tests/test_export.py
+++ b/src/echoflow/transcription/tests/test_export.py
@@ -1,0 +1,169 @@
+from pathlib import Path
+from unittest.mock import Mock, call
+
+import pytest
+
+from echoflow.runner.models import ProcessingProfile
+from echoflow.transcription.export import (
+    TranscriptExportError,
+    TranscriptExporter,
+    TranscriptExportFormat,
+    render_subrip,
+    render_text,
+    render_webvtt,
+)
+from echoflow.transcription.models import (
+    CanonicalTranscript,
+    DecodeStrategy,
+    EngineProvenance,
+    RecognizedSegment,
+    TranscriptSource,
+)
+from echoflow.workspace.models import Artifact, ArtifactKind, Job, JobId
+
+
+def transcript(*segments: RecognizedSegment) -> CanonicalTranscript:
+    return CanonicalTranscript(
+        job_id="job-1",
+        source=TranscriptSource(
+            sha256="0" * 64,
+            size_bytes=10,
+            modified_ns=1,
+            container_format="wav",
+            duration_seconds=8_000,
+            audio_stream_index=0,
+        ),
+        profile=ProcessingProfile.BALANCED,
+        provisional=False,
+        decode_strategy=DecodeStrategy.DIRECT,
+        engine=EngineProvenance(
+            name="faster-whisper",
+            package_version="1.2.1",
+            model="small",
+            model_revision=None,
+            device="cpu",
+            compute_type="int8",
+            cpu_threads=4,
+            beam_size=5,
+            requested_language=None,
+        ),
+        detected_language="en",
+        language_probability=0.99,
+        segments=segments,
+    )
+
+
+def test_text_export_is_utf8_canonical_text_with_terminal_newline():
+    value = transcript(
+        RecognizedSegment(0, 0, 1, "  Hello  "),
+        RecognizedSegment(1, 1, 2, "世界"),
+    )
+    assert render_text(value) == "Hello 世界\n".encode()
+
+
+def test_subrip_uses_source_relative_timestamps_and_outward_millisecond_rounding():
+    value = transcript(
+        RecognizedSegment(0, 3_661.0004, 3_662.9991, "first line\nsecond line"),
+        RecognizedSegment(1, 7_200, 7_200.0001, "Later"),
+    )
+    assert render_subrip(value).decode() == (
+        "1\n"
+        "01:01:01,000 --> 01:01:03,000\n"
+        "first line second line\n\n"
+        "2\n"
+        "02:00:00,000 --> 02:00:00,001\n"
+        "Later\n\n"
+    )
+
+
+def test_webvtt_keeps_stable_canonical_segment_ids():
+    value = transcript(
+        RecognizedSegment(0, 0, 1.25, "Hello"),
+        RecognizedSegment(1, 601.5, 602, "After segmentation boundary"),
+    )
+    assert render_webvtt(value).decode() == (
+        "WEBVTT\n\n"
+        "segment-000000\n"
+        "00:00:00.000 --> 00:00:01.250\n"
+        "Hello\n\n"
+        "segment-000001\n"
+        "00:10:01.500 --> 00:10:02.000\n"
+        "After segmentation boundary\n\n"
+    )
+
+
+def test_subtitle_export_rejects_nul_instead_of_writing_invalid_cue():
+    value = transcript(RecognizedSegment(0, 0, 1, "unsafe\x00text"))
+    with pytest.raises(
+        TranscriptExportError, match="^Transcript contains text that cannot be exported$"
+    ):
+        render_webvtt(value)
+
+
+def test_empty_transcript_has_valid_empty_views():
+    value = transcript()
+    assert render_text(value) == b"\n"
+    assert render_subrip(value) == b""
+    assert render_webvtt(value) == b"WEBVTT\n\n"
+
+
+def test_exporter_renders_before_reserving_and_deduplicates_formats(tmp_path):
+    workspace = Mock()
+    file_manager = Mock()
+    job = Job(
+        JobId("job-1"),
+        tmp_path / "input.wav",
+        tmp_path / "state/jobs/job-1",
+        tmp_path / "output",
+    )
+    text_artifact = Artifact(job.job_id, ArtifactKind.TEXT, tmp_path / "output/input.txt")
+    srt_artifact = Artifact(job.job_id, ArtifactKind.SUBRIP, tmp_path / "output/input.srt")
+    workspace.reserve_artifact.side_effect = [text_artifact, srt_artifact]
+    exporter = TranscriptExporter(workspace_service=workspace, file_manager=file_manager)
+
+    result = exporter.publish(
+        job,
+        transcript(RecognizedSegment(0, 0, 1, "Hello")),
+        (
+            TranscriptExportFormat.TEXT,
+            TranscriptExportFormat.TEXT,
+            TranscriptExportFormat.SUBRIP,
+        ),
+    )
+
+    assert result.artifacts == (text_artifact, srt_artifact)
+    assert workspace.reserve_artifact.call_count == 2
+    file_manager.save_file.assert_any_call(b"Hello\n", text_artifact.path)
+    assert file_manager.save_file.call_count == 2
+
+
+def test_exporter_rolls_back_entire_derived_set_without_touching_canonical(tmp_path):
+    workspace = Mock()
+    file_manager = Mock()
+    job = Job(
+        JobId("job-1"),
+        tmp_path / "input.wav",
+        tmp_path / "state/jobs/job-1",
+        tmp_path / "output",
+    )
+    text_artifact = Artifact(job.job_id, ArtifactKind.TEXT, tmp_path / "output/input.txt")
+    vtt_artifact = Artifact(job.job_id, ArtifactKind.WEBVTT, tmp_path / "output/input.vtt")
+    workspace.reserve_artifact.side_effect = [text_artifact, vtt_artifact]
+    file_manager.save_file.side_effect = [None, OSError("disk full")]
+    exporter = TranscriptExporter(workspace_service=workspace, file_manager=file_manager)
+
+    with pytest.raises(OSError, match="disk full"):
+        exporter.publish(
+            job,
+            transcript(RecognizedSegment(0, 0, 1, "Hello")),
+            (TranscriptExportFormat.TEXT, TranscriptExportFormat.WEBVTT),
+        )
+
+    assert file_manager.delete_file.call_args_list == [
+        call(text_artifact.path),
+        call(vtt_artifact.path),
+    ]
+    assert all(
+        invoked.args[0].suffix != ".json"
+        for invoked in file_manager.delete_file.call_args_list
+    )

--- a/src/echoflow/transcription/tests/test_export.py
+++ b/src/echoflow/transcription/tests/test_export.py
@@ -1,12 +1,11 @@
-from pathlib import Path
 from unittest.mock import Mock, call
 
 import pytest
 
 from echoflow.runner.models import ProcessingProfile
 from echoflow.transcription.export import (
-    TranscriptExportError,
     TranscriptExporter,
+    TranscriptExportError,
     TranscriptExportFormat,
     render_subrip,
     render_text,

--- a/src/echoflow/transcription/tests/test_media_acceptance.py
+++ b/src/echoflow/transcription/tests/test_media_acceptance.py
@@ -1,0 +1,114 @@
+import shutil
+import subprocess
+import wave
+from pathlib import Path
+
+import pytest
+
+from echoflow.media.models import StreamKind
+from echoflow.media.probe import FfprobeMediaProbe
+from echoflow.transcription.audio import FfmpegAudioDecoder
+from echoflow.transcription.models import (
+    DecodeConfiguration,
+    DecodeStrategy,
+    SegmentationConfiguration,
+)
+from echoflow.transcription.segmentation import WaveAudioSegmenter
+
+
+def _native_tool(name: str) -> str:
+    executable = shutil.which(name)
+    if executable is None:
+        pytest.skip(f"{name} is not installed")
+    return executable
+
+
+def _make_video(path: Path) -> None:
+    ffmpeg = _native_tool("ffmpeg")
+    command = [
+        ffmpeg,
+        "-nostdin",
+        "-v",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=64x64:r=1",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=440:sample_rate=48000",
+        "-t",
+        "2.25",
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0",
+        "-c:v",
+        "mpeg4",
+        "-c:a",
+        "aac",
+        "-y",
+        str(path),
+    ]
+    subprocess.run(command, check=True, capture_output=True)  # noqa: S603
+
+
+def test_real_ffmpeg_video_probe_decode_and_segment_pipeline(tmp_path):
+    _native_tool("ffprobe")
+    source = tmp_path / "synthetic-interview.mp4"
+    workspace = tmp_path / "private-job"
+    workspace.mkdir()
+    _make_video(source)
+
+    media = FfprobeMediaProbe().probe(source)
+    assert any(stream.kind is StreamKind.VIDEO for stream in media.streams)
+    assert media.primary_audio_stream.kind is StreamKind.AUDIO
+    assert media.primary_audio_stream.codec == "aac"
+
+    decoder_config = DecodeConfiguration(
+        DecodeStrategy.FFMPEG_NORMALIZE,
+        "pcm_s16le",
+        16_000,
+        1,
+    )
+    decoder = FfmpegAudioDecoder()
+    decoded = decoder.decode(media, decoder_config, workspace)
+    assert decoded.temporary is True
+    assert decoded.path == workspace / "normalized.wav"
+
+    with wave.open(str(decoded.path), "rb") as normalized:
+        assert normalized.getframerate() == 16_000
+        assert normalized.getnchannels() == 1
+        assert normalized.getsampwidth() == 2
+        assert normalized.getnframes() > 32_000
+
+    segmenter = WaveAudioSegmenter()
+    windows = segmenter.plan(
+        decoded.path,
+        decoder_config,
+        SegmentationConfiguration(segment_duration_seconds=1),
+    )
+    assert len(windows) >= 3
+    assert windows[0].start_frame == 0
+    assert all(
+        current.start_frame == previous.end_frame
+        for previous, current in zip(windows, windows[1:], strict=False)
+    )
+
+    materialized = segmenter.materialize(
+        decoded.path,
+        windows[1],
+        decoder_config,
+        workspace,
+    )
+    with wave.open(str(materialized.path), "rb") as segment:
+        assert segment.getnframes() == windows[1].end_frame - windows[1].start_frame
+        assert segment.getframerate() == 16_000
+        assert segment.getnchannels() == 1
+
+    segmenter.cleanup(materialized)
+    assert not materialized.path.exists()
+    decoder.cleanup(decoded)
+    assert not decoded.path.exists()
+    assert source.exists()


### PR DESCRIPTION
## What changed

- Added deterministic TXT, SubRip (SRT), and WebVTT renderers derived only from the canonical transcript.
- Added repeatable `echoflow transcribe INPUT --export txt|srt|vtt` publication without changing the default transcription artifact set yet.
- Kept canonical JSON authoritative. Derived formats are rendered after successful canonical publication and are not part of the recognition/checkpoint contract.
- Derived export publication renders before reserving paths, reserves the requested set, writes each artifact through EchoFlow's atomic file boundary, and rolls the derived set back on failure while leaving the completed canonical JSON untouched.
- Subtitle timestamps use canonical source-relative segment times with deterministic outward millisecond rounding so application-owned 10-minute segmentation never resets the public subtitle timeline.
- WebVTT cue identifiers retain stable canonical segment IDs.
- Added real native-media acceptance coverage that generates a small non-sensitive MP4 and exercises production FFprobe inspection, production FFmpeg audio extraction/normalization, canonical WAV validation, deterministic segmentation, materialization, and cleanup.
- CI now explicitly requires `ffmpeg` and `ffprobe` before tests on Ubuntu, macOS, and Windows so the native acceptance path cannot become a silent skip in project CI.
- Added exporter/CLI/DI tests and included export decision logic in the targeted mutation-testing scope.

## Why

EchoFlow already had strong unit coverage around the FFmpeg command contract, but that test mocked `subprocess.run`. Before multiplying public transcript formats, this PR proves the native probe/decode/segmentation seam against real FFmpeg/FFprobe in the supported OS matrix.

TXT/SRT/VTT are views, not new transcript authorities. Recognition runs once, canonical JSON keeps provenance and recovery semantics, and derived files can be discarded without losing the authoritative result.

## Deliberate boundaries

- No diarization, speaker identification, alignment model, sentence splitting, or plugin framework is introduced here.
- No real model download/inference is added to mandatory GitHub Actions. Backend/session behavior remains covered deterministically; real ASR performance belongs in local/representative-device acceptance and calibration rather than network-coupled hosted CI.
- Derived exports remain opt-in in this PR. Making TXT a consumer default can be a later UX policy change after real-recording dogfooding.

## Validation target

The existing quality stack should pass dependency audit, Ruff lint/format, strict mypy, Vulture, complexity, branch coverage, native macOS/Windows source suites, distribution builds, and clean-wheel verification. The new native-media acceptance test additionally requires real FFmpeg/FFprobe on every CI operating system.