### PR TITLE
Harden acceptance coverage across local seams

### DIFF
--- a/.github/workflows/engine-acceptance.yml
+++ b/.github/workflows/engine-acceptance.yml
@@ -1,0 +1,39 @@
+name: Engine Acceptance
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 9 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: engine-acceptance
+  cancel-in-progress: false
+
+jobs:
+  faster-whisper-cpu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.33"
+          enable-cache: true
+
+      - name: Install locked transcription dependencies
+        run: uv sync --locked --extra transcription
+
+      - name: Execute real faster-whisper acceptance
+        run: uv run python scripts/verify_engine_acceptance.py

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -155,6 +155,11 @@ def _verify_clean_install(wheel: Path) -> None:
         )
         _run([str(console), "--help"], cwd=work_dir, env=env)
         _run([str(python), "-m", "echoflow", "--help"], cwd=work_dir, env=env)
+        _run(
+            [str(python), "-m", "echoflow.benchmarking", "--help"],
+            cwd=work_dir,
+            env=env,
+        )
         _run([str(console), "init", "--json"], cwd=work_dir, env=env)
         _run([str(console), "doctor", "--json"], cwd=work_dir, env=env)
         _run([str(console), "runner", "--json"], cwd=work_dir, env=env)

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tempfile
 import venv
+import wave
 import zipfile
 from email import policy
 from email.parser import BytesParser
@@ -93,6 +94,14 @@ def _run(command: list[str], *, cwd: Path, env: dict[str, str]) -> None:
     subprocess.run(command, cwd=cwd, env=env, check=True)  # noqa: S603
 
 
+def _write_acceptance_wave(path: Path) -> None:
+    with wave.open(str(path), "wb") as audio:
+        audio.setnchannels(1)
+        audio.setsampwidth(2)
+        audio.setframerate(16_000)
+        audio.writeframes(b"\x00\x00" * 16_000)
+
+
 def _verify_clean_install(wheel: Path) -> None:
     with tempfile.TemporaryDirectory(prefix="echoflow-dist-") as temporary:
         root = Path(temporary).resolve()
@@ -104,6 +113,8 @@ def _verify_clean_install(wheel: Path) -> None:
         python = _venv_python(venv_dir)
         console = _console_script(venv_dir)
         requirement = f"echoflow[transcription] @ {wheel.as_uri()}"
+        sample_audio = work_dir / "acceptance.wav"
+        _write_acceptance_wave(sample_audio)
 
         env = os.environ.copy()
         env.pop("PYTHONPATH", None)
@@ -113,6 +124,8 @@ def _verify_clean_install(wheel: Path) -> None:
         env["ECHOFLOW_CACHE_DIR"] = str(root / "cache")
         env["ECHOFLOW_MODEL_DIR"] = str(root / "cache" / "models")
         env["ECHOFLOW_OUTPUT_DIR"] = str(root / "output")
+        env["ECHOFLOW_MIN_FREE_DISK_BYTES"] = "0"
+        env["ECHOFLOW_WARN_FREE_DISK_BYTES"] = "0"
 
         _run(
             [
@@ -142,8 +155,23 @@ def _verify_clean_install(wheel: Path) -> None:
         )
         _run([str(console), "--help"], cwd=work_dir, env=env)
         _run([str(python), "-m", "echoflow", "--help"], cwd=work_dir, env=env)
+        _run([str(console), "init", "--json"], cwd=work_dir, env=env)
+        _run([str(console), "doctor", "--json"], cwd=work_dir, env=env)
         _run([str(console), "runner", "--json"], cwd=work_dir, env=env)
         _run([str(console), "strategies", "--json"], cwd=work_dir, env=env)
+        _run(
+            [
+                str(console),
+                "transcribe",
+                str(sample_audio),
+                "--dry-run",
+                "--profile",
+                "screening",
+                "--json",
+            ],
+            cwd=work_dir,
+            env=env,
+        )
 
 
 def main() -> int:

--- a/scripts/verify_engine_acceptance.py
+++ b/scripts/verify_engine_acceptance.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import wave
+from pathlib import Path
+
+from echoflow.transcription.backend import FasterWhisperTranscriber
+from echoflow.transcription.models import CpuEngineConfiguration
+
+_SAMPLE_RATE_HZ = 16_000
+
+
+def _write_silence(path: Path) -> None:
+    with wave.open(str(path), "wb") as audio:
+        audio.setnchannels(1)
+        audio.setsampwidth(2)
+        audio.setframerate(_SAMPLE_RATE_HZ)
+        audio.writeframes(b"\x00\x00" * _SAMPLE_RATE_HZ)
+
+
+def _configuration(model_cache: Path) -> CpuEngineConfiguration:
+    return CpuEngineConfiguration(
+        engine="faster-whisper",
+        model="tiny",
+        device="cpu",
+        compute_type="int8",
+        cpu_threads=2,
+        beam_size=1,
+        language="en",
+        model_cache_path=model_cache,
+    )
+
+
+def verify_engine() -> None:
+    with tempfile.TemporaryDirectory(prefix="echoflow-engine-") as temporary:
+        root = Path(temporary).resolve()
+        model_cache = root / "models"
+        audio_path = root / "acceptance.wav"
+        model_cache.mkdir()
+        _write_silence(audio_path)
+
+        configuration = _configuration(model_cache)
+        transcriber = FasterWhisperTranscriber()
+
+        downloaded_session = transcriber.open_session(
+            configuration,
+            allow_model_download=True,
+        )
+        downloaded_result = downloaded_session.transcribe(audio_path)
+
+        local_session = transcriber.open_session(
+            configuration,
+            allow_model_download=False,
+        )
+        local_result = local_session.transcribe(audio_path)
+
+        if downloaded_result.engine_version != local_result.engine_version:
+            raise RuntimeError("engine version changed within one acceptance run")
+        if not downloaded_result.engine_version.strip():
+            raise RuntimeError("engine version was not reported")
+        if not any(model_cache.iterdir()):
+            raise RuntimeError("model download did not populate the private cache")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download and execute the smallest configured faster-whisper model, then "
+            "reopen it with network retrieval disabled."
+        )
+    )
+    parser.parse_args()
+    verify_engine()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/echoflow/benchmarking/tests/test_resources.py
+++ b/src/echoflow/benchmarking/tests/test_resources.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from types import SimpleNamespace
 
 import psutil
@@ -58,6 +60,31 @@ def test_sampler_collects_process_tree_rss_and_cpu_without_external_io():
     assert observation.peak_cpu_percent == 90.0
     assert observation.mean_cpu_percent == 82.5
     assert observation.to_dict()["cpu_percent_basis"] == "process_tree_sum"
+
+
+def test_sampler_observes_a_real_python_child_process():
+    sampler = ProcessTreeSampler(sample_interval_seconds=0.02)
+    sampler.start()
+    subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            (
+                "import time; "
+                "payload = bytearray(16 * 1024 * 1024); "
+                "time.sleep(0.3); "
+                "assert payload[0] == 0"
+            ),
+        ],
+        check=True,
+    )
+    observation = sampler.stop()
+
+    assert observation.sample_count >= 2
+    assert observation.baseline_rss_bytes > 0
+    assert observation.peak_rss_bytes > observation.baseline_rss_bytes
+    assert observation.peak_incremental_rss_bytes > 0
+    assert observation.mean_rss_bytes > 0
 
 
 def test_sampler_ignores_disappearing_children_and_child_enumeration_failure():

--- a/src/echoflow/interfaces/tests/test_local_file_manager.py
+++ b/src/echoflow/interfaces/tests/test_local_file_manager.py
@@ -1,4 +1,6 @@
 import os
+from concurrent.futures import ProcessPoolExecutor
+from itertools import repeat
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -14,6 +16,14 @@ from echoflow.core.errors import (
 )
 from echoflow.interfaces.base_file_manager import FileManager
 from echoflow.interfaces.local_file_manager import LocalFileManager
+
+
+def _reserve_from_process(path: str) -> bool:
+    try:
+        LocalFileManager().reserve_file(path)
+    except StorageAlreadyExistsError:
+        return False
+    return True
 
 
 @pytest.fixture
@@ -107,6 +117,18 @@ def test_directory_and_file_reservations_are_exclusive(manager, tmp_path):
         manager.reserve_directory(directory)
     with pytest.raises(StorageAlreadyExistsError):
         manager.reserve_file(artifact)
+
+
+def test_file_reservation_is_exclusive_across_processes(tmp_path):
+    artifact = tmp_path / "contended-transcript.json"
+    with ProcessPoolExecutor(max_workers=4) as executor:
+        outcomes = tuple(
+            executor.map(_reserve_from_process, repeat(str(artifact), 4))
+        )
+
+    assert outcomes.count(True) == 1
+    assert outcomes.count(False) == 3
+    assert artifact.is_file()
 
 
 @pytest.mark.parametrize(("name", "expected"), [("", "_"), (".", "_"), ("..", "__")])

--- a/src/echoflow/interfaces/tests/test_local_file_manager.py
+++ b/src/echoflow/interfaces/tests/test_local_file_manager.py
@@ -122,9 +122,7 @@ def test_directory_and_file_reservations_are_exclusive(manager, tmp_path):
 def test_file_reservation_is_exclusive_across_processes(tmp_path):
     artifact = tmp_path / "contended-transcript.json"
     with ProcessPoolExecutor(max_workers=4) as executor:
-        outcomes = tuple(
-            executor.map(_reserve_from_process, repeat(str(artifact), 4))
-        )
+        outcomes = tuple(executor.map(_reserve_from_process, repeat(str(artifact), 4)))
 
     assert outcomes.count(True) == 1
     assert outcomes.count(False) == 3

--- a/src/echoflow/transcription/tests/test_media_acceptance.py
+++ b/src/echoflow/transcription/tests/test_media_acceptance.py
@@ -1,16 +1,24 @@
+import json
 import shutil
 import subprocess
 import wave
 from pathlib import Path
 
 import pytest
+from dependency_injector import providers
 
+from echoflow.app.app_container import AppContainer
+from echoflow.core.config import AppConfig
 from echoflow.media.models import StreamKind
 from echoflow.media.probe import FfprobeMediaProbe
+from echoflow.runner.models import ProcessingProfile
 from echoflow.transcription.audio import FfmpegAudioDecoder
+from echoflow.transcription.export import TranscriptExportFormat
 from echoflow.transcription.models import (
     DecodeConfiguration,
     DecodeStrategy,
+    EngineTranscript,
+    RecognizedSegment,
     SegmentationConfiguration,
 )
 from echoflow.transcription.segmentation import WaveAudioSegmenter
@@ -52,6 +60,58 @@ def _make_video(path: Path) -> None:
         str(path),
     ]
     subprocess.run(command, check=True, capture_output=True)  # noqa: S603
+
+
+class _AcceptanceSession:
+    engine_version = "acceptance-fake-asr-1"
+
+    def transcribe(self, audio_path: Path) -> EngineTranscript:
+        with wave.open(str(audio_path), "rb") as audio:
+            duration = audio.getnframes() / audio.getframerate()
+        return EngineTranscript(
+            segments=(
+                RecognizedSegment(
+                    index=0,
+                    start_seconds=0.0,
+                    end_seconds=duration,
+                    text="Synthetic segment.",
+                ),
+            ),
+            language="en",
+            language_probability=1.0,
+            engine_version=self.engine_version,
+        )
+
+
+class _AcceptanceTranscriber:
+    def open_session(
+        self,
+        _configuration,
+        *,
+        allow_model_download: bool,
+        detected_language: str | None = None,
+    ) -> _AcceptanceSession:
+        assert allow_model_download is False
+        assert detected_language is None
+        return _AcceptanceSession()
+
+
+def _acceptance_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        APP_ENV="test",
+        DEBUG=False,
+        LOG_LEVEL="INFO",
+        STATE_DIR=tmp_path / "state",
+        CACHE_DIR=tmp_path / "cache",
+        MODEL_DIR=tmp_path / "cache" / "models",
+        OUTPUT_DIR=tmp_path / "output",
+        MIN_FREE_DISK_BYTES=0,
+        WARN_FREE_DISK_BYTES=0,
+        FFMPEG_TIMEOUT_SECONDS=2.0,
+        FFPROBE_TIMEOUT_SECONDS=10.0,
+        FFMPEG_PROCESS_TIMEOUT_SECONDS=30.0,
+        _env_file=None,
+    )
 
 
 def test_real_ffmpeg_video_probe_decode_and_segment_pipeline(tmp_path):
@@ -112,3 +172,46 @@ def test_real_ffmpeg_video_probe_decode_and_segment_pipeline(tmp_path):
     decoder.cleanup(decoded)
     assert not decoded.path.exists()
     assert source.exists()
+
+
+def test_real_local_pipeline_publishes_and_cleans_up_with_only_asr_faked(tmp_path):
+    _native_tool("ffprobe")
+    source = tmp_path / "synthetic-research-interview.mp4"
+    _make_video(source)
+
+    container = AppContainer()
+    container.config.override(_acceptance_config(tmp_path))
+    container.transcriber.override(providers.Factory(_AcceptanceTranscriber))
+
+    plan = container.transcription_planner().plan(
+        source,
+        profile=ProcessingProfile.SCREENING,
+    )
+    result = container.transcription_executor().execute(plan)
+
+    assert source.exists()
+    assert result.artifact.path.is_file()
+    canonical = json.loads(result.artifact.path.read_text(encoding="utf-8"))
+    assert canonical["job_id"] == result.job.job_id.value
+    assert canonical["transcript"]["text"] == "Synthetic segment."
+    assert canonical["engine"]["package_version"] == "acceptance-fake-asr-1"
+
+    assert not (result.job.workspace_dir / "normalized.wav").exists()
+    assert not tuple(result.job.workspace_dir.glob("audio-*.wav"))
+    checkpoint_dir = result.job.workspace_dir / "checkpoints"
+    assert checkpoint_dir.is_dir()
+    assert list(checkpoint_dir.iterdir()) == []
+
+    exports = container.transcript_exporter().publish(
+        result.job,
+        result.transcript,
+        (
+            TranscriptExportFormat.TEXT,
+            TranscriptExportFormat.SUBRIP,
+            TranscriptExportFormat.WEBVTT,
+        ),
+    )
+    by_kind = {artifact.kind.value: artifact.path for artifact in exports.artifacts}
+    assert by_kind["txt"].read_text(encoding="utf-8") == "Synthetic segment.\n"
+    assert "00:00:00,000 -->" in by_kind["srt"].read_text(encoding="utf-8")
+    assert by_kind["vtt"].read_text(encoding="utf-8").startswith("WEBVTT\n\n")

--- a/src/echoflow/transcription/tests/test_media_acceptance.py
+++ b/src/echoflow/transcription/tests/test_media_acceptance.py
@@ -193,7 +193,7 @@ def test_real_local_pipeline_publishes_and_cleans_up_with_only_asr_faked(tmp_pat
     assert result.artifact.path.is_file()
     canonical = json.loads(result.artifact.path.read_text(encoding="utf-8"))
     assert canonical["job_id"] == result.job.job_id.value
-    assert canonical["transcript"]["text"] == "Synthetic segment."
+    assert canonical["text"] == "Synthetic segment."
     assert canonical["engine"]["package_version"] == "acceptance-fake-asr-1"
 
     assert not (result.job.workspace_dir / "normalized.wav").exists()


### PR DESCRIPTION
## What changed

- Extended the clean-wheel verifier to exercise installed `echoflow init --json`, `echoflow doctor --json`, `python -m echoflow.benchmarking --help`, and a real `transcribe acceptance.wav --dry-run --profile screening --json` outside the source checkout.
- Added a cross-platform process-tree acceptance test that samples the real EchoFlow pytest process plus a real short-lived Python child with psutil.
- Added a cross-process artifact reservation race: four Python processes contend for one path and exactly one must acquire the exclusive file reservation.
- Added a local pipeline acceptance test that uses the real AppContainer, planner, runner/resource admission, FFprobe, workspace/private-storage policy, FFmpeg decoder, WAV segmenter, checkpoint store, transcript assembler, canonical artifact writer, cleanup, and TXT/SRT/VTT exporter. Only ASR is replaced with a deterministic fake, so mandatory CI remains offline and model-download independent.
- Added a separate `Engine Acceptance` workflow plus `scripts/verify_engine_acceptance.py`. Weekly or on manual dispatch, it downloads and initializes the real faster-whisper `tiny` CPU/int8 model, transcribes a generated local WAV through EchoFlow's real adapter, then reopens the same cache with model downloads disabled and transcribes again.

## Why

Focused unit tests should keep mocks where they make decisions precise or inject failures safely. PR #41 showed, however, that a mocked native boundary can leave an important integration seam unproven. This PR adds reality at OS/process/filesystem/package/engine boundaries without deleting useful unit isolation.

The acceptance ladder becomes:

1. focused unit/contract tests for exact decisions and failure behavior,
2. local acceptance with real native/process/filesystem seams and fake ASR only,
3. installed-wheel acceptance outside the source checkout,
4. scheduled/manual real faster-whisper/CTranslate2 acceptance without making every PR depend on a model download.

## Deliberate boundaries

- No production behavior changes.
- No normal unit mocks are removed merely for being mocks.
- No Hugging Face model download is added to mandatory PR CI.
- The real-engine workflow is not considered runtime-validated until it executes after landing on the default branch or via manual dispatch.
- No claim of power-loss durability or same-user race resistance is introduced. Exception-driven crash/resume remains distinct from abrupt-process and storage-power-loss testing.
