### PR TITLE
Sync architecture docs with current library and diarization contracts

### DIFF
--- a/docs/architecture/diarization.md
+++ b/docs/architecture/diarization.md
@@ -13,9 +13,10 @@ recording is the same person in another recording.
 The first adapter targets the open-source pyannote `community-1` pipeline. Upstream
 currently requires accepting the model conditions and authenticating with Hugging
 Face for initial model acquisition. EchoFlow does not store an HF token in its own
-configuration. Model acquisition uses the standard Hugging Face credential flow and
-the same explicit `--allow-model-download` authorization used for ASR model
-retrieval.
+configuration. Model acquisition uses the standard Hugging Face credential flow and a
+narrow `--allow-diarization-model-download` authorization that applies only to this
+optional capability. ASR model acquisition remains a separate explicit
+`echoflow models install MODEL` action.
 
 Pyannote telemetry is disabled by EchoFlow before the pyannote package is imported.
 The adapter records `telemetry_enabled: false` in diarization provenance. Recording
@@ -61,8 +62,20 @@ containing the merged fix is available and qualified.
 Diarization is opt-in:
 
 ```bash
-uv run echoflow transcribe interview.wav --diarize --allow-model-download
+uv run echoflow transcribe interview.wav --diarize
 ```
+
+If the Community-1 snapshot is not already available in EchoFlow's configured model
+cache and the security gate has been cleared, acquisition must be authorized narrowly:
+
+```bash
+uv run echoflow transcribe interview.wav \
+  --diarize \
+  --allow-diarization-model-download
+```
+
+This flag does not authorize faster-whisper model downloads. ASR execution still
+requires a separately installed, verified managed model revision.
 
 If the speaker count is known, the user can provide an exact count:
 
@@ -97,9 +110,15 @@ Raw backend labels are not stable API. EchoFlow sorts turns deterministically an
 maps backend labels to `speaker-01`, `speaker-02`, and so on in first-seen timeline
 order.
 
-Canonical transcript schema version 3 stores both the exact `speaker_turns` and the
-diarization provenance. Non-diarized transcripts remain schema version 2 and retain
-their existing wire shape.
+EchoFlow's one current pre-production canonical transcript schema is version 1.
+Diarization is represented inside that same shape with optional `diarization`,
+`speaker_turns`, and per-segment `speaker_ref` evidence. A transcript without
+diarization keeps those optional capability fields empty rather than switching to a
+different schema version.
+
+Schema numbers represent structural evolution of the canonical contract, not feature
+combinations. EchoFlow intentionally does not retain the earlier unreleased v2/v3
+feature-version split.
 
 ## Conservative text projection
 
@@ -130,8 +149,13 @@ timestamps or becomes canonical custody.
 ## Model and dependency boundary
 
 The adapter resolves the configured pyannote snapshot into EchoFlow's private model
-cache. With `--allow-model-download` absent, snapshot resolution is cache-only. Once
-resolved, pyannote receives the local snapshot path for inference.
+cache. Without scoped diarization download authorization, snapshot resolution is
+cache-only. Once resolved, pyannote receives the local snapshot path for inference and
+does not need to fetch model bytes during execution.
+
+The internal diarization adapter carries an `allow_model_download` decision only for
+this pyannote resolution boundary. It is not a general application permission and does
+not reopen the removed transcription-time faster-whisper download path.
 
 The `diarization` extra is intentionally separate because the current pyannote 4.x
 stack resolves a substantial PyTorch dependency graph. Representative CPU-only

--- a/docs/architecture/processing-capabilities.md
+++ b/docs/architecture/processing-capabilities.md
@@ -7,7 +7,8 @@ one.
 For detailed media/timestamp semantics, see
 [media-and-timeline.md](media-and-timeline.md). For model custody, see
 [model-management.md](model-management.md). For preprocessing, see
-[speech-enhancement.md](speech-enhancement.md).
+[speech-enhancement.md](speech-enhancement.md). For corpus retrieval, see
+[corpus-search.md](corpus-search.md).
 
 ## Current transcription path
 
@@ -196,12 +197,25 @@ erasure.
 
 ## Transcript library boundary
 
-`TranscriptIndex` is a database-neutral application port for derived, rebuildable
-transcript search state. It exposes transcript-library behavior rather than generic SQL.
-A future DuckDB or other embedded adapter may implement it.
+`TranscriptIndex` is the database-neutral application port for derived, rebuildable
+transcript search state. The current `DuckDbTranscriptIndex` adapter stores private
+index state under `STATE_DIR/library/transcripts.duckdb` and implements deterministic
+local BM25-style ranking from ordinary document, segment, and term-statistic tables.
 
-The search database is never canonical custody. Deleting/rebuilding it must not mutate
-canonical transcript JSON or source recordings.
+`SearchQuery` keeps text, phrase mode, ANY/ALL semantics, speaker/language/document
+filters, sort order, and result limits above the storage boundary. User input is passed
+as parameterized values rather than SQL fragments. EchoFlow deliberately does not
+install or load DuckDB's FTS extension for this first tranche, so search does not gain a
+surprise network dependency on a fresh machine.
+
+`TranscriptLibraryService` discovers canonical transcripts, validates a narrow searchable
+projection, performs transactional rebuilds, exposes evidence-bearing matches, and can
+verify whether the bytes currently at a known source path still match the SHA-256
+recorded for transcription.
+
+The search database is never canonical custody. Deleting or rebuilding it must not
+mutate canonical transcript JSON or source recordings, and canonical transcript JSON
+remains the authoritative corpus artifact.
 
 ## Capability ownership
 
@@ -224,7 +238,9 @@ canonical transcript JSON or source recordings.
 | `LinguaLanguageAttributor` | Conservative text-language labels | Acoustic decoding |
 | `SpeakerDiarizer` | Anonymous speaker evidence | Biometric identity |
 | `TranscriptExporter` | TXT/SRT/VTT derived publication | Recognition truth |
-| `TranscriptIndex` | Rebuildable search behavior | Canonical custody |
+| `TranscriptIndex` | Database-neutral rebuildable search contract | Canonical custody |
+| `DuckDbTranscriptIndex` | Private lexical index and BM25 execution | Authoritative transcript state |
+| `TranscriptLibraryService` | Discovery, rebuild, search, and source-integrity receipts | SQL or canonical transcript ownership |
 | `WorkspaceService` | Private/public path allocation | Audio semantics |
 
 Protocols are introduced around real substitutable behavior, not pre-emptively for
@@ -246,8 +262,10 @@ EchoFlow does not currently claim:
 - storage durability across sudden power loss;
 - malicious same-user TOCTOU resistance;
 - secure erasure;
-- a production transcript-library backend; or
+- word-level alignment, semantic/vector retrieval, saved collections, tags/notes, or
+  generated corpus answers; or
 - a polished installer or desktop GUI.
 
-The next product work is representative-device and enhancement qualification, followed
-by evidence-first corpus search and a typed query layer.
+The next product work is dogfooding the current execution and library contracts,
+representative-device and enhancement qualification, corpus retrieval UX, and then
+word/timestamp alignment where real use shows the need for finer evidence coordinates.


### PR DESCRIPTION
## What changed

- update `processing-capabilities.md` to describe the implemented DuckDB transcript-library adapter, typed `SearchQuery`, offline BM25 ranking, evidence receipts, and current post-#55 capability boundaries
- update `diarization.md` to document the scoped `--allow-diarization-model-download` flag, the one current canonical transcript schema, and the current pyannote cache/download boundary
- leave the dated August 2 security audit unchanged because it is historical evidence, not living capability documentation

## Why

PRs #54 and #55 changed these contracts after parts of the architecture documentation were written. The stale language incorrectly described DuckDB/search as future work and retained the unreleased diarization schema/download behavior.

## Validation

This is a docs-only change based on a direct comparison against current `main` implementation and the already-current README, ROADMAP, SECURITY, corpus-search, and model-management documentation.