### PR TITLE
docs: give EchoFlow a human-first documentation voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,89 @@
-# EchoFlow
+# EchoFlow 🦝✨
 
-EchoFlow is a local-first Python application for audio processing, transcription, and
-analysis. It is designed to keep private, potentially large recordings on the user's
-machine.
+**Private local transcription that remembers where everything came from.**
 
-The product target is a privacy-by-default, resource-aware, reproducible, and resumable
-workflow for sensitive recordings rather than a model-specific transcription GUI.
-EchoFlow derives execution plans from CPU, system memory, and execution-capable
-accelerators actually available to the current process, keeps source media authoritative,
-makes local model and preprocessing provenance explicit, and provides evidence-first
-local search across completed transcripts.
+EchoFlow is a local-first Python application for turning recordings into durable,
+searchable evidence. It is designed for interviews, research recordings, meetings,
+lectures, oral histories, and other audio you may not want wandering off to a hosted
+transcription service.
 
-EchoFlow does not require a hosted transcription account. Durability, reliability,
-performance on ordinary hardware, local storage awareness, and portable user-owned
-artifacts are first-class constraints. See [`docs/getting-started.md`](docs/getting-started.md)
-for the short user path and [`ROADMAP.md`](ROADMAP.md) for current work and research
-candidates.
+The application does more than run a speech model. It inspects the machine it is running
+on, chooses a safe execution strategy, manages local model custody, survives interrupted
+work, preserves source provenance, publishes portable transcripts, and builds a private
+searchable library over completed recordings.
 
-## Project status
+The original recording remains read-only input. Canonical transcript JSON is the
+authoritative transcript artifact. Working audio and search databases are derived state
+that can be regenerated.
 
-EchoFlow is pre-production. Its current tested foundation includes:
+> **EchoFlow's product rule:** do complicated work locally, keep the evidence
+> understandable, portable, and owned by the user.
 
-- a Typer/Rich CLI with deterministic JSON output;
-- `echoflow doctor`, first-run initialization, and platform-aware private state;
-- process-visible CPU, affinity, cgroup, memory, accelerator, and runtime capability
-  inspection;
-- resource-admitted faster-whisper CPU/int8 and CUDA execution strategies with no
-  silent fallback for explicit selections;
-- FFprobe media inspection and deterministic audio-stream selection;
-- FFmpeg canonicalization to mono 16 kHz PCM16 WAV where needed;
-- exact source-relative frame segmentation and one job-scoped faster-whisper session;
-- bounded one-segment CPU preparation overlap for accelerated inference;
-- durable private checkpoints and validated resume;
-- multilingual faster-whisper decoding plus conservative local language attribution;
-- optional anonymous local speaker diarization, currently security-held when its
-  locked dependency graph is unsafe;
-- canonical JSON with deterministic TXT, SRT, and WebVTT derived exports;
-- explicit faster-whisper model inventory, recommendation, installation, local
-  verification, immutable revision pinning, and exact-revision removal;
-- mandatory managed-model custody for ASR planning and execution;
-- optional deterministic local FFmpeg speech noise suppression with private derived
-  audio, timeline-preservation checks, and transcript provenance;
-- a database-neutral transcript-index port with a private rebuildable DuckDB backend,
-  deterministic offline BM25-style lexical ranking, and typed evidence search;
-- canonical transcript SHA-256 projection and semantic corpus-fingerprint stale-state
-  detection;
-- deterministic segment-anchored search chunks and a separate rebuildable semantic
-  DuckDB index using numeric `FLOAT[]` vectors;
-- a strict-local multilingual-E5 embedding adapter with explicit query/passage
-  semantics and immutable profile provenance;
-- exact local semantic similarity plus BM25+dense reciprocal-rank hybrid retrieval;
-- one evidence-bearing retrieval response contract with lexical, semantic, and fused
-  ranks;
-- human-readable transcript evidence receipts with canonical/source locations,
-  recorded source SHA-256, and current source-integrity verification;
-- storage preflight for normalization, enhancement, segment materialization, model
-  acquisition, and published artifacts;
-- cross-platform private-storage enforcement and Linux/macOS/Windows CI.
+For the human-friendly documentation lobby, start at **[docs/README.md](docs/README.md)**.
+For the shortest path from clone to transcript, use
+**[Getting started](docs/getting-started.md)**.
 
-The Sentence Transformers runtime is intentionally not added to the locked dependency
-graph in the semantic-foundation tranche. Semantic search therefore remains an optional
-capability for environments that already provide a compatible local runtime and an
-immutable local `intfloat/multilingual-e5-small` snapshot. Lexical BM25 search remains
-fully available without it.
+🧜‍♀️
 
-Accelerator memory estimates and performance ranks remain conservative heuristics until
-representative-device qualification is complete. Standalone end-user installers and a
-graphical UI are not implemented yet.
+## What can it do right now?
 
-## Requirements and installation
+EchoFlow is pre-production, but the current backend already covers a surprisingly large
+part of the local recording lifecycle.
 
-EchoFlow does not publish end-user installers or Releases yet. The supported path is a
-source/developer install with Python 3.12 and `uv`:
+| Area | Current foundation |
+|---|---|
+| Local transcription | faster-whisper CPU/int8 and CUDA-capable strategies with explicit managed model revisions |
+| Hardware awareness | process-visible CPU/RAM, affinity/cgroup limits, accelerator topology, engine capability negotiation, and resource admission |
+| Media handling | FFprobe inspection, deterministic audio-stream selection, FFmpeg canonicalization, exact source-relative frame windows |
+| Reliability | durable private checkpoints, validated resume, contiguous checkpoint ordering, bounded accelerated prefetch |
+| Languages | multilingual decoding plus conservative local text-language attribution |
+| Speakers | optional anonymous recording-scoped diarization, currently blocked when its locked dependency security gate is unsafe |
+| Difficult audio | optional deterministic local FFmpeg noise suppression with provenance and timeline-preservation checks |
+| Model custody | explicit inventory, recommendation, install, local revalidation, immutable revision pinning, and exact-revision removal |
+| Transcript output | canonical JSON plus deterministic TXT, SRT, and WebVTT derived views |
+| Search | private local BM25 lexical retrieval, optional semantic retrieval, and inspectable hybrid RRF ranking |
+| Evidence | source/canonical SHA-256, timestamps, speaker/language context, provenance, stale-index detection, and integrity receipts |
+| Portability | Linux, macOS, and Windows CI plus clean-wheel/package verification |
+
+The point of this list is not that users should learn every subsystem. It is that most
+of the annoying decisions around local transcription are becoming application behavior
+instead of homework.
+
+## The journey from recording to something useful
+
+```mermaid
+flowchart LR
+    A[Original recording] --> B[Inspect source + machine]
+    B --> C[Choose safe local strategy]
+    C --> D[Transcribe + checkpoint]
+    D --> E[Canonical transcript]
+    E --> F[TXT / SRT / WebVTT]
+    E --> G[Lexical search]
+    E --> H[Optional semantic search]
+    G --> I[Evidence-bearing results]
+    H --> I
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef publish fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A evidence
+    class B,C compute
+    class D process
+    class E,F publish
+    class G,H,I result
+```
+
+That flow is intentionally evidence-first. Search results still point back to passages,
+timestamps, speakers/languages, and canonical transcript coordinates instead of
+replacing the corpus with an uncited generated answer.
+
+## Install the current source build
+
+EchoFlow does not publish end-user installers or Releases yet. The current supported
+path is a source/developer install with Python 3.12 and `uv`:
 
 ```bash
 git clone https://github.com/SSD1805/EchoFlow.git
@@ -79,200 +91,125 @@ cd EchoFlow
 uv sync --locked --extra transcription
 ```
 
-Run the CLI and initialize local directories:
+Initialize private application state and inspect the machine:
 
 ```bash
-uv run echoflow
 uv run echoflow init
 uv run echoflow doctor
 uv run echoflow runner
-uv run echoflow strategies
 ```
 
-CUDA is not assumed merely because a GPU is visible. EchoFlow selects CUDA only when
-physical topology, the CTranslate2 runtime, compute type, system-memory budget, and
-device-memory budget all agree. CPU/int8 remains the reference fallback strategy.
-
-## Install a transcription model first
-
-ASR model acquisition is an explicit model-management action. Transcription itself does
-not download faster-whisper models and does not treat arbitrary Hugging Face cache
-entries as managed state.
-
-Inspect the local catalog and current recommendation:
+## Let EchoFlow recommend a transcription model
 
 ```bash
-uv run echoflow models
 uv run echoflow models recommend
 ```
 
-Install the model required by the strategy/profile you intend to use:
+Install the model you intend to use:
 
 ```bash
 uv run echoflow models install small
 ```
 
-The install is disk-admitted, downloaded into EchoFlow's private model cache, structurally
-verified, and recorded with provider/repository/resolved-revision provenance. New
-transcription plans require a verified managed revision. If the selected model is not
-managed, planning fails with an install-first message.
+Model installation is an explicit network-bearing action. Transcription itself does not
+silently download faster-whisper weights.
 
-Inventory and recommendation are offline. `models install` is the explicit network-
-bearing ASR model operation.
+EchoFlow records and locally revalidates the immutable model revision it manages. A
+cached model does not become trusted application state merely because some bytes happen
+to exist in a Hugging Face cache.
 
-See
-[`docs/architecture/model-management.md`](docs/architecture/model-management.md) for
-the custody contract and current verification boundary.
+## Plan before you run
 
-## Plan and transcribe
-
-Dry-run is side-effect free with respect to job/output reservation and model acquisition:
+A dry run inspects the source and machine and shows the intended execution plan without
+starting recognition:
 
 ```bash
-uv run echoflow transcribe /path/to/recording.wav --dry-run
-uv run echoflow transcribe /path/to/recording.wav --dry-run --profile screening --json
-uv run echoflow transcribe /path/to/recording.wav --strategy small-cpu-int8 --dry-run
+uv run echoflow transcribe interview.m4a --dry-run
 ```
 
-Execute locally:
+Then transcribe locally:
 
 ```bash
-uv run echoflow transcribe /path/to/interview.mp4
-uv run echoflow transcribe /path/to/interview.mp4 --export txt
-uv run echoflow transcribe /path/to/interview.mp4 --export srt --export vtt
+uv run echoflow transcribe interview.m4a
 ```
 
-The faster-whisper adapter is local-only at execution time and loads the exact managed
-revision already recorded in the plan.
-
-TXT, SRT, and WebVTT are derived views of completed canonical JSON. Selecting an export
-does not invoke recognition again. Canonical JSON remains authoritative; derived files
-can be removed or regenerated without becoming checkpoint or recognition state.
-
-## Optional local noise suppression
-
-EchoFlow can apply deterministic local FFmpeg noise suppression before ASR:
+Add derived publication formats when useful:
 
 ```bash
-uv run echoflow transcribe /path/to/noisy-interview.wav --enhance
+uv run echoflow transcribe interview.m4a --export txt --export srt --export vtt
 ```
 
-Enhancement is off by default. The first provider uses the application-owned FFmpeg
-`afftdn=nf=-50:nr=12` contract. Enhanced audio is private derived execution material,
-not a replacement for the source recording and not published by default.
+The recording is not overwritten. Canonical JSON remains authoritative; TXT/SRT/VTT can
+be deleted and regenerated.
 
-ASR consumes the enhanced derivative when enabled. Anonymous diarization continues to
-inspect the unmodified canonical decode in this first version because EchoFlow has not
-yet established that denoising improves speaker evidence.
+## Resume interrupted work
 
-The provider must preserve channel count, sample width, sample rate, and frame count.
-A timeline mismatch fails closed. Canonical transcript JSON records provider version,
-operation, and parameters when enhancement affected ASR input.
+If an in-progress job is interrupted, EchoFlow can restore its validated checkpoint
+contract:
 
-There is no automatic enhancement mode yet. Representative benchmarks must show an
-end-to-end ASR benefit before EchoFlow invents heuristics for when to turn it on.
+```bash
+uv run echoflow transcribe interview.m4a --resume JOB_ID
+```
 
-See
-[`docs/architecture/speech-enhancement.md`](docs/architecture/speech-enhancement.md).
+Resume rechecks source identity and current resource admission. It does not silently
+change model revision, selected audio stream, enhancement contract, or execution target
+just to get moving again.
 
-## Search the local transcript library
+## Optional noise suppression
 
-Completed canonical transcripts can be projected into private rebuildable local search
-state. Canonical JSON remains authoritative. Search databases are disposable derived
-state and may not contain the only copy of user-authored information.
+For a difficult recording, deterministic local FFmpeg noise suppression can be enabled
+explicitly:
 
-Build or rebuild the lexical library from EchoFlow's known completed transcripts:
+```bash
+uv run echoflow transcribe noisy-interview.wav --enhance
+```
+
+The enhanced audio is private derived processing material, not a replacement for the
+source. EchoFlow verifies that preprocessing did not change the frame/timeline shape
+before allowing ASR to consume it.
+
+See **[Local speech enhancement](docs/architecture/speech-enhancement.md)** for the exact
+provider and failure contract.
+
+## Optional anonymous speaker diarization
+
+The user surface is:
+
+```bash
+uv run echoflow transcribe interview.wav --diarize
+```
+
+Diarization produces anonymous recording-scoped labels such as `speaker-01`; it does not
+perform biometric identity or cross-recording speaker linking.
+
+The current pyannote dependency path is **security-held** while its locked Lightning
+version is affected by a compensated advisory. EchoFlow fails closed before pyannote
+execution/model acquisition while that condition remains true. See
+**[Anonymous speaker diarization](docs/architecture/diarization.md)** and
+**[SECURITY.md](SECURITY.md)**.
+
+## Search your transcript library
+
+Build the private lexical library:
 
 ```bash
 uv run echoflow library rebuild
-uv run echoflow library
 ```
 
-Additional canonical transcript files or directories can be included explicitly:
-
-```bash
-uv run echoflow library rebuild /path/to/transcripts
-```
-
-Lexical search uses deterministic local BM25-style ranking. DuckDB is an implementation
-detail below the application boundary; users do not provide SQL, and EchoFlow does not
-install or load a network-fetched DuckDB FTS extension.
+Search for exact or related words:
 
 ```bash
 uv run echoflow library search "housing insecurity"
-uv run echoflow library search "housing insecurity" --phrase
+```
+
+Filter by transcript evidence when needed:
+
+```bash
 uv run echoflow library search \
   "rent increase" \
-  --all-terms \
   --speaker speaker-02 \
   --language en
 ```
-
-Search results preserve evidence context including the canonical transcript, source
-recording path when known, source and canonical SHA-256 evidence, source-relative
-timestamps, speaker/language evidence, and retrieval ranks.
-
-### Optional semantic and hybrid retrieval
-
-Semantic state is separate, private, and rebuildable. EchoFlow combines adjacent ASR
-segments into deterministic search windows, embeds those windows with one coherent
-profile, stores numeric vectors in a separate DuckDB projection, and binds the
-generation to the exact canonical corpus fingerprint.
-
-The current real embedding adapter targets `intfloat/multilingual-e5-small` with:
-
-- 384 dimensions;
-- L2 normalization;
-- mean pooling provenance;
-- dot-product retrieval;
-- explicit `query: ` and `passage: ` transforms;
-- immutable model revision;
-- `search-chunk-v1` chunking provenance.
-
-The adapter requires a local immutable model snapshot and loads it with local-only model
-resolution and remote code disabled. The project does not yet declare a locked
-Sentence Transformers dependency extra, so this path is intended for environments that
-already provide a compatible runtime.
-
-Build semantic state:
-
-```bash
-uv run echoflow library embeddings build \
-  /path/to/models--intfloat--multilingual-e5-small/snapshots/<revision> \
-  --revision <revision>
-```
-
-Inspect semantic provenance:
-
-```bash
-uv run echoflow library embeddings
-uv run echoflow library embeddings --json
-```
-
-Exact dense retrieval:
-
-```bash
-uv run echoflow library search \
-  "people struggling to make rent" \
-  --mode semantic
-```
-
-Hybrid BM25 + dense retrieval uses reciprocal rank fusion rather than pretending BM25
-scores and dense similarity scores share a scale:
-
-```bash
-uv run echoflow library search \
-  "people struggling to make rent" \
-  --mode hybrid
-```
-
-Hard transcript/language/speaker constraints are applied before semantic top-K ranking.
-ANN/HNSW is intentionally absent until measured corpus scale demonstrates that exact
-local search misses an interactive latency target.
-
-If canonical JSON changes after embeddings were built, semantic/hybrid search refuses
-the stale generation and requires a rebuild rather than silently comparing against old
-vectors.
 
 Inspect one transcript's custody and source-integrity evidence:
 
@@ -280,119 +217,109 @@ Inspect one transcript's custody and source-integrity evidence:
 uv run echoflow library show JOB_ID
 ```
 
-The evidence receipt distinguishes the original recording, canonical transcript, and
-private search indexes. It reports the SHA-256 recorded for transcription, the canonical
-artifact SHA-256 recorded during projection, and can re-hash the file currently at the
-recorded source path to show whether those bytes still match. A match proves current
-byte identity with the recorded fingerprint; it does not claim that no external process
-ever modified and later restored the file.
+### ✨ Optional semantic and hybrid search
 
-EchoFlow treats the supplied source recording as read-only input. Canonicalization,
-segmentation, enhancement, checkpoints, exports, and search data are written separately
-rather than overwriting that source.
+Lexical search is good at finding the words you typed. Semantic search can also find a
+passage whose wording differs but whose meaning is related.
 
-See
-[`docs/architecture/corpus-search.md`](docs/architecture/corpus-search.md).
+For example, the query:
 
-## Resume interrupted work
-
-An interrupted job retains completed segment results in private local state. Resume
-requires the original input and the job ID printed when execution began:
-
-```bash
-uv run echoflow transcribe /path/to/interview.mp4 --resume JOB_ID
+```text
+people struggling to afford housing
 ```
 
-The current checkpoint contract binds source identity, selected audio stream,
-profile/provisional state, managed engine/model/revision, CPU/device/compute type,
-decode settings, enhancement off/on/provider/parameters, segmentation settings,
-resource requirements, and exact PCM frame windows.
+may help retrieve:
 
-Resume restores that contract rather than accepting overrides. The input is
-fingerprinted again and the restored strategy must still satisfy current CPU, memory,
-and, where applicable, accelerator admission before work continues. Completed segment
-checkpoints must form a validated contiguous prefix and use one engine version.
-
-Successful publication removes checkpoint payloads on a best-effort basis. Checkpoint
-deletion is not secure erasure.
-
-## Optional speaker diarization
-
-Diarization is a separate optional enrichment:
-
-```bash
-uv run echoflow transcribe interview.wav --diarize
+```text
+I was spending almost seventy percent of my pay on the apartment.
 ```
 
-The current pyannote capability remains fail-closed while its locked Lightning
-dependency is affected by the compensated security advisory documented in
-[`SECURITY.md`](SECURITY.md). If model acquisition is explicitly needed for this
-optional capability, authorization is narrowly scoped to
-`--allow-diarization-model-download`; that flag does not authorize ASR model downloads.
+The current semantic foundation uses a strict-local Multilingual E5 Small profile and
+private rebuildable vectors. It is deliberately optional: the locked project dependency
+graph does not yet include Sentence Transformers, so a compatible local runtime and
+immutable local model snapshot are currently advanced setup rather than base-install
+requirements.
 
-Diarization produces anonymous recording-scoped labels such as `speaker-01`; it does
-not perform biometric identity or cross-recording speaker linking.
+Hybrid retrieval combines BM25 and dense ranks using reciprocal rank fusion instead of
+pretending their raw scores share one scale.
 
-## Configuration
+Read **[Semantic search, without the mystery box](docs/semantic-search.md)** before
+opening the deeper **[corpus-search architecture](docs/architecture/corpus-search.md)**.
 
-Configuration uses namespaced `ECHOFLOW_*` environment variables, including:
+## What belongs to you? 🦝
 
-- `ECHOFLOW_STATE_DIR`
-- `ECHOFLOW_CACHE_DIR`
-- `ECHOFLOW_MODEL_DIR`
-- `ECHOFLOW_OUTPUT_DIR`
-- `ECHOFLOW_PROCESSING_PROFILE`
-- resource ceilings and FFmpeg/FFprobe timeouts
+The custody boundary is intentionally simple:
 
-EchoFlow ignores generic variables such as `OUTPUT_DIR` and never loads an ambient
-`.env` from the current directory. Select an explicit dotenv file before the command:
+| Artifact | Role | Rebuildable? |
+|---|---|---|
+| Original recording | source evidence | **No** |
+| Canonical transcript JSON | authoritative transcript artifact | **No** |
+| Future notes/tags/annotations | user-authored knowledge | **No** |
+| TXT/SRT/WebVTT | publication views | Yes |
+| Normalized/enhanced working audio | private processing material | Yes |
+| Lexical search database | private search projection | Yes |
+| Semantic chunks/vectors | private search projection | Yes |
 
-```bash
-uv run echoflow --config /private/path/echoflow.env runner --json
-```
+A database is allowed to make evidence useful. It is not allowed to become the only
+place the evidence exists.
 
-There is no faster-whisper revision override. ASR revisions come from verified managed
-model state.
+## For maintainers
 
-See [`.env.example`](.env.example) for supported settings.
+The architecture is organized around narrow capabilities rather than one universal
+pipeline manager. Start with **[docs/architecture/README.md](docs/architecture/README.md)**.
 
-## Development
+The most important references are:
 
-Production code uses a standard `src/` layout. Tests are colocated under a `tests/`
-directory beneath the package whose contract they protect and are excluded from built
-distributions.
+- **[Processing capabilities](docs/architecture/processing-capabilities.md)** for the
+  end-to-end execution map.
+- **[Adaptive heterogeneous execution](docs/architecture/adaptive-heterogeneous-execution.md)**
+  for machine discovery, engine capability, strategy admission, and bounded overlap.
+- **[Media and timeline](docs/architecture/media-and-timeline.md)** for stream selection,
+  canonical audio, and timestamp semantics.
+- **[Model management](docs/architecture/model-management.md)** for explicit acquisition,
+  immutable revisions, and local custody.
+- **[Speech enhancement](docs/architecture/speech-enhancement.md)** for optional
+  preprocessing and provenance.
+- **[Diarization](docs/architecture/diarization.md)** for anonymous speaker evidence and
+  the current security hold.
+- **[Corpus search](docs/architecture/corpus-search.md)** for lexical/semantic/hybrid
+  retrieval and data ownership.
 
-Install hooks once:
+Documentation itself has a contract now too. See
+**[docs/documentation-style.md](docs/documentation-style.md)**.
 
-```bash
-uv run pre-commit install
-```
+## Quality and development
 
-Run normal repository gates:
+Production code uses a `src/` layout. Tests are colocated beneath the package whose
+contract they protect.
 
-```bash
-uv run ruff check .
-uv run ruff format --check .
-uv run mypy
-uv run vulture
-uv run radon cc src/echoflow --total-average
-uv run radon mi src/echoflow
-uv run pytest --cov=echoflow --cov-branch --cov-report=term-missing
-uv lock --check
-uv build
-uv run python scripts/verify_distribution.py dist
-```
+Normal repository qualification includes Ruff lint/format/security rules, strict mypy,
+Vulture, Radon complexity/maintainability checks, branch coverage, locked dependency
+verification/auditing, package builds, clean-wheel verification, and Linux/macOS/Windows
+CI.
 
-Normal CI also audits locked dependencies, builds distributions, verifies clean-wheel
-installs, and runs platform smoke coverage on Linux, macOS, and Windows. The enforced
-quality budgets include Ruff complexity <= 10, branch coverage >= 90%, strict mypy,
-100%-confidence Vulture findings, and Ruff security rules.
+Mutation testing with Poodle is targeted qualification for load-bearing decisions rather
+than a routine per-commit gate. See
+**[docs/development/testing-and-bisect.md](docs/development/testing-and-bisect.md)**.
 
-Mutation testing is deliberate qualification, not a per-commit gate. For load-bearing
-decision code, tests should first anticipate comparator, Boolean, threshold, fallback,
-fail-open, ordering, cleanup, resume, provenance, and concurrency mutations. Targeted
-Poodle runs are then used locally/sandboxed or through the manual workflow after normal
-tests are green.
+## Where the project goes next
 
-See
-[`docs/development/testing-and-bisect.md`](docs/development/testing-and-bisect.md).
+The backend is broad enough that the next high-value work is increasingly about finer
+evidence navigation and ordinary-user delivery rather than inventing another ASR
+pipeline.
+
+The likely sequence is **word/timestamp alignment**, then richer **original-media
+timecode/capture-time provenance**, then **better speaker overlap/display-label UX**.
+Source separation for overlapping speakers is a later, heavier capability once the
+simpler temporal evidence model is strong enough to support it.
+
+Installers and a thin graphical interface remain important for non-developer adoption.
+They should sit on top of the same application services, not fork the product into a
+second implementation.
+
+See **[ROADMAP.md](ROADMAP.md)** for the current sequencing and deliberate limits.
+
+---
+
+**EchoFlow is trying to make sensitive local transcription boringly dependable, then
+make the resulting evidence easy to find without giving the corpus away.** 💃

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,367 +1,426 @@
-# EchoFlow roadmap
+# EchoFlow roadmap 🗺️✨
 
-EchoFlow is a local-first, privacy-conscious, resource-aware audio transcription and
-analysis application. It does not try to out-engine speech-recognition runtimes. Its job
-is to make sensitive local transcription dependable, resumable, inspectable, portable,
-and usable on ordinary computers.
+EchoFlow is becoming a **private local workspace for recorded evidence**.
 
-## Current phase
+Its job is not to out-engine speech-recognition runtimes. Its job is to make local
+transcription dependable, resumable, inspectable, searchable, and usable on ordinary
+computers while keeping source evidence and user-owned artifacts under clear custody.
 
-Modern EchoFlow effectively restarted on August 2, 2026. The foundation now includes a
-real local transcription vertical slice, deterministic media handling, segmentation,
-private checkpoints, resource admission, durable lifecycle state, multilingual
-semantics, anonymous speaker diarization, adaptive CPU/CUDA execution, explicit local
-ASR model custody, optional provenance-bearing noise suppression, and an evidence-first
-transcript library with lexical, semantic, and hybrid retrieval contracts.
+Modern EchoFlow restarted on August 2, 2026. Since then, the project has moved very
+quickly from “can we transcribe a file?” to “can we preserve and navigate a local corpus
+of recorded evidence without giving the corpus away?”
 
-The project is moving from **engine trust** to **product legibility and empirical
-qualification**. Backend contracts should remain strict while ordinary users gain clear
-progress, intentional recovery, predictable local model management, useful
-preprocessing for difficult recordings, evidence-first corpus search, and eventually a
-thin graphical shell.
+That is a substantially different product.
 
-Current foundation:
+## Where we are now
 
-- real faster-whisper CPU/int8 transcription;
-- deterministic FFprobe inspection and audio-stream selection;
-- FFmpeg extraction/normalization to mono 16 kHz PCM16 WAV where needed;
-- exact frame-based segmentation with one job-scoped ASR session;
-- private durable checkpoints and validated resume;
-- durable job lifecycle metadata plus discoverable status and cleanup;
-- Rich interactive progress over the execution-observer seam;
-- source-relative canonical timestamps with TXT/SRT/WebVTT derived exports;
-- process-visible CPU/memory and storage admission;
-- accelerator topology separated from engine capability negotiation;
-- engine-neutral strategy admission across system RAM and dedicated/shared/unified
-  accelerator memory;
-- bounded one-segment CPU preparation overlap for accelerated inference while
-  preserving ordered checkpoints and resumability;
-- explicit faster-whisper model inventory, disk-admitted installation,
-  provider/revision provenance, local revalidation, exact-revision removal, and
-  mandatory immutable managed-revision pinning for ASR plans;
-- local-only ASR execution with no transcription-time model download fallback;
-- optional deterministic FFmpeg noise suppression before ASR, with explicit off/on
-  selection, private derived audio, timeline-preservation validation, storage
-  admission, checkpoint identity, and canonical transcript provenance;
-- cross-platform private-storage enforcement;
-- empirical benchmarking instrumentation;
-- native-media, abrupt-process, clean-wheel, known-speech, and diarization evidence
-  lanes;
-- multilingual faster-whisper decoding plus conservative local language attribution;
-- anonymous recording-scoped speaker diarization with conservative text projection;
-- a database-neutral `TranscriptIndex` lexical port with a private rebuildable DuckDB
-  backend;
-- deterministic offline BM25-style lexical ranking with phrase, ANY/ALL term, speaker,
-  language, transcript, and sort constraints;
-- canonical transcript SHA-256 projection in addition to source-media SHA-256;
-- deterministic `search-chunk-v1` semantic windows anchored to exact canonical segment
-  IDs and timestamps;
-- an `EmbeddingProvider` contract with separate query/passages semantics;
-- a strict-local `SentenceTransformersE5Provider` targeting
-  `intfloat/multilingual-e5-small`;
-- explicit semantic profile provenance: immutable revision, dimensions,
-  normalization, pooling, distance metric, query/passage transforms, chunk profile,
-  and embedding schema;
-- a separate private `DuckDbSemanticIndex` storing numeric `FLOAT[]` vectors;
-- exact local dense similarity with hard metadata constraints before top-K ranking;
-- hybrid BM25+dense retrieval with inspectable reciprocal rank fusion;
-- a unified `SearchResponse` carrying evidence coordinates and lexical, semantic, and
-  fused ranks;
-- a semantic corpus fingerprint over exact canonical JSON digests so stale vectors
-  fail closed; and
-- human-readable transcript evidence receipts exposing canonical/source locations,
-  source/canonical SHA-256 evidence, and current source-integrity status.
+The backend foundation is broad enough that the next work is increasingly about
+**evidence navigation, qualification, packaging, and interface quality**, not inventing
+another transcription pipeline.
 
-Canonical transcript JSON and checkpoint files remain authoritative execution evidence.
-Lifecycle metadata describes job state. Managed ASR model manifests describe local
-execution dependencies. Enhanced audio is private derived processing material. Lexical
-and semantic search databases are rebuildable derived state and contain no unique
-user-authored information.
+```mermaid
+flowchart LR
+    A[Local media] --> B[Reliable local transcription]
+    B --> C[Evidence-preserving canonical corpus]
+    C --> D[Lexical + semantic retrieval]
+    D --> E[Finer evidence navigation]
+    E --> F[Beginner-friendly product shell]
 
-The current semantic adapter is implemented without adding an unresolved package to the
-locked dependency graph. A compatible Sentence Transformers runtime and immutable local
-multilingual-E5 snapshot are therefore an optional environment capability for this
-tranche. Locking, auditing, and integrating semantic model acquisition into EchoFlow's
-managed-model custody are separate qualification work.
+    classDef done fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+    classDef now fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef next fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
 
-## Pre-production contract policy
+    class A,B,C,D done
+    class E now
+    class F next
+```
 
-EchoFlow has not been released or meaningfully dogfooded yet. Internal durable
-contracts therefore use one current canonical shape instead of accumulating migration
-branches for hypothetical historical users.
+## The current foundation: yes, we have been busy 💃
 
-Current code deliberately removes obsolete pre-production compatibility paths when a
-better invariant replaces them. In particular:
+### Local execution and hardware awareness
 
-- ASR planning requires a verified managed model revision;
-- transcription does not download faster-whisper models;
-- an arbitrary configuration revision cannot bypass managed ASR model custody;
-- one current multilingual execution behavior replaces the earlier language-mode
-  compatibility split;
-- one current job-plan/transcript/checkpoint contract represents optional capabilities
-  with typed fields instead of feature-version schema proliferation; and
-- semantic generations bind to exact canonical artifact hashes rather than assuming a
-  source-media hash proves the search projection is current.
+EchoFlow currently has:
 
-When EchoFlow has a real released/dogfooded compatibility boundary, schema migrations
-should be introduced deliberately from that evidence rather than pre-built in advance.
+- process-visible CPU and memory inspection, including relevant affinity/cgroup limits;
+- physical accelerator topology kept separate from engine/runtime capability;
+- resource-admitted faster-whisper CPU/int8 and CUDA-capable strategies;
+- explicit refusal instead of silent substitution for infeasible user-selected
+  strategies;
+- dedicated/shared/unified accelerator-memory accounting; and
+- bounded one-segment CPU preparation overlap during accelerated inference while
+  preserving ordered checkpoints.
 
-## Product and interface direction
+Performance ranks and memory estimates remain conservative heuristics pending
+representative-device qualification.
 
-EchoFlow remains CLI-first while backend contracts mature:
+### Media, timeline, and local preprocessing
 
-- interactive terminals may use Rich progress, tables, stage names, and safe prompts;
-- `--json` remains deterministic and presentation-noise free;
-- long-running work has durable job IDs, progress, resume evidence, and explicit
-  private-state cleanup;
-- hardware selection happens through typed application services rather than CLI GPU
-  switches;
-- ASR model acquisition/removal happens through model-management actions, never hidden
-  inside transcription;
-- enhancement is explicit until evidence justifies automation;
-- corpus search compiles through one typed `SearchQuery` contract rather than exposing
-  SQL or DuckDB;
-- lexical/semantic/hybrid results use one evidence-bearing response shape; and
-- a future desktop/web UI remains a presentation adapter over the same services rather
-  than a second pipeline implementation.
+The current media foundation includes:
 
-A polished installer and graphical UI remain deferred until the backend, model,
-enhancement, and search contracts have survived representative dogfooding.
+- FFprobe inspection with file-only protocol access and complete source SHA-256;
+- deterministic audio-stream selection;
+- FFmpeg canonicalization to mono 16 kHz PCM16 WAV when required;
+- exact integer-frame work windows and source-relative transcript timestamps;
+- optional deterministic FFmpeg noise suppression;
+- timeline-preservation checks around enhanced audio; and
+- provenance recording for preprocessing that affected ASR input.
 
-## Engineering qualification policy
+The original recording remains read-only evidence. Normalized/enhanced WAV files remain
+private derived processing material.
 
-Routine commit and pull-request gates should remain fast enough for iterative work:
-deterministic tests, Hypothesis, branch coverage, Ruff, formatting, strict mypy,
-Vulture, Radon, locked dependency/security audit, package builds, clean-wheel checks,
-and cross-platform smoke tests.
+### Model custody
 
-Mutation testing serves a different purpose. Poodle is targeted development and
-qualification for asking whether tests detect plausible bad decisions, not a routine
-per-commit gate. For load-bearing logic, anticipate boundary, Boolean, threshold,
-fallback, fail-open, ordering, cleanup, resume, provenance, stale-state, filtering, and
-concurrency mutations while designing ordinary tests.
+Faster-whisper model management currently provides:
 
-## Near-term direction
+- offline inventory and recommendation;
+- explicit disk-admitted installation;
+- provider/repository provenance;
+- immutable resolved revisions;
+- local structural revalidation;
+- exact-revision removal; and
+- mandatory managed-model identity for ASR planning/execution.
 
-### 1. Dogfood the complete local workflow
+Transcription itself does not silently download ASR weights.
 
-Exercise interruption/resume, stale-process reconciliation, progress rendering,
-accelerator re-admission, bounded prefetch cleanup, managed ASR model
-removal/reinstall, enhancement on long/noisy recordings, transcript-library rebuilds,
-source-integrity receipts, and lexical/semantic/hybrid search over real multi-recording
-corpora.
+### Reliability and recovery
 
-Particular retrieval questions:
+EchoFlow has:
 
-- Are 220-word target / 300-word maximum chunks good enough across interviews,
-  lectures, meetings, and oral histories?
-- Does exact vector scan remain interactive at realistic personal/research corpus
-  sizes?
-- Does RRF improve conceptual recall without burying exact identifiers, names, and
-  acronyms that BM25 handles well?
-- Do speaker/language/document constraints behave as users expect on mixed chunks?
-- Which retrieval metadata actually belongs in the normal interface versus an
-  inspector/details surface?
+- durable private per-work-unit checkpoints;
+- validated resume;
+- source/model/stream/preprocessing/execution contract binding;
+- contiguous-prefix checkpoint semantics;
+- cleanup of speculative/derived work without masking primary failures; and
+- durable lifecycle evidence around long-running work.
 
-### 2. Qualify the semantic dependency and model custody
+The goal is that an interrupted long recording is an inconvenience, not a fresh start.
 
-Resolve and audit a locked optional semantic dependency set before advertising semantic
-search as a normal source install.
+### Language and speaker evidence
 
-The target direction is:
+The system currently supports:
 
-- one explicit semantic extra;
-- no silent model download during search;
-- managed acquisition of the exact multilingual-E5 snapshot;
-- immutable resolved revision in model custody;
-- private cache placement;
-- disk/resource admission;
-- offline query execution after installation; and
-- clean-wheel/platform qualification.
+- multilingual faster-whisper decoding;
+- conservative local text-language attribution that may leave ambiguous text unlabeled;
+- optional recording-scoped anonymous speaker diarization;
+- deterministic speaker-label normalization; and
+- conservative speaker projection that refuses ambiguous multi-speaker ASR segments.
 
-Do not bypass `uv.lock` consistency merely to make the optional capability look more
-finished.
+The diarization path is **integrated but security-held** while its locked Lightning
+dependency is affected by the compensated CVE-2026-58659/PYSEC-2026-3624 advisory.
+EchoFlow fails closed before pyannote execution/acquisition while that gate is active.
 
-### 3. Representative-device qualification
+### Canonical transcript and exports
 
-Collect repeated benchmark evidence from:
+Canonical JSON is authoritative transcript evidence.
 
-- 8 GB Windows machines;
-- 16 GB commodity machines;
-- Apple Silicon;
-- discrete-GPU laptops; and
-- larger workstations.
+It carries source and execution provenance, source-relative timestamps, language
+evidence, optional enhancement provenance, and optional speaker-turn evidence.
 
-Measure cold/warm model behavior, sustained real-time factor, thermal effects, CPU/RAM
-pressure, accelerator memory/utilization where reliable counters exist, private disk
-cost, raw-ASR versus enhancement-plus-ASR accuracy/cost, embedding build cost, and
-semantic-query latency.
+TXT, SRT, and WebVTT are deterministic publication views that can be regenerated without
+rerunning recognition.
 
-Calibrate strategy and semantic defaults from measurements, not hardware names.
+### Transcript library and retrieval
 
-### 4. Corpus library retrieval UX
+The local library now includes:
 
-The retrieval engine now supports lexical, exact dense, and hybrid ranking. The next
-library work should be driven by real search use and may add:
+- a database-neutral lexical search application port;
+- private DuckDB document/segment/term projections;
+- deterministic offline BM25-style ranking;
+- phrase, ANY/ALL, speaker, language, document, and timeline constraints;
+- canonical transcript SHA-256 in addition to source-media SHA-256;
+- deterministic `search-chunk-v1` retrieval windows anchored to exact canonical segment
+  IDs/timestamps;
+- an `EmbeddingProvider` + immutable `EmbeddingProfile` contract;
+- a strict-local Multilingual E5 Small provider;
+- private numeric semantic vectors;
+- exact local dense similarity with hard filters before top-K;
+- reciprocal-rank hybrid BM25 + dense retrieval;
+- one evidence-bearing `SearchResponse` with lexical/semantic/fused ranks; and
+- corpus-fingerprint stale-vector refusal when canonical transcript bytes change.
 
-- richer snippets and highlights;
+Semantic search is currently an advanced optional capability because the locked project
+dependency graph does not yet include Sentence Transformers. Lexical search remains the
+normal dependency-light default.
+
+### Security, privacy, and quality foundation
+
+The project currently has:
+
+- path-redacted routine logs;
+- platform-specific private storage enforcement;
+- explicit network-bearing model acquisition boundaries;
+- no hosted transcription integration or application telemetry;
+- Linux/macOS/Windows CI;
+- strict mypy, Ruff lint/format/security rules, Vulture, Radon, and branch coverage;
+- locked dependency auditing and clean-wheel/package checks;
+- Hypothesis property tests around load-bearing invariants; and
+- targeted Poodle mutation qualification for decision-heavy code.
+
+See [SECURITY.md](SECURITY.md) for the exact threat boundary. “Local-first” is not a
+claim that the entire host operating system or every native dependency is trusted.
+
+## The product principle that should survive every feature
+
+EchoFlow now has several kinds of data with deliberately different deletion semantics.
+
+| Class | Examples | Rule |
+|---|---|---|
+| Authoritative evidence | original recording, canonical transcript | never treat as cache |
+| User-authored knowledge | future notes, speaker display labels, tags, annotations, collections | must survive index rebuilds |
+| Rebuildable projection | lexical index, semantic chunks/vectors, derived exports | may be regenerated from durable evidence |
+| Private execution state | normalization, enhancement, checkpoints, temporary segments | lifecycle-managed, not source truth |
+
+This distinction becomes more important as EchoFlow evolves from a transcription tool
+into a research library.
+
+🦝 The raccoon may rebuild an index. The raccoon may not eat your annotations.
+
+# Near-term product sequence
+
+The next features should make evidence **finer, easier to navigate, and easier to name**
+before EchoFlow adds heavier generative/audio-processing machinery.
+
+## 1. Word/timestamp alignment
+
+**Likely next feature.**
+
+Current canonical ASR segments are durable evidence coordinates, but they are often too
+coarse for precise highlighting, speaker handoffs, annotations, and jump-to-audio.
+
+Alignment should add finer timestamp evidence without rewriting raw ASR truth.
+
+Primary uses:
+
+- word/phrase highlighting in search results;
+- precise jump-to-audio;
+- finer speaker attribution near handoffs;
+- better handling of partially overlapping turns;
+- durable annotation anchors smaller than an entire ASR segment; and
+- improved subtitle/transcript interaction in a future GUI.
+
+### Architectural direction
+
+Alignment should be an **enrichment capability** over canonical transcript/audio
+evidence.
+
+Its output must record provider/model/version/revision as applicable and remain traceable
+to canonical segments and source-relative time.
+
+A neural model-backed aligner must reuse the model-custody family rather than inventing
+a hidden download path.
+
+## 2. Original-media timecode and capture-time provenance
+
+EchoFlow currently exposes one clear canonical clock: elapsed source-relative seconds
+from the selected audio origin.
+
+That should remain stable.
+
+The next provenance layer should preserve additional clocks when the input actually
+contains them:
+
+- non-zero container/stream presentation origins;
+- SMPTE timecode;
+- stream start-time offsets;
+- camera/device capture timestamps;
+- timezone/offset metadata when trustworthy; and
+- explicit synchronization relationships between sources when known.
+
+These should be typed parallel provenance, not collapsed into an ambiguous `timestamp`
+field.
+
+The design should distinguish “metadata exists” from “metadata is trustworthy enough to
+map onto the transcript.”
+
+## 3. Better speaker UX: overlap + user-assigned display labels
+
+Anonymous diarization evidence should remain anonymous-by-default and recording-scoped.
+
+But users should eventually be able to map stable anonymous refs to meaningful display
+labels such as:
+
+```text
+speaker-01 → Dr. Chen
+speaker-02 → Interviewer
+```
+
+Those labels are **user-authored state**. They must not be disposable search/index
+metadata and should not rewrite the underlying anonymous speaker-turn evidence.
+
+Overlap handling should also improve in presentation:
+
+- preserve multiple active speaker refs where evidence supports overlap;
+- use word/fine alignment where available;
+- avoid forcing one speaker label onto genuinely ambiguous text; and
+- render overlap clearly in human/GUI views.
+
+## 4. Search/research workspace UX
+
+The retrieval engine now supports lexical, semantic, and hybrid ranking. Real corpus use
+should drive the next interface layer:
+
+- better snippets/highlighting;
 - result-context expansion;
 - facets;
 - exportable result sets;
-- direct jump-to-audio;
-- saved searches and collections; and
-- tags, notes, and annotations.
+- precise jump-to-audio;
+- saved searches/collections; and
+- durable tags, notes, and annotations.
 
-The ownership boundary is non-negotiable: user-authored state may not share the deletion
-semantics of the rebuildable index. Notes/annotations must anchor to durable canonical
-segment coordinates, not only to disposable chunk IDs.
+The ownership rule is non-negotiable: user-authored state does not share deletion
+semantics with rebuildable indexes.
 
-### 5. Typed search grammar and query builder
+## 5. Qualify semantic dependency and managed embedding custody
 
-The current `SearchQuery` supports text, phrase, ANY/ALL lexical semantics, speaker,
-language, transcript/document, sorting, and bounded limits.
+Before semantic search is advertised as a normal source install, qualify a locked
+optional semantic dependency set.
 
-Extend only as product evidence requires date, tag, duration, enrichment, exclusion,
-facet, or collection constraints. CLI syntax, future query chips/dropdowns, and any
-local natural-language parser should compile to the same typed contract.
+Target direction:
 
-### 6. Word/timestamp alignment
+- one explicit semantic extra;
+- managed acquisition of the exact qualified E5 snapshot;
+- immutable revision custody;
+- private cache placement;
+- disk/resource admission;
+- no silent model download during search/indexing;
+- offline execution after installation; and
+- clean-wheel/platform qualification.
 
-Add alignment as a separate enrichment capability so speaker projection,
-search-result highlighting, jump-to-audio behavior, and future durable annotations can
-become more precise without rewriting raw ASR or diarization evidence.
+Do not bypass `uv.lock` coherence to make the feature look more finished.
 
-### 7. Bounded failure recovery
+## 6. Representative-device and enhancement qualification
 
-Add deterministic audio bisection/retry only if real long-recording failures justify
-it. Do not front-load recovery machinery for failures representative use has not shown.
+Collect repeated benchmark evidence from at least:
 
-### 8. Release/install and graphical UI
+- 8 GB Windows consumer hardware;
+- 16 GB commodity hardware;
+- Apple Silicon;
+- a discrete-GPU laptop; and
+- larger 32/64 GB workstations.
 
-Revisit after backend, lifecycle, model-management, enhancement, and retrieval contracts
-have survived representative dogfooding. The eventual interface should stay thin and
-replaceable.
+Measure cold/warm model behavior, real-time factor, thermal effects, CPU/RAM pressure,
+device memory/utilization where reliable, private disk cost, enhancement benefit/cost,
+embedding build cost, and semantic-query latency.
 
-## Corpus-search product principles
+Calibrate from measurements, not hardware marketing names.
 
-The database should be power, not homework. A researcher should be able to search for
-`housing insecurity` and receive ranked passages across recordings with source,
-speaker, language, timestamp, and canonical-evidence context without knowing DuckDB
-exists.
+# Beginner-ready milestone
 
-Current retrieval ladder:
+The backend is already beginner-oriented in many internal decisions: resource discovery,
+model custody, recovery, provenance, and search are designed so the user does **not**
+need to manually operate those systems.
 
-1. deterministic BM25 lexical retrieval;
-2. deterministic metadata constraints;
-3. exact local dense retrieval over segment-anchored chunks;
-4. inspectable RRF hybrid fusion.
+But a beginner-friendly product also needs a beginner-friendly delivery surface.
 
-Likely UX progression:
+A reasonable pre-1.0 usability milestone is:
 
-1. better snippets/highlighting and context navigation;
-2. richer deterministic filters/facets;
-3. saved searches and collections in durable user state;
-4. structured query chips/visual builder;
-5. optional constrained local natural-language-to-`SearchQuery` translation; and
-6. only later, optional local summarization over an explicitly selected evidence set.
+1. word/fine alignment for precise evidence navigation;
+2. richer media time provenance;
+3. clearer speaker labels/overlap behavior;
+4. semantic dependency/model setup that no longer requires advanced manual environment
+   preparation;
+5. representative qualification on ordinary hardware;
+6. polished error/recovery language;
+7. an installer/package path that does not require a developer environment; and
+8. a thin graphical shell over the existing application services.
 
-EchoFlow should not begin with “chat with your transcripts.” Generated answers can hide
-omissions and provenance. Primary results remain inspectable passages, source
-recordings, speakers, timestamps, and canonical transcript coordinates.
+The GUI should be a presentation adapter, not a second implementation of transcription,
+search, or model policy.
 
-Natural-language convenience must not require sending the corpus to a hosted LLM. A
-deterministic grammar can cover common queries first. A later optional local model may
-translate a sentence into the typed query representation, but should not need the
-transcript corpus and should show the interpreted query back to the user.
+# Later capability: speech/source separation for overlapping speakers
 
-## Semantic and hybrid retrieval policy
+Source separation is valuable, but it is intentionally **later** than better alignment
+and overlap representation.
 
-Semantic retrieval is an optional layer over proven lexical search, not a replacement.
+Separating mixed speech into estimated source signals adds:
 
-Current architecture:
+- substantial compute/model cost;
+- new model custody/dependency concerns;
+- uncertainty about which separated signal corresponds to which human speaker;
+- timeline/provenance requirements for derived sources;
+- new failure modes; and
+- a need to prove end-to-end recognition benefit on representative overlap cases.
 
-```text
-canonical transcripts
-  -> deterministic segment-anchored chunks
-  -> BM25 + optional local multilingual-E5 embeddings
-  -> exact local dense scan
-  -> hard metadata constraints before top-K
-  -> optional RRF hybrid ranking
-  -> evidence-bearing SearchResponse
-```
+EchoFlow should first become excellent at representing overlap honestly.
 
-Embedding state is disposable. One generation has one coherent embedding space.
-EchoFlow does not dynamically mix embedding models by document language.
+Then, if real recordings demonstrate that overlap remains a major recognition failure,
+source separation can be evaluated as a targeted capability rather than an impressive
+but unqualified checkbox.
 
-Exact similarity remains the reference execution strategy. Approximate structures such
-as HNSW are optional only when measured corpus scale shows exact search misses an
-interactive latency target. An 8 GB laptop should not pay an ANN tax because ANN is
-fashionable.
+🧜‍♀️ We enter the deep water after learning to swim.
 
-RRF precedes learned reranking because it is simple, local, inspectable, and avoids
-score-normalization fiction. A cross-encoder may later rerank a small explicit candidate
-set if representative evaluation demonstrates worthwhile gains at acceptable resource
-cost.
+# Other near-term engineering work
 
-The product rule stays evidence-first: semantic retrieval returns passages and source
-locations, not an uncited generated answer.
+## Dogfood the complete workflow
 
-## Current capability boundaries
+Use real multi-recording corpora to exercise:
 
-- Multilingual decoding can reconsider acoustic language within each durable work unit;
-  conservative local language attribution may leave ambiguous text unlabeled.
-- Clause/utterance-level code switching is supported better than arbitrary word-level
-  or romanized Hinglish attribution.
-- Timestamps are elapsed source-relative seconds from the selected audio origin.
-  Arbitrary container PTS origins, SMPTE timecode, and wall-clock capture timestamps
-  are not yet exposed as separate provenance.
-- Anonymous diarization is optional local enrichment. It does not perform biometric
-  identity or cross-recording linking.
-- Pyannote's locked Lightning dependency is security-gated as documented in
-  `SECURITY.md`.
-- Lifecycle state improves discoverability and recovery, but EchoFlow is a synchronous
-  local application rather than a background daemon or distributed task system.
-- Adaptive execution has a real CPU/int8 path and a CUDA-capable faster-whisper path.
-  Other accelerators remain future adapters.
-- Performance ranks and accelerator-memory estimates are conservative heuristics
-  pending representative-device qualification.
-- ASR model management owns verified private manifests and immutable revisions.
-- Noise suppression is explicit optional local preprocessing and does not replace
-  source authority.
-- Semantic retrieval code exists, but the Sentence Transformers runtime/model
-  acquisition is not yet a qualified locked EchoFlow extra.
-- Exact dense search exists; ANN/HNSW and learned reranking do not.
-- Saved searches, collections, tags, notes, user annotations, word-level alignment,
-  generated corpus answers, polished installers, and a desktop GUI remain later work.
-- Source-integrity inspection proves whether current source bytes match the digest
-  captured for transcription. It cannot prove no external process ever changed and
-  restored the file.
+- interruption/resume;
+- stale-process reconciliation;
+- progress rendering;
+- accelerator re-admission;
+- managed model removal/reinstall;
+- enhancement on noisy/long recordings;
+- transcript-library rebuilds;
+- source-integrity receipts; and
+- lexical/semantic/hybrid search.
 
-## Research candidates
+Retrieval questions worth measuring include whether current 220/300-word chunks behave
+well across interviews, lectures, meetings, and oral histories; whether exact vector scan
+remains interactive at realistic corpus sizes; and whether RRF improves conceptual
+recall without burying exact names/acronyms.
 
-These are investigations, not release promises:
+## Typed query evolution
 
-- finer-grained language attribution for intra-clause and romanized switching;
-- better overlap handling and user-assigned display labels for anonymous speakers;
-- alignment/word timestamps;
-- original-media timecode/capture-time provenance;
-- evidence-driven automatic enhancement after measured benefit;
-- later speech/source separation for overlapping speakers;
-- corpus-statistical related terms and richer facets;
-- constrained deterministic natural-language query grammar;
-- optional tiny local natural-language-to-typed-search translation;
-- optional summarization only over selected/citable evidence;
-- alternative multilingual embedding models;
-- character n-gram/fuzzy retrieval for ASR names, acronyms, and misspellings;
-- a small cross-encoder reranker only after measured benefit;
+`SearchQuery` already owns text, phrase, ANY/ALL semantics, speaker, language,
+document/transcript, sorting, and bounded limits.
+
+Add date/tag/duration/facet/collection constraints only when real product use requires
+them.
+
+CLI syntax, future query chips, and any local natural-language convenience layer should
+compile to the same typed contract instead of growing separate search semantics.
+
+## Bounded failure recovery
+
+Audio bisection/retry should be added only if representative long-recording failures show
+it is needed.
+
+Do not front-load a recovery labyrinth for hypothetical failures.
+
+# Pre-production contract policy
+
+EchoFlow has not had a released/dogfooded durable compatibility boundary yet.
+
+Internal durable contracts therefore use one current canonical shape rather than
+accumulating migration branches for every unreleased intermediate state.
+
+Unsupported schema versions still fail closed.
+
+When a real compatibility obligation exists, migrations should be introduced against
+actual persisted fixtures from that boundary.
+
+# Research candidates, not promises
+
+Interesting later investigations include:
+
+- finer intra-clause/romanized language attribution;
+- richer original-media capture/timecode provenance;
+- improved overlap rendering and source separation;
+- alternative qualified multilingual embedding models;
+- character n-gram/fuzzy retrieval for ASR names/acronyms/misspellings;
+- a small local cross-encoder reranker if measured benefit justifies it;
 - resource-admitted HNSW only when exact-search latency justifies it;
-- additional local ASR engines when they provide a concrete advantage;
-- additional accelerator backends when a real engine can consume them; and
-- multiple simultaneous inference workers only if measurements beat the current
-  bounded-overlap design without unacceptable memory/recovery cost.
+- constrained deterministic natural-language query grammar;
+- optional local query translation that shows the interpreted typed query to the user;
+- optional summarization only over an explicitly selected/citable evidence set;
+- additional ASR engines when they provide a concrete advantage; and
+- additional accelerator backends when a real engine can consume them.
 
-The order may change when benchmarks, security review, complexity, or dogfooding
-contradicts an assumption. The stable direction is narrower:
+The order can change when security review, dogfooding, hardware evidence, or complexity
+contradicts an assumption.
 
-**make sensitive local transcription boringly dependable, then make its evidence easy
-to find without giving the corpus away.**
+The stable direction is much narrower:
+
+> **Make sensitive local transcription boringly dependable. Make its evidence easy to
+> navigate. Do not give the corpus away.** 💃

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,167 @@
+# Welcome to EchoFlow 🦝✨
+
+EchoFlow is a **local-first workspace for recorded evidence**.
+
+It can inspect a recording, choose a safe way to run on the computer you actually have,
+transcribe locally, survive interruptions, preserve provenance, enrich the transcript,
+and help you find the important bit again later.
+
+You do **not** need to understand CUDA, DuckDB, BM25, vector spaces, immutable model
+revisions, or why a raccoon has been granted library privileges to use the product.
+Those details exist because somebody has to care about them. EchoFlow would like that
+somebody to be EchoFlow.
+
+> **The short version:** your recording stays yours, the canonical transcript remains
+> inspectable evidence, and most of the machinery EchoFlow builds around it can be
+> thrown away and rebuilt.
+
+🧜‍♀️
+
+## What can EchoFlow do today?
+
+EchoFlow is still pre-production, but the backend is no longer a toy transcription
+script. The current foundation already covers the full local journey from media to a
+searchable evidence corpus.
+
+| You want to… | EchoFlow currently… |
+|---|---|
+| Transcribe a recording privately | runs faster-whisper locally from a verified managed model |
+| Avoid melting a smaller laptop | inspects process-visible CPU, RAM, and compatible acceleration before choosing a strategy |
+| Use a GPU when it is *actually* usable | separates physical hardware discovery from engine/runtime capability instead of assuming “GPU visible = GPU works” |
+| Survive an interruption | checkpoints completed work and validates the original contract on resume |
+| Keep the original recording intact | treats source media as read-only evidence and writes processing artifacts separately |
+| Handle video files | deterministically selects an audio stream and transcribes the audio-bearing source |
+| Clean up a noisy recording | optionally applies deterministic local noise suppression with provenance and timeline checks |
+| Work with multiple languages | supports multilingual decoding plus conservative local language attribution |
+| Distinguish speakers | has optional anonymous recording-scoped diarization, currently held behind a dependency security gate |
+| Publish useful transcript formats | produces canonical JSON plus rebuildable TXT, SRT, and WebVTT views |
+| Find an exact phrase later | builds a private local lexical/BM25 transcript library |
+| Find an idea even when the wording changed | supports optional local semantic retrieval |
+| Get the best of both search styles | combines lexical and semantic results with inspectable reciprocal-rank fusion |
+| Verify where a result came from | carries timestamps, speakers/languages, hashes, canonical coordinates, and retrieval provenance |
+
+That is a lot of machinery. The point is not to make you operate the machinery. The
+point is to make sensitive local transcription feel boringly dependable.
+
+## Pick your doorway
+
+### 💃 I just want to use the thing
+
+Start with **[Getting started](getting-started.md)**.
+
+It walks through installation, model setup, transcription, resume, exports, and search
+without requiring an architecture degree.
+
+### 🔎 I want to search my transcripts
+
+Read **[Semantic search, without the mystery box](semantic-search.md)** for the
+plain-language explanation of lexical, semantic, and hybrid search, including what an
+embedding is and what stays local.
+
+### 🔐 I care about privacy and security boundaries
+
+Read **[SECURITY.md](../SECURITY.md)**. That document intentionally uses less glitter.
+Security claims should be boring enough to audit.
+
+### 🔧 I am maintaining or extending EchoFlow
+
+Open the **[architecture maintenance hatch](architecture/README.md)**.
+
+Those documents contain the exact contracts for media handling, execution strategy,
+model custody, checkpoints, diarization, enhancement, and transcript retrieval.
+
+### 🧪 I am here to break things professionally
+
+The [development docs](development/) cover benchmarking, test design, bisect strategy,
+and targeted mutation qualification.
+
+---
+
+## The EchoFlow family portrait
+
+The product makes more sense when its capabilities are grouped by the job they perform.
+
+```mermaid
+flowchart LR
+    U[Your recording] --> C[Custodian\nsource + provenance]
+    C --> H[Hardware sommelier\nfit work to this machine]
+    H --> T[Transcription engine room\nASR + checkpoints + enrichment]
+    T --> A[Archivist\ncanonical transcript + exports]
+    A --> L[Librarian\nlexical + semantic + hybrid search]
+    L --> E[Evidence you can inspect again]
+
+    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class U,C source
+    class H compute
+    class T process
+    class A evidence
+    class L,E result
+```
+
+The shared rule across the whole family is simple:
+
+**Do complicated work locally. Keep the evidence understandable, portable, and owned by
+the user.**
+
+## What belongs to you, and what can the raccoon rebuild? 🦝
+
+EchoFlow uses different custody rules for different kinds of data.
+
+| Data | What it is | Rebuildable? |
+|---|---|---|
+| Original recording | source evidence | **No** |
+| Canonical transcript JSON | authoritative transcript artifact | **No** |
+| Future notes, tags, labels, annotations | user-authored knowledge | **No** |
+| TXT / SRT / WebVTT | publication views | Yes |
+| Normalized/enhanced working audio | private processing material | Yes |
+| Checkpoint machinery after successful publication | execution/recovery state | Usually disposable after completion |
+| Lexical search database | derived search projection | Yes |
+| Semantic chunks and vectors | derived search projection | Yes |
+
+If deleting a search index destroys unique user-authored information, something has gone
+very wrong.
+
+## Why the docs have different personalities
+
+Not every reader needs the same depth.
+
+- **Welcome/onboarding docs** explain the product in ordinary language and may contain
+  raccoons, mermaids, dancing women, and other signs of life.
+- **Feature guides** explain *why* a capability exists before exposing implementation
+  detail.
+- **Architecture docs** keep exact contracts, but each should still provide a
+  plain-English doorway and useful diagrams.
+- **Security, audit, schema, and command contracts** prioritize unambiguous language over
+  jokes.
+
+The detailed editorial rules live in **[documentation-style.md](documentation-style.md)**.
+
+## What is next?
+
+The backend is now broad enough that the next work is less about inventing a
+transcription engine and more about making evidence easier to navigate and the product
+easier to enter.
+
+The likely evidence-navigation sequence is:
+
+1. **word/timestamp alignment**, so highlighting, speaker attribution, annotations, and
+   jump-to-audio can use finer coordinates;
+2. **original-media timecode and capture-time provenance**, so source-relative seconds
+   can coexist with container/SMPTE/device time when the source provides it;
+3. **better speaker UX**, including user-assigned display labels for anonymous speakers
+   and better presentation of overlap; and
+4. **later, source separation for overlapping speech**, only after the simpler temporal
+   evidence model is strong enough to justify the additional compute and uncertainty.
+
+Packaging, installers, and a thin graphical interface remain important for ordinary
+non-developer use. The architecture is already intentionally arranged so those can sit
+on top of the same services rather than creating a second pipeline.
+
+For the fuller sequencing and research boundary, see **[ROADMAP.md](../ROADMAP.md)**.
+
+💃 **You are now allowed to leave the documentation lobby.**

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,34 +1,64 @@
-# EchoFlow architecture
+# EchoFlow architecture 🔧
 
-EchoFlow is organized around small capability boundaries rather than one inheritance
-hierarchy or generic plugin framework. The composition root lives in
-`src/echoflow/app/app_container.py` and uses Dependency Injector to wire concrete
-local implementations.
+Welcome to the maintenance hatch.
 
-For a user-oriented path before opening the maintenance hatch, start with
-[`docs/getting-started.md`](../getting-started.md).
+The user-facing docs explain what EchoFlow does. These pages explain **why the boundaries
+exist, what each capability owns, what it refuses to own, and which invariants must
+survive refactors**.
 
-## Start here
+If you are trying to transcribe a file rather than maintain the system, back out gently
+and use **[Getting started](../getting-started.md)**. There is no prize for learning
+cgroup accounting before lunch.
 
-- [Processing capabilities](processing-capabilities.md) describes the current
-  execution pipeline, capability ownership, recovery semantics, multilingual
-  behavior, and deliberate product boundaries.
-- [Media normalization and transcript timeline](media-and-timeline.md) explains what
-  FFprobe inspection does, how audio streams are selected, how FFmpeg canonicalizes
-  media, and exactly what transcript timestamps mean.
-- [Local model management](model-management.md) defines explicit model acquisition,
-  private manifest custody, local revalidation, immutable revision pinning, and the
-  rule that ASR execution never downloads models implicitly.
-- [Local speech enhancement](speech-enhancement.md) defines optional deterministic
-  noise suppression, private derived audio, timeline preservation, provenance, and the
-  raw-audio boundary retained for diarization.
-- [Evidence-first corpus search](corpus-search.md) defines canonical-vs-derived
-  ownership, BM25, deterministic chunks, exact dense retrieval, multilingual-E5
-  provenance, stale-index detection, and hybrid RRF ranking.
-- [`ROADMAP.md`](../../ROADMAP.md) separates implemented foundation from near-term
-  product work and later research.
-- [`SECURITY.md`](../../SECURITY.md) documents the supported security/privacy threat
-  boundary and the claims EchoFlow intentionally does not make.
+## The shape of the system
+
+EchoFlow is built around narrow local capabilities instead of one universal pipeline or
+generic plugin framework. The composition root lives in
+`src/echoflow/app/app_container.py` and wires concrete implementations with Dependency
+Injector.
+
+```mermaid
+flowchart LR
+    A[Source media] --> M[Media inspection]
+    M --> R[Resource + runtime inspection]
+    R --> P[Immutable plan]
+    P --> X[Local execution]
+    X --> C[Canonical transcript]
+    C --> E[Derived exports]
+    C --> L[Rebuildable search projections]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef publish fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A,C evidence
+    class M,R,P compute
+    class X process
+    class E publish
+    class L result
+```
+
+The architectural through-line is custody: source evidence and canonical transcript
+truth remain distinguishable from temporary execution state, model dependencies, and
+rebuildable search infrastructure.
+
+## Where to look
+
+| Page | What question it answers |
+|---|---|
+| [Processing capabilities](processing-capabilities.md) | How does the whole local transcription system fit together? |
+| [Adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) | How does EchoFlow decide what this machine can safely run? |
+| [Media and timeline](media-and-timeline.md) | What source did we inspect, which audio stream did we use, and what do timestamps mean? |
+| [Local model management](model-management.md) | Which model revision is allowed to execute, and how did it get here? |
+| [Speech enhancement](speech-enhancement.md) | How can preprocessing affect ASR without becoming source truth? |
+| [Anonymous speaker diarization](diarization.md) | How are speaker turns represented without pretending anonymous labels are identities? |
+| [Corpus search](corpus-search.md) | How does canonical evidence become lexical/semantic/hybrid retrieval without becoming database-owned? |
+| [ROADMAP](../../ROADMAP.md) | What is implemented, what is next, and what remains research? |
+| [SECURITY](../../SECURITY.md) | What does the security boundary actually claim? |
+
+🧜‍♀️ The mermaid has no architectural responsibility. She is observing.
 
 ## Package map
 
@@ -40,28 +70,64 @@ For a user-oriented path before opening the maintenance hatch, start with
 | `media` | Read-only source inspection and deterministic audio-stream selection |
 | `runner` | Process-visible CPU/memory inspection and execution-budget policy |
 | `model_management` | Explicit local model inventory, acquisition, verification, provenance, and removal |
-| `transcription` | Planning, normalization, optional enhancement, segmentation, ASR, checkpoints, language attribution, diarization, assembly, exports |
+| `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language attribution, diarization, assembly, exports |
 | `workspace` | Private job paths and public artifact allocation |
 | `benchmarking` | Privacy-minimized local execution measurement |
 | `library` | Evidence-first lexical/semantic retrieval over rebuildable transcript projections |
 
-`runner` refers to the local compute environment available to the process; it is not
-an orchestration/task runner. `media.probe` performs inspection, not transcoding.
-Canonical audio normalization and optional noise suppression live under the
-transcription execution boundary.
+A couple of names are easy to misread. `runner` means the local compute environment
+available to the process; it is not a distributed task runner. `media.probe` performs
+inspection, not transcoding.
 
-## Dependency conventions
+## Capability boundaries
 
-- External/configuration/durable-data boundaries may use Pydantic where schema
-  parsing and serialization are valuable.
-- Small internal immutable domain values generally use frozen/slotted dataclasses.
-- Services depend on narrow `Protocol` capabilities when substitution is real and
-  useful for testing or multiple implementations.
-- Structlog is isolated behind `core.observability.ILogger`; application services do
-  not need to import Structlog directly.
-- Canonical transcript/checkpoint files are authoritative. Model manifests describe
-  execution dependencies. Search databases are derived and rebuildable.
-- User-authored notes/tags/collections must not share the deletion semantics of
-  rebuildable lexical or semantic indexes.
-- New frameworks, adapters, and abstraction layers require a concrete capability or
-  invariant they protect; file count alone is not a reason to add a manager.
+EchoFlow prefers a small object with one clear job over a grand abstraction that owns
+everything vaguely adjacent to it.
+
+External/configuration/durable-data boundaries may use Pydantic where parsing and
+serialization are valuable. Small internal immutable values generally use frozen/slotted
+dataclasses. Services use narrow `Protocol` capabilities when substitution is real and
+useful for testing or multiple implementations.
+
+Structlog remains behind `core.observability.ILogger`; application services should not
+need to import Structlog directly.
+
+## The custody rules 🦝
+
+These rules are load-bearing:
+
+1. **Original media is source evidence and treated as read-only input.**
+2. **Canonical transcript/checkpoint artifacts carry execution truth.**
+3. **Managed model manifests describe verified local execution dependencies.**
+4. **Lexical and semantic databases are derived, private, and rebuildable.**
+5. **Future user-authored notes, labels, tags, collections, and annotations must not
+   share deletion semantics with rebuildable indexes.**
+6. **A convenience layer may not quietly become the only place unique evidence lives.**
+
+That fifth rule matters more as the product becomes a research library. Search
+infrastructure is allowed to disappear. User-authored knowledge is not.
+
+## New abstraction test
+
+Before adding a manager, framework, registry, adapter hierarchy, or generalized plugin
+system, ask which concrete capability or invariant it protects.
+
+File count is not an architectural problem. Repeated policy, unclear ownership, and
+unprovable invariants are.
+
+## Documentation contract
+
+Architecture docs may be technical. They should not require a reader to decode a wall of
+implementation nouns before learning the purpose.
+
+Each architecture page should aim to provide:
+
+- a plain-English doorway;
+- a visual model when structure matters;
+- the exact implementation contract;
+- ownership/failure semantics; and
+- explicit current limits or future seams.
+
+See **[documentation-style.md](../documentation-style.md)** for the editorial contract.
+
+The code can be serious without the prose developing a fear of joy. 💃

--- a/docs/architecture/adaptive-heterogeneous-execution.md
+++ b/docs/architecture/adaptive-heterogeneous-execution.md
@@ -1,207 +1,278 @@
-# Adaptive heterogeneous execution
+# Adaptive heterogeneous execution 🖥️✨
 
-Status: implemented architecture, representative-device qualification pending  
+Status: implemented architecture; representative-device qualification pending  
 Last updated: August 17, 2026
 
-## Purpose
+## The human version
 
-EchoFlow should use the machine a recording is actually running on without turning
-transcription into a collection of vendor-specific conditionals. A commodity laptop
-may have useful CPU capacity, system RAM, and an accelerator that its owner rarely
-uses directly. Those resources are not interchangeable, and merely detecting a GPU
-does not prove that the installed transcription engine can execute on it.
+EchoFlow should use the computer in front of it **without asking the user to become a
+hardware scheduler**.
 
-The adaptive-execution architecture therefore separates four decisions:
+A small Windows laptop, an Apple Silicon machine, a desktop with a discrete GPU, and a
+large workstation do not have the same resources. More importantly, “a GPU exists” does
+not mean the installed speech engine can actually use it.
 
-1. discover process-visible compute and memory topology;
-2. ask each engine adapter which execution targets its installed runtime can really
-   use;
-3. admit and rank concrete strategies against the current resource budgets; and
-4. overlap independent CPU-side preparation with accelerator inference without
-   weakening checkpoint ordering or resumability.
+So EchoFlow separates the problem into four questions:
 
-This is deliberately not a general tensor-sharding or distributed-compute system.
+1. **What compute and memory can this process really see?**
+2. **What can the installed engine/runtime really execute on?**
+3. **Which concrete strategy safely fits the current budgets?**
+4. **Can we overlap a little preparation work without breaking resume or ordering?**
 
-## Resources are not all compute
+For an ordinary user, the intended outcome is simple: EchoFlow chooses a sensible local
+strategy, refuses impossible explicit requests, and does not pretend that a detected
+accelerator is magic extra RAM.
 
-CPU cores and accelerators execute work. System RAM and accelerator memory provide
-capacity and bandwidth for model weights, buffers, audio, queues, and intermediate
-state. EchoFlow models those roles separately.
+```mermaid
+flowchart LR
+    A[Inspect this machine] --> B[CPU + system memory]
+    A --> C[Physical accelerators]
+    C --> D[Ask engine what it can really use]
+    B --> E[Admit safe strategies]
+    D --> E
+    E --> F[Rank eligible choices]
+    F --> G[Run locally]
+    G --> H[Checkpoint in order]
 
-The existing `RunnerInspector` remains authoritative for process-visible CPU and
-system-memory capacity. It already accounts for CPU affinity, Linux cgroup CPU
-quotas, Linux cgroup memory ceilings, and current process-visible free memory. The
-new `HardwareTopologyInspector` composes that stable inspection with an independent
-accelerator probe.
+    classDef inspect fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef decision fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef run fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+
+    class A,B,C,D inspect
+    class E,F decision
+    class G run
+    class H evidence
+```
+
+No tensor-sharding opera is hiding behind this diagram. The current system is
+purposefully narrower.
+
+## Why the distinction matters
+
+CPU cores and accelerators **execute work**. System RAM and accelerator memory provide
+capacity for model weights, buffers, audio, queues, and intermediate state. Those roles
+are related but not interchangeable.
+
+A machine with 16 GiB of unified memory does not suddenly contain 32 GiB because the GPU
+can also see it. EchoFlow models the physical budget rather than summoning fictional
+memory from the spreadsheet dimension.
+
+## Resource discovery
+
+`RunnerInspector` is authoritative for process-visible CPU and system-memory capacity.
+It accounts for relevant constraints including:
+
+- CPU affinity;
+- Linux cgroup CPU quotas;
+- Linux cgroup memory ceilings; and
+- current process-visible free memory.
+
+`HardwareTopologyInspector` adds independent accelerator evidence.
 
 Accelerator memory has an explicit topology:
 
-- **dedicated** memory is a distinct device-memory pool, such as discrete NVIDIA
-  VRAM;
-- **shared** and **unified** memory consume the same physical capacity available to
-  the host and therefore must also count against the system-memory budget;
-- **unknown** memory is not guessed. Strategies that require an unknown device-memory
-  budget fail closed.
+- **dedicated**: a distinct device-memory pool such as discrete NVIDIA VRAM;
+- **shared/unified**: consumes the same physical capacity available to the host and must
+  also count against the system-memory budget; and
+- **unknown**: not guessed safe. A strategy requiring unknown device-memory capacity
+  fails admission.
 
-EchoFlow must never add shared or unified accelerator memory to system RAM and call
-the result extra capacity. A machine with 16 GiB of unified memory still has 16 GiB
-of physical memory, not 16 GiB plus a fictional GPU allocation.
+That distinction protects ordinary machines from double-counting memory simply because
+an accelerator API reports a second view of the same pool.
 
-## Physical visibility is not engine capability
+## Physical hardware is not engine capability
 
 A visible accelerator is necessary but not sufficient for accelerated execution.
-The current engine may not support its driver/runtime, compute type, operating
-system, or device API.
 
-`EngineCapabilityRegistry` keeps that question inside engine-specific providers.
-The application planner asks for capabilities by engine name and receives concrete
-execution targets such as:
+The runtime may not support the driver, operating system, device API, or compute type.
+EchoFlow therefore keeps engine-specific capability knowledge behind
+`EngineCapabilityRegistry` providers.
 
-- `cpu:0` with `int8`;
-- `cuda:0` with `float16`; or
-- `cuda:0` with `int8_float16`.
+The planner receives concrete execution targets such as:
 
-The planner does not contain NVIDIA, CUDA, Metal, DirectML, ROCm, or OpenVINO policy.
-A future engine adapter can advertise different targets without changing the
-strategy evaluator.
+```text
+cpu:0   + int8
+cuda:0  + float16
+cuda:0  + int8_float16
+```
+
+The application planner itself does not contain NVIDIA, CUDA, Metal, DirectML, ROCm, or
+OpenVINO policy.
 
 The first physical accelerator probe uses `nvidia-smi` because faster-whisper's
-CTranslate2 runtime can consume CUDA. Discovery is intentionally lightweight and
-optional. A missing command, broken driver, timeout, malformed response, or runtime
-import failure degrades to a CPU-capable machine instead of preventing EchoFlow from
-starting.
+CTranslate2 runtime can consume CUDA. Discovery is optional and lightweight. A missing
+command, broken driver, timeout, malformed response, or runtime import failure degrades
+to a CPU-capable machine instead of preventing EchoFlow from starting.
 
-CTranslate2 capability inspection is separate from physical discovery. A CUDA
-strategy is eligible only when both the physical device and the installed runtime
-agree on the exact device and compute type. EchoFlow never treats a detected but
-unsupported GPU as useful acceleration.
+CTranslate2 capability inspection remains separate. A CUDA strategy is eligible only
+when physical device evidence **and** installed runtime capability agree on the exact
+device and compute type.
+
+🦝 A GPU may live under the floorboards. EchoFlow still asks whether it has a job.
 
 ## Strategy admission
 
-`StrategyDefinition` describes execution placement as well as model quality and cache
-cost. A strategy has an engine, model, device, compute type, optional accelerator
-backend, system-memory estimate, optional device-memory estimate, quality rank, and
-performance rank.
+`StrategyDefinition` describes a concrete execution choice:
 
-The evaluator remains deterministic. It does not benchmark during planning and does
-not use marketing names as hardware heuristics. It asks whether the declared strategy
-fits the current evidence.
+- engine;
+- model;
+- device;
+- compute type;
+- optional accelerator backend;
+- estimated system-memory requirement;
+- optional device-memory requirement;
+- quality rank; and
+- performance rank.
+
+`StrategyEvaluator` is deterministic. It does not benchmark during planning and does not
+infer performance from marketing names.
 
 For dedicated accelerator memory, EchoFlow reserves headroom before admission. The
-initial device-memory budget is 80 percent of currently free device memory. This is a
-conservative heuristic until representative-machine measurements justify a different
-value.
+initial budget is **80% of currently free device memory**. This is a conservative
+heuristic pending representative-device measurements.
 
-For shared or unified memory, the accelerator requirement is also charged against the
-system-memory budget. Unknown memory topology or unknown available device memory fails
-closed for strategies that require device memory.
+For shared/unified memory, the accelerator requirement is also charged against system
+RAM. Unknown device-memory availability is not treated as safe.
 
-An explicit strategy selection is never silently replaced. If the requested target
-is unavailable or no longer safe, EchoFlow returns a typed resource-admission failure.
-Automatic selection may fall back to an equally suitable CPU strategy.
+### Explicit means explicit
 
-## Why pipeline parallelism comes before model sharding
+If a user explicitly selects a strategy and it is no longer available or safe, EchoFlow
+returns a typed resource-admission failure.
+
+It does **not** silently swap the explicit request for something else.
+
+Automatic selection may choose a suitable CPU strategy when acceleration is unavailable.
+CPU/int8 remains the reference compatibility path.
+
+## Why bounded pipeline overlap comes before model sharding
 
 EchoFlow owns media preparation, deterministic segmentation, checkpointing, transcript
 assembly, enrichment, and publication. It does not own the tensor graph inside every
 speech engine.
 
-Splitting one model between CPU and GPU would couple the application to engine-specific
-partitioning behavior, add memory-transfer overhead, complicate packaging, and make
-recovery semantics harder to reason about. It may eventually be useful for a specific
-engine, but it is not the first optimization boundary.
+Splitting one model across CPU and GPU would couple the application to engine-specific
+partitioning behavior, introduce transfer overhead, complicate packaging, and make
+recovery semantics harder to reason about.
 
-The first concurrency optimization is therefore bounded pipeline overlap:
+The first concurrency optimization is therefore much less glamorous and much easier to
+prove:
 
-1. the accelerator transcribes segment N;
-2. one CPU worker may materialize segment N+1 concurrently;
-3. the main execution path checkpoints N before it can commit N+1; and
-4. at most one unconsumed materialized segment exists.
+```mermaid
+sequenceDiagram
+    participant M as Main execution path
+    participant G as Accelerator inference
+    participant P as One CPU prefetch worker
+    participant C as Checkpoint store
 
-A prefetch worker is not free. When an accelerated plan has more than one safe CPU
-thread, EchoFlow reserves one thread of headroom for segment preparation and gives the
-remaining threads to the inference engine. If only one effective CPU thread is
-available, accelerated inference may still run, but prefetch depth becomes zero and
-materialization remains sequential. EchoFlow does not oversubscribe a CPU quota merely
-to claim parallelism.
+    M->>G: transcribe segment N
+    par while N is in flight
+        M->>P: materialize segment N+1
+    end
+    G-->>M: result N
+    M->>C: commit checkpoint N
+    P-->>M: prepared N+1
+    M->>G: transcribe N+1
+```
 
-The same boundedness applies to storage. A CPU plan admits disk for one materialized
-segment. An accelerated plan with prefetch enabled admits disk for the current segment
-plus one future materialized segment. If prefetch is disabled for lack of CPU
-headroom, the storage estimate returns to one segment. Storage admission therefore
-matches the maximum temporary files the scheduler can actually own.
+The invariants are:
 
-There is still one job-scoped inference session and one ordered checkpoint writer.
-Prefetch depth is a local scheduling decision, not transcript identity. On resume,
-EchoFlow restores the original engine/device/compute contract and can reduce prefetch
-depth if the current runner has less spare CPU capacity without invalidating completed
-checkpoints.
+1. at most one future materialized segment exists;
+2. segment `N` is checkpointed before `N+1` can become committed work;
+3. there remains one job-scoped inference session and one ordered checkpoint writer; and
+4. completed checkpoints form a contiguous prefix of the deterministic segment plan.
 
-If future work has not started when a failure occurs, it can be canceled without a
-file ever existing. If future materialization has started or completed, its unconsumed
-segment is cleaned during unwinding. Cleanup failure does not mask the primary error.
+## CPU and storage accounting for prefetch
+
+Prefetch is not free.
+
+When an accelerated strategy has more than one safe CPU thread, EchoFlow may reserve one
+thread for segment preparation and give the remaining threads to inference.
+
+If only one effective CPU thread is available, acceleration may still run, but prefetch
+depth becomes zero and materialization stays sequential. EchoFlow does not oversubscribe
+a cgroup or affinity-constrained CPU budget merely so a diagram can contain the word
+“parallel.”
+
+Storage admission mirrors that boundedness:
+
+- CPU/sequential execution admits one materialized segment;
+- accelerated execution with prefetch admits current + one future materialized segment;
+- if prefetch is disabled, the estimate returns to one segment.
+
+The storage estimate therefore describes the maximum temporary segment files the
+scheduler can actually own.
+
+## Failure cleanup
+
+If future work has not started when a failure occurs, it can be canceled before a file
+exists.
+
+If future materialization has started or completed, unconsumed prepared audio is cleaned
+while unwinding. Cleanup failure is logged but does not mask the primary error.
+
 The current segment remains owned by the main execution path and is cleaned there.
 
-This preserves the existing resume invariant: completed checkpoints are a contiguous
-prefix of the deterministic segment plan.
+This protects the resume invariant rather than treating speculative work as completed
+state.
 
-## Re-admission and changing machines
+## Re-admission when the world changes
 
-Planning is not a permanent reservation of hardware. EchoFlow already rechecks CPU
-and system-memory capacity before model initialization. Accelerated execution adds a
-fresh accelerator probe and engine-capability check before model load.
+Planning is not a permanent reservation.
+
+Before model initialization, EchoFlow rechecks CPU/system-memory capacity. Accelerated
+execution also performs fresh accelerator and engine-capability checks.
 
 A GPU that disappears, loses enough free VRAM, or becomes unsupported after planning
-causes a safe refusal. Resume similarly restores the original engine/device/compute
-contract and re-admits it against the current machine rather than silently changing
-execution placement. Scheduling optimizations such as prefetch can become more
-conservative when current CPU headroom shrinks, provided the immutable engine and
-checkpoint requirements still fit.
+causes a safe refusal.
 
-## Benchmarking and calibration
+Resume restores the original engine/device/compute contract and re-admits it on the
+current machine rather than silently changing execution placement.
 
-The strategy estimates in this first implementation are deliberately conservative
-heuristics. They are not a claim that a particular GPU, laptop, or compute type is
-faster than another in sustained use.
+Scheduling details that are **not transcript identity**, such as prefetch depth, may
+become more conservative when current CPU headroom shrinks, provided the immutable
+engine and checkpoint requirements still fit.
 
-Representative-device qualification should measure at least:
+## What still needs empirical qualification
+
+Current memory estimates and performance ranks are conservative heuristics. They are not
+a claim that a particular laptop/GPU/compute type is faster under sustained real use.
+
+Representative-device qualification should measure:
 
 - engine/model/device/compute type;
-- cold and warm model-cache behavior;
-- process-tree peak RSS and CPU usage;
-- stage timings, including materialization and inference;
-- real-time factor over recordings long enough to expose thermal throttling;
-- peak accelerator memory and utilization when the backend exposes those values
-  reliably;
-- whether one reserved CPU preparation thread improves sustained throughput on the
-  target machine; and
-- failure/recovery behavior under CPU, RAM, and device-memory contraction.
+- cold and warm model behavior;
+- process-tree peak RSS and CPU use;
+- stage timings and real-time factor;
+- thermal effects on longer recordings;
+- accelerator memory/utilization where reliable counters exist;
+- whether reserving a CPU preparation thread improves throughput; and
+- recovery behavior when CPU, RAM, or device-memory availability contracts.
 
-Those measurements can later drive private local calibration. The planner should
-prefer observed evidence over hard-coded hardware-name rules. If measurements show
-that overlap is counterproductive on a particular topology, the scheduling layer can
-become more conservative without changing canonical transcript semantics.
+The intended future rule is **measure the machine, not the logo on the machine**.
 
 ## Privacy and security
 
 Topology and capability detection are local. EchoFlow does not need to upload hardware
 inventory, recordings, transcripts, or benchmark results to choose a strategy.
 
-Accelerator discovery uses fixed argument vectors without a shell. Probe failures are
-not allowed to expose arbitrary driver output in routine user-facing errors. Engine
-capability checks are read-only and do not authorize model downloads.
+Accelerator discovery uses fixed argument vectors without a shell. Routine user-facing
+errors do not expose arbitrary driver output. Capability inspection does not authorize
+model downloads.
 
-The same explicit download authorization and private model-cache boundaries apply to
-CPU and accelerated strategies.
+Model acquisition remains a separate explicit boundary under local model management.
 
 ## Compatibility rule
 
-The CPU/int8 execution path remains the fallback and the reference compatibility
-contract. Future accelerator backends should plug into the same topology, capability,
-strategy, observer, checkpoint, and application-runner seams instead of teaching the
-CLI or transcription core about hardware brands.
+CPU/int8 remains the fallback and reference compatibility contract.
 
-The stable architectural rule is:
+Future accelerator backends should plug into the same topology, capability, strategy,
+observer, checkpoint, and application-runner seams instead of teaching the CLI or
+transcription core about hardware brands.
 
-> detect resources, negotiate capabilities, admit a concrete strategy, and keep
-> checkpoint semantics independent of where inference runs.
+The stable rule is:
+
+> **detect resources → negotiate real engine capability → admit a concrete strategy →
+> keep checkpoint semantics independent of where inference runs.**
+
+That is the whole little hardware cabaret. 💃

--- a/docs/architecture/corpus-search.md
+++ b/docs/architecture/corpus-search.md
@@ -1,100 +1,130 @@
-# Evidence-first corpus search
+# Evidence-first corpus search 🔎🦝
 
 Status: lexical retrieval implemented; semantic/hybrid foundation implemented with a strict-local optional E5 adapter  
 Last updated: August 17, 2026
 
-## Product intent
+## The human version
 
-EchoFlow makes a local transcript corpus searchable without turning a database, a vector
-store, or a chat model into the product. A researcher should be able to retrieve a
-passage, inspect its timestamps and speaker/language evidence, and trace it back to the
-canonical transcript that produced it.
+A transcript library should help you find **what was said** without quietly replacing
+your evidence with a database, vector store, or generated answer.
 
-The core ownership rule is:
+EchoFlow therefore supports three ways to retrieve transcript passages:
 
-> canonical transcript JSON is evidence; database state is a projection.
+| Mode | Best when… | Example |
+|---|---|---|
+| Lexical | you remember the actual words, names, acronyms, or identifiers | `rent increase` |
+| Semantic | you remember the idea but not the wording | `people struggling to afford housing` |
+| Hybrid | you want exact terminology and conceptual similarity to support each other | research across a mixed corpus |
 
-The original recording is treated as read-only input. Canonical JSON is the durable,
-portable transcript artifact. DuckDB exists to make that evidence searchable and may be
-deleted and rebuilt.
+The result is still a passage from the transcript with timestamps and evidence context.
+
+The load-bearing ownership rule is:
+
+> **Canonical transcript JSON is evidence. Search databases are projections.**
+
+That one sentence explains a large amount of the implementation below.
 
 ```mermaid
-flowchart TD
+flowchart LR
     A[Original recording] -->|read only| B[Canonical transcript JSON]
     B --> C[Lexical projection]
-    B --> D[Deterministic search chunks]
-    C --> E[BM25]
-    D --> F[Dense embeddings]
-    E --> G[TranscriptSearch]
-    F --> G
-    G --> H[Evidence-bearing SearchResponse]
-    H --> I[CLI]
-    H --> J[Future GUI]
-    H --> K[Future Python/MCP adapters]
+    B --> D[Deterministic semantic chunks]
+    C --> E[BM25 ranking]
+    D --> F[Local embeddings]
+    F --> G[Exact semantic ranking]
+    E --> H[Optional hybrid fusion]
+    G --> H
+    E --> I[Evidence-bearing results]
+    G --> I
+    H --> I
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A,B evidence
+    class C,D derived
+    class E,F,G,H process
+    class I result
 ```
 
-## Three durability classes
+For a non-architecture explanation of embeddings and the local privacy boundary, read
+**[Semantic search, without the mystery box](../semantic-search.md)** first.
 
-EchoFlow deliberately separates data by whether it can be reconstructed.
+## 🦝 What lives under the floorboards? Three durability classes
 
-### Authoritative
+Search becomes much easier to reason about when data is classified by whether it can be
+reconstructed.
+
+### Authoritative evidence
 
 - original recording supplied by the user;
 - canonical transcript JSON.
 
-### User-authored
+### User-authored knowledge
 
-Future notes, tags, collections, annotations, and saved searches belong here. They are
-not retrieval cache and must never be discarded by an index rebuild. When annotation
-work is added, it must anchor to durable transcript evidence coordinates rather than
-only to a derived chunk ID.
+Future notes, tags, collections, speaker display labels, annotations, and saved searches
+belong here.
 
-### Rebuildable
+They are **not retrieval cache**. An index rebuild must never delete them. Durable
+annotations should anchor to canonical evidence coordinates, not only to disposable
+semantic chunk IDs.
+
+### Rebuildable projections
 
 - document projection;
 - segment projection;
 - lexical term statistics;
 - deterministic search chunks;
-- dense embeddings;
+- dense embeddings; and
 - retrieval statistics.
 
-Removing rebuildable state must not destroy unique user information.
+If every search database disappeared, EchoFlow should be able to reconstruct search
+from canonical transcripts without losing unique user-authored information.
 
-## Canonical hashing and stale-index detection
+## Canonical hashing and stale-state refusal
 
-The lexical document projection now records two distinct digests:
+EchoFlow records two different SHA-256 digests in the lexical document projection:
 
-- `source_sha256`: the source recording digest recorded when transcription was planned;
-- `canonical_sha256`: the SHA-256 of the exact canonical transcript JSON bytes indexed
+- `source_sha256`: the recording digest captured when transcription was planned;
+- `canonical_sha256`: the digest of the exact canonical transcript JSON bytes indexed
   by the library.
 
-These answer different questions. A source recording can remain byte-identical while a
-canonical transcript changes because the transcript was regenerated, enriched, or
-replaced.
+They answer different questions.
+
+The original recording may remain byte-identical while the canonical transcript changes
+because it was regenerated, enriched, corrected, or replaced.
 
 Every semantic generation records a `corpus_fingerprint` derived from sorted
-`(document_id, canonical_sha256)` pairs. Semantic or hybrid search refuses to run when
-the current lexical projection no longer matches that fingerprint.
+`(document_id, canonical_sha256)` pairs.
 
-The failure mode is therefore explicit:
+```mermaid
+flowchart LR
+    A[Canonical JSON changes] --> B[Lexical rebuild sees new canonical SHA]
+    B --> C{Semantic fingerprint still matches?}
+    C -->|yes| D[Search normally]
+    C -->|no| E[Refuse semantic / hybrid search]
+    E --> F[Rebuild embeddings]
 
-```text
-canonical JSON changes
-    -> lexical rebuild sees new canonical_sha256
-    -> semantic corpus fingerprint no longer matches
-    -> semantic/hybrid retrieval refuses
-    -> embeddings must be rebuilt
+    classDef changed fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef ok fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+    classDef stop fill:#FFD6D6,stroke:#9E3434,stroke-width:2px,color:#351616
+
+    class A,B changed
+    class C,D ok
+    class E,F stop
 ```
 
 EchoFlow does not quietly search stale vectors.
 
 ## Lexical retrieval
 
-`DuckDbTranscriptIndex` remains the lexical adapter. It stores ordinary document,
+`DuckDbTranscriptIndex` is the current lexical adapter. It stores ordinary document,
 segment, and term-statistic tables and computes deterministic BM25-style ranking without
 installing DuckDB's FTS extension.
 
-The public query contract remains `SearchQuery`:
+The public application query remains typed through `SearchQuery`:
 
 ```text
 SearchQuery
@@ -108,328 +138,281 @@ SearchQuery
   limit = 100
 ```
 
-User values remain parameterized. The storage adapter owns its SQL.
+User values remain parameterized. The storage adapter owns SQL. The user does not.
 
-## Deterministic semantic chunks
+Lexical search remains the base/default mode and does not require a semantic runtime.
 
-ASR segments are evidence coordinates, not necessarily good embedding units. A segment
-may contain only `"Yeah."` or `"And then we moved."`.
+## Why semantic search needs chunks
 
-EchoFlow therefore creates deterministic windows over adjacent canonical segments.
+ASR segments are evidence coordinates, not automatically good retrieval units.
+
+A canonical segment might contain only:
+
+```text
+Yeah.
+```
+
+or:
+
+```text
+And then we moved.
+```
+
+Embedding tiny fragments like that can lose useful surrounding meaning. EchoFlow
+therefore combines adjacent canonical segments into deterministic retrieval windows.
 
 `search-chunk-v1` currently uses:
 
 - target size: 220 whitespace-delimited words;
 - maximum target size: 300 words;
-- no synthetic splitting inside one source segment;
+- no synthetic splitting inside one canonical ASR segment;
 - no overlap in v1;
 - stable document/segment ordering;
 - content SHA-256;
-- first/last segment IDs and the complete ordered segment-ID tuple;
-- exact source-relative start/end timestamps;
+- first/last segment IDs plus the complete ordered segment-ID tuple;
+- exact source-relative start/end timestamps; and
 - sorted language and anonymous speaker references observed in the window.
 
-A source segment larger than the target remains one chunk. EchoFlow does not cut a
-canonical segment into invented evidence coordinates merely to satisfy a retrieval
+If one canonical segment is already larger than the target/max window, it remains one
+chunk. EchoFlow does not invent fake evidence coordinates merely to satisfy a retrieval
 heuristic.
 
-A chunk is never canonical evidence. It is a disposable retrieval window that points
-back to canonical segments.
+A search chunk is **never canonical evidence**. It is a disposable window pointing back
+to canonical segments.
 
-## Embedding profile
+## Embedding profile: the model is not the whole contract
 
-One semantic index generation has exactly one coherent embedding profile. EchoFlow will
-not mix English E5 vectors with multilingual E5 vectors in the same space.
+One semantic index generation has one coherent `EmbeddingProfile`.
 
-The first real adapter is designed for:
+The first qualified real adapter targets:
 
 ```text
 model_id             intfloat/multilingual-e5-small
 dimensions           384
 normalization        l2
+pooling               mean
 distance_metric      dot
 query_transform      "query: {text}"
 passage_transform    "passage: {text}"
 chunking_profile     search-chunk-v1
 resolved_revision    immutable snapshot revision
+embedding_schema     1
 ```
 
-`EmbeddingProvider` exposes two separate methods:
+That profile matters because two models can disagree about dimensions, pooling,
+normalization, query instructions, passage instructions, and distance semantics even if
+both advertise themselves as “embeddings.”
+
+The model is replaceable. **The retrieval contract must remain explicit.**
+
+`EmbeddingProvider` therefore exposes separate methods:
 
 ```python
 embed_queries(texts)
 embed_passages(texts)
 ```
 
-That distinction is intentional. E5 retrieval uses different query-side and
-passage-side text transforms. EchoFlow does not flatten this into a misleading generic
-`embed(text)` contract.
+E5 uses distinct query-side and passage-side transforms, so EchoFlow does not flatten
+the interface into a misleading generic `embed(text)` call.
 
-The stored profile records model identity, immutable resolved revision, dimensions,
-normalization, metric, transforms, chunking profile, and the local snapshot path needed
-to restore the same provider.
+## Strict-local model boundary 🔐
 
-## Strict-local model boundary
+`SentenceTransformersE5Provider` accepts a local snapshot directory. The directory name
+must agree with the recorded immutable revision.
 
-`SentenceTransformersE5Provider` accepts a local snapshot directory and requires the
-directory name to equal the recorded immutable revision. It loads
-`SentenceTransformer` from that local path and never passes a repository ID to the
-runtime.
+The provider loads `SentenceTransformer` from that local path with:
 
-The provider validates:
+- local-only model resolution; and
+- remote model code disabled.
 
-- non-empty input;
+It never hands a repository ID to the runtime during indexing/search.
+
+Provider output is checked before it can replace valid semantic state. Validation covers:
+
+- non-empty text inputs;
 - one output vector per input;
-- exactly 384 dimensions;
-- finite numeric values;
-- L2-normalized output.
+- exactly 384 dimensions for this profile;
+- finite numeric values; and
+- expected L2 normalization.
 
-The adapter lazy-imports `sentence_transformers`. EchoFlow's locked dependency graph
-does **not yet** declare a semantic extra in this tranche. That is deliberate: the
-repository's CI requires `pyproject.toml` and `uv.lock` to remain coherent, and this
-change does not claim an unqualified dependency lock that was not actually resolved and
-audited.
+A failed rebuild must not destroy the previous valid semantic generation.
 
-Consequently, semantic build/search is an implemented optional capability for an
-environment that already has a compatible Sentence Transformers runtime and a local
-immutable multilingual-E5 snapshot. Base EchoFlow and lexical search remain unchanged.
-A later dependency-qualification tranche can add a locked `semantic` extra and managed
-model acquisition without changing the retrieval contracts introduced here.
+### Dependency boundary
 
-## Numeric vector storage
+The locked project dependency graph does **not yet** declare Sentence Transformers as a
+semantic extra. That is deliberate.
 
-`DuckDbSemanticIndex` stores vectors as DuckDB `FLOAT[]`.
+Semantic search is currently an implemented optional capability for environments that
+already provide a compatible runtime and local immutable Multilingual E5 Small snapshot.
+A later qualification tranche can add an audited/locked semantic extra and managed model
+acquisition without changing the application retrieval contract.
 
-Vectors are not serialized to opaque BLOBs. The application boundary remains
-`tuple[float, ...]`, so another adapter may later choose a fixed-length vector type,
-compressed representation, or different backend without changing domain contracts.
+Lexical search remains fully available without it.
 
-The semantic database is private rebuildable state at:
+## Numeric vector storage, now that we have earned the jargon
+
+EchoFlow keeps semantic vectors as numeric data that the current search backend can
+inspect directly.
+
+In `DuckDbSemanticIndex`, vectors are stored as DuckDB `FLOAT[]` rather than opaque
+BLOBs.
+
+There. We have reached the sentence that used to be thrown at readers without a
+staircase. 💃
+
+The application boundary remains `tuple[float, ...]`, so a later adapter can choose a
+fixed-length vector type, compressed representation, or different backend without
+changing the domain contract.
+
+The semantic database is private rebuildable state under:
 
 ```text
 STATE_DIR/library/semantic.duckdb
 ```
 
-It is intentionally separate from the lexical database in this tranche. This keeps
-semantic rebuild/storage evolution independent from the already-working BM25 index and
-makes deletion semantics obvious. Both databases remain disposable projections of
-canonical JSON.
+It is intentionally separate from the lexical database in this tranche so semantic
+storage/rebuild evolution does not destabilize the already-working BM25 path.
 
 ## Exact local similarity first
 
-The first semantic retrieval implementation performs an exact scan over the filtered
-local chunk set.
+The first semantic implementation performs an **exact scan** over eligible local chunks.
 
 Hard filters are applied before top-K ranking:
 
-- transcript/document;
+- transcript/document IDs;
 - language;
 - speaker;
-- exact phrase when requested;
+- exact phrase when requested; and
 - `ALL` lexical terms when requested.
 
-This avoids filter starvation. A query for one speaker must not search the global top
-100 vectors and only then discover that all 100 belonged to someone else.
+Filtering first avoids starvation. A search constrained to one speaker must not inspect
+the global top 100 vectors and only afterward discover that none belonged to that
+speaker.
 
-No ANN/HNSW structure is introduced yet. Approximate nearest-neighbor indexing is an
-execution optimization, not a product requirement. It should be added only if measured
-corpus size and latency demonstrate that exact local search misses an interactive
-target.
+No ANN/HNSW index exists yet. Approximate nearest-neighbor indexing is an optimization,
+not a product requirement. It should appear only when measured corpus size shows that an
+exact local scan misses an interactive latency target.
 
-## Hybrid retrieval and RRF
+An 8 GB laptop should not pay an ANN tax because ANN is fashionable.
 
-`TranscriptSearch` composes narrow capabilities:
+## 💃 Bringing the ranks together: hybrid retrieval
+
+Lexical BM25 scores and dense semantic similarity scores do not share one trustworthy
+scale.
+
+EchoFlow therefore does not normalize them into a fake universal relevance probability.
+It combines **ranks** using reciprocal rank fusion (RRF) with `k=60`.
 
 ```mermaid
 flowchart TD
-    Q[SearchQuery] --> L[LexicalRetriever / BM25]
-    Q --> S[SemanticIndex / exact dense search]
+    Q[SearchQuery] --> L[Lexical retrieval / BM25]
+    Q --> S[Semantic retrieval / exact dense search]
     L --> LR[Lexical chunk ranks]
     S --> SR[Semantic chunk ranks]
-    LR --> R[Reciprocal Rank Fusion]
+    LR --> R[RRF k=60]
     SR --> R
     R --> E[Evidence-bearing SearchResponse]
+
+    classDef query fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef rank fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef fuse fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class Q query
+    class L,S,LR,SR rank
+    class R fuse
+    class E result
 ```
 
-Hybrid ranking uses reciprocal rank fusion with `k=60`:
+The core formula is:
 
 ```text
 RRF(d) = Σ 1 / (60 + rank_i(d))
 ```
 
-RRF avoids pretending BM25 scores and cosine/dot similarities are directly comparable.
-EchoFlow exposes ranks rather than converting unlike scores into a fake universal
-"relevance probability."
+Hybrid retrieval overfetches candidate ranks before fusion so one retrieval mode has
+room to contribute candidates that the other missed. Current implementation bounds the
+candidate pool rather than allowing unbounded work.
 
-The public result includes:
+`SearchResponse` preserves lexical, semantic, and fused rank provenance. Timeline
+presentation may reorder results chronologically without falsely rewriting that stored
+relevance rank.
 
-- canonical/source identity;
-- chunk ID when a derived chunk was used;
-- complete segment evidence coordinates;
-- lexical-matched segment IDs;
-- source-relative timestamps;
-- language and speaker evidence;
-- lexical rank when applicable;
-- semantic rank when applicable;
-- fused rank;
-- retrieval provenance.
+## Evidence-bearing results
 
-Timeline sorting changes presentation order but does not erase the recorded relevance
-ranks.
+The retrieval response is not just `text + score`.
 
-## Unified retrieval response
+A `SearchPassage` can carry:
 
-`TranscriptLibraryService.retrieve()` returns one `SearchResponse` shape for lexical,
-semantic, and hybrid modes.
+- document/source identity;
+- canonical transcript identity/hash;
+- deterministic chunk ID;
+- constituent canonical segment IDs;
+- start/end timestamps;
+- speaker and language evidence;
+- lexical rank;
+- semantic rank;
+- fused rank; and
+- the actual transcript passage.
 
-```text
-SearchResponse
-  query
-  retrieval mode
-  lexical backend ID
-  semantic backend ID
-  embedding profile
-  fusion profile
-  results[]
-    evidence coordinates
-    passage
-    timestamps
-    speakers
-    languages
-    lexical rank
-    semantic rank
-    fused rank
+That means a presentation layer can show a useful result while retaining the route back
+to source evidence.
+
+## Provider interoperability without model roulette
+
+The search core depends on `EmbeddingProvider` + `EmbeddingProfile`, not an E5-specific
+domain type.
+
+Tests include a fake non-E5 provider to prove that the application/service contract is
+provider-agnostic.
+
+The ordinary CLI nevertheless qualifies one concrete profile today. It does **not**
+accept arbitrary Hugging Face repository IDs as if all embedding models were
+interchangeable.
+
+A future provider registry can expose additional qualified local profiles once EchoFlow
+can validate their full retrieval contract.
+
+## What happens when a better model arrives?
+
+Canonical transcripts do not need to migrate.
+
+```mermaid
+flowchart LR
+    T[Canonical transcripts] --> P1[Embedding profile v1]
+    T --> P2[Embedding profile v2]
+    P1 --> V1[Old rebuildable vectors]
+    P2 --> V2[New rebuildable vectors]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef profile fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+
+    class T evidence
+    class P1,P2 profile
+    class V1,V2 derived
 ```
 
-`TranscriptLibraryService.search()` remains as a compatibility path for direct lexical
-segment results. New presentation adapters should prefer `retrieve()`.
+Vectors are derived state. Replace the qualified profile, rebuild the semantic
+projection, keep the evidence.
 
-This lets future CLI, GUI, Python, and MCP surfaces share behavior rather than each
-inventing retrieval semantics.
+## Current deliberate limits
 
-## CLI
+The current search system does not provide:
 
-Lexical retrieval remains the default and requires no semantic runtime:
-
-```bash
-uv run echoflow library rebuild
-uv run echoflow library search "housing insecurity"
-```
-
-Build semantic state from a local immutable multilingual-E5 snapshot:
-
-```bash
-uv run echoflow library embeddings build \
-  /path/to/models--intfloat--multilingual-e5-small/snapshots/<revision> \
-  --revision <revision>
-```
-
-Inspect semantic provenance:
-
-```bash
-uv run echoflow library embeddings
-uv run echoflow library embeddings --json
-```
-
-Run exact semantic search:
-
-```bash
-uv run echoflow library search \
-  "people struggling to make rent" \
-  --mode semantic
-```
-
-Run hybrid BM25 + dense retrieval:
-
-```bash
-uv run echoflow library search \
-  "people struggling to make rent" \
-  --mode hybrid
-```
-
-Filters are shared:
-
-```bash
-uv run echoflow library search \
-  "housing insecurity" \
-  --mode hybrid \
-  --speaker speaker-02 \
-  --language en \
-  --limit 20
-```
-
-`--json` emits query, retrieval provenance, result count, and evidence-bearing results.
-
-## Rebuild behavior
-
-A lexical rebuild validates the complete searchable projection before replacing the
-BM25 index transactionally.
-
-A semantic rebuild:
-
-1. discovers and validates canonical transcripts;
-2. computes deterministic chunks;
-3. embeds passages using one explicit profile;
-4. rebuilds the lexical projection from the same validated corpus;
-5. replaces semantic state transactionally;
-6. records the exact corpus fingerprint and profile.
-
-If embedding fails, the semantic database is not partially replaced. If canonical state
-later changes, fingerprint validation prevents reuse of stale semantic vectors.
-
-## Source-integrity evidence
-
-`echoflow library show TRANSCRIPT_ID` remains the source/custody inspection surface.
-
-It distinguishes:
-
-- original recording path when known;
-- recorded source SHA-256;
-- canonical transcript SHA-256;
-- current source-integrity recheck;
-- canonical transcript path;
-- private rebuildable index custody.
-
-These are separate claims. EchoFlow does not collapse them into a vague trust badge.
-
-## User-authored state boundary
-
-Tags, notes, collections, saved searches, and annotations are intentionally not
-implemented in the semantic database.
-
-When added, they must live in a non-rebuildable user-state layer and anchor to canonical
-evidence coordinates such as:
-
-```text
-document_id
-first_segment_id
-last_segment_id
-start_seconds (optional)
-end_seconds (optional)
-```
-
-A chunk ID may be cached as convenience, but may not be the only durable anchor because
-chunking policy is versionable and disposable.
-
-## Deliberate exclusions
-
-This tranche does not add:
-
+- generated corpus answers or “chat with your transcripts” as the primary interface;
+- arbitrary-model CLI selection;
+- bundled embedding weights;
 - ANN/HNSW;
-- a learned reranker;
-- ColBERT/late interaction;
-- SPLADE/learned sparse retrieval;
-- LLM query expansion;
-- generated corpus answers;
-- a GUI;
-- user-authored notes/tags/collections;
-- a stable public Python package API;
-- a declared/locked Sentence Transformers dependency extra.
+- learned reranking;
+- saved searches, collections, tags, notes, or annotations; or
+- word-level alignment for sub-segment highlighting/anchoring.
 
-Those are separate product decisions. The retrieval contract no longer depends on them.
+The next retrieval UX work should be driven by real corpora: snippets/highlighting,
+context expansion, facets, exportable result sets, precise jump-to-audio, saved/user
+state, and finer alignment coordinates.
 
-## Stable rule
+The product rule stays evidence-first:
 
-> Local evidence first. Canonical JSON owns transcript truth. User-authored state is
-> durable. Retrieval state is rebuildable. Ranking remains inspectable. Model and
-> chunking provenance are explicit.
+> **Search may become smarter. The result should remain inspectable evidence, not an
+> uncited answer floating above the corpus.**

--- a/docs/architecture/diarization.md
+++ b/docs/architecture/diarization.md
@@ -1,72 +1,88 @@
-# Anonymous speaker diarization
+# Anonymous speaker diarization 👥
 
-EchoFlow treats speaker diarization as an optional enrichment capability, separate
-from speech recognition and separate from human identity.
+EchoFlow treats diarization as **speaker-timeline evidence**, not identity.
 
-## Privacy boundary
+In ordinary language: diarization tries to answer **who spoke when inside this one
+recording?** It gives recording-scoped labels such as `speaker-01` and `speaker-02` so a
+transcript can say which anonymous voice most likely owns a passage.
 
-Diarization answers **who spoke when within this recording** using anonymous,
-recording-scoped labels such as `speaker-01` and `speaker-02`. EchoFlow does not use
-those labels as biometric identities and does not infer that a speaker in one
-recording is the same person in another recording.
+It does **not** mean “identify this human,” and EchoFlow does not infer that
+`speaker-01` in one recording is the same person as `speaker-01` in another.
 
-The first adapter targets the open-source pyannote `community-1` pipeline. Upstream
-currently requires accepting the model conditions and authenticating with Hugging
-Face for initial model acquisition. EchoFlow does not store an HF token in its own
-configuration. Model acquisition uses the standard Hugging Face credential flow and a
-narrow `--allow-diarization-model-download` authorization that applies only to this
-optional capability. ASR model acquisition remains a separate explicit
-`echoflow models install MODEL` action.
+```mermaid
+flowchart LR
+    A[Recording audio] --> D[Local diarization]
+    D --> T[Speaker-turn timeline]
+    T --> P[Conservative projection onto transcript]
+    P --> C[Canonical transcript evidence]
 
-Pyannote telemetry is disabled by EchoFlow before the pyannote package is imported.
-The adapter records `telemetry_enabled: false` in diarization provenance. Recording
-audio remains local during inference.
+    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
 
-## Installation
-
-Diarization is deliberately not part of the ordinary transcription dependency set.
-Pyannote brings a large PyTorch-based dependency graph and must be installed
-explicitly:
-
-```bash
-uv sync --locked --extra transcription --extra diarization
+    class A source
+    class D,P process
+    class T,C evidence
 ```
 
-The first model acquisition also requires that the user has accepted the upstream
-Community-1 model conditions and authenticated through Hugging Face's supported
-credential mechanism. EchoFlow does not put access tokens in `.env` or canonical
-artifacts.
+## What the user would see
 
-## Temporary upstream security gate
-
-As of August 2026, pyannote 4.0.7 requires Lightning and the current lock resolves
-Lightning 2.6.5. Lightning 2.6.5 is affected by CVE-2026-58659 /
-PYSEC-2026-3624, a checkpoint-loading remote-code-execution vulnerability. Pyannote
-subclasses `lightning.LightningModule` and loads pretrained model checkpoints through
-Lightning, so this advisory intersects EchoFlow's actual diarization path rather than
-being an unrelated transitive dependency.
-
-Upstream merged the fix in July 2026, but no patched normal 2.x Lightning release is
-available yet. EchoFlow therefore fails closed: before importing pyannote or resolving
-or downloading any diarization model, it inspects the installed Lightning release.
-Known-affected releases and versions whose safety cannot be established are rejected.
-The current locked 2.6.5 runtime is consequently **not executable for diarization**.
-
-Dependency auditing carries a single documented exception for PYSEC-2026-3624 while
-that compensating control is in place. All other advisories still fail the audit.
-The exception and runtime gate should be removed once a compatible upstream release
-containing the merged fix is available and qualified.
-
-## CLI contract
-
-Diarization is opt-in:
+The intended CLI surface is opt-in:
 
 ```bash
 uv run echoflow transcribe interview.wav --diarize
 ```
 
-If the Community-1 snapshot is not already available in EchoFlow's configured model
-cache and the security gate has been cleared, acquisition must be authorized narrowly:
+If the speaker count is known:
+
+```bash
+uv run echoflow transcribe focus-group.wav --diarize --speakers 4
+```
+
+Or provide a bounded range:
+
+```bash
+uv run echoflow transcribe meeting.wav --diarize --min-speakers 2 --max-speakers 6
+```
+
+Exact and bounded speaker-count options are mutually exclusive. Speaker-count options
+are invalid without `--diarize`.
+
+## Current operational status: integrated, but security-held 🔐
+
+The first adapter targets the open-source pyannote `community-1` pipeline.
+
+As of August 2026, pyannote 4.0.7 requires Lightning and the current lock resolves
+Lightning 2.6.5. That release is affected by CVE-2026-58659 / PYSEC-2026-3624, a
+checkpoint-loading remote-code-execution vulnerability.
+
+This is not an irrelevant transitive advisory. Pyannote subclasses
+`lightning.LightningModule` and loads pretrained checkpoints through Lightning, so the
+vulnerable path intersects the feature EchoFlow would actually execute.
+
+EchoFlow therefore **fails closed** before pyannote import or model acquisition when the
+installed Lightning safety cannot be established.
+
+The dependency audit carries one narrow documented exception for that exact advisory
+while the runtime compensating control remains in place. Other advisories still fail the
+audit.
+
+Once a compatible patched Lightning release is available and qualified, both the audit
+exception and runtime hold should be removed.
+
+So the current product description is deliberately precise:
+
+> **Diarization is integrated, tested at the application boundary, and security-gated;
+> it is not currently an operationally qualified everyday feature.**
+
+## Privacy and model-acquisition boundary
+
+Pyannote model acquisition may require accepting upstream model conditions and
+authenticating with Hugging Face.
+
+EchoFlow does not store a Hugging Face token in its own configuration.
+
+Any model download authorization is narrowly scoped to diarization:
 
 ```bash
 uv run echoflow transcribe interview.wav \
@@ -74,31 +90,31 @@ uv run echoflow transcribe interview.wav \
   --allow-diarization-model-download
 ```
 
-This flag does not authorize faster-whisper model downloads. ASR execution still
-requires a separately installed, verified managed model revision.
+That flag does **not** authorize faster-whisper model downloads. ASR model acquisition
+remains the separate explicit `echoflow models install MODEL` path.
 
-If the speaker count is known, the user can provide an exact count:
+Pyannote telemetry is disabled by EchoFlow before package import. Diarization provenance
+records `telemetry_enabled: false`. Recording audio remains local during inference.
+
+Once a snapshot is resolved into EchoFlow's configured private model cache, inference
+uses the local snapshot path.
+
+## Dependency footprint
+
+Diarization is intentionally a separate dependency extra because pyannote brings a
+large PyTorch-based stack:
 
 ```bash
-uv run echoflow transcribe focus-group.wav --diarize --speakers 4
+uv sync --locked --extra transcription --extra diarization
 ```
 
-Or a bounded range:
+Representative CPU-only Windows/Linux/macOS installation size, peak RAM, and sustained
+real-time factor still need physical-device qualification before EchoFlow should call
+this a comfortable feature for an 8 GB machine.
 
-```bash
-uv run echoflow transcribe meeting.wav --diarize --min-speakers 2 --max-speakers 6
-```
+## The evidence model
 
-Exact and bounded speaker-count options are mutually exclusive. Speaker-count
-options are invalid without `--diarize`.
-
-While the temporary Lightning security gate above is active, these diarization
-commands fail before pyannote import or model acquisition rather than executing the
-known-vulnerable checkpoint-loading path.
-
-## Evidence model
-
-The primary diarization evidence is a source-relative speaker-turn timeline:
+The primary diarization artifact is a source-relative speaker-turn timeline:
 
 ```text
 00:00.0 ─ 00:12.4  speaker-01
@@ -106,26 +122,22 @@ The primary diarization evidence is a source-relative speaker-turn timeline:
 00:18.1 ─ 00:20.0  speaker-01   # overlap can exist
 ```
 
-Raw backend labels are not stable API. EchoFlow sorts turns deterministically and
-maps backend labels to `speaker-01`, `speaker-02`, and so on in first-seen timeline
-order.
+Overlap is real evidence, not an error condition.
 
-EchoFlow's one current pre-production canonical transcript schema is version 1.
-Diarization is represented inside that same shape with optional `diarization`,
-`speaker_turns`, and per-segment `speaker_ref` evidence. A transcript without
-diarization keeps those optional capability fields empty rather than switching to a
-different schema version.
+Raw backend labels are not stable API. EchoFlow sorts turns deterministically and maps
+them to `speaker-01`, `speaker-02`, and so on in first-seen timeline order.
 
-Schema numbers represent structural evolution of the canonical contract, not feature
-combinations. EchoFlow intentionally does not retain the earlier unreleased v2/v3
-feature-version split.
+The current canonical transcript schema keeps optional diarization fields in the same
+structural contract rather than inventing a new schema version for each combination of
+features.
 
-## Conservative text projection
+## Why EchoFlow is conservative about putting a speaker name on text
 
-ASR segments and diarization turns are produced independently. Without word-level
-alignment, an ASR segment can cross a speaker handoff or overlap two speakers.
-EchoFlow therefore only assigns `RecognizedSegment.speaker_ref` when exactly one
-unique diarized speaker overlaps that segment.
+ASR segments and diarization turns are produced independently.
+
+Without word-level alignment, one ASR segment may cross a speaker handoff or overlap two
+speakers. EchoFlow therefore assigns `RecognizedSegment.speaker_ref` only when exactly
+one unique diarized speaker overlaps that segment.
 
 ```text
 ASR segment overlaps speaker-01 only
@@ -138,59 +150,122 @@ ASR segment overlaps speaker-01 + speaker-02
     → speaker_ref = null
 ```
 
-The exact turn evidence is still preserved even when text projection is ambiguous.
-This avoids converting uncertain temporal reconciliation into false speaker
-precision. A later alignment capability can split or associate words more finely.
+The exact speaker-turn timeline is still preserved when projection is ambiguous.
 
-Derived TXT, SRT, and WebVTT views prefix an unambiguous segment with its anonymous
-speaker label. Ambiguous segments remain unlabeled. Export rendering never changes
-timestamps or becomes canonical custody.
+That refusal matters. It is better to preserve “we know these voices overlap here” than
+to confidently put the wrong speaker label in front of a sentence.
 
-## Model and dependency boundary
+## Why word/timestamp alignment is the next important seam ✨
 
-The adapter resolves the configured pyannote snapshot into EchoFlow's private model
-cache. Without scoped diarization download authorization, snapshot resolution is
-cache-only. Once resolved, pyannote receives the local snapshot path for inference and
-does not need to fetch model bytes during execution.
+Word-level or fine-grained timestamp alignment would give EchoFlow smaller evidence
+coordinates than an entire ASR segment.
 
-The internal diarization adapter carries an `allow_model_download` decision only for
-this pyannote resolution boundary. It is not a general application permission and does
-not reopen the removed transcription-time faster-whisper download path.
+That unlocks several improvements at once:
 
-The `diarization` extra is intentionally separate because the current pyannote 4.x
-stack resolves a substantial PyTorch dependency graph. Representative CPU-only
-Windows/Linux/macOS installation size, peak RAM, and real-time factor still require
-physical-device qualification before EchoFlow should advertise diarization as
-appropriate for an 8 GB machine.
+- finer speaker attribution near handoffs;
+- better presentation of overlapping turns;
+- precise transcript highlighting;
+- more exact jump-to-audio behavior;
+- durable annotations anchored to smaller evidence spans; and
+- cleaner future speaker-label UX.
 
-## Evidence ladder and deliberate limits
+Alignment does not solve every overlap problem, but it lets EchoFlow stop treating a
+long ASR segment as the smallest practical text unit.
 
-The adapter, cache-only/download policy, telemetry-disable behavior, deterministic
-label normalization, canonical schema, executor integration, conservative fusion,
-derived exports, and fail-closed Lightning security gate are covered by deterministic
-tests.
+## User-assigned display labels without biometric identity
 
-The locked diarization dependency graph is included in normal and scheduled
-vulnerability auditing. A separate distribution lane installs `echoflow[diarization]`
-from the built wheel outside the source checkout and imports the real pyannote and
-PyTorch runtimes. This proves packaging/runtime compatibility without authorizing
-model execution.
+A useful future feature is allowing the user to say:
 
-A dedicated real-model acceptance workflow exists but remains intentionally blocked
-by the Lightning security gate until a patched compatible release is available. Once
-unblocked, that lane is manual and credential-gated: it generates a non-sensitive
-local speech fixture, runs real Community-1 inference, and then reopens the same cache
-with model downloads disabled. Ordinary pull-request CI remains free of gated
-credentials and model downloads.
+```text
+speaker-01 → Dr. Chen
+speaker-02 → Interviewer
+```
 
-Until both the upstream security gate is cleared and the real-model lane has
-completed successfully on representative hardware, EchoFlow should describe
-Community-1 diarization as integrated but not operationally qualified.
+The important design rule is that this should be **display/user-authored state**, not a
+rewrite of the underlying anonymous diarization evidence.
 
-This capability does not provide:
+Conceptually:
+
+```mermaid
+flowchart LR
+    A[speaker-01 evidence] --> B[User-authored display label: Dr. Chen]
+    A --> C[Canonical speaker-turn coordinates]
+
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+
+    class A,C evidence
+    class B user
+```
+
+The label is meaningful user knowledge and must **not** share the deletion semantics of
+a rebuildable search index.
+
+EchoFlow can remain anonymous-by-default while still letting a researcher make their own
+recording understandable.
+
+## Better overlap handling before source separation
+
+Overlap deserves two distinct product steps.
+
+First, EchoFlow should improve **representation and presentation** of overlap using
+better temporal alignment, clearer multi-speaker evidence, and UI/export behavior that
+does not force one speaker when multiple voices are active.
+
+Only later should EchoFlow consider **speech/source separation**, where the audio itself
+is decomposed into estimated sources before or during recognition.
+
+Source separation is materially heavier. It adds compute, model/dependency custody,
+quality uncertainty, and new provenance questions. It should be justified by real
+recordings after the simpler evidence model is strong.
+
+🧜‍♀️ Deep technical water is permitted. Inventing confidence is not.
+
+## Canonical and derived output behavior
+
+When a segment has one unambiguous `speaker_ref`, derived TXT/SRT/WebVTT views may prefix
+that anonymous speaker label.
+
+Ambiguous segments remain unlabeled. Export rendering never changes timestamps or
+becomes canonical custody.
+
+Future user-assigned display labels should remain a presentation layer over stable
+anonymous speaker references and durable transcript coordinates.
+
+## Qualification boundary
+
+The current deterministic test surface covers:
+
+- adapter/cache-only versus download policy;
+- telemetry-disable behavior;
+- deterministic label normalization;
+- canonical schema integration;
+- executor integration;
+- conservative speaker projection;
+- derived exports; and
+- the fail-closed Lightning security gate.
+
+The locked diarization dependency graph remains in normal/scheduled vulnerability
+auditing.
+
+A clean-wheel distribution lane imports the real pyannote/PyTorch runtime without
+executing the gated model. A dedicated real-model acceptance workflow exists but remains
+blocked by the dependency security gate; once unblocked, it is manual and
+credential-gated rather than ordinary PR CI.
+
+## Current deliberate limits
+
+This capability does not currently provide:
 
 - biometric speaker identification;
 - cross-recording speaker linking;
+- user-assigned display labels;
 - guaranteed word-level speaker attribution;
-- a claim that speaker labels are correct when temporal evidence is ambiguous;
-- a lightweight dependency footprint on low-memory devices.
+- polished overlap presentation;
+- simultaneous-speaker/source separation; or
+- a claim that the dependency footprint is suitable for every low-memory device.
+
+The stable rule is:
+
+> **Preserve speaker evidence first. Add convenience only when it does not fabricate
+> certainty.**

--- a/docs/architecture/media-and-timeline.md
+++ b/docs/architecture/media-and-timeline.md
@@ -1,136 +1,166 @@
-# Media normalization and transcript timeline
+# Media normalization and transcript timeline 🎙️🕰️
 
-EchoFlow treats every supported recording as an **audio-bearing local media source**.
-Audio files and videos enter through the same inspection boundary. Video is not a
-separate downstream pipeline: EchoFlow selects one audio stream and discards video,
-subtitle, attachment, and data streams before transcription work begins.
+EchoFlow has to answer two deceptively simple questions before it can produce a useful
+transcript:
 
-## Pipeline
+1. **What exactly did we transcribe?**
+2. **What does a timestamp in the transcript actually mean?**
 
-```text
-local recording
-    ↓
-FFprobe media inspection
-    ↓
-MediaInfo + complete source fingerprint
-    ↓
-AudioStreamSelector
-  first audio stream by default
-  or explicit --audio-stream INDEX
-    ↓
-TranscriptionJobPlanner
-  runner/resource policy
-  managed ASR strategy + immutable model revision
-  canonical-audio plan
-  optional enhancement contract
-    ↓
-DIRECT if already canonical
-or
-FFmpeg extraction + normalization
-    ↓
-canonical PCM16 mono 16 kHz WAV
-    ↓
-optional private FFmpeg noise suppression
-    ↓
-exact integer-frame windows
-    ↓
-managed local faster-whisper ASR
-    ↓
-source-relative transcript assembly
-    ↓
-canonical JSON → TXT/SRT/VTT views
+Those questions get complicated quickly when the input is a video with multiple audio
+streams, a container with a non-zero presentation timestamp, or a camera file carrying
+capture-time metadata.
+
+The current implementation solves the first layer rigorously: deterministic stream
+selection, source fingerprinting, canonical audio, exact frame windows, and one
+source-relative elapsed-time transcript.
+
+The next provenance step is to preserve **original-media timecode/capture-time evidence**
+without overloading that existing source-relative timeline.
+
+## The human version
+
+Today, if EchoFlow says a passage begins at `4221.7` seconds, it means:
+
+> **4221.7 seconds after the beginning of the selected recording audio.**
+
+That timeline survives normalization, segmentation, checkpoints, enhancement, and
+assembly.
+
+It does **not yet** mean “camera wall-clock time 14:32:08,” “SMPTE 01:10:21:17,” or “the
+container's original PTS value.” Those are distinct pieces of provenance and should stay
+distinct.
+
+```mermaid
+flowchart LR
+    A[Local media file] --> B[FFprobe inspection + fingerprint]
+    B --> C[Choose one audio stream]
+    C --> D[Canonical PCM timeline]
+    D --> E[Optional enhancement]
+    E --> F[Exact frame windows]
+    F --> G[Local ASR]
+    G --> H[Source-relative canonical transcript]
+
+    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef inspect fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+
+    class A source
+    class B,C inspect
+    class D,E,F,G process
+    class H evidence
 ```
 
-When enhancement is enabled, ASR reads the private enhanced derivative. Anonymous
-speaker diarization deliberately continues to read the unmodified canonical decoded
-audio in the first enhancement version.
+## One input boundary for audio and video
 
-## What the media probe does
+EchoFlow treats every supported input as **audio-bearing local media**.
 
-`FfprobeMediaProbe` is read-only inspection. It does not transcode media, install
-models, choose preprocessing, or choose a transcription strategy. For one local file
-it:
+Video is not a second downstream pipeline. FFprobe discovers the streams, EchoFlow
+selects one audio stream, and later processing discards video/subtitle/attachment/data
+streams.
+
+That means `interview.m4a`, `lecture.wav`, and `meeting.mp4` all converge on the same
+transcription contract once one audio stream has been selected.
+
+## What media inspection owns
+
+`FfprobeMediaProbe` performs read-only inspection. It does not transcode, install models,
+choose enhancement, or choose a transcription strategy.
+
+For one local source it:
 
 - snapshots filesystem identity before inspection;
-- runs FFprobe with a file-only protocol whitelist;
-- reads container duration and stream metadata;
+- invokes FFprobe with a file-only protocol whitelist;
+- reads bounded container/stream metadata;
 - validates that at least one audio stream exists;
 - fingerprints the complete source with SHA-256;
-- snapshots filesystem identity again and refuses the input if it changed during
-  inspection; and
-- returns immutable `MediaInfo` metadata.
+- snapshots filesystem identity again; and
+- refuses the input if the source changed during inspection.
 
-The source path is required locally to perform work, but routine logs omit paths by
-default.
+The result is immutable `MediaInfo` evidence.
 
-## Stream selection
+Routine logs omit local paths by default because recording names and directory layouts
+may themselves be sensitive.
 
-`AudioStreamSelector` makes one deterministic choice from streams returned by the
-probe. Without an override, the first discovered audio stream is selected. With
-`--audio-stream INDEX`, EchoFlow validates that the requested index is audio and records
-it in the job/source contract. Resume restores the same stream index and refuses a
-changed source contract.
+## Deterministic audio-stream selection
 
-Selection does not mutate FFprobe's discovered metadata. It returns a new `MediaInfo`
-whose `primary_audio_stream_index` identifies the chosen stream.
+`AudioStreamSelector` chooses exactly one discovered audio stream.
 
-## Canonical audio format
+Without an override, the first audio stream is selected. With:
 
-The current segmentation representation is:
+```bash
+uv run echoflow transcribe meeting.mp4 --audio-stream 2
+```
+
+EchoFlow validates that stream index `2` is actually audio and records that choice in
+the job/source contract.
+
+Resume restores the same selected stream. It does not decide that a different track is
+close enough.
+
+Selection returns new immutable metadata rather than mutating the FFprobe discovery
+record.
+
+## Canonical working audio
+
+The current deterministic processing representation is:
 
 | Property | Value |
 |---|---|
 | container | WAV |
-| audio codec | signed 16-bit little-endian PCM (`pcm_s16le`) |
+| codec | signed 16-bit little-endian PCM (`pcm_s16le`) |
 | sample rate | 16,000 Hz |
 | channels | 1 (mono) |
 
-If a source WAV already satisfies this contract, the planner chooses `DIRECT` and no
-normalization copy is produced. Other supported audio-bearing media uses
-`FFMPEG_NORMALIZE`.
+If a source WAV already satisfies the contract, planning can choose `DIRECT`.
 
-Normalization maps exactly the selected audio stream, drops video/subtitle/data
-streams, sets the planned channel count/sample rate/codec, and writes `normalized.wav`
-inside the private job workspace. The canonical WAV is an execution artifact, not a
-public artifact and not another source of truth.
+Other supported audio-bearing media uses `FFMPEG_NORMALIZE`, mapping exactly the selected
+audio stream and dropping unrelated streams.
+
+The resulting `normalized.wav` lives inside the private job workspace.
+
+It is **not a second source of truth**. It is a deterministic working representation that
+can be discarded after the job lifecycle no longer needs it.
 
 ## Optional enhanced derivative
 
-With `--enhance`, EchoFlow applies its current deterministic FFmpeg noise-suppression
-contract after canonical decode and before ASR segmentation. The output is
-`enhanced.wav` inside the private job workspace.
+With `--enhance`, EchoFlow creates a private `enhanced.wav` after canonical decode and
+before ASR segmentation.
 
-The enhanced WAV is derived processing material only. It does not replace the original
-recording, is not automatically exported, and does not change source custody.
+The enhanced file may change sample values. It may not silently change the timeline
+shape.
 
-Enhancement is permitted to alter sample values but not the canonical timeline shape.
-Before accepting the derivative, EchoFlow compares input and output for:
+EchoFlow checks:
 
 - channel count;
 - sample width;
 - sample rate; and
 - frame count.
 
-Any mismatch fails closed and the derived file is removed. This protects downstream
-frame-window and timestamp assumptions from a preprocessing provider that silently
-resamples, trims, pads, or changes channel structure.
+Any mismatch fails closed and the derived output is removed where possible.
 
-See [speech enhancement](speech-enhancement.md) for provider/provenance details.
+Why so fussy? Because if preprocessing trims, pads, resamples, or changes the channel
+structure without telling anyone, every downstream timestamp becomes suspicious.
 
-## Timestamp basis
+Anonymous diarization intentionally continues to consume the unmodified canonical
+decode in the first enhancement version. See
+**[speech-enhancement.md](speech-enhancement.md)** for that provider boundary.
 
-Public transcript timestamps are **elapsed seconds from the start of the selected
-recording audio**, with zero as the source-relative origin.
+## Source-relative timestamps
 
-Neither normalization nor enhancement creates a new public timeline. Canonical and
-enhanced WAV files exist so deterministic local processing can operate on a known frame
-representation. Each application-owned segment is represented by integer `start_frame`
-and `end_frame` offsets; seconds are derived from those frames and the canonical sample
-rate.
+Canonical transcript timestamps are elapsed seconds from the start of the selected audio
+origin.
 
-faster-whisper returns timestamps local to the materialized work interval. Assembly
-adds the work interval's source-relative offset and produces one continuous timeline.
-For example:
+Application-owned work units are represented by integer PCM frame intervals:
+
+```text
+[start_frame, end_frame)
+```
+
+Seconds are derived from those exact frames and the canonical sample rate.
+
+Faster-whisper returns timestamps relative to the materialized work interval. Assembly
+adds the interval's source-relative offset:
 
 ```text
 work interval 0 starts at 0 s
@@ -140,44 +170,136 @@ work interval 7 starts at 4200 s
 engine timestamp 21.7 s   → canonical timestamp 4221.7 s
 ```
 
-SRT and WebVTT are rendered from canonical timestamps, so segmentation/checkpoint
-boundaries never reset subtitle time to zero.
+SRT and WebVTT render from canonical timestamps. Segment/checkpoint boundaries therefore
+do not reset subtitle time to zero.
 
-## Source authority and provenance
+💃 The timeline survives the choreography.
 
-The original local media file remains authoritative. EchoFlow separately records:
+## Current source/provenance record
 
-- source fingerprint and media identity;
+The original local media file remains authoritative.
+
+EchoFlow separately records enough execution context to explain how canonical text was
+produced, including:
+
+- source fingerprint/media identity;
 - selected audio stream;
 - decode strategy;
 - managed ASR engine/model/revision and execution target;
 - enhancement provider/version/operation/parameters when used;
-- language and optional diarization evidence; and
+- language and optional speaker evidence; and
 - source-relative segment timestamps.
 
-Derived audio can therefore be discarded without losing the description of how the
-canonical transcript was produced.
+Derived audio can therefore disappear without erasing the description of the path from
+source to transcript.
 
-## What is not currently preserved
+## ✨ Next provenance layer: original media timecode and capture time
 
-The source-relative timeline is not every possible media timebase. EchoFlow does not
-currently claim to preserve or expose:
+Source-relative seconds are useful but incomplete for some research, documentary,
+forensic, archival, and multi-device recordings.
 
-- arbitrary non-zero container/stream presentation timestamp origins;
-- SMPTE timecode tracks;
-- camera/device wall-clock capture time; or
-- synchronization offsets between independently recorded devices.
+A future timeline provenance model should be able to preserve **additional clocks** when
+the media exposes them, without redefining the canonical elapsed-time coordinate.
 
-Those are legitimate future provenance capabilities. They should be represented by a
-dedicated timeline/timecode model rather than overloaded onto elapsed seconds.
+Potential evidence includes:
+
+- non-zero container or stream PTS/DTS origins;
+- SMPTE timecode tracks or tags;
+- camera/device creation or capture timestamps;
+- timezone/offset information when it is actually encoded and trustworthy;
+- stream start-time offsets; and
+- synchronization relationships between independently recorded sources when explicitly
+  known.
+
+The key design rule is **parallel provenance, not timeline mutation**.
+
+Conceptually:
+
+```mermaid
+flowchart TD
+    S[Selected audio stream] --> R[Canonical source-relative timeline]
+    S --> P[Original presentation-time evidence]
+    S --> T[SMPTE / embedded timecode evidence]
+    S --> C[Capture-time metadata]
+    R --> X[Canonical transcript segments]
+    P --> X
+    T --> X
+    C --> X
+
+    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef canonical fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef provenance fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+
+    class S source
+    class R,X canonical
+    class P,T,C provenance
+```
+
+A transcript segment could then say, in effect:
+
+> This passage begins 4221.7 seconds into the selected audio **and**, where trustworthy
+> source metadata exists, corresponds to original media timecode/capture coordinates X.
+
+Those values should be typed and qualified, not collapsed into a single ambiguous
+`timestamp` field.
+
+## Why this should be its own model
+
+Container/media time is messy.
+
+A creation timestamp may represent file creation rather than acoustic capture. A stream
+can begin at a non-zero presentation timestamp. Timecode may have frame-rate/drop-frame
+semantics. Device clocks may be wrong. Some metadata may be missing, malformed, or
+contradictory.
+
+EchoFlow should therefore preserve:
+
+- the **kind** of time evidence;
+- its raw/normalized representation;
+- the stream/container it came from;
+- confidence/qualification rules where needed; and
+- whether it can be deterministically mapped to source-relative seconds.
+
+It should not pretend every media timestamp is interchangeable.
+
+## Relationship to word/timestamp alignment
+
+Original-media timecode and word alignment solve different problems.
+
+**Word/timestamp alignment** gives finer coordinates *within the canonical source-relative
+timeline*.
+
+**Original-media timecode/capture provenance** gives additional clocks or source metadata
+that can be mapped alongside that timeline.
+
+Together they eventually make very precise evidence receipts possible:
+
+```text
+word "budget"
+  canonical elapsed time: 01:10:21.700
+  original media timecode: 02:14:03:17   (if available/qualified)
+  capture timestamp: 2026-07-04T14:32:08-04:00   (if present/qualified)
+```
+
+Neither should be invented when the source does not provide trustworthy evidence.
 
 ## Why the stages remain separate
 
-Inspection answers **what is this source?** Selection answers **which audio stream are
-we using?** Normalization answers **what deterministic representation will local
-processing consume?** Enhancement answers **did the user request a provenance-bearing
-acoustic transform before ASR?**
+Inspection answers **what source and streams exist?**
 
-Keeping those responsibilities separate leaves metadata discovery side-effect free,
-keeps source authority explicit, and lets future preprocessing providers change without
-rewriting media inspection or transcript timeline semantics.
+Selection answers **which audio stream are we using?**
+
+Normalization answers **what deterministic representation will local processing use?**
+
+Enhancement answers **did the user request a provenance-bearing acoustic transform?**
+
+Alignment will answer **where do finer text units sit on the canonical timeline?**
+
+Original timecode/capture provenance will answer **what other source clocks can be
+preserved alongside that timeline?**
+
+Keeping these responsibilities separate makes metadata discovery side-effect free,
+keeps source authority explicit, and leaves room for richer evidence without rewriting
+the meaning of timestamps that already exist.
+
+🧜‍♀️ Multiple clocks. One transcript. No temporal soup.

--- a/docs/architecture/model-management.md
+++ b/docs/architecture/model-management.md
@@ -1,207 +1,283 @@
-# Local model management
+# Local model management 📦🔐
 
-## Purpose
+## The human version
 
-EchoFlow treats local inference models as versioned execution dependencies rather than
-opaque cache entries. Model management gives the application an explicit inventory,
-installation, verification, provenance, recommendation, and removal boundary without
-inventing a second model storage format or requiring hosted control-plane state.
+EchoFlow needs speech models to transcribe locally. Those model files are large,
+versioned execution dependencies, not mysterious cache confetti.
 
-The first implementation manages faster-whisper models. Later model-backed local
-capabilities should reuse the same custody contracts rather than create parallel
-network, cache, and provenance paths.
+So EchoFlow keeps one very deliberate boundary around them:
 
-## Ownership and custody
+> **Downloading a model is an explicit action. Running transcription uses a model that
+> EchoFlow has already installed, verified, and pinned to an immutable revision.**
 
-The Hugging Face cache remains the byte-level storage layout consumed by
-faster-whisper. EchoFlow does not copy model weights into a proprietary format.
-Instead, EchoFlow owns private manifests describing the exact cached snapshots it
-deliberately installed and verified.
+That gives ordinary users a simpler experience and gives maintainers something they can
+actually reason about.
 
-A cached model is not automatically an EchoFlow-managed model. Management begins only
-after an explicit install succeeds and a private manifest is committed. Arbitrary
-pre-existing cache contents are not adopted implicitly.
+```mermaid
+flowchart LR
+    A[Model catalog] --> B[Recommend]
+    B --> C[Explicit install]
+    C --> D[Disk admission]
+    D --> E[Provider download]
+    E --> F[Verify snapshot]
+    F --> G[Private managed manifest]
+    G --> H[Local transcription plan]
+    H --> I[Local-only execution]
 
-A managed manifest records at least:
+    classDef info fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef network fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef run fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A,B,D info
+    class C,E network
+    class F,G evidence
+    class H,I run
+```
+
+## Why EchoFlow does not just trust whatever is in a cache
+
+The Hugging Face cache is a useful byte-level storage layout. EchoFlow does not need to
+copy model weights into a proprietary format.
+
+But “some files exist in a cache directory” is not enough to answer:
+
+- which model EchoFlow intended to install;
+- which provider repository it came from;
+- which immutable revision was resolved;
+- whether the expected files are still present; or
+- whether a transcription plan can safely refer to that exact dependency later.
+
+So the provider cache remains the physical home of the bytes while EchoFlow owns private
+**managed manifests** describing snapshots it deliberately installed and verified.
+
+A pre-existing cache entry is not silently adopted as managed state.
+
+## What a managed manifest records
+
+The current contract records at least:
 
 - logical model ID and engine;
 - provider repository ID;
 - requested provider revision, when supplied;
 - resolved immutable revision;
-- absolute snapshot path;
+- absolute local snapshot path;
 - measured snapshot size; and
 - verification method.
 
-The manifest is application state, not a copy of the model. The provider cache remains
-the physical source of model bytes.
+The manifest is a receipt and dependency record, not a second copy of the model.
 
-## Components
+## The three main responsibilities
 
 `ModelCatalog` describes the finite set of models EchoFlow knows how to reason about.
-For faster-whisper it derives cache-size and quality metadata from the transcription
-strategy catalog instead of duplicating execution policy.
+For faster-whisper, quality/cache metadata is derived from the transcription strategy
+catalog instead of duplicated.
 
-`ModelManager` owns offline inventory, explicit install, manifest custody, local
-revalidation, resolved-revision lookup, and removal.
+`ModelManager` owns application-level inventory, explicit installation, manifest custody,
+local revalidation, resolved-revision lookup, and removal.
 
-`ModelProvider` owns provider-specific mechanics such as downloading a Hugging Face
-snapshot, validating provider layout, and deleting an exact cached revision.
+`ModelProvider` owns provider-specific mechanics such as obtaining a Hugging Face
+snapshot, validating its layout, and removing an exact cached revision.
 
-`ModelStorageAdmitter` runs before downloads. The application container adapts the
-shared disk-admission policy to this port so model management does not depend on
-transcription internals.
+`ModelStorageAdmitter` checks disk capacity before acquisition starts.
+
+The split matters because “what models does EchoFlow support?” and “how does this
+provider download bytes?” are different questions.
 
 ## Install transaction
 
-A model install follows this ordering:
+A model install follows this order:
 
-1. Resolve the model ID through the catalog.
-2. Reject an invalid or blank requested revision.
-3. Admit the catalog's estimated cache requirement against current disk capacity.
-4. Create private model/cache/registry directories only after admission succeeds.
-5. Ask the provider to acquire the requested repository and revision.
-6. Reject any returned snapshot outside EchoFlow's configured model cache.
-7. Bind the snapshot path to the declared provider repository cache directory.
-8. Require the snapshot directory name to equal the resolved revision.
-9. Verify provider-specific required files exist and are non-empty.
-10. Measure the installed snapshot and construct provenance.
-11. Commit the private EchoFlow manifest last.
+1. resolve the model ID through the catalog;
+2. reject an invalid/blank requested revision;
+3. admit the estimated cache requirement against current disk capacity;
+4. create private model/cache/registry directories only after admission succeeds;
+5. ask the provider to acquire the requested repository/revision;
+6. reject a returned snapshot outside EchoFlow's configured model cache;
+7. bind the snapshot path to the declared provider repository cache directory;
+8. require the snapshot directory name to equal the resolved immutable revision;
+9. verify provider-specific required files exist and are non-empty;
+10. measure the installed snapshot and construct provenance; and
+11. commit the private EchoFlow manifest **last**.
 
-The ordering is intentional. Disk refusal cannot begin a large download, and a failed
-or malformed provider result cannot become managed state.
+That ordering is intentional.
+
+A disk refusal should not begin a giant download. A malformed provider result should not
+become managed state. A manifest should mean “the install made it through verification,”
+not “we started trying.”
+
+🦝 The raccoon gets a receipt after the groceries are actually in the pantry.
+
+## User surface
+
+The normal flow is deliberately boring:
+
+```bash
+uv run echoflow models recommend
+uv run echoflow models install small
+uv run echoflow transcribe recording.m4a
+```
+
+Inventory is offline:
+
+```bash
+uv run echoflow models
+```
+
+Removal is explicit:
+
+```bash
+uv run echoflow models remove small
+```
+
+The CLI requires confirmation unless `--yes` is supplied.
 
 ## Inventory and local revalidation
 
 Inventory and resolved-revision lookup are offline and side-effect free. They do not
-create directories, download models, or repair cache state.
+create directories, download models, or repair provider state.
 
-When a managed manifest exists, EchoFlow revalidates it before reporting the model as
-managed or returning its revision to a planner. Validation checks:
+When a managed manifest exists, EchoFlow revalidates it before claiming the model is
+usable. Validation checks that:
 
-- manifest identity matches the catalog model and repository;
-- the snapshot remains inside the configured model cache;
+- manifest identity still matches the catalog model/repository;
+- the snapshot remains inside EchoFlow's configured model cache;
 - the snapshot belongs to the declared provider repository cache directory;
-- the snapshot path agrees with the recorded resolved revision;
-- the recorded verification method is supported; and
-- required provider files still exist and remain non-empty.
+- the path agrees with the recorded resolved revision;
+- the verification method is supported; and
+- required provider files remain present/non-empty.
 
-If external deletion or tampering makes a manifest stale, EchoFlow fails closed instead
-of treating an old receipt as proof that the model remains usable.
+If external deletion or tampering makes the manifest stale, EchoFlow fails closed.
 
-This verification establishes structural/provider provenance. It does not claim an
-independently maintained cryptographic allowlist for upstream model weights. A future
-provider may add digest or signature evidence without changing the application custody
-boundary.
+The receipt is evidence of what EchoFlow verified earlier. It is not allowed to become a
+magic amulet that makes missing bytes reappear.
+
+## What current verification does and does not prove
+
+Current faster-whisper verification establishes structural/provider provenance:
+expected cache layout, repository/revision identity, and required non-empty files.
+
+It does **not** claim an independently maintained cryptographic allowlist/signature for
+upstream model weights.
+
+A future provider can add stronger digest/signature evidence without changing the
+application custody boundary.
 
 ## Transcription custody boundary
 
 There is one ASR model path.
 
 A new transcription plan must resolve the selected faster-whisper model through the
-verified managed registry. If the selected model is not installed and locally
-revalidated, planning fails with an install-first error. A successful plan therefore
-always records a non-empty immutable resolved revision.
+verified managed registry.
 
-Transcription execution is local-only with respect to ASR model acquisition. The
-faster-whisper adapter uses `local_files_only=True` and the exact revision already
-recorded in the plan. There is no transcription-time ASR download flag, ambient
-Hugging Face cache fallback, or configuration override that can substitute an
-unmanaged revision.
+If the model is not installed and locally revalidated, planning fails with an
+install-first message.
 
-Model acquisition happens through the explicit user action:
+A successful plan therefore records a non-empty immutable resolved revision.
 
-```text
-echoflow models install MODEL
-```
+At execution time, faster-whisper loads that exact local revision with
+`local_files_only=True`.
 
-Resume restores the exact managed model revision already recorded in the checkpoint
-contract. It never replans to a newer revision and never downloads a replacement as a
-side effect of resume.
+There is no:
 
-EchoFlow is pre-production, so this contract intentionally replaces earlier
-compatibility scaffolding rather than carrying migration branches for behavior that has
-not been dogfooded or released.
+- transcription-time ASR download flag;
+- ambient-cache fallback;
+- arbitrary configuration revision override; or
+- silent substitution of a newer model because the old one is inconvenient.
+
+Resume restores the exact managed model revision recorded in the checkpoint contract.
+It never downloads a replacement as a side effect.
+
+## Network boundary 🔐
+
+`echoflow models install MODEL` is the explicit network-bearing ASR model action.
+
+Inventory, recommendation, planning with an already-managed model, and execution do not
+need to contact the model provider.
+
+Model management never uploads source media, transcripts, job metadata, or application
+telemetry to the provider.
+
+This is why the install boundary is visible to the user instead of being buried inside
+`transcribe`.
 
 ## Removal transaction
 
-Removal is deliberately asymmetric with installation:
+Removal is intentionally asymmetric with installation:
 
-1. Resolve and validate the managed manifest.
-2. Reconstruct the exact installed snapshot identity.
-3. Ask the provider to remove that resolved revision from the local cache.
-4. Delete the EchoFlow manifest only after provider removal succeeds.
+1. resolve and validate the managed manifest;
+2. reconstruct the exact installed snapshot identity;
+3. ask the provider to remove that resolved revision from the local cache; and
+4. delete the EchoFlow manifest **only after provider removal succeeds**.
 
-If provider removal fails, the manifest is retained. EchoFlow must not claim that it
-forgot ownership while managed bytes may still remain on disk.
+If provider removal fails, the manifest is retained.
 
-The CLI requires confirmation unless `--yes` is supplied.
+EchoFlow should not forget that it owns bytes it failed to remove.
 
-## User surface
+## Failure semantics
 
-The model-management CLI is explicit:
+Private registry/model state lives under EchoFlow's application model root.
 
-- `echoflow models` lists offline managed inventory;
-- `echoflow models recommend` reuses current resource-aware strategy assessment and
-  reports whether the recommended model is managed;
-- `echoflow models install MODEL` authorizes provider network acquisition, verifies the
-  resulting snapshot, and records provenance; and
-- `echoflow models remove MODEL` removes an exact managed revision after confirmation.
+These conditions fail closed:
 
-A normal first transcription flow is therefore:
+- corrupt registry data;
+- path escape;
+- repository mismatch;
+- stale/missing snapshot;
+- unsupported verification method;
+- required-file verification failure;
+- storage refusal; and
+- provider removal failure.
 
-```text
-echoflow models recommend
-echoflow models install small
-echoflow transcribe recording.m4a
-```
+Routine public errors should describe the application failure without leaking private
+internal paths.
 
-The selected model may differ by profile or explicit strategy, so the model required by
-a plan must be managed before that plan can execute.
+## Reusing the custody pattern for future local models
 
-## Failure and privacy semantics
+Future model-backed capabilities should reuse the same ideas:
 
-Registry manifests and model storage live under EchoFlow's private application model
-root. Inventory and recommendation do not contact the network. Installation is the
-explicit network-bearing ASR model operation.
+- capability-specific catalog/qualified profiles;
+- provider adapters for acquisition/verification;
+- immutable resolved revisions;
+- private manifests;
+- disk admission before acquisition;
+- offline inventory/revalidation; and
+- execution through verified model identity.
 
-Public errors describe the application failure without leaking internal paths. Corrupt
-registry data, path escape, repository mismatch, stale snapshots, verification
-failure, storage refusal, and provider removal failure all fail closed.
+The current FFmpeg speech-noise-suppression provider is model-free, so it does not
+pretend to have a model manifest.
 
-No transcript, source media, job metadata, or telemetry is sent to the model provider
-as part of model management.
+If a future neural enhancement, alignment, source-separation, or embedding provider adds
+weights, those weights should enter through this custody family rather than inventing a
+new hidden download path.
 
-## Extension contract for future local models
+## Generalize only when reality asks
 
-A future model-backed capability should reuse these concepts:
+The first implementation manages faster-whisper models. Semantic embeddings currently
+have their own strict-local profile/snapshot boundary and are not yet a locked managed
+extra.
 
-- a capability-specific catalog may describe provider/model choices;
-- provider adapters may implement structural or cryptographic verification;
-- private manifests record immutable resolved revisions;
-- disk admission happens before acquisition;
-- inventory remains offline; and
-- execution planners consume verified model identity through narrow application ports.
+A broader shared model-custody abstraction should emerge when a second qualified
+model-backed capability exposes real common variation.
 
-The first speech noise-suppression provider is intentionally model-free and therefore
-does not fabricate a model manifest. If EchoFlow later adopts a neural enhancement
-provider with weights, those weights must enter through this custody boundary.
+EchoFlow does not need a speculative universal model marketplace merely because such an
+abstraction would look impressive on a diagram.
 
-The shared abstraction should be generalized only when a second real model-backed
-provider exposes necessary variation. EchoFlow does not need a speculative universal
-model marketplace.
+## Current deliberate limits
 
-## Out of scope
+Model management does not currently provide:
 
-The current tranche does not provide:
+- automatic/background model updates;
+- adoption of arbitrary cache entries;
+- generic arbitrary model hubs;
+- model quota/garbage-collection policy;
+- hosted inventory/telemetry; or
+- independent cryptographic attestation of upstream weights.
 
-- automatic model updates or background downloads;
-- adoption of arbitrary pre-existing cache entries as managed state;
-- generic support for arbitrary model hubs;
-- model garbage collection or quota management;
-- hosted telemetry or a remote inventory service; or
-- a claim that structural required-file verification equals independent cryptographic
-  attestation of upstream weights.
+The stable rule is:
 
-The stable rule is simple: EchoFlow knows which local model dependency it chose, where
-it came from, which immutable revision it verified, whether it is still present, and
-when it is safe to remove it.
+> **EchoFlow should know which local model dependency it chose, where it came from,
+> which immutable revision it verified, whether it is still present, and when it is safe
+> to remove it.**
+
+Not glamorous. Extremely useful. 💃

--- a/docs/architecture/processing-capabilities.md
+++ b/docs/architecture/processing-capabilities.md
@@ -1,300 +1,302 @@
-# Processing capabilities
+# Processing capabilities 🎛️
 
-EchoFlow composes small local capabilities into one reproducible transcription job. It
-avoids a generic pipeline/plugin framework until multiple real implementations require
-one.
+EchoFlow is not one giant transcription function. It composes small local capabilities
+into a reproducible job whose source, execution choices, recovery state, transcript, and
+search projections remain explainable afterward.
 
-For detailed media/timestamp semantics, see
-[media-and-timeline.md](media-and-timeline.md). For model custody, see
-[model-management.md](model-management.md). For preprocessing, see
-[speech-enhancement.md](speech-enhancement.md). For corpus retrieval, see
-[corpus-search.md](corpus-search.md).
+This page is the **family portrait** for maintainers.
 
-## Current transcription path
+For the narrower contracts, see:
 
-```text
-local recording
-    ↓
-FFprobe inspection + complete source fingerprint
-    ↓
-deterministic audio-stream selection
-    ↓
-process-visible CPU/RAM + accelerator topology
-    ↓
-engine capability negotiation + safe strategy selection
-    ↓
-verified managed faster-whisper revision
-    ↓
-canonical audio plan
-    ↓
-DIRECT or FFmpeg normalization
-    ↓
-optional private FFmpeg noise suppression
-    ↓
-exact PCM frame windows
-    ↓
-job-scoped managed local faster-whisper session
-    ↓
-ordered private per-window checkpoints
-    ↓
-source-relative transcript assembly
-    ↓
-local language attribution + optional anonymous diarization
-    ↓
-canonical JSON
-    ↓
-TXT / SRT / WebVTT derived views
+- [adaptive heterogeneous execution](adaptive-heterogeneous-execution.md);
+- [media and timeline](media-and-timeline.md);
+- [model management](model-management.md);
+- [speech enhancement](speech-enhancement.md);
+- [diarization](diarization.md); and
+- [corpus search](corpus-search.md).
+
+## What the user experiences
+
+The intended experience is much simpler than the machinery:
+
+1. give EchoFlow a recording;
+2. let it inspect the source and current machine;
+3. install a recommended model explicitly if needed;
+4. transcribe locally;
+5. resume if interrupted;
+6. export useful views; and
+7. search completed transcripts later.
+
+Underneath that, EchoFlow is preserving enough evidence to explain how each result was
+produced.
+
+```mermaid
+flowchart LR
+    A[Local recording] --> B[Inspect source]
+    B --> C[Inspect machine + runtime]
+    C --> D[Build immutable plan]
+    D --> E[Normalize / enhance if needed]
+    E --> F[Segment + local ASR]
+    F --> G[Checkpoint ordered work]
+    G --> H[Language + optional speaker evidence]
+    H --> I[Canonical transcript]
+    I --> J[Derived exports]
+    I --> K[Lexical / semantic search]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef inspect fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef publish fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A,I evidence
+    class B,C,D inspect
+    class E,F,G,H process
+    class J publish
+    class K result
 ```
 
-The implementation exercises real FFprobe/FFmpeg on Linux, macOS, and Windows CI and
-has a faster-whisper/CTranslate2 known-speech acceptance path. Hosted CI proves
-contracts and portability, not representative machine performance.
+That diagram is the product shape in one picture.
 
-## Media inspection and canonical audio
+## 1. Media inspection: what is this file?
 
-`FfprobeMediaProbe` owns source facts, not transcoding. It reads container/stream
-metadata with file-only protocol access, fingerprints the complete source, and refuses
-a file that changes during inspection. `AudioStreamSelector` chooses one discovered
-audio stream, using the first audio stream by default or explicit
-`--audio-stream INDEX`.
+`FfprobeMediaProbe` owns source facts, not transcoding.
 
-The selected stream is part of checkpoint provenance. Resume re-probes the source and
-restores the original stream choice rather than silently selecting another track.
+It reads bounded FFprobe metadata with file-only protocol access, fingerprints the
+complete source, and refuses a file whose observed identity changes during inspection.
 
-The current canonical processing format is WAV, `pcm_s16le`, 16 kHz, mono. An
-already-canonical WAV may use `DIRECT`; other supported audio-bearing media uses
-`FFMPEG_NORMALIZE`. FFmpeg maps exactly the selected audio stream and discards video,
-subtitle, attachment, and data streams.
+`AudioStreamSelector` then chooses one deterministic audio stream, using the first audio
+stream by default or an explicit `--audio-stream INDEX`.
 
-Normalization changes representation, not the public timeline. Exact PCM frame offsets
-define work windows and assembly rebases engine-local timestamps onto one continuous
-source-relative timeline.
+The stream choice becomes provenance. Resume restores it rather than silently selecting
+a different track.
 
-## Optional local noise suppression
+## 2. Resource/runtime inspection: what can this computer really do?
 
-When the immutable plan enables enhancement, `FfmpegAfftdnEnhancer` consumes the
-canonical decoded audio and creates a private `enhanced.wav` using the fixed current
-`afftdn=nf=-50:nr=12` contract.
+`RunnerInspector` observes CPU and system memory actually visible to the process,
+including relevant affinity/cgroup limits.
 
-The provider validates that channel count, sample width, sample rate, and frame count
-are unchanged. A mismatch fails closed because preprocessing must not shift EchoFlow's
-source-relative timeline.
+`HardwareTopologyInspector` adds physical accelerator evidence.
 
-ASR segmentation consumes the enhanced derivative. Anonymous diarization continues to
-consume the unmodified canonical decode in the first version. The transcript records
-enhancement provider/version/operation/parameters when ASR input was transformed.
+`EngineCapabilityRegistry` separately asks the installed engine/runtime which concrete
+device/compute targets are actually executable.
 
-The extra full-recording derivative is included in private storage admission.
-Enhancement is explicit with `--enhance`; there is no automatic selector yet.
+`StrategyEvaluator` admits and ranks safe strategies against system RAM, device memory,
+runtime capability, and profile intent.
 
-## Compute and strategy policy
+A visible GPU is not assumed usable. Shared/unified accelerator memory is not counted as
+bonus physical RAM. Explicit impossible strategies fail instead of being silently
+replaced.
 
-`RunnerInspector` observes CPU and memory actually visible to the process, including
-relevant container limits. `HardwareTopologyInspector` adds physical accelerator
-evidence without claiming the ASR runtime can use it. Engine capability probes then
-report the concrete device/compute targets the installed runtime can execute.
+See [adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) for the
+whole hardware cabaret. 💃
 
-`RunnerPolicyPlanner` derives a CPU-thread and system-memory budget from the processing
-profile. `StrategyEvaluator` admits concrete faster-whisper CPU/int8 and CUDA
-candidates against system RAM, device memory, runtime capabilities, and profile intent.
-An explicit infeasible strategy is refused instead of silently downgraded.
-
-Shared/unified accelerator memory is charged to system RAM rather than counted as extra
-capacity. Unknown accelerator memory is not guessed safe.
-
-Current performance ranks and memory estimates remain conservative heuristics until
-representative-device qualification.
-
-## Managed ASR model custody
+## 3. Model custody: which exact dependency is allowed to execute?
 
 A safe strategy is not executable until its selected faster-whisper model has a verified
-managed revision.
+managed immutable revision.
 
-`ModelManager` is the only ASR acquisition/custody path. A plan asks the manager for the
-locally revalidated immutable revision. If none exists, planning fails with an
-install-first error.
+`ModelManager` owns explicit ASR acquisition/custody. Planning asks it for the locally
+revalidated resolved revision.
 
-The faster-whisper backend then executes with `local_files_only=True` and that exact
-revision. It never downloads ASR weights as a transcription side effect and never falls
-back to an arbitrary ambient Hugging Face cache entry or configuration revision.
+If the model is not managed, planning fails with an install-first message.
 
-## Segmentation and checkpointing
+At execution time, faster-whisper runs with `local_files_only=True` and the exact
+revision already recorded in the plan.
 
-EchoFlow owns durable segmentation so interrupted work has deterministic identity:
+No transcription-time ASR download fallback exists.
+
+## 4. Canonical audio: one deterministic working representation
+
+The current canonical processing format is:
+
+```text
+WAV
+pcm_s16le
+16 kHz
+mono
+```
+
+Already-canonical WAV may use `DIRECT`; other supported audio-bearing media uses
+`FFMPEG_NORMALIZE`.
+
+Normalization changes representation, not the public transcript timeline.
+
+Exact PCM frame intervals define durable work windows.
+
+## 5. Optional enhancement: help ASR without rewriting the source
+
+When `--enhance` is enabled, the current `FfmpegAfftdnEnhancer` creates a private
+`enhanced.wav` from canonical audio using the fixed current filter contract.
+
+ASR may consume the enhanced derivative. The original recording remains authoritative.
+
+EchoFlow checks channel count, sample width, sample rate, and frame count before
+accepting the derivative so preprocessing cannot quietly shift the transcript timeline.
+
+Anonymous diarization deliberately continues to read the unmodified canonical decode in
+enhancement v1.
+
+## 6. Segmentation and checkpointing: make interruption survivable
+
+EchoFlow owns deterministic segmentation:
 
 - exact integer PCM frame boundaries;
 - stable zero-based `audio-XXXXXX` work IDs;
 - 600-second maximum work windows;
-- no overlap;
-- one job-scoped model session;
-- strictly ordered checkpoint commits; and
-- at most one future CPU materialization while accelerated inference handles the
-  current segment.
+- no work-window overlap;
+- one job-scoped ASR session; and
+- strictly ordered checkpoint commits.
 
-Every completed result is atomically checkpointed before it becomes resumable. The
-completed set must remain a contiguous prefix.
+Accelerated execution may materialize at most one future segment while the current one
+is being inferred.
 
-The current pre-production checkpoint contract binds source identity, stream choice,
-profile, engine/model/revision, execution target, decode settings, enhancement state,
-segmentation, resource requirements, and exact frame windows. Resume restores that one
-current contract and re-admits current CPU/RAM/accelerator capacity.
+A completed checkpoint set must remain a contiguous prefix of the deterministic work
+plan.
 
-EchoFlow does not carry legacy job-plan or language-mode migration branches for
-unreleased behavior. A real migration layer should be introduced when a released or
-dogfooded contract creates an actual compatibility obligation.
+Resume restores the original source/model/device/decode/enhancement/segmentation contract
+and re-admits current resources.
 
-## Multilingual behavior
+## 7. Recognition and multilingual attribution
 
-Automatic faster-whisper decoding uses the current native multilingual behavior for
-each durable work unit. With no explicit language, the backend uses an 8-second
-multilingual window and disables previous-text conditioning so a prior work unit does
-not force a language prompt across a detected change.
+The faster-whisper backend performs managed local ASR.
 
-Published text-language labels come from the local `LinguaLanguageAttributor`, not from
-fabricated per-word acoustic labels. Attribution uses deterministic text units and an
-uncertainty floor. Ambiguous short text may remain unlabeled.
+With no explicit language, the current multilingual behavior can reconsider language
+within durable work units rather than latching one job-wide acoustic prompt forever.
 
-This supports language changes better than a job-latched language but is not a claim of
-perfect arbitrary word-level or romanized Hinglish attribution.
+Published text-language labels come from local deterministic language attribution,
+which can leave ambiguous short text unlabeled rather than fabricating certainty.
 
-## Anonymous speaker diarization
+This is better support for changing languages, not a claim of perfect arbitrary
+word-level code-switch attribution.
 
-Diarization is optional local enrichment with recording-scoped anonymous speaker refs.
-It does not perform biometric identity or cross-recording linking.
+## 8. Optional anonymous speaker evidence
 
-Its pyannote dependency path is security-gated. The current locked Lightning dependency
-is affected by CVE-2026-58659, so EchoFlow blocks diarization before pyannote import or
-model acquisition until a compatible patched dependency is available.
+Diarization is recording-scoped enrichment, not identity.
 
-Diarization model download authorization remains narrowly separate from ASR model
-management for now. This does not reopen a general transcription-time ASR download
-path.
+The current pyannote capability is security-gated because the locked Lightning
+dependency is affected by a compensated advisory. EchoFlow refuses the vulnerable path
+before pyannote import/model acquisition.
 
-## Canonical transcript and exports
+When operationally qualified, diarization contributes an exact speaker-turn timeline
+and conservative per-segment speaker references.
 
-Canonical JSON is authoritative. The one current transcript contract records:
+The next useful seam is finer word/timestamp alignment, which can improve handoff and
+overlap projection without pretending the underlying speaker evidence is more certain
+than it is.
 
-- source provenance and selected stream;
-- profile/provisional state;
-- managed engine/model/revision and execution target;
-- language evidence;
-- optional enhancement provenance;
-- optional diarization provenance/speaker turns; and
-- timestamped recognized segments.
+## 9. Canonical transcript and derived exports
 
-TXT, SRT, and WebVTT are deterministic derived views. They can be deleted and
-regenerated without changing recognition/checkpoint truth.
+Canonical JSON is authoritative transcript evidence.
 
-## Privacy and observability
+The current contract records source/stream provenance, execution plan identity,
+managed model revision, timestamps, language evidence, optional enhancement provenance,
+and optional diarization evidence.
 
-Structured logging uses Structlog behind `ILogger`. Routine logs redact local paths by
-default. Private job/checkpoint state, model caches, normalized audio, enhanced audio,
-and segment materializations are distinct from user-visible transcript artifacts.
+TXT, SRT, and WebVTT are deterministic publication views.
 
-POSIX systems enforce owner-only mode bits; Windows uses current-user DACL policy.
+They are useful. They are not recognition truth.
+
+## 10. Transcript library and search 🦝
+
+Canonical transcript JSON can be projected into private rebuildable search state.
+
+Lexical retrieval uses the database-neutral `TranscriptIndex` application port and a
+current DuckDB BM25 implementation.
+
+Semantic retrieval adds deterministic segment-anchored chunks, an
+`EmbeddingProvider`/`EmbeddingProfile` contract, strict-local Multilingual E5 Small,
+private numeric vectors, exact dense similarity, and corpus-fingerprint stale-state
+refusal.
+
+`TranscriptSearch` can combine lexical and semantic ranks with RRF while preserving
+lexical, semantic, and fused provenance in one evidence-bearing `SearchResponse`.
+
+Search infrastructure must never become the only home of future user-authored notes,
+labels, tags, collections, or annotations.
+
+## 11. Private storage and observability
+
+Structured logging uses Structlog behind `ILogger`.
+
+Routine logs redact local paths by default.
+
+Private job/checkpoint state, model caches, normalized/enhanced audio, and segment
+materializations remain distinct from user-visible transcript artifacts.
+
+POSIX private state uses owner-only mode policy; Windows uses current-user DACL policy.
 These are filesystem access controls, not application-level encryption or secure
 erasure.
 
-## Transcript library and retrieval boundary
-
-Canonical transcript JSON remains authoritative. The lexical and semantic databases are
-private rebuildable projections and must not contain the only copy of user-authored
-information.
-
-`TranscriptIndex` remains the database-neutral lexical port. The current
-`DuckDbTranscriptIndex` adapter stores document, segment, and term statistics under
-`STATE_DIR/library/transcripts.duckdb` and implements deterministic offline BM25-style
-ranking.
-
-Canonical projection now records both the source recording SHA-256 and the SHA-256 of
-the exact canonical JSON artifact. The latter is used to detect stale semantic state.
-
-Semantic retrieval is split across narrower capabilities rather than expanding
-`TranscriptIndex` into a universal search manager:
-
-- `ChunkingProfile` and `build_search_chunks()` create deterministic derived windows
-  anchored to exact canonical segment IDs and timestamps.
-- `EmbeddingProvider` separates query-side and passage-side encoding.
-- `SentenceTransformersE5Provider` implements strict-local
-  `intfloat/multilingual-e5-small` semantics with immutable revision provenance.
-- `DuckDbSemanticIndex` stores numeric `FLOAT[]` vectors and performs exact local
-  similarity after hard metadata filtering.
-- `TranscriptSearch` composes lexical and semantic ranks and implements hybrid RRF.
-- `SearchResponse` exposes evidence coordinates plus lexical, semantic, and fused
-  ranks for presentation adapters.
-
-`SearchQuery` remains above both storage adapters. User values do not become SQL
-fragments.
-
-The first semantic generation records model ID, immutable revision, 384 dimensions,
-L2 normalization, mean pooling, dot-product metric, E5 query/passage transforms,
-embedding schema, chunking profile, and a corpus fingerprint over canonical JSON
-digests. A mismatch between that fingerprint and the current lexical corpus fails
-semantic/hybrid retrieval closed.
-
-The Sentence Transformers runtime is lazy and optional. This tranche does not add an
-unresolved dependency to `pyproject.toml`; the repository's existing locked dependency
-contract remains intact. Lexical retrieval therefore remains available on the base
-install even when the optional semantic runtime is absent.
-
-See [corpus-search.md](corpus-search.md) for the full retrieval and data-ownership
-contract.
-
-## Capability ownership
+## Capability ownership map
 
 | Capability | Owns | Does not own |
 |---|---|---|
-| `FfprobeMediaProbe` | Source identity and stream metadata | Transcoding |
-| `AudioStreamSelector` | Deterministic selected audio stream | FFprobe discovery |
-| `RunnerInspector` | Process-visible CPU/RAM facts | Model choice |
-| `HardwareTopologyInspector` | Physical accelerator evidence | Runtime support claims |
-| `EngineCapabilityRegistry` | Engine/device/compute support | Strategy ranking |
-| `StrategyEvaluator` | Safe strategy admission/ranking | Model acquisition |
-| `ModelManager` | Managed ASR model custody and revision identity | ASR execution |
-| `TranscriptionJobPlanner` | Immutable combined execution plan | Performing work |
-| `FfmpegAudioDecoder` | Selected-stream canonicalization | Acoustic enhancement |
-| `FfmpegAfftdnEnhancer` | Optional deterministic noise suppression | Source authority |
-| `WaveAudioSegmenter` | Exact work windows/materialization | Speech recognition |
-| `FasterWhisperSession` | Managed local ASR recognition | Model download |
-| `LocalCheckpointStore` | Private resumable evidence | Public artifacts |
-| `TranscriptAssembler` | Source-relative assembly | Filesystem policy |
-| `LinguaLanguageAttributor` | Conservative text-language labels | Acoustic decoding |
-| `SpeakerDiarizer` | Anonymous speaker evidence | Biometric identity |
-| `TranscriptExporter` | TXT/SRT/VTT derived publication | Recognition truth |
-| `TranscriptIndex` | Database-neutral lexical search contract | Semantic model execution |
-| `DuckDbTranscriptIndex` | Private lexical index and BM25 execution | Authoritative transcript state |
-| `EmbeddingProvider` | Query/passage embedding semantics | Corpus custody |
-| `DuckDbSemanticIndex` | Rebuildable chunks/vector state and exact similarity | Canonical transcript truth |
-| `TranscriptSearch` | Lexical/semantic composition and RRF | Storage implementation |
-| `TranscriptLibraryService` | Discovery, rebuild, stale-state checks, retrieval, integrity receipts | SQL or canonical transcript ownership |
-| `WorkspaceService` | Private/public path allocation | Audio semantics |
+| `FfprobeMediaProbe` | source identity + stream metadata | transcoding |
+| `AudioStreamSelector` | selected audio stream | media discovery |
+| `RunnerInspector` | process-visible CPU/RAM | model choice |
+| `HardwareTopologyInspector` | physical accelerator evidence | runtime-support claims |
+| `EngineCapabilityRegistry` | engine/device/compute support | strategy ranking |
+| `StrategyEvaluator` | safe strategy admission/ranking | model acquisition |
+| `ModelManager` | managed model custody/revision | ASR execution |
+| `TranscriptionJobPlanner` | immutable combined execution plan | performing work |
+| `FfmpegAudioDecoder` | selected-stream canonicalization | enhancement |
+| `FfmpegAfftdnEnhancer` | optional noise suppression | source authority |
+| `WaveAudioSegmenter` | exact work windows/materialization | recognition |
+| `FasterWhisperSession` | local ASR recognition | model download |
+| `LocalCheckpointStore` | private resumable evidence | public artifacts |
+| `TranscriptAssembler` | source-relative assembly | filesystem policy |
+| `LinguaLanguageAttributor` | conservative text-language labels | acoustic decoding |
+| `SpeakerDiarizer` | anonymous speaker-turn evidence | biometric identity |
+| `TranscriptExporter` | derived TXT/SRT/VTT | recognition truth |
+| `TranscriptIndex` | database-neutral lexical search contract | semantic execution |
+| `DuckDbTranscriptIndex` | private BM25 projection | canonical transcript truth |
+| `EmbeddingProvider` | query/passage embedding semantics | corpus custody |
+| `DuckDbSemanticIndex` | rebuildable vector state + exact similarity | canonical evidence |
+| `TranscriptSearch` | retrieval composition + RRF | storage implementation |
+| `TranscriptLibraryService` | discovery/rebuild/stale-state/retrieval/integrity receipts | SQL ownership |
+| `WorkspaceService` | private/public path allocation | audio semantics |
 
-Protocols are introduced around real substitutable behavior, not pre-emptively for
-every class.
+Protocols exist around real substitutable behavior, not because every class deserves a
+ceremonial interface.
 
-## Current deliberate boundaries
+## Current deliberate limits
 
 EchoFlow does not currently claim:
 
-- calibrated speed/memory/thermal performance across representative devices;
-- that every detected accelerator is usable or faster;
+- calibrated performance across representative hardware;
+- every visible accelerator is useful/faster;
 - alternate ASR engines;
 - arbitrary word-level code-switch attribution;
 - biometric speaker identity;
+- user-assigned speaker display labels;
+- polished overlap handling;
 - simultaneous-speaker/source separation;
-- generative audio restoration;
+- generative restoration;
 - automatic enhancement selection;
-- original SMPTE/container/capture-time provenance beyond source-relative seconds;
+- original SMPTE/container/capture-time provenance beyond source-relative elapsed time;
+- word-level alignment;
 - storage durability across sudden power loss;
 - malicious same-user TOCTOU resistance;
 - secure erasure;
-- word-level alignment;
-- a qualified/locked Sentence Transformers semantic dependency extra;
-- ANN/HNSW, learned reranking, generated corpus answers, or user tags/notes/collections;
+- a qualified locked semantic dependency extra;
+- ANN/HNSW, learned reranking, generated corpus answers, or durable user annotations;
   or
-- a polished installer or desktop GUI.
+- a polished installer/desktop GUI.
 
-The next product work is dogfooding the current execution/retrieval contracts,
-representative-device and enhancement qualification, semantic dependency/model-custody
-qualification, retrieval UX, and word/timestamp alignment where real use shows the need
-for finer evidence coordinates.
+## What is becoming the next product layer?
+
+The backend foundation is broad. The next high-value work is increasingly about making
+evidence **finer and easier to navigate**:
+
+1. word/timestamp alignment;
+2. original-media timecode and capture-time provenance;
+3. better speaker overlap presentation and user-assigned display labels; and
+4. later, source separation for genuinely overlapping speech when evidence and measured
+   benefit justify the additional model/compute complexity.
+
+Those capabilities strengthen the user experience without changing the architecture's
+central rule:
+
+> **Source evidence stays authoritative. Derived machinery stays explainable. User
+> knowledge does not get mistaken for cache.**

--- a/docs/architecture/speech-enhancement.md
+++ b/docs/architecture/speech-enhancement.md
@@ -1,194 +1,275 @@
-# Local speech enhancement and noise suppression
+# Local speech enhancement and noise suppression 🎚️✨
 
-## Purpose
+## The human version
 
-EchoFlow can optionally preprocess difficult recordings before automatic speech
-recognition while preserving the original recording as the authoritative evidence.
-The first implementation is deliberately narrow: deterministic local background-noise
-suppression, explicit user selection, private derived audio, and complete preprocessing
-provenance.
+Some recordings are just noisy.
 
-The feature is not a restoration engine and does not claim that processed audio is a
-better archival source. Its purpose is to test whether a conservative local transform
-can improve downstream transcription on noisy recordings without weakening custody,
-resumability, or timeline guarantees.
+Air conditioners hum. Rooms echo. Microphones sit too far away. Someone decides to move
+a coffee mug directly on top of the only useful sentence in the interview.
 
-## Pipeline boundary
+EchoFlow can optionally apply deterministic local noise suppression **before speech
+recognition** while preserving the original recording as the authoritative evidence.
 
-The current processing path is:
+The first implementation is intentionally modest. It is not an audio-restoration oracle.
+It asks a narrower question:
 
-```text
-source media
-  -> selected audio stream
-  -> canonical decode (mono, 16 kHz, PCM16 WAV)
-  -> optional private noise suppression
-  -> segmentation
-  -> managed local ASR
-  -> canonical transcript
+> Can a conservative, reproducible local transform improve downstream transcription
+> without changing source custody, timeline semantics, or resume behavior?
+
+```mermaid
+flowchart LR
+    A[Original recording] --> B[Canonical decode]
+    B --> C{Enhancement requested?}
+    C -->|no| D[ASR]
+    C -->|yes| E[Private noise-suppressed derivative]
+    E --> F[Timeline identity checks]
+    F --> D
+    D --> G[Canonical transcript + provenance]
+
+    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef check fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef result fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+
+    class A source
+    class B,C,D,E process
+    class F check
+    class G result
 ```
 
-The source media remains authoritative. Canonical decoded audio and enhanced audio are
-private execution material. They are deleted when no longer required and are not
-published merely because enhancement was enabled.
+## User surface
 
-For the first version, anonymous speaker diarization deliberately reads the unmodified
-canonical decoded audio while ASR reads the enhanced derivative. EchoFlow does not yet
-claim that denoising improves speaker-boundary evidence, so it does not silently
-preprocess the diarization input.
+Enhancement is off by default.
 
-## Explicit off/on contract
+Enable it explicitly:
 
-Enhancement is off by default. A user enables it explicitly with:
-
-```text
-echoflow transcribe recording.m4a --enhance
+```bash
+uv run echoflow transcribe recording.m4a --enhance
 ```
 
-There is no automatic enhancement selector in the first version. EchoFlow must first
-collect representative evidence showing when enhancement improves end-to-end ASR
-accuracy enough to justify its extra compute and storage cost.
+There is no automatic “this sounds noisy, so I turned something on” behavior yet.
 
-The immutable plan records the enhancement mode, provider, parameters, and any future
-model identity. The checkpoint contract records the same structure even when
-preprocessing is off. Resume therefore cannot switch provider, parameters, or off/on
-state halfway through a recording.
+That is deliberate. EchoFlow should first collect representative evidence showing when
+enhancement improves end-to-end ASR enough to justify extra compute and disk use.
+
+## Source custody
+
+The source recording remains authoritative.
+
+Canonical decoded audio and enhanced audio are private execution material. They are not
+published merely because preprocessing happened.
+
+The canonical transcript records which preprocessing affected ASR input, but the
+derived WAV does not become a new archival source of truth.
+
+🦝 Derived audio can live under the floorboards. The original recording keeps the deed.
 
 ## First provider
 
-The first provider is FFmpeg's local `afftdn` frequency-domain noise-reduction filter.
-EchoFlow pins an application-owned parameter contract:
+The current provider uses FFmpeg's local `afftdn` frequency-domain noise-reduction
+filter with one application-owned parameter contract:
 
 ```text
 afftdn=nf=-50:nr=12
 ```
 
-The corresponding application provenance is:
+Canonical provenance is:
 
 - provider: `ffmpeg-afftdn`;
 - operation: `noise_suppression`;
 - noise floor: `-50 dB`;
 - noise reduction: `12 dB`; and
-- provider version: the locally verified first line of `ffmpeg -version`.
+- provider version: locally verified first line of `ffmpeg -version`.
 
-The provider is model-free. EchoFlow does not create a fake model manifest merely to
-make the abstraction look uniform. If a future neural provider introduces model
-weights, those weights must use the model-management custody, verification, disk
-admission, explicit-install, and immutable-revision contracts.
+This provider has no model weights.
 
-## Timeline preservation
+EchoFlow does not create a pretend model manifest merely to make the architecture look
+uniform.
 
-Enhancement must not change EchoFlow's source-relative transcript timeline.
+If a future neural enhancement provider introduces weights, those weights must enter
+through the same family of explicit model custody, disk admission, verification, and
+immutable revision rules used by other model-backed capabilities.
 
-Before accepting an enhanced WAV, EchoFlow compares the canonical input and derived
-output for:
+## Timeline preservation is load-bearing
+
+Enhancement may change **sample values**.
+
+It may not silently change the **shape of the timeline** that transcript timestamps rely
+on.
+
+Before accepting the derived WAV, EchoFlow compares input/output:
 
 - channel count;
 - sample width;
 - sample rate; and
 - frame count.
 
-Any mismatch fails closed and the derived output is removed. This protects the
-assumption that segment frame intervals and source-relative timestamps refer to the
-same acoustic timeline before and after preprocessing.
+Any mismatch fails closed and the derived output is removed where possible.
 
-The provider is also instructed to emit mono 16 kHz PCM16 WAV, matching the canonical
-decode contract. This is defense in depth rather than permission for the provider to
-resample arbitrarily.
+The FFmpeg provider is also instructed to emit the same mono 16 kHz PCM16 working format
+as canonical decode. That is defense in depth, not permission to resample and then hope
+nobody notices.
+
+## Why diarization still sees the unmodified canonical decode
+
+In enhancement v1:
+
+- **ASR** consumes the enhanced derivative when enhancement succeeds;
+- **anonymous diarization** continues to consume the unmodified canonical decoded audio.
+
+EchoFlow has not established that denoising improves speaker-boundary evidence.
+
+Preprocessing the diarization input merely because preprocessing helps ASR would be an
+unearned assumption.
+
+Future empirical evidence may justify a different provider path, but the change should
+be explicit and provenance-bearing.
+
+## Immutable plan and resume behavior
+
+The transcription plan records enhancement mode, provider, parameters, and any future
+model identity.
+
+The checkpoint contract records the same structure even when enhancement is off.
+
+Resume therefore cannot switch enhancement on/off, swap provider, or alter parameters
+halfway through a recording.
+
+A resumed transcript should not quietly contain two different acoustic preprocessing
+regimes.
 
 ## Storage admission
 
-Enhancement materializes one additional full-recording canonical-rate WAV in the
-private job workspace. Planning therefore adds that derivative to the private storage
-estimate before job execution begins.
+Enhancement materializes one additional full-recording canonical-rate WAV in the private
+job workspace.
 
-For mono 16 kHz PCM16 audio, the incremental storage estimate is approximately:
+For mono 16 kHz PCM16 audio, the incremental estimate is approximately:
 
 ```text
 duration_seconds * 16,000 * 1 channel * 2 bytes
 ```
 
-The estimate participates in the same storage admission policy as normalization,
-segment materialization, checkpoints, and published outputs. EchoFlow should refuse a
-job before creating large private derivatives if local free space is below the safe
-budget.
+That cost participates in the same storage admission policy as normalization, segment
+materialization, checkpoints, and published artifacts.
 
-## Provenance
+EchoFlow should refuse a job before creating a large derivative when available disk
+space is below the safe budget.
+
+## Canonical provenance
 
 When enhancement is used, canonical transcript JSON records an
-`EnhancementProvenance` object containing the provider, provider version, operation,
-parameters, and any future model identity/revision.
+`EnhancementProvenance` object containing:
 
-The provenance describes the preprocessing that affected ASR input. It does not make
-the enhanced WAV authoritative and it does not imply that the enhanced audio was
-published.
+- provider;
+- provider version;
+- operation;
+- parameters; and
+- any future model identity/revision.
 
-When enhancement is off, the transcript records no enhancement provenance.
+This explains which transform affected ASR input.
 
-## Failure semantics
+It does **not** claim that:
 
-Enhancement fails closed. EchoFlow does not silently fall back to raw audio when the
-user explicitly requested preprocessing.
+- the enhanced audio is authoritative;
+- the enhanced audio was published;
+- the enhanced audio necessarily sounds better; or
+- enhancement necessarily improved ASR for this recording.
+
+When enhancement is off, no enhancement provenance is recorded.
+
+## Failure semantics 🔐
+
+Enhancement fails closed when the user explicitly requested it.
+
+EchoFlow does not silently fall back to raw audio after an enhancement failure and then
+pretend the requested plan executed.
 
 Failure cases include:
 
 - FFmpeg unavailable;
 - FFmpeg runtime version cannot be verified;
-- provider or parameter contract differs from the planned configuration;
-- filtering times out or exits unsuccessfully;
-- output is missing or contains no usable samples; or
-- output violates the canonical timeline identity.
+- provider/parameter contract differs from the plan;
+- filtering timeout/non-zero exit;
+- missing or empty output; or
+- output violating canonical timeline identity.
 
-Partial derived output is removed where possible. Cleanup failure after another primary
-failure is logged and must not replace the primary exception.
+Partial derived output is removed where possible.
+
+Cleanup failure after another primary error is logged and must not replace the primary
+exception.
 
 ## Mutation-oriented test contract
 
-Tests should be designed so the following plausible bad edits are killed before a
-broad mutation run is needed:
+Tests should kill plausible bad decisions such as:
 
-- `off` accidentally invokes the enhancer;
-- `on` silently falls back to raw audio after provider failure;
-- ASR uses the raw path even though enhancement succeeded;
-- diarization unexpectedly uses the enhanced path in v1;
-- provider or parameter values can change without checkpoint incompatibility;
-- enhanced audio is omitted from storage admission;
-- frame-count/sample-rate/channel validation is weakened or inverted;
-- partial output survives a failed transform;
-- enhanced cleanup is skipped or masks a primary failure;
-- provider/version/parameter provenance is omitted from the canonical transcript; and
-- a future model-backed provider bypasses managed model custody.
+- `off` accidentally invoking enhancement;
+- `on` silently falling back to raw audio;
+- ASR reading the raw path after enhancement succeeded;
+- diarization unexpectedly reading enhanced audio in v1;
+- provider/parameters changing without checkpoint incompatibility;
+- enhanced audio disappearing from storage admission;
+- frame/sample-rate/channel validation being weakened or inverted;
+- partial output surviving a failed transform;
+- cleanup masking the primary failure;
+- missing canonical enhancement provenance; and
+- a future model-backed provider bypassing managed model custody.
 
-Poodle remains a targeted manual qualification technique for this decision-heavy code,
-not an automatic per-commit gate.
+Poodle remains targeted qualification for this decision-heavy code rather than a routine
+per-commit gate.
 
-## Qualification criteria
+## What qualification actually has to measure
 
-The product question is not whether denoised audio sounds nicer. Qualification compares
-raw ASR with enhancement-plus-ASR on representative noisy recordings and measures at
-least:
+The product question is not “does the denoised file sound nicer to a human?”
 
-- word error rate or another transcription-accuracy measure when reference text exists;
-- character error rate where appropriate;
+Qualification should compare **raw ASR** with **enhancement + ASR** on representative
+recordings using measures such as:
+
+- WER/CER where reference text exists;
 - end-to-end execution time and real-time factor;
-- CPU/RAM pressure and accelerator impact when relevant;
+- CPU/RAM/accelerator pressure;
 - private disk overhead; and
-- failure behavior on silence, music, clipping, stationary noise, and non-stationary
+- failure behavior across silence, music, clipping, stationary noise, and non-stationary
   noise.
 
-Only after measurements show a reliable relationship between input conditions and
-end-to-end benefit should EchoFlow consider an `auto` mode.
+Only after evidence shows a reliable relationship between input conditions and benefit
+should EchoFlow consider an `auto` mode.
 
-## Out of scope
+## Where source separation belongs later 🧜‍♀️
 
-The first version does not implement:
+Noise suppression and source separation are not the same problem.
+
+The current provider tries to suppress background noise while preserving one acoustic
+timeline.
+
+**Speech/source separation for overlapping speakers** would attempt to decompose a mixed
+recording into estimated speaker/source signals. That introduces substantially more
+model/compute cost and harder provenance questions:
+
+- which separated source produced which recognized words;
+- how separation uncertainty is represented;
+- whether separated outputs remain aligned to the original timeline;
+- which model/revision produced them;
+- whether source separation actually improves recognition on the target corpus; and
+- how derived sources should be retained or discarded.
+
+That is a later capability, after word alignment and overlap representation are strong
+enough to show where separation is actually needed.
+
+## Current deliberate limits
+
+The current feature does not provide:
 
 - simultaneous-speaker separation;
-- arbitrary source separation or music isolation;
-- generative audio restoration;
+- arbitrary music/source isolation;
+- generative restoration;
 - automatic provider/model selection;
-- automatic denoising based on an opaque quality score; or
-- publishing enhanced audio by default.
+- opaque automatic denoising based on a quality score; or
+- automatic publication of enhanced audio.
 
-The stable rule is evidence-first: preprocessing may help recognition, but the source
-recording remains truth and every transform affecting ASR must remain inspectable,
-reproducible, private by default, and safe to resume.
+The stable rule is:
+
+> **Preprocessing may help recognition. The source recording remains truth, and every
+> transform that affects ASR must remain explicit, reproducible, private by default,
+> and safe to resume.**
+
+That is enough glamour for one filter. 💃

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,67 @@
+# EchoFlow development docs 🧪🔧
+
+This is where the project stops saying “EchoFlow tries very hard not to melt your
+laptop” and starts showing **how we prove that claim is not merely aspirational prose**.
+
+The development docs are for maintainers, contributors, and anyone who enjoys turning
+subtle bad decisions into failing tests.
+
+## Start here
+
+| Page | What it is for |
+|---|---|
+| [Testing and regression bisection](testing-and-bisect.md) | the general test strategy, colocation rules, mutation anticipation, and deterministic bisect oracles |
+| [Semantic retrieval qualification](semantic-retrieval-testing.md) | property, negative, boundary, integration, and mutation coverage for the transcript-library V2 search decisions |
+| [Empirical benchmarking and calibration](benchmarking.md) | how EchoFlow measures real execution without turning hosted CI timing into folklore |
+
+## The quality philosophy
+
+EchoFlow has a lot of decision-heavy code: resource admission, model custody, stale-state
+rejection, resume, cleanup ordering, search filtering, rank composition, and privacy
+boundaries.
+
+Line coverage alone cannot prove those decisions are correct.
+
+The preferred ladder is:
+
+```mermaid
+flowchart LR
+    A[Named unit tests] --> B[Negative + boundary cases]
+    B --> C[Property tests]
+    C --> D[Package / integration tests]
+    D --> E[Branch coverage + static gates]
+    E --> F[Targeted mutation qualification]
+    F --> G[Cross-platform / package evidence]
+    G --> H[Representative real-device evidence]
+
+    classDef fast fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef deep fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef evidence fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A,B,C,D fast
+    class E,F,G deep
+    class H evidence
+```
+
+Each layer answers a different question. Mutation testing does not replace ordinary
+boundary tests. Hosted CI does not replace physical-device calibration. Benchmarks do
+not silently rewrite planner policy.
+
+🦝 **If a comparator changes from `<` to `<=`, we would like a test to notice before the
+raccoon notices in production.**
+
+## Colocation
+
+Tests live with the capability whose contract they protect. Shared fixtures stay at the
+narrowest useful scope. Built distributions exclude test packages.
+
+That convention makes source-to-test navigation boring, which is exactly what we want.
+
+## Documentation voice
+
+Development docs use the medium-personality register from
+[documentation-style.md](../documentation-style.md): exact commands and contracts, but
+with enough explanation that a new contributor can understand why a test exists before
+reading the mutant it is trying to kill.
+
+💃 Happy breaking.

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -1,116 +1,164 @@
-# Empirical benchmarking and calibration
+# Empirical benchmarking and calibration 📏
 
-EchoFlow's resource estimates and relative strategy ranks are intentionally
-conservative heuristics until they can be compared with measured execution. The
-benchmarking subsystem is a local-only harness for collecting that evidence without
-creating a second transcription implementation.
+EchoFlow's resource estimates and relative strategy ranks are intentionally conservative
+heuristics until real machines prove them right or wrong.
 
-ASR models must already be installed through model management before a benchmark can
-plan or execute. Benchmarking never authorizes a hidden faster-whisper download.
+The benchmarking subsystem exists to collect that evidence **without creating a second
+transcription implementation**.
 
-The current development interface is:
+The important separation is:
+
+> **Benchmarks describe what happened. A later reviewed policy change decides whether
+> those observations justify different planner behavior.**
+
+One fast laptop run does not get to rewrite the product's memory policy by vibes.
+
+## Quick start
+
+ASR models must already be installed through normal model management. Benchmarking never
+authorizes a hidden faster-whisper download.
 
 ```bash
 uv run python -m echoflow.benchmarking /path/to/recording.wav
 uv run python -m echoflow.benchmarking /path/to/recording.wav --json
 ```
 
-An interrupted job can be measured as a separate resumed attempt:
+Measure a resumed attempt separately:
 
 ```bash
 uv run python -m echoflow.benchmarking /path/to/recording.wav --resume JOB_ID
 ```
 
-The harness is experimental. Once its schema and behavior have been validated on real
-devices it may be promoted into the primary `echoflow` command surface.
+The harness is experimental. Once its schema and behavior survive real-device use, it
+may graduate into the primary `echoflow` command surface.
 
-## What is measured
+## What problem are we trying to solve?
 
-A benchmark report describes one execution attempt and currently includes:
+The planner currently estimates whether a strategy fits and ranks eligible choices.
+Those estimates should become better because of **measured behavior on representative
+machines**, not because somebody remembers that one GPU sounded fast in a product page.
+
+```mermaid
+flowchart LR
+    A[Planner prediction] --> B[Real execution]
+    B --> C[Local benchmark report]
+    C --> D[Compare predicted vs observed]
+    D --> E[Reviewed calibration change]
+    E --> A
+
+    classDef predict fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef measure fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef policy fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A predict
+    class B measure
+    class C,D evidence
+    class E policy
+```
+
+## What one benchmark report records
+
+A report describes one execution attempt and currently includes:
 
 - EchoFlow and Python versions;
 - path-minimized source provenance: SHA-256, size, modification timestamp, container,
-  duration, and audio stream index;
+  duration, and selected audio stream;
 - process-visible runner resources and selected execution policy;
-- path-free managed engine/model/revision, execution target, decoder, enhancement,
-  segmentation, and resource-estimate contracts;
+- path-free managed engine/model/revision and execution target;
+- decoder, enhancement, segmentation, and resource-estimate contracts;
 - planning, execution, and total wall-clock duration;
 - whole-run and execution-only real-time factors;
-- sampled RSS and CPU use for EchoFlow and current descendant processes;
-- aggregate named execution-stage durations and failure counts;
-- segment totals, restored counts, and completed counts where available;
+- sampled process-tree RSS and CPU use;
+- aggregate named execution-stage durations/failure counts;
+- segment totals/restored/completed counts when available;
 - canonical transcript artifact size after successful publication; and
 - the ratio between observed peak process-tree RSS and the planner's peak-memory
   estimate.
 
-Repeated stages are named aggregates rather than fixed columns. Additional capabilities
-can therefore add measurements such as `enhancement.apply`, `speaker.diarize`,
-`alignment`, `embedding.index`, `search.index`, or `gpu.transfer` without a new
-benchmark architecture.
+Repeated stages are named aggregates rather than fixed columns. Future capabilities can
+add stages such as:
 
-CPU percentages sum sampled process-tree CPU and may exceed 100% on multi-core systems.
-RSS is summed across the process tree and may conservatively double-count shared pages.
-These are comparative measurements, not exact operating-system accounting.
+```text
+enhancement.apply
+speaker.diarize
+alignment
+embedding.index
+search.index
+gpu.transfer
+```
 
-## Privacy boundary
+without redesigning the benchmark schema.
 
-Benchmarking does not transmit results and EchoFlow has no benchmark telemetry.
+CPU percentages may exceed 100% because sampled process-tree CPU is summed across cores.
+RSS is also summed across the process tree and may conservatively double-count shared
+pages. These are comparative measurements, not perfect OS accounting.
+
+## Privacy boundary 🔐
+
+Benchmarking does not transmit reports. EchoFlow has no benchmark telemetry.
+
 Reports are user-owned JSON files in the selected output directory.
 
-Reports intentionally omit source paths/filenames, model-cache paths, transcript text,
-and exception messages. They retain source digest and other provenance needed to
-compare equivalent runs. A source digest can still be linkable when another party has
-the same recording, so a report for sensitive media is not automatically anonymous.
+They intentionally omit:
 
-Public sharing should use a redistributable/synthetic corpus or a future intentionally
+- source paths/filenames;
+- model-cache paths;
+- transcript text; and
+- exception messages.
+
+They retain source digest and enough provenance to compare equivalent runs.
+
+A source digest can still be linkable if another party has the same recording, so a
+benchmark report from sensitive media is not automatically anonymous.
+
+Public sharing should use synthetic/redistributable media or a future deliberately
 shareable report format with reduced provenance.
 
 ## Interruption and resume
 
-Ctrl+C and ordinary Python-level failures persist a partial benchmark report before the
-benchmark command exits. It identifies the attempt as interrupted/failed, includes only
-the exception type, and preserves measurements already recorded.
+Ctrl+C and ordinary Python-level failures persist a partial benchmark report before exit
+when finalization can run.
+
+The report marks the attempt interrupted/failed, includes only the exception type, and
+preserves measurements already recorded.
 
 The transcription checkpoint contract remains authoritative for recovery. Completed
-segments are checkpointed before they count as complete, so a later resume benchmark
-measures the resumed attempt without redefining recovery semantics. The checkpoint also
-binds managed model revision and enhancement state, preventing a resumed benchmark from
-quietly changing preprocessing or weights.
+segments are checkpointed before they count as complete.
 
-A hard process kill, power loss, kernel termination, or machine crash cannot execute
-benchmark-finalization code, so no final report is promised for those failures. Durable
-transcription checkpoints and lifecycle state remain recovery evidence.
+A later `--resume` benchmark therefore measures the resumed attempt without redefining
+resume semantics.
 
-## Qualification layers
+Hard kills, power loss, kernel termination, or machine crashes cannot run benchmark
+finalization code, so a final benchmark report is not promised for those cases. Durable
+transcription checkpoints/lifecycle state remain the recovery evidence.
 
-Calibration needs three evidence layers that answer different questions.
+## Three qualification layers
 
 ### 1. Deterministic unit and contract tests
 
-These validate the measurement system itself:
+These prove the measurement machinery itself behaves correctly:
 
-- ordinary transcription uses a no-op observer without changing semantics;
+- normal transcription uses a no-op observer without semantic changes;
 - repeated stage measurements aggregate correctly;
-- failed stages are recorded without swallowing the original error;
-- reports omit sensitive paths and transcript content;
+- failed stages are recorded without swallowing the primary error;
+- reports omit sensitive paths/transcript text;
 - interruption/failure produce partial reports;
-- process-tree sampling tolerates disappearing children;
+- process-tree sampling tolerates disappearing child processes;
 - resume uses the checkpointed current contract; and
-- report/schema validation fails closed on invalid values.
-
-These remain deterministic and fast.
+- invalid report/schema values fail closed.
 
 ### 2. Cross-platform CI
 
-Linux, macOS, and Windows GitHub Actions runners execute tests, build distributions,
-and exercise clean-wheel behavior. CI proves psutil sampling, packaging, observer
-injection, file handling, native media tools, and CLI behavior on supported operating
-systems.
+Linux, macOS, and Windows GitHub Actions runners exercise tests, packaging,
+clean-wheel behavior, psutil sampling, file handling, native media tools, and CLI
+contracts.
 
-Hosted-runner timing is **not calibration truth**. Runner generations, neighboring
-workloads, virtualization, CPU frequency policy, caches, and infrastructure change
-outside EchoFlow's control. CI can reveal catastrophic regressions, but planner
-heuristics should not be fitted to one hosted-runner measurement.
+Hosted-runner timing is **not calibration truth**.
+
+Runner generations, virtualization, neighboring workloads, frequency policy, caches, and
+infrastructure can change outside the project. CI is useful for regression evidence, not
+for fitting device policy.
 
 ### 3. Representative real-device runs
 
@@ -122,63 +170,84 @@ The initial physical matrix should include:
 - a discrete-GPU laptop; and
 - a larger 32/64 GB workstation.
 
-For comparisons, keep input bytes, EchoFlow version, managed model revision,
-profile/strategy, enhancement condition, and relevant configuration identical. Record
-whether caches are cold/warm. Run repeated trials and compare medians/spread rather
-than one fastest result.
+For comparisons, hold constant the input bytes, EchoFlow version, managed model revision,
+profile/strategy, enhancement condition, and relevant configuration.
 
-Thermal throttling, battery/power mode, other applications, storage speed, and OS
+Record cold/warm cache state. Prefer repeated trials and medians/spread over one heroic
+fastest result.
+
+Thermal throttling, battery/power mode, background applications, storage speed, and OS
 updates are legitimate consumer conditions. Record them as experimental context when
-known rather than silently inferring/uploading them.
+known instead of pretending they do not exist.
 
-## Raw ASR versus enhancement-plus-ASR
+🧜‍♀️ A benchmark without context is just a number wearing a lab coat.
 
-Noise suppression is qualified by **transcription outcome and total cost**, not by
-whether processed audio sounds nicer.
+## Raw ASR versus enhancement + ASR
 
-Use representative noisy recordings and run matched conditions:
+Noise suppression should be qualified by **transcription outcome and total cost**, not
+whether the processed file sounds nicer to a listener.
 
-1. managed-model raw ASR with enhancement off;
-2. the same model/revision/strategy with `--enhance`; and
+Use matched conditions:
+
+1. the same managed model/revision/strategy with enhancement off;
+2. the same setup with `--enhance`; and
 3. repeated runs when variance matters.
 
-Where reference transcripts exist, compare at least WER and, where useful, CER. Also
-compare:
+Where reference transcripts exist, compare WER and, where useful, CER.
 
-- total and stage-specific wall-clock time;
+Also compare:
+
+- total/stage wall-clock time;
 - real-time factor;
 - CPU/RAM pressure;
-- accelerator impact when applicable;
+- accelerator impact;
 - private disk overhead;
 - checkpoint/resume behavior; and
 - failures on silence, clipping, stationary/non-stationary noise, music, and mixed
   acoustic conditions.
 
-The first FFmpeg `afftdn` provider is a fixed deterministic condition. Its presence in
-the product does not imply it improves every recording.
+The current FFmpeg `afftdn` provider is a fixed deterministic condition. Its existence in
+EchoFlow is not a claim that it improves every recording.
 
-An automatic enhancement mode should not exist until measurements show a sufficiently
+An automatic enhancement mode should wait until measurements show a sufficiently
 reliable relationship between observable input conditions and end-to-end ASR benefit.
-If enhancement worsens transcription or adds unjustified cost for a class of inputs,
-that is evidence against automatic activation for that class.
 
-## How evidence changes policy
+## Future alignment, diarization, search, and source-separation measurements
 
-The harness exists first for **measurement, not self-tuning**. A single benchmark must
-not rewrite conservative planner constants or enhancement policy.
+The same observer/stage model can eventually measure newer capabilities without
+inventing parallel harnesses.
+
+Useful future dimensions include:
+
+- alignment wall time and memory cost;
+- diarization real-time factor/peak memory after the security gate is cleared;
+- embedding-index build cost;
+- semantic-query latency at increasing corpus size;
+- exact-scan break-even points before considering ANN/HNSW; and
+- source-separation cost/recognition benefit on genuine overlap cases.
+
+Source separation in particular should be judged on end-to-end evidence quality, not on
+whether separated audio sounds technologically impressive.
+
+## How measurements become policy
+
+The harness is for **measurement first, self-tuning never by accident**.
 
 After a sufficient matrix exists, compare predicted and observed:
 
-- peak memory and device memory;
+- peak system/device memory;
 - real-time factor;
 - model initialization;
-- decode and enhancement cost;
-- segment materialization/inference/checkpoint cost;
+- decode/enhancement/alignment cost;
+- segmentation/inference/checkpoint cost;
 - cold/warm behavior; and
-- raw-ASR versus enhanced-ASR accuracy.
+- accuracy outcomes where reference text exists.
 
-Only then should a separate reviewed change propose calibrated constants, safety
-margins, hardware classes, or an evidence-driven enhancement heuristic.
+Only then should a separate reviewed change propose new constants, safety margins,
+hardware classes, or automatic preprocessing heuristics.
 
-The separation keeps evidence auditable: benchmark reports say what happened; policy
-changes explain why those observations justify different admission or selection.
+Benchmark reports say what happened. Policy changes explain why that evidence justifies
+a different decision.
+
+That separation keeps calibration auditable and prevents the planner from becoming a
+self-modifying raccoon with a stopwatch. 🦝

--- a/docs/development/semantic-retrieval-testing.md
+++ b/docs/development/semantic-retrieval-testing.md
@@ -1,80 +1,150 @@
-# Semantic retrieval qualification
+# Semantic retrieval qualification 🧪🔎
 
-Transcript Library V2 is decision-heavy code. Its tests protect evidence custody,
-chunking, vector-space coherence, filter ordering, stale-index rejection, and hybrid
-ranking. A high line count by itself is not enough.
+Transcript Library V2 is full of small decisions that can quietly make search wrong
+while the happy path still looks fine.
+
+Chunk boundaries can drop evidence. Filters can be applied too late. A stale vector
+space can look plausible. One malformed embedding can poison a rebuild. Hybrid ranking
+can claim provenance it did not actually earn.
+
+So the qualification question is not “did we write a lot of tests?”
+
+It is:
+
+> **If one of these decisions were subtly wrong, would a specific test notice?**
 
 ## Qualification matrix
-
-The semantic tranche uses several complementary test styles.
 
 | Test style | What it protects | Current examples |
 |---|---|---|
 | Positive | intended retrieval behavior | deterministic chunks, exact vector ranking, RRF fusion |
 | Negative | fail-closed behavior | stale corpus, missing model, malformed vectors, embedding failure |
-| Boundary | thresholds and invalid contracts | chunk target/max sizes, indivisible oversize source segments |
-| Property-based | invariants over many generated cases | every source segment appears exactly once in deterministic chunks |
+| Boundary | thresholds and invalid contracts | chunk target/max sizes, indivisible oversized source segments |
+| Property-based | invariants over many generated cases | every canonical segment appears exactly once in deterministic chunks |
 | Integration | cross-component behavior | canonical JSON → projection → vectors → DuckDB → hybrid search |
-| Mutation | strength of decision tests | targeted Poodle workflow for semantic/retrieval/service modules |
+| Mutation | strength of decision tests | targeted Poodle workflow over semantic/retrieval/service modules |
 
-Factory Boy is intentionally not introduced for this capability. The tested objects are
-small immutable domain values rather than ORM graphs. Narrow builders and Hypothesis
-strategies provide the useful construction behavior without another dependency.
+The different styles are complementary. Property tests do not make named boundary tests
+obsolete. Mutation testing does not make ordinary negative tests optional.
 
-## Hypothesis invariants
+## Why there is no Factory Boy here
+
+The semantic tests mostly construct small immutable domain values, not sprawling ORM
+object graphs with lifecycle hooks.
+
+Narrow builders and Hypothesis strategies give the useful construction behavior without
+another dependency.
+
+If object construction later becomes genuinely lifecycle-heavy, revisit the decision.
+Do not add a factory framework merely because test data exists.
+
+🦝 The raccoon is perfectly capable of constructing a frozen dataclass by hand.
+
+## Hypothesis: protect segment custody, not only examples
 
 `src/echoflow/library/tests/test_semantic.py` generates varied segment word counts and
-chunking thresholds and checks these invariants:
+chunking thresholds and protects invariants such as:
 
-- the same input/profile produces the same chunks and IDs;
-- every canonical segment appears exactly once in the flattened chunk sequence;
-- no chunk invents or drops an evidence coordinate;
-- chunk timestamps are inherited from the first/last canonical segments;
-- exceeding `max_words` is allowed only when one indivisible source segment is itself
-  larger than the maximum.
+- same input/profile → same chunks and IDs;
+- every canonical segment appears **exactly once** in the flattened chunk sequence;
+- no chunk invents, duplicates, or drops an evidence coordinate;
+- chunk timestamps come from the first/last canonical source segments; and
+- exceeding `max_words` is permitted only when one indivisible source segment is itself
+  larger than that maximum.
 
-Keep named examples for important boundaries even when a property test could generate
-them. A future maintainer should be able to see why `target_words=0` and
-`max_words < target_words` are invalid without reverse-engineering a strategy.
+Named cases still call out important boundaries such as:
 
-## Embedding-provider failure cases
+```text
+target_words = 0                  → invalid
+max_words < target_words          → invalid
+one source segment > max_words    → remains indivisible
+```
 
-The E5 adapter tests should reject at least:
+A future maintainer should not have to reverse-engineer a Hypothesis strategy to learn
+which boundary is load-bearing.
 
-- unavailable snapshot directory;
+## Embedding-provider defensive checks
+
+The qualified E5 adapter should reject at least:
+
+- unavailable local snapshot directory;
 - snapshot/revision mismatch;
 - blank input text;
 - wrong number of output vectors;
 - wrong vector dimensions;
-- non-finite values;
-- vectors that violate the declared L2-normalized contract.
+- non-finite values such as NaN/Infinity; and
+- vectors that violate the declared L2-normalized profile contract.
 
-The model runtime is faked for these tests. Qualification must not require downloading a
-model or sending text to an external service.
+The runtime is faked for these unit tests.
+
+Qualification should not require downloading a model or sending text anywhere.
+
+## Failure preservation: a bad rebuild must not destroy a good one
+
+One especially important invariant is transactional replacement of semantic state.
+
+```mermaid
+flowchart LR
+    A[Existing valid generation] --> B[Attempt rebuild]
+    B --> C{Embedding / validation succeeds?}
+    C -->|yes| D[Commit new generation]
+    C -->|no| E[Keep previous valid generation]
+
+    classDef good fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+    classDef work fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef stop fill:#FFD6D6,stroke:#9E3434,stroke-width:2px,color:#351616
+
+    class A,D good
+    class B,C work
+    class E stop
+```
+
+Tests cover embedding failure and invalid semantic replacement so a failed rebuild does
+not erase the previous usable corpus fingerprint/chunk state.
 
 ## Projection and service failure cases
 
-The service/index tests protect:
+The service/index suite protects:
 
-- hard metadata/phrase constraints before semantic top-K;
-- invalid semantic replacement leaving previous state intact;
-- embedding failure leaving the previous semantic generation intact;
+- hard metadata/phrase constraints **before** semantic top-K;
 - canonical transcript changes invalidating stale semantic vectors;
+- semantic/hybrid search refusing stale generations;
 - lexical search remaining available without semantic capability;
+- failed semantic rebuild preserving prior valid state; and
 - a non-E5 fake provider satisfying the application-level `EmbeddingProvider` contract.
 
-The last case matters for architecture: the library core is provider-agnostic even
-though the normal CLI currently qualifies one concrete local E5 profile.
+That final case proves something architectural but limited:
 
-## Mutation testing
+> The library core is provider-agnostic.
 
-Run the dedicated manual workflow:
+It does **not** prove that arbitrary embedding models are mathematically interchangeable.
+The normal CLI still qualifies one concrete local E5 profile because dimensions,
+pooling, normalization, transforms, and distance semantics are load-bearing.
+
+## Rank provenance tests
+
+Search presentation must not manufacture relevance provenance.
+
+Qualification should preserve distinctions such as:
+
+- lexical-only relevance sorting can carry lexical rank;
+- timeline-sorted lexical presentation must not pretend chronological order is BM25
+  relevance rank;
+- semantic-only results carry semantic rank but no fused rank; and
+- hybrid results may carry lexical, semantic, and fused ranks as applicable.
+
+A presentation reorder is allowed. Rewriting the stored provenance to match the display
+order is not.
+
+## Mutation testing: ask the bad edits on purpose 💃
+
+The dedicated manual workflow is:
 
 ```text
 .github/workflows/mutation-library.yml
 ```
 
-It establishes a focused semantic-library baseline and asks Poodle to mutate:
+It establishes a focused baseline and asks Poodle to mutate:
 
 ```text
 src/echoflow/library/semantic.py
@@ -83,23 +153,30 @@ src/echoflow/library/retrieval.py
 src/echoflow/library/service.py
 ```
 
-The mutations we care about include:
+The mutation hypotheses we care about include:
 
 - changing chunk boundary comparisons;
+- synthetically splitting source segments;
+- dropping canonical hashes from corpus fingerprints;
 - accepting stale corpus fingerprints;
-- weakening vector dimension/normalization checks;
+- swapping query/passage prefixes;
+- weakening dimension/normalization checks;
 - applying filters after top-K;
 - changing RRF rank arithmetic;
-- claiming lexical/semantic/fused ranks when that retrieval path did not run;
+- claiming lexical/semantic/fused ranks when that path did not run;
+- allowing timeline presentation to overwrite relevance rank;
 - replacing semantic state after a failed build;
-- mixing incompatible embedding profiles;
-- turning a local-only model path into a network-capable resolution path.
+- mixing incompatible embedding profiles; and
+- turning strict-local model resolution into a network-capable path.
 
-Mutation testing remains a deliberate qualification tool, not a routine PR gate. Run it
-when these decisions change and inspect surviving mutations as evidence of a missing test
-contract.
+Mutation testing remains deliberate qualification, not a routine PR gate.
 
-## Feedback ladder for this capability
+Run it when these decisions change and inspect surviving mutants as evidence of a missing
+or weak contract.
+
+## Feedback ladder
+
+Start narrow, then widen:
 
 ```bash
 # Focused semantic/domain tests
@@ -121,5 +198,25 @@ uv run mypy
 uv run vulture
 ```
 
-The repository-wide branch-coverage gate remains 90%. A semantic change is not considered
-qualified merely because its focused tests pass if the full quality workflow is red.
+The repository-wide branch-coverage gate remains 90%.
+
+A semantic change is not qualified merely because its focused test file is green while
+the full quality workflow is red.
+
+## Why this much fuss for search?
+
+Because retrieval is becoming a research interface over user-owned evidence.
+
+A wrong search result is not the same as a corrupted transcript, but the product still
+needs to distinguish:
+
+- what evidence exists;
+- which projection generated a candidate;
+- which filters were applied;
+- whether the semantic state still corresponds to current canonical bytes; and
+- how a result earned its displayed rank.
+
+That is exactly the kind of decision surface where a cheerful green test suite can hide
+a very specific hole.
+
+Our job is to make the hole boringly hard to create. 🧜‍♀️

--- a/docs/development/testing-and-bisect.md
+++ b/docs/development/testing-and-bisect.md
@@ -1,4 +1,18 @@
-# Testing and regression bisection
+# Testing and regression bisection 🧪🦝
+
+EchoFlow has enough failure-sensitive logic that “the happy path passed” is not a
+satisfying definition of tested.
+
+The testing strategy therefore prefers **small deterministic oracles, explicit boundary
+cases, property invariants, and targeted mutation hypotheses** before expensive broad
+qualification.
+
+The question to keep asking is:
+
+> **If this comparator, Boolean, threshold, fallback, ordering decision, or cleanup path
+> were subtly wrong, which exact test would fail?**
+
+If the answer is “probably something somewhere,” strengthen the test contract.
 
 ## Colocation rule
 
@@ -13,150 +27,244 @@ src/echoflow/interfaces/local_file_manager.py
 src/echoflow/interfaces/tests/test_local_file_manager.py
 ```
 
-Repository-wide pytest configuration belongs in root `conftest.py`. Shared fixtures
-remain local to the narrowest package that needs them. Test packages are excluded from
-built distributions.
+Repository-wide pytest configuration belongs in root `conftest.py`.
+
+Shared fixtures stay at the narrowest package that needs them. Test packages are
+excluded from built distributions.
+
+This makes source-to-test navigation predictable without needing a test metadata system.
 
 ## Feedback ladder
 
-Use the smallest trustworthy oracle first, then widen it:
+Use the smallest trustworthy oracle first, then widen:
 
-1. One test node: `uv run pytest path/to/test.py::test_name`
-2. One capability suite: `uv run pytest path/to/test.py`
-3. One package suite: `uv run pytest src/echoflow/PACKAGE/tests`
-4. Most recent failures: `uv run pytest --last-failed`
-5. Full behavioral suite: `uv run pytest`
-6. Full branch coverage:
-   `uv run pytest --cov=echoflow --cov-branch --cov-report=term-missing`
-7. Static/metric gates: Ruff check/format, strict mypy, Vulture, and Radon.
-8. Targeted mutation scope for changed decision logic, followed by build, clean-wheel,
-   and lock verification.
+```text
+one test node
+    ↓
+one capability file
+    ↓
+one package suite
+    ↓
+last failures
+    ↓
+full behavioral suite
+    ↓
+full branch coverage
+    ↓
+static / complexity / dead-code gates
+    ↓
+targeted mutation qualification
+    ↓
+build + clean-wheel + lock verification
+```
 
-## Mutation anticipation rule
+Typical commands:
 
-Mutation testing should not be the first place EchoFlow discovers weak test contracts.
-For load-bearing decision logic, define plausible bad edits while designing ordinary
-tests and identify the exact test expected to kill each one.
+```bash
+uv run pytest path/to/test.py::test_name
+uv run pytest path/to/test.py
+uv run pytest src/echoflow/PACKAGE/tests
+uv run pytest --last-failed
+uv run pytest
+uv run pytest --cov=echoflow --cov-branch --cov-report=term-missing
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy
+uv run vulture
+uv run radon cc src/echoflow --total-average
+uv run radon mi src/echoflow
+```
 
-At minimum, review changed decision logic for:
+The narrow test should answer the local question. The wide suite should answer whether
+the change broke a contract you did not realize was adjacent.
 
-- boundary/operator changes such as `<` vs `<=`, `>` vs `>=`, `==` vs `!=`;
-- Boolean changes such as `and` vs `or`, removed `not`, or inverted predicates;
-- threshold/constant perturbations around zero, one, counts, sizes, durations,
-  percentages, schema versions, and resource limits;
-- arithmetic/accounting changes such as `+` vs `-`, omitted/double-counted terms,
-  integer rounding, or multipliers;
-- fallback mutations that silently downgrade/upgrade or choose another
-  provider/device/model;
-- fail-open mutations where exceptions, missing capability, malformed probes, or
-  uncertain security state become success;
-- ordering mutations around checkpoint, persistence, publish, cleanup, cancellation,
-  model-manifest commits, and provenance writes;
-- ownership/lifecycle mutations such as skipped cleanup, double cleanup, leaked
-  prefetched/derived work, or stale-state reuse;
-- resume/idempotence mutations that accept mismatched source, model, revision,
-  preprocessing, engine, version, or execution contract;
-- provenance/serialization mutations that omit or alter evidence needed to explain an
-  artifact; and
-- concurrency mutations such as increased prefetch depth, oversubscription, changed
-  worker counts, or out-of-order commits.
+## Mutation anticipation: think like a tiny malicious editor
 
-The preferred shape is explicit positive, negative, boundary, and failure-path coverage
-where the contract warrants it. Hypothesis is useful for invariants spanning many
-values, but named boundary cases remain valuable for safety decisions.
+Mutation testing should not be the first place EchoFlow discovers that tests are vague.
 
-The review question is:
+When changing load-bearing decision logic, enumerate plausible bad edits during test
+design.
 
-**if this comparator, Boolean, threshold, fallback, or ordering decision were subtly
-wrong, which exact test would fail?**
+### Comparator and boundary mutations
 
-If there is no clear answer, strengthen ordinary tests before asking Poodle to find the
-blind spot.
+Examples:
 
-Run Poodle only after deterministic tests are green and over the smallest relevant
-module set. Inspect survivors as evidence about test strength. Routine CI does not gate
-on mutation sweeps; use an available local/sandbox checkout or the manual workflow for
-deliberate qualification.
+- `<` ↔ `<=`;
+- `>` ↔ `>=`;
+- `==` ↔ `!=`;
+- zero/one/count/size/duration thresholds shifting by one; and
+- percentages or schema versions drifting across a boundary.
+
+Named tests should exist when the exact threshold is meaningful.
+
+### Boolean and fallback mutations
+
+Examples:
+
+- `and` ↔ `or`;
+- removed/inverted `not`;
+- missing capability becoming success;
+- an explicit strategy silently falling back;
+- a security uncertainty becoming fail-open; and
+- a provider/model/device being substituted without authorization.
+
+### Arithmetic/accounting mutations
+
+Examples:
+
+- `+` ↔ `-`;
+- double-counted or omitted memory/disk terms;
+- rounding changes; and
+- altered multipliers.
+
+These matter especially in resource/storage admission.
+
+### Ordering and lifecycle mutations
+
+Examples:
+
+- manifest committed before provider verification;
+- checkpoint committed after work is exposed as resumable;
+- publish/cleanup ordering reversed;
+- speculative prefetched work leaked;
+- derived audio not removed after failure; and
+- cleanup error masking the primary exception.
+
+### Resume/provenance mutations
+
+Examples:
+
+- mismatched source accepted;
+- model revision changed;
+- preprocessing changed halfway through a job;
+- engine/runtime version mismatch ignored;
+- execution target changed silently; and
+- evidence/provenance fields omitted from durable artifacts.
+
+### Concurrency mutations
+
+Examples:
+
+- prefetch depth increased beyond the admitted bound;
+- worker count oversubscribed;
+- future work committed out of order; and
+- cleanup races leave unowned files behind.
+
+💃 Mutation testing is not chaos testing. It is asking whether the test suite notices
+plausible wrong code decisions.
+
+## Hypothesis where the invariant spans many values
+
+Property tests are particularly useful when the contract is easier to state than to
+cover with examples.
+
+Current semantic chunking is a good example: every generated source segment must appear
+exactly once and in order regardless of word-count/profile combinations.
+
+Named boundary cases remain valuable even when Hypothesis could generate them. A reader
+should be able to see why a specific threshold is invalid without waiting for a
+property-based failure seed.
 
 ## Model-custody mutation hypotheses
 
-For model-management and the ASR planning/execution boundary, tests should kill at
-least these plausible bad edits when the related logic changes:
+When model-management or ASR custody changes, tests should kill bad edits such as:
 
-- failed structural verification is treated as managed;
-- a manifest points outside EchoFlow's model cache;
-- repository identity can be substituted while required files still look valid;
-- recorded revision and snapshot directory disagree;
-- requested revision is silently replaced by another provider revision;
-- insufficient disk is admitted before acquisition;
-- manifest commit happens before provider verification completes;
-- removal deletes the manifest before provider deletion succeeds;
-- external deletion leaves a stale manifest reported as usable;
-- a transcription plan accepts an unmanaged/ambient cache entry;
-- a managed revision is replaced by a configuration override;
-- faster-whisper execution changes `local_files_only=True` to a network-capable path;
-  or
-- model/repository/revision/verification provenance is omitted.
+- failed structural verification treated as managed;
+- manifest path escaping EchoFlow's model cache;
+- provider repository identity substituted;
+- recorded revision/snapshot path disagreeing;
+- requested revision silently replaced;
+- insufficient disk admitted before acquisition;
+- manifest committed before verification;
+- removal deleting the manifest before provider deletion succeeds;
+- external model deletion leaving a stale manifest reported usable;
+- transcription planning accepting an unmanaged ambient cache entry;
+- configuration overriding managed revision identity;
+- faster-whisper changing from `local_files_only=True` to network-capable resolution; or
+- model/repository/revision/verification provenance disappearing.
 
-The pre-production current contract has **no ASR transcription-time download fallback**.
-A test expecting that old compatibility behavior should be rewritten or removed rather
-than forcing production code to preserve it.
+There is no ASR transcription-time download fallback in the current pre-production
+contract. Tests should not preserve obsolete behavior merely because an earlier branch
+once had it.
 
 ## Enhancement mutation hypotheses
 
-For optional speech noise suppression, tests should kill:
+When optional speech enhancement changes, tests should kill:
 
-- `off` invokes the enhancer;
-- `on` skips enhancement or silently falls back to raw audio after a provider failure;
-- ASR consumes raw audio after enhancement succeeded;
-- diarization consumes enhanced audio in the current v1 contract;
-- provider or parameters can change without checkpoint incompatibility;
-- enhanced full-recording storage is omitted or double-counted;
-- channel/sample-width/sample-rate/frame-count validation is weakened or inverted;
-- partial enhanced output survives a failed transform;
-- cleanup is skipped, duplicated unsafely, or masks the primary error;
-- provider/version/operation/parameters disappear from transcript provenance;
-- enhancement modifies the original recording;
-- enhanced audio becomes a public artifact without an explicit export contract; or
-- a future model-backed enhancer bypasses model-management custody.
+- `off` invoking enhancement;
+- `on` skipping enhancement;
+- explicit enhancement failure silently falling back to raw audio;
+- ASR reading raw audio after enhancement succeeded;
+- diarization reading enhanced audio in the current v1 contract;
+- provider/parameters changing without checkpoint incompatibility;
+- enhanced full-recording storage omitted or double-counted;
+- channel/sample-width/sample-rate/frame validation weakened;
+- partial enhanced output surviving failure;
+- cleanup skipped/duplicated/masking the primary error;
+- provenance disappearing;
+- original recording modified; or
+- a future model-backed enhancer bypassing model custody.
 
-Tests should compare paths and ownership explicitly. “Enhancer was called” is not enough
-to prove ASR used its output or that diarization retained the raw canonical decode.
+“Enhancer was called” is not enough. Tests should prove **which path ASR actually
+consumed** and which path diarization retained.
+
+## Semantic/search mutation hypotheses
+
+When transcript-library retrieval changes, ask whether tests would notice:
+
+- stale semantic generations being accepted;
+- canonical hashes disappearing from the corpus fingerprint;
+- filters moving after top-K;
+- chunk boundaries dropping/duplicating canonical segments;
+- vector dimensions/normalization being accepted incorrectly;
+- query/passage transforms being swapped;
+- failed rebuild replacing valid semantic state;
+- RRF arithmetic changing;
+- timeline presentation overwriting relevance provenance; or
+- local-only embedding restoration becoming network-capable.
+
+See [semantic-retrieval-testing.md](semantic-retrieval-testing.md) for the focused matrix.
 
 ## Pre-production schema rule
 
 EchoFlow currently has no released/dogfooded durable-schema compatibility obligation.
-Tests protect **one current job-plan, checkpoint, and canonical-transcript contract**.
-Do not retain old schema branches solely because an earlier PR once emitted them during
-development.
 
-When a real compatibility boundary exists, migration tests should be added against
-actual persisted fixtures from that boundary. Until then, deleting obsolete
-pre-production branches is preferable to multiplying migration paths nobody uses.
+Tests protect **one current job-plan, checkpoint, and canonical-transcript contract**.
+
+Do not retain obsolete pre-production branches solely because an earlier PR once emitted
+them.
+
+When a real compatibility boundary exists, add migration tests against actual persisted
+fixtures from that boundary.
+
+Until then, deleting unused compatibility scaffolding is usually safer than maintaining
+fictional history.
 
 ## Sandbox readiness
 
-A sandbox can run repository-local tools only when it actually has an EchoFlow
-checkout. The repository cannot force an external execution environment to mount that
-checkout, so every coding session verifies workspace availability before claiming local
-mutation capability.
+A sandbox can run repository-local tools only when an EchoFlow checkout is actually
+mounted.
 
-When a checkout exists, prepare it with:
+When a checkout exists:
 
 ```bash
 python scripts/prepare_dev_environment.py
 ```
 
-This performs a locked development sync and verifies Poodle is runnable. If the
-checkout is absent, use the connected GitHub repository for inspection and the manual
-mutation workflow for qualification rather than making per-commit mutation CI a
-substitute for a local workspace.
+This performs a locked development sync and verifies Poodle availability.
+
+If the checkout is absent, inspect through the connected repository and use the manual
+mutation workflow instead of pretending a local mutation run happened.
+
+The environment is allowed to have boundaries. The documentation must tell the truth
+about them. 🧜‍♀️
 
 ## Git bisect
 
-A bisect oracle must be deterministic, noninteractive, and narrow enough to run
-repeatedly. Start from a known bad revision and a known good revision, then let Git
-invoke the smallest test proving the regression:
+A bisect oracle must be deterministic, noninteractive, and narrow enough to run many
+times.
+
+Start from known bad/good revisions and use the smallest test proving the regression:
 
 ```bash
 git bisect start BAD GOOD
@@ -165,17 +273,30 @@ git bisect reset
 ```
 
 Use a package/full-suite oracle only when a smaller contract cannot reproduce the
-failure. A test depending on network access, mutable model cache, wall-clock timing, or
-mutable user state is not a valid bisect oracle until those inputs are controlled.
+failure.
+
+A test that depends on network access, mutable model cache, wall-clock timing, or mutable
+user state is not a trustworthy bisect oracle until those inputs are controlled.
 
 Model acquisition tests should fake the provider boundary. Enhancement-provider tests
-should fake subprocess behavior or use intentionally generated local audio when the
-native-media boundary itself is under test.
+should fake subprocess behavior or use generated local audio only when the native media
+boundary itself is the subject.
 
 ## Source-to-test navigation
 
-The path convention is the primary index: changed production files and their tests
-share a package. `rg`, `pytest --collect-only`, coverage, and Git's changed-file list
-cover current navigation needs. Static test-to-symbol mapping can use Python `ast`
-later if repository scale justifies it. Tree-sitter would not improve Git bisect,
-pytest collection, or Python-only symbol parsing today.
+The path convention is the primary index: changed production files and their tests share
+a package.
+
+`rg`, `pytest --collect-only`, coverage, and Git's changed-file list cover current
+navigation needs.
+
+Static test-to-symbol mapping can use Python `ast` later if repository scale justifies
+it. Tree-sitter would not improve Git bisect, pytest collection, or Python-only symbol
+parsing today.
+
+## The stable testing rule
+
+**Make the smallest important wrong decision fail loudly. Then widen the evidence.**
+
+That is much more useful than admiring a large green test count while one load-bearing
+branch quietly has no witness. 🦝

--- a/docs/documentation-style.md
+++ b/docs/documentation-style.md
@@ -1,0 +1,234 @@
+# EchoFlow documentation voice 🦝🧜‍♀️✨
+
+EchoFlow documentation should be **rigorous enough to maintain and pleasant enough to
+finish reading**.
+
+The project deals with privacy, provenance, media pipelines, model custody, recovery,
+search, and security. Those subjects deserve precision. They do not require the prose to
+sound like drywall.
+
+This guide exists so future documentation changes preserve one recognizable voice
+without turning every page into a novelty README.
+
+## The governing rule
+
+**Personality may decorate or clarify a contract. It may not replace one.**
+
+If a sentence controls deletion, privacy, security, provenance, compatibility, recovery,
+or failure behavior, state the exact rule plainly. A joke can follow it. The joke may
+not be the only way to discover what the software does.
+
+Good:
+
+> Semantic vectors are rebuildable derived state. Deleting them must not delete the
+> canonical transcript or future user-authored annotations.
+>
+> The raccoon may rebuild the index. The raccoon may not eat your notes.
+
+Bad:
+
+> 🦝 Don't worry babe, the vibes are immutable.
+
+That is charming and operationally useless.
+
+## Three registers
+
+### 💃 1. Human-facing guides: high personality
+
+Examples:
+
+- `docs/README.md`
+- `docs/getting-started.md`
+- `docs/semantic-search.md`
+- future guides for speakers, noisy audio, search, recovery, and privacy
+
+These documents should:
+
+- begin with what the user is trying to accomplish;
+- explain unfamiliar terms before using them as shorthand;
+- use examples drawn from real recordings, interviews, meetings, lectures, and research;
+- use occasional playful headings, raccoons, mermaids, dancing women, stars, or other
+  visual punctuation;
+- prefer diagrams over long prose when the idea is structural; and
+- tell the reader *why* EchoFlow behaves a certain way, not merely which command exists.
+
+The user should not have to know what CTranslate2, BM25, RRF, a vector dimension, or a
+cgroup is unless they deliberately open the maintenance hatch.
+
+### 🧜‍♀️ 2. Architecture and development docs: medium personality
+
+These documents are for maintainers and technically curious readers.
+
+They may use exact terms such as `FLOAT[]`, `SearchResponse`, cgroup limits, immutable
+revisions, or reciprocal-rank fusion. They should still provide:
+
+1. a plain-English doorway;
+2. a visual model where one helps;
+3. the exact contract;
+4. failure and ownership semantics; and
+5. links to adjacent boundaries.
+
+A good architecture page should let a new contributor understand *why the boundary
+exists* before reading every implementation detail.
+
+### 🔐 3. Security, audit, schemas, and command contracts: low personality
+
+Security claims must remain auditable and literal.
+
+Light warmth or a memorable heading is fine. Decorative language must never obscure:
+
+- what is protected;
+- what is not protected;
+- what is local;
+- what may use the network;
+- what fails closed;
+- which threat actors remain out of scope; or
+- which advisory or dependency gate is active.
+
+Dated audit records are archival evidence. Do not retroactively rewrite them merely to
+match the current voice.
+
+## Recurring visual language
+
+Use motifs sparingly enough that they stay useful.
+
+- **🦝 Raccoon**: rebuildable machinery, caches, indexes, internal floorboards, or a
+  memorable explanation of what can safely be regenerated.
+- **💃 Dancing woman**: orchestration, bringing multiple components together, or a
+  celebratory transition after a successful workflow.
+- **🧜‍♀️ Mermaid**: occasional decorative interruption, especially around diagrams or
+  deep technical water. It does not need to represent a service.
+- **✨ Sparkles**: optional/enhanced capability, reveal, or conceptual payoff.
+- **🔐 Lock**: actual privacy/security boundary, not generic decoration.
+
+Do not put emoji into every diagram node simply because Mermaid and mermaid sound alike.
+The diagram should communicate structure first.
+
+## Mermaid diagrams: make the color mean something
+
+Black-and-white diagrams are valid but should not be the automatic default when color
+can explain ownership or lifecycle.
+
+Prefer a small semantic palette. For example:
+
+```mermaid
+flowchart LR
+    A[Original recording] --> B[Canonical transcript]
+    B --> C[Derived search state]
+    C --> D[Search result]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A,B evidence
+    class C derived
+    class D result
+```
+
+Suggested meanings:
+
+| Treatment | Meaning |
+|---|---|
+| warm pink | user-owned / authoritative evidence |
+| blue | compute, machine capability, or rebuildable infrastructure |
+| lavender | processing / enrichment |
+| gold | canonical publication / provenance |
+| green | result, success, or user-facing retrieval |
+| red | failure, refusal, stale state, or safety gate |
+
+Exact hex values may evolve. Consistency matters more than color-brand perfection.
+
+Diagrams must still be understandable from their labels and surrounding prose for
+readers who cannot distinguish the colors.
+
+## Jargon has to earn rent
+
+Write the ordinary-language concept first, then name the technical mechanism.
+
+Instead of:
+
+> `DuckDbSemanticIndex` stores vectors as `FLOAT[]` rather than BLOBs.
+
+Prefer:
+
+> EchoFlow keeps semantic vectors as numeric data that the search backend can inspect
+> directly. In the current DuckDB adapter, those vectors are stored as `FLOAT[]` rather
+> than opaque BLOBs.
+
+Nothing became less precise. The reader simply got a staircase instead of a trapdoor.
+
+## Explain the benefit before the mechanism
+
+For user-facing docs, prefer this order:
+
+1. **What problem does this solve?**
+2. **What does the user experience?**
+3. **What stays private / authoritative?**
+4. **How do I use it?**
+5. **How does it work?**
+6. **What are the current limits?**
+7. **Where is the deep architecture reference?**
+
+Architecture docs can invert steps 4 and 5, but should still start with purpose.
+
+## Humor should help memory
+
+A joke earns its place when it:
+
+- makes a distinction memorable;
+- relieves a dense transition;
+- gives a difficult concept a concrete mental model; or
+- makes the reader want to continue.
+
+It does not earn its place when it:
+
+- makes an error ambiguous;
+- trivializes a security or privacy failure;
+- appears in every paragraph;
+- relies on an in-group reference to understand the technical point; or
+- sounds like a corporate account trying to impersonate a person.
+
+Camp needs negative space.
+
+## Searchability still matters
+
+Playful headings should retain descriptive nouns whenever possible.
+
+Good:
+
+- `## 🦝 What lives under the floorboards? Rebuildable search state`
+- `## 💃 Bringing the ranks together: hybrid retrieval`
+- `## 🔐 Privacy boundary`
+
+Less useful:
+
+- `## She has arrived`
+- `## The girls are fighting`
+
+The latter may be funny in prose. They are poor anchors for someone searching a repo.
+
+## Accessibility
+
+- Emoji supplements text; it does not replace meaning.
+- Diagrams receive surrounding prose.
+- Color is never the only carrier of state.
+- Commands and identifiers remain copyable and exact.
+- Avoid joke-heavy error examples that obscure the real failure message.
+- Prefer headings that remain meaningful to screen-reader and search users.
+
+## The desired reader experience
+
+A reader should be able to enter EchoFlow knowing almost nothing about local ML and
+leave understanding:
+
+- what the application does;
+- what happens to their recording;
+- which artifacts are authoritative;
+- what can safely be rebuilt;
+- what stays local;
+- how to resume and search work; and
+- where to go when they want the exact engineering contract.
+
+If they accidentally learn a little systems architecture while a scholarly raccoon
+points at a provenance table, that is considered a feature.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,12 +1,47 @@
-# Getting started with EchoFlow
+# Getting started with EchoFlow 💃
 
-EchoFlow keeps recording, transcription, and search work on your computer. The original
-recording is treated as read-only input. The main transcript is portable canonical JSON;
-TXT/SRT/VTT and search databases are derived views that can be regenerated.
+This is the **use-the-thing** guide.
+
+You do not need to understand the architecture to follow it. EchoFlow will make several
+technical decisions for you, including what resources are safely available, which local
+transcription strategy fits, where private working state belongs, and how completed work
+can be resumed or searched later.
+
+If you want the tour first, visit **[Welcome to EchoFlow](README.md)**.
+
+## Before we begin
+
+EchoFlow is still pre-production. There is no polished desktop installer yet, so the
+current path uses Python 3.12, `uv`, and the command line.
+
+The workflow itself is local-first:
+
+```mermaid
+flowchart LR
+    A[Your recording] --> B[Inspect source + computer]
+    B --> C[Choose a safe local plan]
+    C --> D[Transcribe]
+    D --> E[Canonical transcript]
+    E --> F[Exports]
+    E --> G[Private local search]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef publish fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A evidence
+    class B,C compute
+    class D process
+    class E,F publish
+    class G result
+```
+
+The original recording is treated as read-only input. EchoFlow writes working files,
+checkpoints, transcripts, exports, and search state separately.
 
 ## 1. Install the source build
-
-EchoFlow is pre-production and does not publish end-user installers yet.
 
 ```bash
 git clone https://github.com/SSD1805/EchoFlow.git
@@ -14,52 +49,142 @@ cd EchoFlow
 uv sync --locked --extra transcription
 ```
 
-Initialize private application directories and inspect the machine:
+Initialize EchoFlow's private application directories:
 
 ```bash
 uv run echoflow init
+```
+
+Then ask EchoFlow to inspect the machine:
+
+```bash
 uv run echoflow doctor
 uv run echoflow runner
 ```
 
-## 2. See which transcription model fits
+`doctor` checks important local dependencies and configuration. `runner` shows the
+compute and memory EchoFlow can actually use.
+
+You do **not** need to manually translate that into “therefore I should use four threads,
+CUDA device zero, and model X.” That is application work.
+
+## 2. Install a transcription model
+
+Ask EchoFlow which managed model currently fits the machine and processing policy:
 
 ```bash
 uv run echoflow models recommend
 ```
 
-Install the recommended managed model before transcription:
+Then install the model you intend to use. For example:
 
 ```bash
 uv run echoflow models install small
 ```
 
-Model installation is explicit because it is a network-bearing action. Transcription
-itself does not silently download ASR weights.
+### Why is installation a separate step?
 
-## 3. Transcribe a recording
+Because downloading model weights is a network-bearing action.
 
-Inspect the plan without starting recognition:
+EchoFlow makes that boundary explicit instead of quietly reaching out to the internet
+when you start transcription. Once a verified managed model is present locally,
+transcription uses that local immutable revision.
+
+🦝 **Raccoon translation:** downloading the toolbox and using the toolbox are different
+things. EchoFlow does not pretend otherwise.
+
+## 3. Inspect a recording before doing the work
+
+A dry run tells EchoFlow to inspect the media and machine and build a plan without
+starting recognition:
 
 ```bash
 uv run echoflow transcribe interview.m4a --dry-run
 ```
 
-Then transcribe:
+This is useful when you want to see which strategy, model, stream, storage estimate, and
+resource budget would be used before committing to a long run.
+
+For machine-readable output:
+
+```bash
+uv run echoflow transcribe interview.m4a --dry-run --json
+```
+
+## 4. Transcribe locally
 
 ```bash
 uv run echoflow transcribe interview.m4a
 ```
 
-Optional derived exports:
+EchoFlow may need to decode or normalize the selected audio stream into a deterministic
+working format. That working audio is private derived state. Your original recording is
+not overwritten.
+
+The durable transcript is canonical JSON. If you also want ordinary reading/subtitle
+formats:
 
 ```bash
-uv run echoflow transcribe interview.m4a --export txt --export srt
+uv run echoflow transcribe interview.m4a --export txt --export srt --export vtt
 ```
 
-## 4. Search completed transcripts
+TXT, SRT, and WebVTT are publication views. They can be regenerated from canonical JSON
+without running speech recognition again.
 
-Build the private lexical library:
+## 5. If something interrupts the job
+
+Long recordings and laptops occasionally have opinions.
+
+When a job has durable checkpoints, resume it with the original input and the job ID:
+
+```bash
+uv run echoflow transcribe interview.m4a --resume JOB_ID
+```
+
+Resume is deliberately conservative. EchoFlow rechecks source identity and current
+resources and restores the original execution contract rather than silently switching
+models, streams, or preprocessing halfway through the evidence trail.
+
+## 6. Optional: clean up a noisy recording
+
+You can explicitly ask EchoFlow to apply its current deterministic local FFmpeg noise
+suppression before ASR:
+
+```bash
+uv run echoflow transcribe noisy-interview.wav --enhance
+```
+
+Enhancement is off by default. The processed audio remains private working material and
+does not replace the source recording.
+
+EchoFlow also verifies that preprocessing did not alter the frame count/sample rate or
+otherwise shift the timeline it uses for transcript timestamps.
+
+For the engineering contract, see
+**[Local speech enhancement](architecture/speech-enhancement.md)**.
+
+## 7. Optional: anonymous speakers
+
+The intended CLI surface is:
+
+```bash
+uv run echoflow transcribe focus-group.wav --diarize
+```
+
+Diarization uses anonymous recording-scoped labels such as `speaker-01` and
+`speaker-02`. EchoFlow does not treat them as biometric identities or link them across
+recordings.
+
+**Current limitation:** the integrated pyannote path is held behind a dependency security
+gate while the locked Lightning version is affected by a compensated advisory. While
+that gate is active, EchoFlow refuses diarization before model execution/acquisition.
+
+See **[Anonymous speaker diarization](architecture/diarization.md)** and
+**[SECURITY.md](../SECURITY.md)** for the exact boundary.
+
+## 8. Build your local transcript library 🔎
+
+Once you have completed canonical transcripts, build the private lexical library:
 
 ```bash
 uv run echoflow library rebuild
@@ -71,7 +196,7 @@ Search it:
 uv run echoflow library search "housing insecurity"
 ```
 
-Filter by available transcript evidence:
+Filter by evidence when you know more about what you want:
 
 ```bash
 uv run echoflow library search \
@@ -80,149 +205,99 @@ uv run echoflow library search \
   --language en
 ```
 
-Inspect where one transcript came from:
+Inspect one transcript's evidence receipt:
 
 ```bash
 uv run echoflow library show JOB_ID
 ```
 
-## What EchoFlow stores
+The search database is a rebuildable projection. The canonical transcript remains the
+authoritative artifact.
 
-```mermaid
-flowchart LR
-    A[🎙️ Your recording] -->|read only| B[EchoFlow processing]
-    B --> C[Private temporary state]
-    B --> D[📜 Canonical transcript JSON]
-    D --> E[TXT / SRT / VTT]
-    D --> F[Private lexical index]
-    D --> G[✨ Optional private semantic index]
-    A -. never overwritten .-> A
-```
+## 9. Optional: search by meaning, not only matching words ✨
 
-The important distinction is ownership:
+Lexical search is excellent when the transcript contains the words you remember.
+Semantic search helps when you remember the idea but not the wording.
 
-- **Your recording**: source evidence, never overwritten by EchoFlow.
-- **Canonical transcript JSON**: authoritative transcript artifact.
-- **TXT/SRT/VTT**: derived publication formats.
-- **DuckDB indexes**: private rebuildable search state.
-
-Deleting a search index should not delete transcript evidence.
-
-## 5. Optional semantic and hybrid search
-
-Lexical search finds the words you typed. Semantic search can also find passages with a
-similar meaning, even when they use different wording.
-
-For example, a search for:
+A query like:
 
 ```text
 people struggling to afford housing
 ```
 
-may help surface a transcript passage such as:
+may help surface:
 
 ```text
 I was spending almost seventy percent of my pay on the apartment.
 ```
 
-The words differ, but the idea is related.
+Those sentences share little vocabulary, but they express a related idea.
 
-EchoFlow does this with a **local sentence-embedding model**. The model converts your
-query and transcript passages into small numeric vectors that can be compared for
-similarity. EchoFlow still returns the original transcript passage with timestamps,
-speaker/language evidence, and canonical-source provenance.
+EchoFlow's current semantic foundation uses a local sentence-embedding model and private
+rebuildable vectors. Search results still return original transcript passages with their
+evidence coordinates.
+
+### Is this sent to a hosted AI service?
+
+Not during semantic indexing or search in the current implementation.
+
+The embedding provider loads from a local immutable model snapshot. Acquiring model
+weights is a separate network-bearing action.
+
+### Is semantic search part of the normal install yet?
+
+Not quite.
+
+The locked project dependency graph does not yet include Sentence Transformers, so the
+semantic path currently expects an environment that already supplies a compatible local
+runtime and Multilingual E5 Small snapshot. Lexical search works without any of this.
+
+If you want the full explanation without being thrown into vector-storage internals,
+read **[Semantic search, without the mystery box](semantic-search.md)**.
+
+## What EchoFlow stores 🦝
 
 ```mermaid
 flowchart LR
-    Q[🔎 Search phrase] --> L[Exact words<br/>BM25]
-    Q --> S[Related meaning<br/>local embeddings]
-    L --> H[💃 Hybrid ranking]
-    S --> H
-    H --> E[📜 Evidence-bearing passages]
+    A[Original recording] -->|read only| B[Canonical transcript]
+    B --> C[TXT / SRT / VTT]
+    B --> D[Lexical search state]
+    B --> E[Optional semantic search state]
+    A --> F[Private working audio + checkpoints]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef work fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+
+    class A,B evidence
+    class C,D,E derived
+    class F work
 ```
 
-Semantic search is **optional**. Lexical search remains the default and has no semantic
-model requirement.
+The useful distinction is not “database versus file.” It is **can this be reconstructed
+without losing something the user authored or relied on as evidence?**
 
-### Privacy boundary
+- The original recording is source evidence.
+- Canonical transcript JSON is the authoritative transcript artifact.
+- Future notes/tags/annotations are user-authored state and must not be treated as cache.
+- TXT/SRT/VTT and search indexes are derived and rebuildable.
+- Working audio and most execution material are private processing state.
 
-Semantic indexing and search run locally. EchoFlow loads the embedding model from a
-local immutable snapshot and does not send transcript passages to a hosted embedding
-API.
+Delete a search index? Rebuild her.
 
-Obtaining a model is a separate concern. Downloading a model from a provider such as
-Hugging Face may require network access, but building/searching the semantic index from
-a model already present locally does not.
+Delete the only canonical transcript or a future annotation? That is data loss.
 
-The repository does not bundle model weights.
+## Where do I go when I want more detail?
 
-### Why Multilingual E5 Small?
+**[docs/README.md](README.md)** is the documentation lobby.
 
-EchoFlow's first qualified semantic profile is
-`intfloat/multilingual-e5-small`.
+The **[architecture index](architecture/README.md)** is the maintenance hatch for
+contributors and technically curious readers. It covers resource admission, media and
+timeline semantics, model custody, diarization, enhancement, checkpoints, and search in
+exact terms.
 
-It is a conservative local default because it gives EchoFlow multilingual retrieval,
-compact 384-dimensional vectors, explicit retrieval-oriented query/passage semantics,
-and a comparatively lightweight local execution profile.
+The **[security policy](../SECURITY.md)** defines what “local-first” protects and what it
+does not claim.
 
-The model is not treated as permanent product truth. EchoFlow records an immutable
-embedding profile so a future model can rebuild the derived semantic projection without
-changing canonical transcripts.
-
-The locked project dependency graph does not yet include Sentence Transformers. Until a
-semantic dependency tranche is resolved and audited, this capability requires an
-environment that already supplies a compatible `sentence_transformers` runtime and a
-local immutable Multilingual E5 Small snapshot.
-
-Build the private semantic index:
-
-```bash
-uv run echoflow library embeddings build \
-  /path/to/models--intfloat--multilingual-e5-small/snapshots/<revision> \
-  --revision <revision>
-```
-
-Inspect what was indexed:
-
-```bash
-uv run echoflow library embeddings
-```
-
-Semantic retrieval:
-
-```bash
-uv run echoflow library search \
-  "people struggling to make rent" \
-  --mode semantic
-```
-
-Hybrid lexical + semantic retrieval:
-
-```bash
-uv run echoflow library search \
-  "people struggling to make rent" \
-  --mode hybrid
-```
-
-For the plain-language explanation of embeddings, privacy, model custody, and future
-provider interoperability, see [`semantic-search.md`](semantic-search.md).
-
-## How search results stay tied to evidence
-
-```mermaid
-flowchart TD
-    Q[SearchQuery] --> L[BM25]
-    Q --> S[Optional multilingual E5]
-    L --> R[Ranked lexical evidence]
-    S --> V[Ranked semantic chunks]
-    R --> H[Optional RRF hybrid rank]
-    V --> H
-    H --> E[Segments + timestamps + speaker/language + canonical source]
-```
-
-Semantic chunks are retrieval windows, not replacement transcript text. Each window
-points to the exact canonical segment IDs and source-relative time range from which it
-was built.
-
-For the full architecture, see
-[`architecture/corpus-search.md`](architecture/corpus-search.md).
+And if the documentation suddenly starts discussing `FLOAT[]`, cgroup ceilings, or RRF
+constants, you have probably wandered into the engine room. 🧜‍♀️

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -1,142 +1,221 @@
-# ✨ Semantic search, without the mystery box
+# Semantic search, without the mystery box ✨
 
-EchoFlow can search transcripts in two different ways.
+EchoFlow can search transcripts in three different ways.
 
-**Lexical search** looks for the words you typed. If you search for `rent increase`, it
-is very good at finding `rent increase`.
+**Lexical search** looks for the words you typed. Search for `rent increase`, and it is
+very good at finding passages containing those words.
 
-**Semantic search** looks for passages with a similar meaning. If you search for
-`people struggling to afford housing`, it can help find a passage such as:
+**Semantic search** looks for passages with a related meaning. Search for:
 
-> I was spending almost seventy percent of my pay on the apartment.
+```text
+people struggling to afford housing
+```
 
-The passage did not use the words *struggling to afford housing*, but it expresses a
-closely related idea.
+and it may help find:
 
-EchoFlow can also use **hybrid search**, which combines lexical and semantic results so
-exact terminology and conceptual similarity can support each other.
+```text
+I was spending almost seventy percent of my pay on the apartment.
+```
+
+The vocabulary differs, but the idea is related.
+
+**Hybrid search** lets exact terminology and conceptual similarity support each other.
 
 ```mermaid
 flowchart LR
-    Q[🔎 Your search] --> L[Exact words<br/>BM25]
-    Q --> S[Related meaning<br/>semantic embeddings]
-    L --> H[✨ Hybrid ranking]
+    Q[Your search] --> L[Exact words / BM25]
+    Q --> S[Related meaning / semantic embeddings]
+    L --> H[Hybrid rank fusion]
     S --> H
-    H --> E[📜 Transcript passages<br/>timestamps + speakers + source evidence]
+    H --> E[Transcript passages + evidence]
+
+    classDef query fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef lexical fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef semantic fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class Q query
+    class L lexical
+    class S,H semantic
+    class E result
 ```
 
-Semantic search is optional. Lexical search remains the default and does not require a
-semantic model.
+Semantic search is optional. Lexical search remains the default and requires no semantic
+model runtime.
 
 ## What is an embedding?
 
-An embedding is a numeric representation of text used for comparison. EchoFlow turns a
-search phrase and small transcript passages into vectors, then compares those vectors to
-find nearby meanings.
+An embedding is a numeric representation of text used for comparison.
 
-The vector is **derived search data**. It is not a replacement transcript, and it is not
-a generated summary of what somebody said.
+EchoFlow turns a search phrase and small transcript passages into vectors, then compares
+those vectors to find passages that sit near the query in the model's learned semantic
+space.
+
+The important thing for a user is what an embedding **is not**:
+
+- it is not a replacement transcript;
+- it is not a generated summary;
+- it is not a hosted database requirement; and
+- it is not the only place your transcript exists.
+
+The vector is **derived search data**.
 
 ```mermaid
 flowchart TD
     A[Canonical transcript passage] --> B[Local embedding model]
-    B --> C[384-number vector]
-    Q[Search phrase] --> D[Same local embedding model]
-    D --> E[384-number query vector]
-    C --> F[Local similarity comparison]
-    E --> F
-    F --> G[Original transcript passage]
+    Q[Search phrase] --> B
+    B --> C[Numeric vectors]
+    C --> D[Local similarity comparison]
+    D --> E[Original transcript passages]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A,Q evidence
+    class B,D process
+    class C derived
+    class E result
 ```
 
-The result EchoFlow shows is still the source passage, with transcript identity,
-segment coordinates, timestamps, language/speaker evidence, and retrieval provenance.
+EchoFlow's first qualified semantic profile produces 384-number vectors. Those numbers
+are useful because they let the application compare meaning efficiently. You are not
+expected to read them. Please do not spend your evening trying. 🧜‍♀️
 
 ## 💃 What happens when you turn semantic search on?
 
-EchoFlow creates a private, rebuildable semantic search index from your canonical
-transcripts.
+EchoFlow builds a private, rebuildable semantic projection from canonical transcripts.
 
-1. Adjacent transcript segments are combined into deterministic search windows.
-2. A local embedding model converts each window into a numeric vector.
-3. EchoFlow stores those vectors in a private DuckDB projection.
-4. Searches are embedded locally and compared with the stored vectors.
-5. Results point back to the canonical transcript segments that produced them.
+1. Adjacent canonical ASR segments are combined into deterministic search windows.
+2. A local embedding model converts each window into a vector.
+3. EchoFlow stores those vectors in a private DuckDB semantic index.
+4. Search queries are embedded locally with the same profile.
+5. The index compares the query vector with eligible local passage vectors.
+6. Results point back to the canonical transcript segments that produced them.
 
-Your original recording is not modified. Your canonical transcript remains the
+Your original recording is not modified. Canonical transcript JSON remains the
 user-owned evidence artifact.
-
-```mermaid
-flowchart LR
-    R[🎙️ Original recording] -->|read only| T[📜 Canonical transcript JSON]
-    T --> L[Lexical index]
-    T --> C[Deterministic chunks]
-    C --> M[Local embedding model]
-    M --> V[Private semantic vectors]
-    L --> S[Search]
-    V --> S
-    S --> P[Evidence-bearing passages]
-```
 
 ## 🔐 Does transcript text leave my computer?
 
-Not during semantic indexing or search.
+Not during semantic indexing or search in the current implementation.
 
-EchoFlow's semantic provider is loaded from a **local model snapshot**. Model loading is
-configured with local-only resolution and remote model code disabled. Transcript
-passages are embedded on the machine running EchoFlow.
+EchoFlow's semantic provider loads from a **local model snapshot**. Model loading is
+configured for local-only resolution with remote model code disabled.
 
-There are three different network/privacy questions worth separating:
+It helps to separate three different network/privacy questions:
 
-- **Searching/indexing transcripts:** local. Transcript text is not sent to a hosted
-  embedding API by this implementation.
-- **Obtaining a model:** may require a network connection if you choose to download a
-  model from somewhere such as Hugging Face. That acquisition step is separate from
-  transcript processing.
-- **Using a model already present locally:** offline. EchoFlow accepts the local immutable
-  snapshot path and does not resolve a repository ID while indexing/searching.
+### Searching or indexing transcripts
 
-EchoFlow does not currently bundle model weights in this repository. Shipping hundreds
-of megabytes of model data inside the source tree would make repository custody,
-updates, licensing, and installations worse.
+Local. Transcript passages are not sent to a hosted embedding API by this
+implementation.
+
+### Obtaining a model
+
+Potentially network-bearing. If you download model weights from a provider such as
+Hugging Face, that acquisition step uses the network.
+
+### Using a model already present locally
+
+Offline. EchoFlow accepts the local immutable snapshot path and does not resolve a
+repository ID while indexing/searching.
+
+That explicit boundary matters. “Uses a machine-learning model” does not automatically
+mean “uploads your transcript to somebody else's server.”
+
+## Why aren't the model weights inside the EchoFlow repository?
+
+Because model weights are large binary dependencies, not application source code.
+
+Vendoring them would make repository size, upgrades, licensing/distribution custody,
+caching, and independent model replacement worse.
+
+EchoFlow instead records the qualified profile/revision used to create semantic state.
 
 ## Why Multilingual E5 Small?
 
-EchoFlow's first qualified semantic profile is
-`intfloat/multilingual-e5-small`.
+The first qualified semantic profile is:
 
-It is used as a conservative local default because the profile gives EchoFlow a useful
-combination of:
+```text
+intfloat/multilingual-e5-small
+```
+
+It gives EchoFlow a conservative combination of:
 
 - multilingual retrieval rather than an English-only search space;
 - compact 384-dimensional vectors;
-- a retrieval-specific query/passage contract;
-- practical local inference compared with larger embedding families;
+- retrieval-specific query/passage instructions;
+- practical local inference compared with much larger embedding families; and
 - a mature Sentence Transformers-compatible execution path.
 
-The important product decision is not that this model is sacred. It is that **one
-semantic index generation uses one explicit, reproducible embedding profile**.
+The important product decision is **not** that this particular model is sacred.
 
-EchoFlow records the model ID, immutable revision, dimensions, normalization, pooling
-provenance, distance metric, query/passage transforms, and chunking profile. If the
-profile changes, the derived semantic index is rebuilt instead of silently mixing two
-vector spaces.
+The important decision is that one semantic index generation uses one explicit,
+reproducible embedding profile.
 
-## 🦝 What lives under the floorboards?
+> **The model is not sacred. The profile is.**
 
-Semantic search creates infrastructure, not new evidence.
+EchoFlow records model identity, immutable revision, dimensions, normalization, pooling,
+distance metric, query/passage transforms, embedding schema, and chunking profile.
 
-| Data | Role | Can EchoFlow rebuild it? |
+If the profile changes, the semantic projection is rebuilt instead of silently mixing
+incompatible vector spaces.
+
+## 🦝 What can the raccoon rebuild?
+
+Semantic search creates infrastructure, not new source evidence.
+
+| Data | Role | Rebuildable? |
 |---|---|---|
-| Original recording | source evidence | no |
-| Canonical transcript JSON | authoritative transcript | no |
-| Lexical term statistics | search projection | yes |
-| Semantic chunks | derived retrieval windows | yes |
-| Embedding vectors | derived search projection | yes |
-| Future notes/tags/annotations | user-authored state | **must not be treated as disposable** |
+| Original recording | source evidence | **No** |
+| Canonical transcript JSON | authoritative transcript | **No** |
+| Future notes/tags/annotations | user-authored knowledge | **No** |
+| Lexical term statistics | search projection | Yes |
+| Semantic chunks | derived retrieval windows | Yes |
+| Embedding vectors | derived search projection | Yes |
 
-If the semantic database disappears, EchoFlow should be able to rebuild it from the
-canonical transcripts. If an annotation disappears, that is data loss. Those are
-intentionally different custody classes.
+If the semantic database disappears, EchoFlow should be able to rebuild it from
+canonical transcripts.
+
+If a future annotation disappears, that is data loss.
+
+Those are intentionally different custody classes.
+
+## Why are transcript passages grouped into chunks?
+
+ASR segments are evidence coordinates, but some are tiny:
+
+```text
+Yeah.
+```
+
+or:
+
+```text
+And then we moved.
+```
+
+Embedding each tiny segment independently can discard useful context.
+
+EchoFlow therefore combines adjacent canonical segments into deterministic retrieval
+windows. Those chunks carry the IDs/timestamps of their source segments and can be
+recreated later.
+
+EchoFlow does not split one canonical ASR segment into invented evidence coordinates
+merely to hit a preferred chunk size.
+
+## What does hybrid search actually combine?
+
+BM25 lexical scores and semantic similarity scores are different mathematical things.
+EchoFlow does not pretend they share one universal “relevance percentage.”
+
+Hybrid mode instead combines **rank positions** with reciprocal rank fusion (RRF).
+
+That makes the composition simple, inspectable, and local.
+
+The deeper ranking contract is documented in
+**[architecture/corpus-search.md](architecture/corpus-search.md)**.
 
 ## Using semantic search
 
@@ -148,7 +227,9 @@ uv run echoflow library search "housing insecurity"
 ```
 
 The current semantic foundation expects a compatible Sentence Transformers runtime and
-a local immutable Multilingual E5 Small snapshot. Build the semantic projection with:
+a local immutable Multilingual E5 Small snapshot.
+
+Build semantic state:
 
 ```bash
 uv run echoflow library embeddings build \
@@ -171,7 +252,7 @@ uv run echoflow library search \
   --mode semantic
 ```
 
-Or combine semantic and lexical retrieval:
+Or combine lexical and semantic retrieval:
 
 ```bash
 uv run echoflow library search \
@@ -179,38 +260,46 @@ uv run echoflow library search \
   --mode hybrid
 ```
 
-## Advanced model interoperability
+## Why is semantic setup still an advanced path?
 
-EchoFlow's retrieval core is deliberately **provider-agnostic**. Search depends on an
-`EmbeddingProvider` contract with separate query and passage embedding operations, plus
-an immutable `EmbeddingProfile` describing the vector space.
+The locked project dependency graph does not yet include Sentence Transformers.
+
+That means the current semantic tranche proves the architecture and local retrieval
+contract without pretending the optional dependency/model acquisition story is already a
+qualified normal install.
+
+A later tranche can add:
+
+- an audited/locked semantic dependency extra;
+- managed acquisition of the qualified embedding snapshot;
+- disk/resource admission;
+- private model-cache placement; and
+- clean-wheel/platform qualification.
+
+Lexical search stays available regardless.
+
+## Advanced provider interoperability
+
+The retrieval core is provider-agnostic through `EmbeddingProvider` and
+`EmbeddingProfile` contracts.
 
 That means another local provider can be implemented without changing canonical
-transcripts, chunk custody, DuckDB semantic storage, hybrid ranking, or the public search
-response.
+transcripts, chunk custody, semantic storage, hybrid ranking, or public search results.
 
-EchoFlow does **not** currently expose “paste any Hugging Face repository ID” as a normal
-CLI option. Different embedding models may disagree about dimensions, normalization,
-pooling, query instructions, passage instructions, and distance semantics. Treating
-those models as drop-in equivalents would make reproducibility worse.
+EchoFlow does **not** currently expose “paste any Hugging Face repository ID and pray”
+as ordinary CLI configuration.
 
-The intended advanced extension is therefore **qualified interoperability**:
+Different embedding models may disagree about dimensions, normalization, pooling,
+query/passage instructions, and distance semantics. Treating them as drop-in equivalents
+would make reproducibility worse.
 
-```text
-EmbeddingProvider
-├── Multilingual E5 Small (current qualified default)
-├── future larger/local profiles
-├── future alternate Sentence Transformers profiles
-└── custom provider adapters that declare a complete EmbeddingProfile
-```
-
-A future advanced CLI/provider registry can expose additional profiles once EchoFlow can
-validate their complete retrieval contract rather than accepting an arbitrary model name
-and hoping its mathematics happen to match.
+Future interoperability should therefore be **qualified interoperability**: another
+provider declares and validates its complete profile, then builds a fresh semantic
+generation.
 
 ## What if a better model appears later?
 
-Nothing about the canonical transcript has to migrate.
+Nothing about canonical transcript evidence has to migrate.
 
 ```mermaid
 flowchart LR
@@ -218,10 +307,26 @@ flowchart LR
     T --> P2[Embedding profile v2]
     P1 --> V1[Old rebuildable vectors]
     P2 --> V2[New rebuildable vectors]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef profile fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+
+    class T evidence
+    class P1,P2 profile
+    class V1,V2 derived
 ```
 
-Because vectors are derived state, EchoFlow can discard the old semantic projection and
-rebuild it with a new qualified profile. Existing transcript evidence remains unchanged.
+Vectors are derived state. Rebuild them. Keep the evidence.
 
-For implementation details, provenance fields, RRF ranking, and stale-index detection,
-see [`architecture/corpus-search.md`](architecture/corpus-search.md).
+## 💃 What if I never turn semantic search on?
+
+Then EchoFlow continues to use lexical search.
+
+Your transcripts remain canonical. BM25 remains local. Nothing sulks.
+
+Semantic retrieval is an enhancement, not a tax every user must pay.
+
+For exact implementation details, stale-state detection, vector storage, provider
+validation, and RRF provenance, descend into
+**[Evidence-first corpus search](architecture/corpus-search.md)**.


### PR DESCRIPTION
## What changed

This PR turns the documentation from a mostly architecture-first reference set into a layered product/documentation experience.

### Human-facing front door

- rewrites the root README around what EchoFlow is, what it can already do, and the user journey
- adds `docs/README.md` as a documentation lobby with clear paths for users, security readers, maintainers, and test contributors
- rewrites `docs/getting-started.md` as the use-the-thing guide rather than opening with internal custody jargon
- refreshes `docs/semantic-search.md` so lexical/semantic/hybrid retrieval is understandable before the reader reaches vector-storage internals

### Documentation voice and visual language

- adds `docs/documentation-style.md`
- defines three registers: high-personality human guides, medium-personality architecture/development docs, low-personality security/audit contracts
- makes humor subordinate to exact contracts
- uses raccoons/mermaids/dancing women as occasional visual punctuation rather than filling every paragraph
- moves Mermaid diagrams toward semantic color palettes instead of emoji-heavy black-and-white boxes
- explicitly keeps dated security audit records archival rather than retroactively stylizing them

### Architecture maintenance hatch

Rewrites the architecture index and all current architecture pages so each starts with a plain-English purpose before descending into exact implementation contracts:

- adaptive heterogeneous execution
- corpus search
- anonymous speaker diarization
- media/timeline provenance
- model management
- processing capabilities
- speech enhancement

The underlying invariants stay explicit: source authority, canonical evidence, model custody, resource admission, fail-closed behavior, checkpoint ordering, rebuildable search state, and user-authored-state deletion semantics.

### Development docs

- adds a development-doc index
- refreshes benchmarking, semantic retrieval qualification, and testing/bisect docs
- keeps exact commands and mutation hypotheses while making the rationale easier to enter

### Roadmap / next evidence-navigation tranches

The roadmap now groups the substantial current foundation rather than presenting it as one giant capability list.

It also makes the likely next sequence explicit:

1. word/timestamp alignment
2. original-media timecode and capture-time provenance
3. better speaker overlap UX plus user-assigned display labels over stable anonymous speaker refs
4. later speech/source separation for genuinely overlapping speakers

The sequencing is intentional: alignment provides finer coordinates for speaker attribution, highlighting, annotations, and jump-to-audio; original-media time provenance adds parallel source clocks without redefining canonical elapsed time; speaker-label/overlap UX can then sit on better temporal evidence; source separation remains a heavier later capability with new model/provenance/compute questions.

## Why

EchoFlow's internals are increasingly designed so ordinary users do not need to understand cgroups, CTranslate2, immutable revisions, DuckDB, BM25, or vector spaces. The docs should expose that product in the same order.

The goal is not to make architecture unserious. It is to give readers stairs instead of trapdoors: user-visible promise → why the boundary exists → exact contract → failure/ownership semantics → current limits.

## Validation

- docs-only branch created from the current merged `main`
- compared against `main`: 18 documentation files changed/added; branch is 18 commits ahead and 0 behind at the time of review
- no production code or dependency files changed
- security policy and dated security audit remain unchanged/archival

Mermaid rendering and normal repository documentation/CI checks should be allowed to validate the final Markdown on the PR.