### PR TITLE
Harden crash recovery and media stream boundaries

### DIFF
--- a/.github/workflows/engine-acceptance.yml
+++ b/.github/workflows/engine-acceptance.yml
@@ -4,6 +4,16 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "17 9 * * 1"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/engine-acceptance.yml"
+      - "scripts/verify_engine_acceptance.py"
+      - "src/echoflow/transcription/backend.py"
+      - "src/echoflow/transcription/models.py"
+      - "src/echoflow/transcription/strategy.py"
+      - "pyproject.toml"
+      - "uv.lock"
 
 permissions:
   contents: read

--- a/src/echoflow/transcription/tests/test_checkpoint_process_acceptance.py
+++ b/src/echoflow/transcription/tests/test_checkpoint_process_acceptance.py
@@ -1,0 +1,129 @@
+import multiprocessing
+import os
+import shutil
+import wave
+from pathlib import Path
+
+import pytest
+
+from echoflow.app.app_container import AppContainer
+from echoflow.core.config import AppConfig
+from echoflow.runner.models import ProcessingProfile
+from echoflow.transcription.models import (
+    AudioSegmentWindow,
+    EngineTranscript,
+    RecognizedSegment,
+)
+from echoflow.workspace.models import JobId
+
+_EXIT_AFTER_CHECKPOINT = 73
+_JOB_ID = JobId("crash-acceptance")
+_WINDOW = AudioSegmentWindow(0, 0, 16_000, 16_000)
+
+
+def _config(root: Path) -> AppConfig:
+    return AppConfig(
+        APP_ENV="test",
+        DEBUG=False,
+        LOG_LEVEL="INFO",
+        STATE_DIR=root / "state",
+        CACHE_DIR=root / "cache",
+        MODEL_DIR=root / "cache" / "models",
+        OUTPUT_DIR=root / "output",
+        MIN_FREE_DISK_BYTES=0,
+        WARN_FREE_DISK_BYTES=0,
+        FFMPEG_TIMEOUT_SECONDS=2.0,
+        FFPROBE_TIMEOUT_SECONDS=10.0,
+        FFMPEG_PROCESS_TIMEOUT_SECONDS=30.0,
+        _env_file=None,
+    )
+
+
+def _make_wav(path: Path) -> None:
+    with wave.open(str(path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(16_000)
+        output.writeframes(b"\x00\x00" * 16_000)
+
+
+def _container(root: Path) -> AppContainer:
+    container = AppContainer()
+    container.config.override(_config(root))
+    return container
+
+
+def _crash_after_checkpoint(root_text: str) -> None:
+    root = Path(root_text)
+    source = root / "source.wav"
+    container = _container(root)
+    planner = container.transcription_planner()
+    plan = planner.plan(
+        source,
+        profile=ProcessingProfile.SCREENING,
+        job_id=_JOB_ID,
+    )
+    job = container.workspace_service().create_job(
+        source,
+        output_dir=_config(root).OUTPUT_DIR,
+        job_id=_JOB_ID,
+    )
+    windows = (_WINDOW,)
+    store = container.checkpoint_store()
+    store.initialize(job, plan, windows)
+    store.save_segment(
+        job,
+        plan,
+        windows,
+        _WINDOW,
+        EngineTranscript(
+            segments=(
+                RecognizedSegment(
+                    index=0,
+                    start_seconds=0.0,
+                    end_seconds=1.0,
+                    text="Durable checkpoint.",
+                ),
+            ),
+            language="en",
+            language_probability=1.0,
+            engine_version="crash-acceptance-engine",
+        ),
+    )
+    os._exit(_EXIT_AFTER_CHECKPOINT)
+
+
+def test_completed_checkpoint_survives_unceremonious_process_exit(tmp_path):
+    if shutil.which("ffprobe") is None:
+        pytest.skip("ffprobe is not installed")
+
+    source = tmp_path / "source.wav"
+    _make_wav(source)
+
+    process = multiprocessing.get_context("spawn").Process(
+        target=_crash_after_checkpoint,
+        args=(str(tmp_path),),
+    )
+    process.start()
+    process.join(timeout=30)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=5)
+        pytest.fail("checkpoint crash worker did not exit")
+
+    assert process.exitcode == _EXIT_AFTER_CHECKPOINT
+
+    container = _container(tmp_path)
+    plan = container.transcription_planner().plan_resume(source, job_id=_JOB_ID)
+    restored = container.checkpoint_store().restore(plan.job, plan, (_WINDOW,))
+
+    assert len(restored.completed) == 1
+    window, transcript = restored.completed[0]
+    assert window == _WINDOW
+    assert transcript.segments[0].text == "Durable checkpoint."
+    assert restored.detected_language == "en"
+    assert restored.engine_version == "crash-acceptance-engine"
+
+    checkpoint = plan.job.workspace_dir / "checkpoints" / "audio-000000.json"
+    assert checkpoint.is_file()
+    assert source.is_file()

--- a/src/echoflow/transcription/tests/test_multistream_media_acceptance.py
+++ b/src/echoflow/transcription/tests/test_multistream_media_acceptance.py
@@ -1,0 +1,106 @@
+import shutil
+import subprocess
+import wave
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from echoflow.media.models import StreamKind
+from echoflow.media.probe import FfprobeMediaProbe
+from echoflow.transcription.audio import FfmpegAudioDecoder
+from echoflow.transcription.models import DecodeConfiguration, DecodeStrategy
+
+
+def _native_tool(name: str) -> str:
+    executable = shutil.which(name)
+    if executable is None:
+        pytest.skip(f"{name} is not installed")
+    return executable
+
+
+def _make_multitrack_video(path: Path) -> None:
+    ffmpeg = _native_tool("ffmpeg")
+    command = [
+        ffmpeg,
+        "-nostdin",
+        "-v",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=64x64:r=1",
+        "-f",
+        "lavfi",
+        "-i",
+        "anullsrc=r=16000:cl=mono",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=880:sample_rate=16000",
+        "-t",
+        "1.25",
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0",
+        "-map",
+        "2:a:0",
+        "-c:v",
+        "mpeg4",
+        "-c:a",
+        "pcm_s16le",
+        "-y",
+        str(path),
+    ]
+    subprocess.run(command, check=True, capture_output=True)  # noqa: S603
+
+
+def _pcm_payload(path: Path) -> bytes:
+    with wave.open(str(path), "rb") as audio:
+        assert audio.getframerate() == 16_000
+        assert audio.getnchannels() == 1
+        assert audio.getsampwidth() == 2
+        return audio.readframes(audio.getnframes())
+
+
+def test_real_ffmpeg_honors_explicit_audio_stream_selection(tmp_path):
+    _native_tool("ffprobe")
+    source = tmp_path / "two-track-interview.mkv"
+    _make_multitrack_video(source)
+
+    media = FfprobeMediaProbe().probe(source)
+    audio_streams = tuple(
+        stream for stream in media.streams if stream.kind is StreamKind.AUDIO
+    )
+    assert len(audio_streams) == 2
+    assert media.primary_audio_stream_index == audio_streams[0].index
+
+    selected = replace(media, primary_audio_stream_index=audio_streams[1].index)
+    configuration = DecodeConfiguration(
+        DecodeStrategy.FFMPEG_NORMALIZE,
+        "pcm_s16le",
+        16_000,
+        1,
+    )
+    first_workspace = tmp_path / "first"
+    second_workspace = tmp_path / "second"
+    first_workspace.mkdir()
+    second_workspace.mkdir()
+    decoder = FfmpegAudioDecoder()
+
+    first = decoder.decode(media, configuration, first_workspace)
+    second = decoder.decode(selected, configuration, second_workspace)
+    first_payload = _pcm_payload(first.path)
+    second_payload = _pcm_payload(second.path)
+
+    assert first_payload
+    assert not any(first_payload)
+    assert any(second_payload)
+    assert selected.primary_audio_stream_index == audio_streams[1].index
+
+    decoder.cleanup(first)
+    decoder.cleanup(second)
+    assert not first.path.exists()
+    assert not second.path.exists()
+    assert source.exists()


### PR DESCRIPTION
## What changed

- Added a real abrupt-process checkpoint acceptance test. A spawned Python process creates a real EchoFlow plan/workspace, persists a completed segment checkpoint through the normal DI/filesystem stack, then exits immediately with `os._exit()` without cleanup. A fresh container in the parent process must restore the checkpoint and original resume contract.
- Added a real FFmpeg/FFprobe multi-track media acceptance test. It generates a Matroska video with two audio streams (silence and an audible tone), probes the actual container, decodes each selected stream through EchoFlow, and verifies that `primary_audio_stream_index` controls which audio FFmpeg extracts.
- Strengthened `Engine Acceptance` so relevant changes merged to `main` automatically run the real faster-whisper/CTranslate2 harness, while PR CI remains model-download independent. Weekly and manual execution remain available.

## Why

PR #42 established real OS/process/native/package acceptance coverage, but two execution contracts still deserved direct proof before feature expansion:

1. checkpoint durability across interpreter death rather than exception-only failure injection,
2. explicit media-stream mapping at the decoder boundary rather than assuming a single audio stream.

The post-merge engine trigger closes a separate evidence gap: a real-engine workflow should not depend solely on a weekly schedule or a human remembering to dispatch it after engine/dependency changes.

These changes establish the evidence needed for the next small architecture change: planner-level deterministic audio-stream selection that is preserved across checkpoint/resume.

## Deliberate boundaries

- This is process-crash recovery testing, not a claim of storage durability across sudden power loss.
- The multi-track test proves the decoder seam can honor an explicitly selected stream. It does not yet expose a CLI stream-selection feature.
- Real model execution remains outside mandatory PR CI.
- No additional media/plugin abstraction is introduced here. The existing probe → decode → segment boundaries remain intact.