### PR TITLE
Prove known speech end to end

### DIFF
--- a/.github/workflows/engine-acceptance.yml
+++ b/.github/workflows/engine-acceptance.yml
@@ -4,14 +4,20 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "17 9 * * 1"
+  pull_request:
+    paths:
+      - ".github/workflows/engine-acceptance.yml"
+      - "scripts/verify_engine_acceptance.py"
   push:
     branches: [main]
     paths:
       - ".github/workflows/engine-acceptance.yml"
       - "scripts/verify_engine_acceptance.py"
-      - "src/echoflow/transcription/backend.py"
-      - "src/echoflow/transcription/models.py"
-      - "src/echoflow/transcription/strategy.py"
+      - "src/echoflow/app/**"
+      - "src/echoflow/interfaces/**"
+      - "src/echoflow/media/**"
+      - "src/echoflow/transcription/**"
+      - "src/echoflow/workspace/**"
       - "pyproject.toml"
       - "uv.lock"
 
@@ -25,11 +31,11 @@ concurrency:
 jobs:
   faster-whisper-cpu:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba80582510c181273ba90b1 # v7
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -42,8 +48,16 @@ jobs:
           version: "0.11.33"
           enable-cache: true
 
+      - name: Install native acceptance tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg espeak-ng
+          command -v ffmpeg
+          command -v ffprobe
+          command -v espeak-ng
+
       - name: Install locked transcription dependencies
         run: uv sync --locked --extra transcription
 
-      - name: Execute real faster-whisper acceptance
+      - name: Execute known-speech end-to-end acceptance
         run: uv run python scripts/verify_engine_acceptance.py

--- a/.github/workflows/engine-acceptance.yml
+++ b/.github/workflows/engine-acceptance.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@3d3c42e5aac5ba80582510c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/scripts/verify_engine_acceptance.py
+++ b/scripts/verify_engine_acceptance.py
@@ -25,7 +25,7 @@ def _run(
     env: dict[str, str] | None = None,
     capture_output: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
+    return subprocess.run(  # noqa: S603
         command,
         check=True,
         env=env,

--- a/scripts/verify_engine_acceptance.py
+++ b/scripts/verify_engine_acceptance.py
@@ -179,19 +179,15 @@ def _words(text: str) -> set[str]:
     return set(re.findall(r"[a-z]+", text.lower()))
 
 
-def _validate_transcript(
-    output_dir: Path,
-    *,
-    input_path: Path,
-    model_dir: Path,
-    expected_decode_strategy: str,
-) -> set[str]:
-    canonical_path = _one_artifact(output_dir, ".json")
-    raw_document = canonical_path.read_text(encoding="utf-8")
+def _load_canonical(output_dir: Path) -> tuple[dict[str, Any], str]:
+    raw_document = _one_artifact(output_dir, ".json").read_text(encoding="utf-8")
     document = json.loads(raw_document)
     if not isinstance(document, dict):
         raise RuntimeError("canonical transcript is not a JSON object")
+    return document, raw_document
 
+
+def _validate_known_speech(document: dict[str, Any]) -> set[str]:
     text = str(document.get("text", "")).strip()
     recognized_expected = _words(text) & _EXPECTED_WORDS
     if len(recognized_expected) < _MIN_EXPECTED_WORDS:
@@ -199,7 +195,12 @@ def _validate_transcript(
             "known speech was not recognized reliably enough: "
             f"matched {sorted(recognized_expected)}"
         )
+    return recognized_expected
 
+
+def _validate_provenance(
+    document: dict[str, Any], *, expected_decode_strategy: str
+) -> None:
     if document.get("schema_version") != 1:
         raise RuntimeError("unexpected canonical transcript schema version")
     if document.get("decode_strategy") != expected_decode_strategy:
@@ -209,23 +210,28 @@ def _validate_transcript(
 
     source = document.get("source")
     engine = document.get("engine")
-    segments = document.get("segments")
     if not isinstance(source, dict) or not isinstance(engine, dict):
         raise RuntimeError("canonical provenance is incomplete")
-    if not isinstance(segments, list) or not segments:
-        raise RuntimeError("known speech produced no canonical recognition segments")
-    if engine.get("name") != "faster-whisper":
-        raise RuntimeError("canonical transcript recorded the wrong engine")
-    if engine.get("model") != "tiny":
-        raise RuntimeError("canonical transcript recorded the wrong model")
+    if engine.get("name") != "faster-whisper" or engine.get("model") != "tiny":
+        raise RuntimeError("canonical transcript recorded the wrong engine or model")
     if engine.get("device") != "cpu" or engine.get("compute_type") != "int8":
         raise RuntimeError("canonical transcript recorded the wrong CPU configuration")
     if not str(engine.get("package_version", "")).strip():
         raise RuntimeError("canonical transcript omitted the engine package version")
 
+
+def _validate_timestamps(document: dict[str, Any]) -> None:
+    source = document.get("source")
+    segments = document.get("segments")
+    if not isinstance(source, dict):
+        raise RuntimeError("canonical transcript source provenance is malformed")
+    if not isinstance(segments, list) or not segments:
+        raise RuntimeError("known speech produced no canonical recognition segments")
+
     duration_seconds = float(source.get("duration_seconds", 0.0))
     if duration_seconds <= 0:
         raise RuntimeError("canonical transcript recorded an invalid source duration")
+
     previous_start = 0.0
     for index, segment in enumerate(segments):
         if not isinstance(segment, dict):
@@ -240,10 +246,14 @@ def _validate_transcript(
             raise RuntimeError("canonical segment timestamp exceeds source duration")
         previous_start = start
 
+
+def _validate_privacy(raw_document: str, *, input_path: Path, model_dir: Path) -> None:
     sensitive_values = (str(input_path), input_path.name, str(model_dir))
     if any(value and value in raw_document for value in sensitive_values):
         raise RuntimeError("canonical transcript leaked a local path or source filename")
 
+
+def _validate_exports(output_dir: Path) -> None:
     txt = _one_artifact(output_dir, ".txt").read_text(encoding="utf-8")
     srt = _one_artifact(output_dir, ".srt").read_text(encoding="utf-8")
     vtt = _one_artifact(output_dir, ".vtt").read_text(encoding="utf-8")
@@ -254,6 +264,20 @@ def _validate_transcript(
     if len(_words(txt) & _EXPECTED_WORDS) < _MIN_EXPECTED_WORDS:
         raise RuntimeError("plain-text export does not contain recognizable known speech")
 
+
+def _validate_transcript(
+    output_dir: Path,
+    *,
+    input_path: Path,
+    model_dir: Path,
+    expected_decode_strategy: str,
+) -> set[str]:
+    document, raw_document = _load_canonical(output_dir)
+    recognized_expected = _validate_known_speech(document)
+    _validate_provenance(document, expected_decode_strategy=expected_decode_strategy)
+    _validate_timestamps(document)
+    _validate_privacy(raw_document, input_path=input_path, model_dir=model_dir)
+    _validate_exports(output_dir)
     return recognized_expected
 
 

--- a/scripts/verify_engine_acceptance.py
+++ b/scripts/verify_engine_acceptance.py
@@ -25,13 +25,20 @@ def _run(
     env: dict[str, str] | None = None,
     capture_output: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(  # noqa: S603
+    completed = subprocess.run(  # noqa: S603
         command,
-        check=True,
+        check=False,
         env=env,
         text=True,
         capture_output=capture_output,
     )
+    if completed.returncode != 0:
+        detail = (completed.stderr or "").strip() if capture_output else ""
+        message = "acceptance subprocess failed"
+        if detail:
+            message = f"{message}: {detail}"
+        raise RuntimeError(message)
+    return completed
 
 
 def _generate_media(root: Path) -> tuple[Path, Path]:
@@ -105,9 +112,11 @@ def _environment(root: Path, output_dir: Path) -> dict[str, str]:
         {
             "ECHOFLOW_STATE_DIR": str(root / "state"),
             "ECHOFLOW_CACHE_DIR": str(root / "cache"),
-            "ECHOFLOW_MODEL_DIR": str(root / "models"),
+            "ECHOFLOW_MODEL_DIR": str(root / "cache" / "models"),
             "ECHOFLOW_OUTPUT_DIR": str(output_dir),
             "ECHOFLOW_MAX_CPU_THREADS": "2",
+            "ECHOFLOW_MIN_FREE_DISK_BYTES": "0",
+            "ECHOFLOW_WARN_FREE_DISK_BYTES": "0",
         }
     )
     return env
@@ -259,7 +268,7 @@ def verify_engine() -> None:
     with tempfile.TemporaryDirectory(prefix="echoflow-engine-") as temporary:
         root = Path(temporary).resolve()
         direct_audio, media_container = _generate_media(root)
-        model_dir = root / "models"
+        model_dir = root / "cache" / "models"
 
         direct_output = root / "output-direct"
         direct_env = _environment(root, direct_output)

--- a/scripts/verify_engine_acceptance.py
+++ b/scripts/verify_engine_acceptance.py
@@ -1,73 +1,311 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
+import re
+import subprocess
+import sys
 import tempfile
-import wave
 from pathlib import Path
+from typing import Any
 
-from echoflow.transcription.backend import FasterWhisperTranscriber
-from echoflow.transcription.models import CpuEngineConfiguration
-
-_SAMPLE_RATE_HZ = 16_000
-
-
-def _write_silence(path: Path) -> None:
-    with wave.open(str(path), "wb") as audio:
-        audio.setnchannels(1)
-        audio.setsampwidth(2)
-        audio.setframerate(_SAMPLE_RATE_HZ)
-        audio.writeframes(b"\x00\x00" * _SAMPLE_RATE_HZ)
+_PHRASE = (
+    "The quick brown fox jumps over the lazy dog. "
+    "Echo Flow keeps local recordings private and recoverable."
+)
+_EXPECTED_WORDS = frozenset({"quick", "brown", "fox", "lazy", "dog"})
+_MIN_EXPECTED_WORDS = 4
+_TIMESTAMP_TOLERANCE_SECONDS = 0.5
 
 
-def _configuration(model_cache: Path) -> CpuEngineConfiguration:
-    return CpuEngineConfiguration(
-        engine="faster-whisper",
-        model="tiny",
-        device="cpu",
-        compute_type="int8",
-        cpu_threads=2,
-        beam_size=1,
-        language="en",
-        model_cache_path=model_cache,
+def _run(
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=True,
+        env=env,
+        text=True,
+        capture_output=capture_output,
     )
+
+
+def _generate_media(root: Path) -> tuple[Path, Path]:
+    synthesized = root / "known-speech-source.wav"
+    canonical = root / "known-speech-direct.wav"
+    container = root / "known-speech-media.mp4"
+
+    _run(
+        [
+            "espeak-ng",
+            "-v",
+            "en-us",
+            "-s",
+            "145",
+            "-w",
+            str(synthesized),
+            _PHRASE,
+        ]
+    )
+    _run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-nostdin",
+            "-y",
+            "-i",
+            str(synthesized),
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-c:a",
+            "pcm_s16le",
+            str(canonical),
+        ]
+    )
+    _run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-nostdin",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=160x120:r=1",
+            "-i",
+            str(canonical),
+            "-map",
+            "0:v:0",
+            "-map",
+            "1:a:0",
+            "-shortest",
+            "-c:v",
+            "mpeg4",
+            "-c:a",
+            "aac",
+            str(container),
+        ]
+    )
+    return canonical, container
+
+
+def _environment(root: Path, output_dir: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "ECHOFLOW_STATE_DIR": str(root / "state"),
+            "ECHOFLOW_CACHE_DIR": str(root / "cache"),
+            "ECHOFLOW_MODEL_DIR": str(root / "models"),
+            "ECHOFLOW_OUTPUT_DIR": str(output_dir),
+            "ECHOFLOW_MAX_CPU_THREADS": "2",
+        }
+    )
+    return env
+
+
+def _initialize(env: dict[str, str]) -> None:
+    completed = _run(
+        [sys.executable, "-m", "echoflow", "init", "--json"],
+        env=env,
+        capture_output=True,
+    )
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, dict):
+        raise RuntimeError("EchoFlow init did not return a JSON object")
+
+
+def _transcribe(
+    input_path: Path,
+    *,
+    env: dict[str, str],
+    allow_model_download: bool,
+) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        "-m",
+        "echoflow",
+        "transcribe",
+        str(input_path),
+        "--profile",
+        "screening",
+        "--strategy",
+        "tiny-cpu-int8",
+        "--export",
+        "txt",
+        "--export",
+        "srt",
+        "--export",
+        "vtt",
+        "--json",
+    ]
+    if allow_model_download:
+        command.append("--allow-model-download")
+    completed = _run(command, env=env, capture_output=True)
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, dict):
+        raise RuntimeError("EchoFlow transcribe did not return a JSON object")
+    return payload
+
+
+def _one_artifact(output_dir: Path, suffix: str) -> Path:
+    matches = tuple(output_dir.glob(f"*{suffix}"))
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one {suffix} artifact, found {len(matches)} in acceptance output"
+        )
+    return matches[0]
+
+
+def _words(text: str) -> set[str]:
+    return set(re.findall(r"[a-z]+", text.lower()))
+
+
+def _validate_transcript(
+    output_dir: Path,
+    *,
+    input_path: Path,
+    model_dir: Path,
+    expected_decode_strategy: str,
+) -> set[str]:
+    canonical_path = _one_artifact(output_dir, ".json")
+    raw_document = canonical_path.read_text(encoding="utf-8")
+    document = json.loads(raw_document)
+    if not isinstance(document, dict):
+        raise RuntimeError("canonical transcript is not a JSON object")
+
+    text = str(document.get("text", "")).strip()
+    recognized_expected = _words(text) & _EXPECTED_WORDS
+    if len(recognized_expected) < _MIN_EXPECTED_WORDS:
+        raise RuntimeError(
+            "known speech was not recognized reliably enough: "
+            f"matched {sorted(recognized_expected)}"
+        )
+
+    if document.get("schema_version") != 1:
+        raise RuntimeError("unexpected canonical transcript schema version")
+    if document.get("decode_strategy") != expected_decode_strategy:
+        raise RuntimeError("canonical transcript recorded the wrong decode strategy")
+    if document.get("detected_language") != "en":
+        raise RuntimeError("known English speech was not detected as English")
+
+    source = document.get("source")
+    engine = document.get("engine")
+    segments = document.get("segments")
+    if not isinstance(source, dict) or not isinstance(engine, dict):
+        raise RuntimeError("canonical provenance is incomplete")
+    if not isinstance(segments, list) or not segments:
+        raise RuntimeError("known speech produced no canonical recognition segments")
+    if engine.get("name") != "faster-whisper":
+        raise RuntimeError("canonical transcript recorded the wrong engine")
+    if engine.get("model") != "tiny":
+        raise RuntimeError("canonical transcript recorded the wrong model")
+    if engine.get("device") != "cpu" or engine.get("compute_type") != "int8":
+        raise RuntimeError("canonical transcript recorded the wrong CPU configuration")
+    if not str(engine.get("package_version", "")).strip():
+        raise RuntimeError("canonical transcript omitted the engine package version")
+
+    duration_seconds = float(source.get("duration_seconds", 0.0))
+    if duration_seconds <= 0:
+        raise RuntimeError("canonical transcript recorded an invalid source duration")
+    previous_start = 0.0
+    for index, segment in enumerate(segments):
+        if not isinstance(segment, dict):
+            raise RuntimeError("canonical transcript contains a malformed segment")
+        if segment.get("index") != index:
+            raise RuntimeError("canonical segment indices are not contiguous")
+        start = float(segment.get("start_seconds", -1.0))
+        end = float(segment.get("end_seconds", -1.0))
+        if start < 0 or end < start or start < previous_start:
+            raise RuntimeError("canonical segment timestamps are not finite and ordered")
+        if end > duration_seconds + _TIMESTAMP_TOLERANCE_SECONDS:
+            raise RuntimeError("canonical segment timestamp exceeds source duration")
+        previous_start = start
+
+    sensitive_values = (str(input_path), input_path.name, str(model_dir))
+    if any(value and value in raw_document for value in sensitive_values):
+        raise RuntimeError("canonical transcript leaked a local path or source filename")
+
+    txt = _one_artifact(output_dir, ".txt").read_text(encoding="utf-8")
+    srt = _one_artifact(output_dir, ".srt").read_text(encoding="utf-8")
+    vtt = _one_artifact(output_dir, ".vtt").read_text(encoding="utf-8")
+    if not txt.strip() or not srt.strip() or not vtt.strip():
+        raise RuntimeError("one or more derived transcript exports are empty")
+    if "-->" not in srt or "-->" not in vtt or not vtt.startswith("WEBVTT"):
+        raise RuntimeError("subtitle exports do not contain timestamp cues")
+    if len(_words(txt) & _EXPECTED_WORDS) < _MIN_EXPECTED_WORDS:
+        raise RuntimeError("plain-text export does not contain recognizable known speech")
+
+    return recognized_expected
+
+
+def _validate_private_cleanup(root: Path) -> None:
+    state_dir = root / "state"
+    leftovers = tuple(state_dir.rglob("*.wav")) if state_dir.exists() else ()
+    if leftovers:
+        raise RuntimeError("successful execution left temporary decoded/segment WAV data")
 
 
 def verify_engine() -> None:
     with tempfile.TemporaryDirectory(prefix="echoflow-engine-") as temporary:
         root = Path(temporary).resolve()
-        model_cache = root / "models"
-        audio_path = root / "acceptance.wav"
-        model_cache.mkdir()
-        _write_silence(audio_path)
+        direct_audio, media_container = _generate_media(root)
+        model_dir = root / "models"
 
-        configuration = _configuration(model_cache)
-        transcriber = FasterWhisperTranscriber()
-
-        downloaded_session = transcriber.open_session(
-            configuration,
+        direct_output = root / "output-direct"
+        direct_env = _environment(root, direct_output)
+        _initialize(direct_env)
+        _transcribe(
+            direct_audio,
+            env=direct_env,
             allow_model_download=True,
         )
-        downloaded_result = downloaded_session.transcribe(audio_path)
+        direct_words = _validate_transcript(
+            direct_output,
+            input_path=direct_audio,
+            model_dir=model_dir,
+            expected_decode_strategy="direct",
+        )
+        if not model_dir.exists() or not any(model_dir.iterdir()):
+            raise RuntimeError("model download did not populate the private cache")
 
-        local_session = transcriber.open_session(
-            configuration,
+        normalized_output = root / "output-normalized"
+        normalized_env = _environment(root, normalized_output)
+        _initialize(normalized_env)
+        _transcribe(
+            media_container,
+            env=normalized_env,
             allow_model_download=False,
         )
-        local_result = local_session.transcribe(audio_path)
+        normalized_words = _validate_transcript(
+            normalized_output,
+            input_path=media_container,
+            model_dir=model_dir,
+            expected_decode_strategy="ffmpeg_normalize",
+        )
 
-        if downloaded_result.engine_version != local_result.engine_version:
-            raise RuntimeError("engine version changed within one acceptance run")
-        if not downloaded_result.engine_version.strip():
-            raise RuntimeError("engine version was not reported")
-        if not any(model_cache.iterdir()):
-            raise RuntimeError("model download did not populate the private cache")
+        if len(direct_words & normalized_words) < 3:
+            raise RuntimeError(
+                "direct and normalized paths did not preserve enough recognizable speech"
+            )
+        _validate_private_cleanup(root)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Download and execute the smallest configured faster-whisper model, then "
-            "reopen it with network retrieval disabled."
+            "Generate known speech, run it through EchoFlow's real CLI and smallest "
+            "faster-whisper strategy, then prove offline cache reuse and the real "
+            "FFmpeg-normalized media path."
         )
     )
     parser.parse_args()

--- a/scripts/verify_engine_acceptance.py
+++ b/scripts/verify_engine_acceptance.py
@@ -241,7 +241,9 @@ def _validate_timestamps(document: dict[str, Any]) -> None:
         start = float(segment.get("start_seconds", -1.0))
         end = float(segment.get("end_seconds", -1.0))
         if start < 0 or end < start or start < previous_start:
-            raise RuntimeError("canonical segment timestamps are not finite and ordered")
+            raise RuntimeError(
+                "canonical segment timestamps are not finite and ordered"
+            )
         if end > duration_seconds + _TIMESTAMP_TOLERANCE_SECONDS:
             raise RuntimeError("canonical segment timestamp exceeds source duration")
         previous_start = start
@@ -250,7 +252,9 @@ def _validate_timestamps(document: dict[str, Any]) -> None:
 def _validate_privacy(raw_document: str, *, input_path: Path, model_dir: Path) -> None:
     sensitive_values = (str(input_path), input_path.name, str(model_dir))
     if any(value and value in raw_document for value in sensitive_values):
-        raise RuntimeError("canonical transcript leaked a local path or source filename")
+        raise RuntimeError(
+            "canonical transcript leaked a local path or source filename"
+        )
 
 
 def _validate_exports(output_dir: Path) -> None:
@@ -262,7 +266,9 @@ def _validate_exports(output_dir: Path) -> None:
     if "-->" not in srt or "-->" not in vtt or not vtt.startswith("WEBVTT"):
         raise RuntimeError("subtitle exports do not contain timestamp cues")
     if len(_words(txt) & _EXPECTED_WORDS) < _MIN_EXPECTED_WORDS:
-        raise RuntimeError("plain-text export does not contain recognizable known speech")
+        raise RuntimeError(
+            "plain-text export does not contain recognizable known speech"
+        )
 
 
 def _validate_transcript(
@@ -285,7 +291,9 @@ def _validate_private_cleanup(root: Path) -> None:
     state_dir = root / "state"
     leftovers = tuple(state_dir.rglob("*.wav")) if state_dir.exists() else ()
     if leftovers:
-        raise RuntimeError("successful execution left temporary decoded/segment WAV data")
+        raise RuntimeError(
+            "successful execution left temporary decoded/segment WAV data"
+        )
 
 
 def verify_engine() -> None:


### PR DESCRIPTION
## What changed

- Replaced the silence-only engine smoke with a known-speech acceptance harness that generates a short English utterance locally at test time.
- Runs the real EchoFlow CLI with the real faster-whisper `tiny` CPU/int8 strategy rather than calling the backend directly.
- Exercises both a canonical mono 16 kHz PCM WAV and the same speech wrapped in a real MP4/AAC container so the second run crosses the production FFprobe/FFmpeg normalization path.
- The first run explicitly authorizes model retrieval. The second run reuses the same private model cache with downloads disabled, proving local-only reopen semantics through the application boundary.
- Validates recognizable words without requiring punctuation-perfect ASR output, canonical schema/provenance, English detection, ordered timestamps bounded by source duration, TXT/SRT/WebVTT timestamp cues, privacy-safe canonical JSON, model-cache population, and cleanup of temporary decoded/segment WAV data.
- Adds a narrow PR trigger only when the acceptance workflow or harness itself changes. Normal feature PRs remain free of model-download requirements; relevant merged execution changes continue to trigger the real engine lane on `main`.
- Installs FFmpeg/FFprobe and `espeak-ng` only inside the dedicated Ubuntu acceptance job. No speech fixture bytes are committed to the repository.

## Why

The previous engine lane proved that faster-whisper/CTranslate2 could download, initialize, transcribe silence, and reopen the model cache offline. It did not prove that recognizable speech survives the complete EchoFlow CLI, provenance, media-normalization, canonicalization, export, and cleanup path. This closes that evidence gap without making ordinary PR CI dependent on a remote speech fixture or a model download.

## Deliberate boundaries

- This PR validates one known English utterance. It does not claim mixed-language/code-switching support.
- Current automatic language detection is still latched for the job after the first detected application segment. Per-span language attribution requires a canonical transcript/language-capability change rather than an acceptance-test shortcut.
- Recognition segments carry source-relative timestamps, but speaker diarization/identification is not implemented here.
