### PR TITLE
feat(transcription): add word-level timestamp alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ transcription service.
 
 The application does more than run a speech model. It inspects the machine it is running
 on, chooses a safe execution strategy, manages local model custody, survives interrupted
-work, preserves source provenance, publishes portable transcripts, and builds a private
-searchable library over completed recordings.
+work, preserves source provenance, publishes portable transcripts, keeps engine-produced
+word timing evidence, and builds a private searchable library over completed recordings.
 
 The original recording remains read-only input. Canonical transcript JSON is the
 authoritative transcript artifact. Working audio and search databases are derived state
@@ -35,14 +35,15 @@ part of the local recording lifecycle.
 | Local transcription | faster-whisper CPU/int8 and CUDA-capable strategies with explicit managed model revisions |
 | Hardware awareness | process-visible CPU/RAM, affinity/cgroup limits, accelerator topology, engine capability negotiation, and resource admission |
 | Media handling | FFprobe inspection, deterministic audio-stream selection, FFmpeg canonicalization, exact source-relative frame windows |
+| Word timing | native faster-whisper per-word timestamps validated, rebased to source-relative time, and preserved through resume |
 | Reliability | durable private checkpoints, validated resume, contiguous checkpoint ordering, bounded accelerated prefetch |
 | Languages | multilingual decoding plus conservative local text-language attribution |
-| Speakers | optional anonymous recording-scoped diarization, currently blocked when its locked dependency security gate is unsafe |
+| Speakers | optional anonymous recording-scoped diarization, with word-level projection when timing evidence exists; currently blocked when its locked dependency security gate is unsafe |
 | Difficult audio | optional deterministic local FFmpeg noise suppression with provenance and timeline-preservation checks |
 | Model custody | explicit inventory, recommendation, install, local revalidation, immutable revision pinning, and exact-revision removal |
 | Transcript output | canonical JSON plus deterministic TXT, SRT, and WebVTT derived views |
 | Search | private local BM25 lexical retrieval, optional semantic retrieval, and inspectable hybrid RRF ranking |
-| Evidence | source/canonical SHA-256, timestamps, speaker/language context, provenance, stale-index detection, and integrity receipts |
+| Evidence | source/canonical SHA-256, segment/word timestamps, speaker/language context, provenance, stale-index detection, and integrity receipts |
 | Portability | Linux, macOS, and Windows CI plus clean-wheel/package verification |
 
 The point of this list is not that users should learn every subsystem. It is that most
@@ -55,7 +56,7 @@ instead of homework.
 flowchart LR
     A[Original recording] --> B[Inspect source + machine]
     B --> C[Choose safe local strategy]
-    C --> D[Transcribe + checkpoint]
+    C --> D[Transcribe + word timing + checkpoint]
     D --> E[Canonical transcript]
     E --> F[TXT / SRT / WebVTT]
     E --> G[Lexical search]
@@ -133,6 +134,10 @@ Then transcribe locally:
 uv run echoflow transcribe interview.m4a
 ```
 
+The current faster-whisper execution path requests native word timestamps. EchoFlow
+validates and rebases those word intervals onto the same source-relative timeline as the
+canonical segment instead of running a second forced-alignment model.
+
 Add derived publication formats when useful:
 
 ```bash
@@ -152,8 +157,11 @@ uv run echoflow transcribe interview.m4a --resume JOB_ID
 ```
 
 Resume rechecks source identity and current resource admission. It does not silently
-change model revision, selected audio stream, enhancement contract, or execution target
-just to get moving again.
+change model revision, selected audio stream, enhancement contract, alignment contract,
+or execution target just to get moving again.
+
+Aligned word evidence already checkpointed for completed work is restored rather than
+recomputed under a potentially different execution contract.
 
 ## Optional noise suppression
 
@@ -182,10 +190,16 @@ uv run echoflow transcribe interview.wav --diarize
 Diarization produces anonymous recording-scoped labels such as `speaker-01`; it does not
 perform biometric identity or cross-recording speaker linking.
 
+When word timing evidence exists, EchoFlow can reconcile speaker turns at the word level.
+A word receives a speaker only when exactly one diarized speaker overlaps that word. A
+segment that crosses a speaker handoff therefore stays unlabeled at the segment level
+rather than being assigned to the wrong person.
+
 The current pyannote dependency path is **security-held** while its locked Lightning
 version is affected by a compensated advisory. EchoFlow fails closed before pyannote
 execution/model acquisition while that condition remains true. See
-**[Anonymous speaker diarization](docs/architecture/diarization.md)** and
+**[Anonymous speaker diarization](docs/architecture/diarization.md)**,
+**[Word-level timestamp alignment](docs/architecture/word-alignment.md)**, and
 **[SECURITY.md](SECURITY.md)**.
 
 ## Search your transcript library
@@ -216,6 +230,10 @@ Inspect one transcript's custody and source-integrity evidence:
 ```bash
 uv run echoflow library show JOB_ID
 ```
+
+Word timing does not change ranking semantics. The current library still indexes
+canonical segment text once; the finer coordinates are available for later precise
+highlighting, jump-to-audio, and annotation UX.
 
 ### ✨ Optional semantic and hybrid search
 
@@ -253,7 +271,7 @@ The custody boundary is intentionally simple:
 | Artifact | Role | Rebuildable? |
 |---|---|---|
 | Original recording | source evidence | **No** |
-| Canonical transcript JSON | authoritative transcript artifact | **No** |
+| Canonical transcript JSON, including word timing evidence | authoritative transcript artifact | **No** |
 | Future notes/tags/annotations | user-authored knowledge | **No** |
 | TXT/SRT/WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
@@ -276,6 +294,8 @@ The most important references are:
   for machine discovery, engine capability, strategy admission, and bounded overlap.
 - **[Media and timeline](docs/architecture/media-and-timeline.md)** for stream selection,
   canonical audio, and timestamp semantics.
+- **[Word-level timestamp alignment](docs/architecture/word-alignment.md)** for native
+  word timing, source-relative rebasing, checkpoint identity, and speaker handoffs.
 - **[Model management](docs/architecture/model-management.md)** for explicit acquisition,
   immutable revisions, and local custody.
 - **[Speech enhancement](docs/architecture/speech-enhancement.md)** for optional
@@ -308,10 +328,11 @@ The backend is broad enough that the next high-value work is increasingly about 
 evidence navigation and ordinary-user delivery rather than inventing another ASR
 pipeline.
 
-The likely sequence is **word/timestamp alignment**, then richer **original-media
-timecode/capture-time provenance**, then **better speaker overlap/display-label UX**.
-Source separation for overlapping speakers is a later, heavier capability once the
-simpler temporal evidence model is strong enough to support it.
+Word timing is now part of the current faster-whisper evidence path. The next sequence is
+**original-media timecode/capture-time provenance**, then **better speaker
+overlap/display-label UX**, then richer research-workspace behavior over those aligned
+coordinates. Source separation for overlapping speakers remains a later, heavier
+capability once the simpler temporal evidence model is strong enough to support it.
 
 Installers and a thin graphical interface remain important for non-developer adoption.
 They should sit on top of the same application services, not fork the product into a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,17 +53,23 @@ EchoFlow currently has:
 Performance ranks and memory estimates remain conservative heuristics pending
 representative-device qualification.
 
-### Media, timeline, and local preprocessing
+### Media, timeline, alignment, and local preprocessing
 
 The current media foundation includes:
 
 - FFprobe inspection with file-only protocol access and complete source SHA-256;
 - deterministic audio-stream selection;
 - FFmpeg canonicalization to mono 16 kHz PCM16 WAV when required;
-- exact integer-frame work windows and source-relative transcript timestamps;
+- exact integer-frame work windows and source-relative segment timestamps;
+- faster-whisper native per-word timestamp evidence rebased onto that same source
+  timeline;
 - optional deterministic FFmpeg noise suppression;
 - timeline-preservation checks around enhanced audio; and
 - provenance recording for preprocessing that affected ASR input.
+
+Word alignment is part of the current faster-whisper execution/checkpoint contract. It
+preserves engine-produced timing rather than claiming an independent forced-alignment
+pass.
 
 The original recording remains read-only evidence. Normalized/enhanced WAV files remain
 private derived processing material.
@@ -88,7 +94,8 @@ EchoFlow has:
 
 - durable private per-work-unit checkpoints;
 - validated resume;
-- source/model/stream/preprocessing/execution contract binding;
+- source/model/stream/preprocessing/execution/alignment contract binding;
+- aligned word evidence persisted through checkpoint/resume;
 - contiguous-prefix checkpoint semantics;
 - cleanup of speculative/derived work without masking primary failures; and
 - durable lifecycle evidence around long-running work.
@@ -102,8 +109,10 @@ The system currently supports:
 - multilingual faster-whisper decoding;
 - conservative local text-language attribution that may leave ambiguous text unlabeled;
 - optional recording-scoped anonymous speaker diarization;
-- deterministic speaker-label normalization; and
-- conservative speaker projection that refuses ambiguous multi-speaker ASR segments.
+- deterministic speaker-label normalization;
+- word-level projection when native word timing exists; and
+- conservative segment labeling that remains null across mixed speaker handoffs or
+  ambiguous overlap.
 
 The diarization path is **integrated but security-held** while its locked Lightning
 dependency is affected by the compensated CVE-2026-58659/PYSEC-2026-3624 advisory.
@@ -113,11 +122,14 @@ EchoFlow fails closed before pyannote execution/acquisition while that gate is a
 
 Canonical JSON is authoritative transcript evidence.
 
-It carries source and execution provenance, source-relative timestamps, language
-evidence, optional enhancement provenance, and optional speaker-turn evidence.
+It carries source and execution provenance, source-relative segment and word timestamps,
+language evidence, optional enhancement provenance, and optional speaker-turn/word
+speaker evidence.
 
-TXT, SRT, and WebVTT are deterministic publication views that can be regenerated without
-rerunning recognition.
+TXT, SRT, and WebVTT remain deterministic segment-oriented publication views that can be
+regenerated without rerunning recognition. More expressive intra-segment speaker
+presentation belongs to the later speaker-UX tranche rather than being smuggled into the
+alignment work.
 
 ### Transcript library and retrieval
 
@@ -137,6 +149,10 @@ The local library now includes:
 - reciprocal-rank hybrid BM25 + dense retrieval;
 - one evidence-bearing `SearchResponse` with lexical/semantic/fused ranks; and
 - corpus-fingerprint stale-vector refusal when canonical transcript bytes change.
+
+Nested word timing is additional canonical evidence. Current lexical/semantic projection
+continues indexing segment text once; later highlighting and jump-to-audio UX can use the
+finer coordinates without changing retrieval ranking semantics.
 
 Semantic search is currently an advanced optional capability because the locked project
 dependency graph does not yet include Sentence Transformers. Lexical search remains the
@@ -177,39 +193,12 @@ into a research library.
 
 # Near-term product sequence
 
-The next features should make evidence **finer, easier to navigate, and easier to name**
-before EchoFlow adds heavier generative/audio-processing machinery.
+Word timing now gives EchoFlow a finer canonical evidence coordinate below the ASR
+segment. The next features should **add source clocks, improve how humans see speaker
+evidence, and then exploit those coordinates in the research workspace** before heavier
+source-separation machinery arrives.
 
-## 1. Word/timestamp alignment
-
-**Likely next feature.**
-
-Current canonical ASR segments are durable evidence coordinates, but they are often too
-coarse for precise highlighting, speaker handoffs, annotations, and jump-to-audio.
-
-Alignment should add finer timestamp evidence without rewriting raw ASR truth.
-
-Primary uses:
-
-- word/phrase highlighting in search results;
-- precise jump-to-audio;
-- finer speaker attribution near handoffs;
-- better handling of partially overlapping turns;
-- durable annotation anchors smaller than an entire ASR segment; and
-- improved subtitle/transcript interaction in a future GUI.
-
-### Architectural direction
-
-Alignment should be an **enrichment capability** over canonical transcript/audio
-evidence.
-
-Its output must record provider/model/version/revision as applicable and remain traceable
-to canonical segments and source-relative time.
-
-A neural model-backed aligner must reuse the model-custody family rather than inventing
-a hidden download path.
-
-## 2. Original-media timecode and capture-time provenance
+## 1. Original-media timecode and capture-time provenance
 
 EchoFlow currently exposes one clear canonical clock: elapsed source-relative seconds
 from the selected audio origin.
@@ -230,9 +219,11 @@ These should be typed parallel provenance, not collapsed into an ambiguous `time
 field.
 
 The design should distinguish “metadata exists” from “metadata is trustworthy enough to
-map onto the transcript.”
+map onto the transcript.” Word timing should remain expressed in canonical elapsed time,
+with additional media clocks providing mappings rather than replacing that coordinate
+system.
 
-## 3. Better speaker UX: overlap + user-assigned display labels
+## 2. Better speaker UX: overlap + user-assigned display labels
 
 Anonymous diarization evidence should remain anonymous-by-default and recording-scoped.
 
@@ -247,30 +238,34 @@ speaker-02 → Interviewer
 Those labels are **user-authored state**. They must not be disposable search/index
 metadata and should not rewrite the underlying anonymous speaker-turn evidence.
 
-Overlap handling should also improve in presentation:
+Word alignment already lets EchoFlow preserve an intra-segment handoff without forcing
+one segment-level speaker. The next presentation layer should make that evidence useful
+to a human:
 
+- render word/fine-grained handoffs legibly;
 - preserve multiple active speaker refs where evidence supports overlap;
-- use word/fine alignment where available;
-- avoid forcing one speaker label onto genuinely ambiguous text; and
-- render overlap clearly in human/GUI views.
+- avoid forcing one speaker label onto genuinely ambiguous text;
+- let users assign display labels over stable anonymous refs; and
+- keep those labels durable and separate from rebuildable indexes.
 
-## 4. Search/research workspace UX
+## 3. Search/research workspace UX over aligned coordinates
 
-The retrieval engine now supports lexical, semantic, and hybrid ranking. Real corpus use
-should drive the next interface layer:
+The retrieval engine now supports lexical, semantic, and hybrid ranking, while canonical
+transcripts now have finer word timing coordinates. Real corpus use should drive the next
+interface layer:
 
-- better snippets/highlighting;
+- exact phrase/word highlighting inside a retrieved passage;
 - result-context expansion;
 - facets;
 - exportable result sets;
 - precise jump-to-audio;
 - saved searches/collections; and
-- durable tags, notes, and annotations.
+- durable tags, notes, and annotations anchored to durable evidence coordinates.
 
 The ownership rule is non-negotiable: user-authored state does not share deletion
 semantics with rebuildable indexes.
 
-## 5. Qualify semantic dependency and managed embedding custody
+## 4. Qualify semantic dependency and managed embedding custody
 
 Before semantic search is advertised as a normal source install, qualify a locked
 optional semantic dependency set.
@@ -288,7 +283,7 @@ Target direction:
 
 Do not bypass `uv.lock` coherence to make the feature look more finished.
 
-## 6. Representative-device and enhancement qualification
+## 5. Representative-device and enhancement qualification
 
 Collect repeated benchmark evidence from at least:
 
@@ -307,30 +302,29 @@ Calibrate from measurements, not hardware marketing names.
 # Beginner-ready milestone
 
 The backend is already beginner-oriented in many internal decisions: resource discovery,
-model custody, recovery, provenance, and search are designed so the user does **not**
-need to manually operate those systems.
+model custody, recovery, provenance, alignment, and search are designed so the user does
+**not** need to manually operate those systems.
 
 But a beginner-friendly product also needs a beginner-friendly delivery surface.
 
 A reasonable pre-1.0 usability milestone is:
 
-1. word/fine alignment for precise evidence navigation;
-2. richer media time provenance;
-3. clearer speaker labels/overlap behavior;
-4. semantic dependency/model setup that no longer requires advanced manual environment
+1. richer original-media time provenance;
+2. clearer speaker labels/overlap behavior over aligned evidence;
+3. semantic dependency/model setup that no longer requires advanced manual environment
    preparation;
-5. representative qualification on ordinary hardware;
-6. polished error/recovery language;
-7. an installer/package path that does not require a developer environment; and
-8. a thin graphical shell over the existing application services.
+4. representative qualification on ordinary hardware;
+5. polished error/recovery language;
+6. an installer/package path that does not require a developer environment; and
+7. a thin graphical shell over the existing application services.
 
 The GUI should be a presentation adapter, not a second implementation of transcription,
 search, or model policy.
 
 # Later capability: speech/source separation for overlapping speakers
 
-Source separation is valuable, but it is intentionally **later** than better alignment
-and overlap representation.
+Source separation is valuable, but it is intentionally **later** than alignment and
+honest overlap representation.
 
 Separating mixed speech into estimated source signals adds:
 
@@ -355,7 +349,7 @@ but unqualified checkbox.
 
 Use real multi-recording corpora to exercise:
 
-- interruption/resume;
+- interruption/resume with aligned word evidence;
 - stale-process reconciliation;
 - progress rendering;
 - accelerator re-admission;
@@ -404,8 +398,9 @@ actual persisted fixtures from that boundary.
 
 Interesting later investigations include:
 
+- independent forced alignment or phoneme-level timing if native word timing proves
+  insufficient for a real use case;
 - finer intra-clause/romanized language attribution;
-- richer original-media capture/timecode provenance;
 - improved overlap rendering and source separation;
 - alternative qualified multilingual embedding models;
 - character n-gram/fuzzy retrieval for ASR names/acronyms/misspellings;

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -51,6 +51,7 @@ rebuildable search infrastructure.
 | [Processing capabilities](processing-capabilities.md) | How does the whole local transcription system fit together? |
 | [Adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) | How does EchoFlow decide what this machine can safely run? |
 | [Media and timeline](media-and-timeline.md) | What source did we inspect, which audio stream did we use, and what do timestamps mean? |
+| [Word-level timestamp alignment](word-alignment.md) | How do engine-produced word timings become source-relative evidence and improve speaker handoffs? |
 | [Local model management](model-management.md) | Which model revision is allowed to execute, and how did it get here? |
 | [Speech enhancement](speech-enhancement.md) | How can preprocessing affect ASR without becoming source truth? |
 | [Anonymous speaker diarization](diarization.md) | How are speaker turns represented without pretending anonymous labels are identities? |
@@ -70,7 +71,7 @@ rebuildable search infrastructure.
 | `media` | Read-only source inspection and deterministic audio-stream selection |
 | `runner` | Process-visible CPU/memory inspection and execution-budget policy |
 | `model_management` | Explicit local model inventory, acquisition, verification, provenance, and removal |
-| `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language attribution, diarization, assembly, exports |
+| `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language attribution, word alignment, diarization, assembly, exports |
 | `workspace` | Private job paths and public artifact allocation |
 | `benchmarking` | Privacy-minimized local execution measurement |
 | `library` | Evidence-first lexical/semantic retrieval over rebuildable transcript projections |

--- a/docs/architecture/diarization.md
+++ b/docs/architecture/diarization.md
@@ -133,44 +133,57 @@ features.
 
 ## Why EchoFlow is conservative about putting a speaker name on text
 
-ASR segments and diarization turns are produced independently.
+ASR and diarization still come from independent evidence streams. Word-level timing
+simply gives EchoFlow finer coordinates for reconciling them.
 
-Without word-level alignment, one ASR segment may cross a speaker handoff or overlap two
-speakers. EchoFlow therefore assigns `RecognizedSegment.speaker_ref` only when exactly
-one unique diarized speaker overlaps that segment.
+When native word timing exists, EchoFlow compares **each word interval** with the
+speaker-turn timeline:
 
 ```text
-ASR segment overlaps speaker-01 only
-    → speaker_ref = speaker-01
+word overlaps speaker-01 only
+    → word.speaker_ref = speaker-01
 
-ASR segment crosses speaker-01 → speaker-02
-    → speaker_ref = null
+word overlaps speaker-01 + speaker-02
+    → word.speaker_ref = null
 
-ASR segment overlaps speaker-01 + speaker-02
-    → speaker_ref = null
+all words in one ASR segment resolve to speaker-01
+    → segment.speaker_ref = speaker-01
+
+words in one ASR segment resolve to speaker-01 → speaker-02
+    → segment.speaker_ref = null
 ```
 
-The exact speaker-turn timeline is still preserved when projection is ambiguous.
+If word evidence is absent, EchoFlow preserves the older conservative whole-segment
+rule: the segment gets a speaker only when exactly one unique diarized speaker overlaps
+that segment.
+
+The exact speaker-turn timeline is preserved either way.
 
 That refusal matters. It is better to preserve “we know these voices overlap here” than
 to confidently put the wrong speaker label in front of a sentence.
 
-## Why word/timestamp alignment is the next important seam ✨
+See [word-level timestamp alignment](word-alignment.md) for the timing, checkpoint, and
+source-relative assembly contract.
 
-Word-level or fine-grained timestamp alignment would give EchoFlow smaller evidence
-coordinates than an entire ASR segment.
+## What alignment now unlocks ✨
 
-That unlocks several improvements at once:
+Word timing lets EchoFlow stop treating a long ASR segment as the smallest practical
+text coordinate.
 
-- finer speaker attribution near handoffs;
-- better presentation of overlapping turns;
+The first payoff is already structural: a speaker handoff can be represented inside one
+recognized segment without assigning the entire segment to either person.
+
+The same evidence seam can later support:
+
 - precise transcript highlighting;
 - more exact jump-to-audio behavior;
-- durable annotations anchored to smaller evidence spans; and
+- durable annotations anchored to smaller evidence spans;
+- clearer overlap presentation; and
 - cleaner future speaker-label UX.
 
-Alignment does not solve every overlap problem, but it lets EchoFlow stop treating a
-long ASR segment as the smallest practical text unit.
+Alignment does **not** solve simultaneous speech. If two active speakers overlap the same
+word interval, the word remains unattributed. Later source separation may provide more
+evidence, but EchoFlow does not manufacture certainty in the meantime.
 
 ## User-assigned display labels without biometric identity
 
@@ -206,11 +219,11 @@ recording understandable.
 
 ## Better overlap handling before source separation
 
-Overlap deserves two distinct product steps.
+Overlap still deserves two distinct product steps.
 
-First, EchoFlow should improve **representation and presentation** of overlap using
-better temporal alignment, clearer multi-speaker evidence, and UI/export behavior that
-does not force one speaker when multiple voices are active.
+First, EchoFlow improves **representation and presentation** using finer word timing,
+explicit multi-speaker turn evidence, and UI/export behavior that does not force one
+speaker when multiple voices are active.
 
 Only later should EchoFlow consider **speech/source separation**, where the audio itself
 is decomposed into estimated sources before or during recognition.
@@ -223,25 +236,28 @@ recordings after the simpler evidence model is strong.
 
 ## Canonical and derived output behavior
 
-When a segment has one unambiguous `speaker_ref`, derived TXT/SRT/WebVTT views may prefix
-that anonymous speaker label.
+When every aligned word in a segment resolves to one anonymous speaker, the segment can
+retain that same `speaker_ref` as a convenience label and derived TXT/SRT/WebVTT views
+may prefix it.
 
-Ambiguous segments remain unlabeled. Export rendering never changes timestamps or
-becomes canonical custody.
+Mixed or ambiguous segments remain unlabeled at the segment level even when some words
+have useful speaker evidence. Export rendering never changes timestamps or becomes
+canonical custody.
 
 Future user-assigned display labels should remain a presentation layer over stable
 anonymous speaker references and durable transcript coordinates.
 
 ## Qualification boundary
 
-The current deterministic test surface covers:
+The deterministic test surface covers:
 
 - adapter/cache-only versus download policy;
 - telemetry-disable behavior;
 - deterministic label normalization;
 - canonical schema integration;
 - executor integration;
-- conservative speaker projection;
+- conservative word/segment speaker projection;
+- mixed-speaker handoffs and ambiguous word overlap;
 - derived exports; and
 - the fail-closed Lightning security gate.
 
@@ -260,7 +276,7 @@ This capability does not currently provide:
 - biometric speaker identification;
 - cross-recording speaker linking;
 - user-assigned display labels;
-- guaranteed word-level speaker attribution;
+- a guarantee that engine word timing or diarization is always correct;
 - polished overlap presentation;
 - simultaneous-speaker/source separation; or
 - a claim that the dependency footprint is suitable for every low-memory device.

--- a/docs/architecture/processing-capabilities.md
+++ b/docs/architecture/processing-capabilities.md
@@ -10,6 +10,7 @@ For the narrower contracts, see:
 
 - [adaptive heterogeneous execution](adaptive-heterogeneous-execution.md);
 - [media and timeline](media-and-timeline.md);
+- [word-level timestamp alignment](word-alignment.md);
 - [model management](model-management.md);
 - [speech enhancement](speech-enhancement.md);
 - [diarization](diarization.md); and
@@ -37,7 +38,7 @@ flowchart LR
     C --> D[Build immutable plan]
     D --> E[Normalize / enhance if needed]
     E --> F[Segment + local ASR]
-    F --> G[Checkpoint ordered work]
+    F --> G[Word timing + ordered checkpoints]
     G --> H[Language + optional speaker evidence]
     H --> I[Canonical transcript]
     I --> J[Derived exports]
@@ -137,7 +138,7 @@ accepting the derivative so preprocessing cannot quietly shift the transcript ti
 Anonymous diarization deliberately continues to read the unmodified canonical decode in
 enhancement v1.
 
-## 6. Segmentation and checkpointing: make interruption survivable
+## 6. Segmentation, word timing, and checkpointing: make interruption survivable
 
 EchoFlow owns deterministic segmentation:
 
@@ -148,18 +149,27 @@ EchoFlow owns deterministic segmentation:
 - one job-scoped ASR session; and
 - strictly ordered checkpoint commits.
 
+The faster-whisper session requests native word timestamps. Each engine-produced word is
+validated inside its ASR segment and later rebased from work-window time onto the same
+source-relative timeline as the canonical segment.
+
+Per-window checkpoints persist that word evidence. The checkpoint manifest records an
+explicit alignment identity so a pre-alignment checkpoint cannot silently resume into a
+partially aligned transcript.
+
 Accelerated execution may materialize at most one future segment while the current one
 is being inferred.
 
 A completed checkpoint set must remain a contiguous prefix of the deterministic work
 plan.
 
-Resume restores the original source/model/device/decode/enhancement/segmentation contract
-and re-admits current resources.
+Resume restores the original source/model/device/decode/enhancement/segmentation and
+alignment contract and re-admits current resources.
 
-## 7. Recognition and multilingual attribution
+## 7. Recognition, word alignment, and multilingual attribution
 
-The faster-whisper backend performs managed local ASR.
+The faster-whisper backend performs managed local ASR and preserves its native per-word
+timing evidence. EchoFlow does not run a separate forced-alignment model in this tranche.
 
 With no explicit language, the current multilingual behavior can reconsider language
 within durable work units rather than latching one job-wide acoustic prompt forever.
@@ -178,24 +188,28 @@ The current pyannote capability is security-gated because the locked Lightning
 dependency is affected by a compensated advisory. EchoFlow refuses the vulnerable path
 before pyannote import/model acquisition.
 
-When operationally qualified, diarization contributes an exact speaker-turn timeline
-and conservative per-segment speaker references.
+When operationally qualified, diarization contributes an exact speaker-turn timeline.
+Word timing now gives projection a finer evidence coordinate than an entire ASR segment:
+a word receives a speaker only when exactly one diarized speaker overlaps its interval.
 
-The next useful seam is finer word/timestamp alignment, which can improve handoff and
-overlap projection without pretending the underlying speaker evidence is more certain
-than it is.
+The enclosing segment keeps a convenience `speaker_ref` only when every aligned word is
+attributed to the same speaker. Mixed handoffs and ambiguous overlap therefore remain
+explicit instead of being flattened into one guessed label.
 
 ## 9. Canonical transcript and derived exports
 
 Canonical JSON is authoritative transcript evidence.
 
 The current contract records source/stream provenance, execution plan identity,
-managed model revision, timestamps, language evidence, optional enhancement provenance,
-and optional diarization evidence.
+managed model revision, source-relative segment timestamps, nested source-relative word
+timing evidence, language evidence, optional enhancement provenance, and optional
+diarization evidence.
 
-TXT, SRT, and WebVTT are deterministic publication views.
+TXT, SRT, and WebVTT remain deterministic segment-oriented publication views.
 
-They are useful. They are not recognition truth.
+They are useful. They are not recognition truth. More expressive word/speaker rendering
+belongs to later presentation work rather than quietly changing caption semantics in the
+alignment tranche.
 
 ## 10. Transcript library and search 🦝
 
@@ -211,6 +225,10 @@ refusal.
 
 `TranscriptSearch` can combine lexical and semantic ranks with RRF while preserving
 lexical, semantic, and fused provenance in one evidence-bearing `SearchResponse`.
+
+The current search projection deliberately ignores nested word evidence and indexes
+canonical segment text once. Future highlighting/jump-to-audio UX may consume word
+coordinates without changing the ranking contract.
 
 Search infrastructure must never become the only home of future user-authored notes,
 labels, tags, collections, or annotations.
@@ -243,9 +261,9 @@ erasure.
 | `FfmpegAudioDecoder` | selected-stream canonicalization | enhancement |
 | `FfmpegAfftdnEnhancer` | optional noise suppression | source authority |
 | `WaveAudioSegmenter` | exact work windows/materialization | recognition |
-| `FasterWhisperSession` | local ASR recognition | model download |
-| `LocalCheckpointStore` | private resumable evidence | public artifacts |
-| `TranscriptAssembler` | source-relative assembly | filesystem policy |
+| `FasterWhisperSession` | local ASR + native word timing | model download or forced alignment |
+| `LocalCheckpointStore` | private resumable segment/word evidence | public artifacts |
+| `TranscriptAssembler` | source-relative segment/word assembly | filesystem policy |
 | `LinguaLanguageAttributor` | conservative text-language labels | acoustic decoding |
 | `SpeakerDiarizer` | anonymous speaker-turn evidence | biometric identity |
 | `TranscriptExporter` | derived TXT/SRT/VTT | recognition truth |
@@ -268,6 +286,7 @@ EchoFlow does not currently claim:
 - every visible accelerator is useful/faster;
 - alternate ASR engines;
 - arbitrary word-level code-switch attribution;
+- independent forced alignment or phoneme-level timing;
 - biometric speaker identity;
 - user-assigned speaker display labels;
 - polished overlap handling;
@@ -275,7 +294,6 @@ EchoFlow does not currently claim:
 - generative restoration;
 - automatic enhancement selection;
 - original SMPTE/container/capture-time provenance beyond source-relative elapsed time;
-- word-level alignment;
 - storage durability across sudden power loss;
 - malicious same-user TOCTOU resistance;
 - secure erasure;
@@ -286,12 +304,13 @@ EchoFlow does not currently claim:
 
 ## What is becoming the next product layer?
 
-The backend foundation is broad. The next high-value work is increasingly about making
-evidence **finer and easier to navigate**:
+Word timing establishes the first finer-grained evidence coordinate below an ASR segment.
+The next high-value work is increasingly about using and extending that evidence:
 
-1. word/timestamp alignment;
-2. original-media timecode and capture-time provenance;
-3. better speaker overlap presentation and user-assigned display labels; and
+1. original-media timecode and capture-time provenance;
+2. better speaker overlap presentation and user-assigned display labels;
+3. search highlighting, precise jump-to-audio, and durable annotation UX over aligned
+   coordinates; and
 4. later, source separation for genuinely overlapping speech when evidence and measured
    benefit justify the additional model/compute complexity.
 

--- a/docs/architecture/word-alignment.md
+++ b/docs/architecture/word-alignment.md
@@ -1,0 +1,228 @@
+# Word-level timestamp alignment 🕰️
+
+A transcript that says *what* somebody said is useful. A transcript that can also point
+to **when each word occurred** is much more useful for speaker handoffs, search
+highlighting, jump-to-audio, precise annotations, and later editing interfaces.
+
+EchoFlow now preserves word timing evidence already produced by faster-whisper. It does
+not invent timestamps from character positions, and it does not run a separate forced
+alignment model in this tranche.
+
+> **The rule:** preserve the engine's word evidence, put it on the same source-relative
+> timeline as the canonical transcript, and stay conservative when that evidence is
+> ambiguous.
+
+🦝 The scholarly raccoon would like the record to show that “more precise coordinates”
+does not mean “permission to become more confident than the evidence.”
+
+## What changes for a user?
+
+Usually, nothing about the command.
+
+Word timing is part of the current faster-whisper transcription contract. A normal local
+transcription can now produce canonical segment evidence shaped conceptually like:
+
+```text
+segment  12.40s ─ 15.10s   "we moved the meeting to Friday"
+
+word     12.40s ─ 12.70s   " we"
+word     12.70s ─ 13.20s   " moved"
+word     13.20s ─ 13.55s   " the"
+word     13.55s ─ 14.20s   " meeting"
+word     14.20s ─ 14.45s   " to"
+word     14.45s ─ 15.10s   " Friday"
+```
+
+The exact word token text is retained from the engine, including meaningful leading
+whitespace. Presentation code may trim or style that text later; canonical evidence does
+not quietly rewrite it for aesthetics.
+
+## The timeline stays the same
+
+EchoFlow already owns deterministic work windows over canonical decoded audio. The ASR
+engine sees one materialized window at a time and returns timestamps relative to that
+window.
+
+Alignment extends the existing assembly rule to words:
+
+```mermaid
+flowchart LR
+    A[Source audio timeline] --> B[Deterministic work window]
+    B --> C[Faster-whisper]
+    C --> D[Segment-relative words]
+    D --> E[Source-relative word evidence]
+    E --> F[Canonical transcript JSON]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A evidence
+    class B,C,D process
+    class E,F result
+```
+
+If work window 7 begins at source second `4200` and the engine reports a word at
+`21.70s`, the canonical word starts at source second `4221.70`.
+
+Segmentation is therefore still an execution detail. It does not reset public word
+coordinates to zero every ten minutes.
+
+## Evidence model
+
+`AlignedWord` is a frozen/slotted value containing:
+
+- `start_seconds`;
+- `end_seconds`;
+- exact engine token text;
+- optional engine word probability; and
+- optional anonymous `speaker_ref` after diarization projection.
+
+`AlignedRecognizedSegment` retains the existing segment contract and adds an ordered
+`words` tuple.
+
+Word evidence is validated before it can become canonical state:
+
+- timestamps must be finite and non-negative;
+- end may equal start because EchoFlow does not fabricate duration for a zero-duration
+  engine observation;
+- words must remain in timeline order;
+- overlapping word intervals are rejected beyond a small boundary tolerance;
+- words must remain within their containing segment beyond that same tolerance;
+- probability, when present, must be finite and between zero and one; and
+- blank word tokens are not accepted as evidence.
+
+The boundary tolerance exists for small floating-point/engine rounding differences. It
+changes **validation**, not stored timestamps. EchoFlow does not nudge every timestamp
+onto a prettier grid.
+
+## Is this forced alignment?
+
+No.
+
+A forced aligner usually takes known text plus audio and performs a separate alignment
+step intended to reconcile that text to acoustic time. This tranche does not do that.
+
+EchoFlow asks faster-whisper to return its native word timestamps and preserves them.
+That has three useful properties:
+
+1. no additional alignment model or model download;
+2. no second heavy inference pass merely to obtain word coordinates; and
+3. timing evidence remains attributable to the same managed ASR execution that produced
+   the recognized text.
+
+It also means EchoFlow should not advertise these timestamps as independently corrected
+forced-alignment truth.
+
+## Speaker handoffs get much better 💃
+
+Before word timing, ASR segments and diarization turns had different boundaries. If one
+ASR segment crossed from `speaker-01` to `speaker-02`, EchoFlow correctly left the whole
+segment unlabeled rather than guessing.
+
+With word intervals, diarization can project onto the finer evidence:
+
+```mermaid
+flowchart TD
+    A[ASR segment spans two speakers] --> B[Aligned words]
+    B --> C[Compare each word with speaker turns]
+    C --> D{Exactly one speaker overlaps?}
+    D -->|yes| E[Attach anonymous speaker ref to word]
+    D -->|no| F[Leave word unattributed]
+    E --> G{Every word has the same speaker?}
+    F --> G
+    G -->|yes| H[Also keep segment-level convenience label]
+    G -->|no| I[Segment speaker stays null]
+
+    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef safe fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+    classDef ambiguous fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+
+    class A,B evidence
+    class C,D,G process
+    class E,H safe
+    class F,I ambiguous
+```
+
+So this:
+
+```text
+speaker-01: "I think we should"
+speaker-02: "move it to Friday"
+```
+
+can live inside one ASR segment without EchoFlow claiming the entire sentence belonged
+to either person.
+
+If two diarized speakers overlap the same word interval, that word remains unattributed.
+Later source separation may provide additional evidence, but alignment alone does not
+solve simultaneous speech.
+
+## Checkpoint and resume semantics
+
+Alignment changes recognized evidence, so it is part of the private checkpoint contract
+rather than a hidden backend switch.
+
+New manifests record an alignment identity containing:
+
+```text
+schema_version = 1
+provider       = faster-whisper
+word_timestamps = true
+```
+
+Per-window checkpoint payloads persist the aligned words themselves. Resume restores
+that evidence before source-relative assembly.
+
+A pre-alignment checkpoint that lacks the alignment contract is refused rather than
+being combined with newly aligned segments. EchoFlow is pre-production, so preserving a
+single current contract is preferable to inventing migration support for unreleased
+checkpoint shapes.
+
+## What happens to search?
+
+Nothing surprising.
+
+Lexical and semantic retrieval continue to index the canonical **segment text once**.
+The transcript-library projection deliberately ignores additional nested word evidence
+for now.
+
+That means alignment does not suddenly turn one sentence into six search documents or
+change BM25 statistics merely because the canonical transcript has finer coordinates.
+Future retrieval UX may use word evidence for highlighting and precise jump-to-audio,
+but the current ranking contract remains segment/chunk based.
+
+## What this unlocks
+
+Word coordinates create a useful seam for several later capabilities:
+
+- highlight the exact returned phrase while preserving segment-level search ranking;
+- jump playback closer to the relevant word rather than only the containing segment;
+- anchor durable annotations more precisely;
+- render speaker handoffs inside a long ASR segment;
+- improve subtitle/caption editing interfaces; and
+- compare future forced-alignment providers without changing the canonical source
+  timeline.
+
+Those consumers should use the timing evidence that actually exists rather than derive
+fake word positions from character counts.
+
+## What this does **not** claim
+
+This tranche does not provide:
+
+- independent forced alignment;
+- phoneme-level timestamps;
+- fabricated character offsets;
+- calibrated probability as a universal confidence score;
+- automatic correction of recognized text from timing evidence;
+- original-media SMPTE/container/capture-time provenance;
+- user-assigned speaker names/display labels; or
+- speech/source separation for simultaneous speakers.
+
+The next provenance tranche is original-media timecode/capture-time representation.
+Better speaker display/overlap UX follows, with source separation intentionally later.
+
+🧜‍♀️ One timeline at a time. The mermaid has seen what happens when clocks are allowed
+to breed unsupervised.

--- a/src/echoflow/library/tests/test_projection.py
+++ b/src/echoflow/library/tests/test_projection.py
@@ -31,6 +31,15 @@ def _document() -> dict[str, object]:
                 "language": "fr",
                 "detected_language": "en",
                 "speaker_ref": "speaker-01",
+                "words": [
+                    {
+                        "start_seconds": 0.0,
+                        "end_seconds": 1.0,
+                        "text": " hello",
+                        "probability": 0.91,
+                        "speaker_ref": "speaker-01",
+                    }
+                ],
             },
             {
                 "segment_id": "segment-000001",
@@ -67,6 +76,7 @@ def test_projection_extracts_only_searchable_canonical_evidence(tmp_path: Path) 
     assert indexed.source_path == str(source.resolve())
     assert [segment.language for segment in indexed.segments] == ["fr", "de", "en"]
     assert indexed.segments[0].speaker_ref == "speaker-01"
+    assert indexed.segments[0].text == "hello"
 
 
 def test_projection_accepts_unknown_source_path(tmp_path: Path) -> None:

--- a/src/echoflow/transcription/__init__.py
+++ b/src/echoflow/transcription/__init__.py
@@ -1,5 +1,10 @@
 """Resource-aware local transcription capability."""
 
+from echoflow.transcription.alignment import (
+    AlignedRecognizedSegment,
+    AlignedWord,
+    aligned_words,
+)
 from echoflow.transcription.audio import DecodedAudio, FfmpegAudioDecoder
 from echoflow.transcription.backend import FasterWhisperTranscriber
 from echoflow.transcription.enhancement import FfmpegAfftdnEnhancer
@@ -29,6 +34,8 @@ from echoflow.transcription.models import (
 from echoflow.transcription.planner import TranscriptionJobPlanner
 
 __all__ = [
+    "AlignedRecognizedSegment",
+    "AlignedWord",
     "CanonicalTranscript",
     "CpuEngineConfiguration",
     "DecodedAudio",
@@ -53,4 +60,5 @@ __all__ = [
     "TranscriptionExecutor",
     "TranscriptionJobPlan",
     "TranscriptionJobPlanner",
+    "aligned_words",
 ]

--- a/src/echoflow/transcription/alignment.py
+++ b/src/echoflow/transcription/alignment.py
@@ -67,10 +67,7 @@ class AlignedRecognizedSegment(RecognizedSegment):
                 raise ValueError("word timestamp starts before its segment")
             if word.end_seconds > self.end_seconds + _WORD_SEGMENT_TOLERANCE_SECONDS:
                 raise ValueError("word timestamp ends after its segment")
-            if (
-                word.start_seconds
-                < previous_end - _WORD_SEGMENT_TOLERANCE_SECONDS
-            ):
+            if word.start_seconds < previous_end - _WORD_SEGMENT_TOLERANCE_SECONDS:
                 raise ValueError("word timestamps must be ordered and non-overlapping")
             previous_end = max(previous_end, word.end_seconds)
 

--- a/src/echoflow/transcription/alignment.py
+++ b/src/echoflow/transcription/alignment.py
@@ -1,0 +1,92 @@
+"""Word-level timestamp evidence layered onto recognized transcript segments."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from echoflow.transcription.models import RecognizedSegment
+
+_TIMESTAMP_TOLERANCE_SECONDS = 1e-6
+
+
+@dataclass(frozen=True, slots=True)
+class AlignedWord:
+    """One engine-produced word interval relative to its containing audio timeline."""
+
+    start_seconds: float
+    end_seconds: float
+    text: str
+    probability: float | None = None
+    speaker_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        if (
+            not math.isfinite(self.start_seconds)
+            or not math.isfinite(self.end_seconds)
+            or self.start_seconds < 0
+            or self.end_seconds < self.start_seconds
+        ):
+            raise ValueError("word timestamps must be finite and ordered")
+        if not self.text.strip():
+            raise ValueError("word text cannot be empty")
+        if self.probability is not None and not (
+            math.isfinite(self.probability) and 0 <= self.probability <= 1
+        ):
+            raise ValueError("word probability must be between 0 and 1")
+        if self.speaker_ref is not None and not self.speaker_ref.strip():
+            raise ValueError("word speaker_ref cannot be empty")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "start_seconds": self.start_seconds,
+            "end_seconds": self.end_seconds,
+            "text": self.text,
+            "probability": self.probability,
+            "speaker_ref": self.speaker_ref,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AlignedRecognizedSegment(RecognizedSegment):
+    """Recognized text carrying optional engine-produced word timing evidence."""
+
+    words: tuple[AlignedWord, ...] = ()
+
+    def __post_init__(self) -> None:
+        RecognizedSegment.__post_init__(self)
+        self._validate_words()
+
+    def _validate_words(self) -> None:
+        previous_end = self.start_seconds
+        for word in self.words:
+            if word.start_seconds < self.start_seconds - _TIMESTAMP_TOLERANCE_SECONDS:
+                raise ValueError("word timestamp starts before its segment")
+            if word.end_seconds > self.end_seconds + _TIMESTAMP_TOLERANCE_SECONDS:
+                raise ValueError("word timestamp ends after its segment")
+            if word.start_seconds < previous_end - _TIMESTAMP_TOLERANCE_SECONDS:
+                raise ValueError("word timestamps must be ordered and non-overlapping")
+            previous_end = word.end_seconds
+
+        if self.speaker_ref is None or not self.words:
+            return
+        word_speakers = tuple(word.speaker_ref for word in self.words)
+        if any(speaker is None for speaker in word_speakers) or set(word_speakers) != {
+            self.speaker_ref
+        }:
+            raise ValueError(
+                "segment speaker_ref requires uniformly attributed aligned words"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **RecognizedSegment.to_dict(self),
+            "words": [word.to_dict() for word in self.words],
+        }
+
+
+def aligned_words(segment: RecognizedSegment) -> tuple[AlignedWord, ...]:
+    """Return word evidence without making every consumer alignment-aware."""
+    if isinstance(segment, AlignedRecognizedSegment):
+        return segment.words
+    return ()

--- a/src/echoflow/transcription/alignment.py
+++ b/src/echoflow/transcription/alignment.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 from echoflow.transcription.models import RecognizedSegment
 
-_TIMESTAMP_TOLERANCE_SECONDS = 1e-6
+_WORD_SEGMENT_TOLERANCE_SECONDS = 0.05
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,13 +60,19 @@ class AlignedRecognizedSegment(RecognizedSegment):
     def _validate_words(self) -> None:
         previous_end = self.start_seconds
         for word in self.words:
-            if word.start_seconds < self.start_seconds - _TIMESTAMP_TOLERANCE_SECONDS:
+            if (
+                word.start_seconds
+                < self.start_seconds - _WORD_SEGMENT_TOLERANCE_SECONDS
+            ):
                 raise ValueError("word timestamp starts before its segment")
-            if word.end_seconds > self.end_seconds + _TIMESTAMP_TOLERANCE_SECONDS:
+            if word.end_seconds > self.end_seconds + _WORD_SEGMENT_TOLERANCE_SECONDS:
                 raise ValueError("word timestamp ends after its segment")
-            if word.start_seconds < previous_end - _TIMESTAMP_TOLERANCE_SECONDS:
+            if (
+                word.start_seconds
+                < previous_end - _WORD_SEGMENT_TOLERANCE_SECONDS
+            ):
                 raise ValueError("word timestamps must be ordered and non-overlapping")
-            previous_end = word.end_seconds
+            previous_end = max(previous_end, word.end_seconds)
 
         if self.speaker_ref is None or not self.words:
             return

--- a/src/echoflow/transcription/assembly.py
+++ b/src/echoflow/transcription/assembly.py
@@ -1,6 +1,11 @@
 import math
 from collections.abc import Sequence
 
+from echoflow.transcription.alignment import (
+    AlignedRecognizedSegment,
+    AlignedWord,
+    aligned_words,
+)
 from echoflow.transcription.errors import TranscriptionError
 from echoflow.transcription.models import (
     AudioSegmentWindow,
@@ -83,8 +88,9 @@ class TranscriptAssembler:
                 )
             previous = window
 
-    @staticmethod
+    @classmethod
     def _append_window(
+        cls,
         output: list[RecognizedSegment],
         window: AudioSegmentWindow,
         result: EngineTranscript,
@@ -114,18 +120,35 @@ class TranscriptAssembler:
                 end_seconds = window.end_seconds
             else:
                 end_seconds = window.start_seconds + segment.end_seconds
-            output.append(
-                RecognizedSegment(
-                    index=len(output),
-                    start_seconds=start_seconds,
-                    end_seconds=end_seconds,
-                    text=segment.text,
-                    average_log_probability=segment.average_log_probability,
-                    no_speech_probability=segment.no_speech_probability,
-                    detected_language=segment.detected_language,
-                    language_probability=segment.language_probability,
-                    language=segment.language,
-                    language_spans=segment.language_spans,
-                    speaker_ref=segment.speaker_ref,
-                )
-            )
+
+            words = tuple(cls._rebase_word(word, window) for word in aligned_words(segment))
+            segment_type = AlignedRecognizedSegment if words else RecognizedSegment
+            keyword_arguments = {
+                "index": len(output),
+                "start_seconds": start_seconds,
+                "end_seconds": end_seconds,
+                "text": segment.text,
+                "average_log_probability": segment.average_log_probability,
+                "no_speech_probability": segment.no_speech_probability,
+                "detected_language": segment.detected_language,
+                "language_probability": segment.language_probability,
+                "language": segment.language,
+                "language_spans": segment.language_spans,
+                "speaker_ref": segment.speaker_ref,
+            }
+            if words:
+                output.append(segment_type(**keyword_arguments, words=words))
+            else:
+                output.append(segment_type(**keyword_arguments))
+
+    @staticmethod
+    def _rebase_word(word: AlignedWord, window: AudioSegmentWindow) -> AlignedWord:
+        return AlignedWord(
+            start_seconds=min(
+                window.end_seconds, window.start_seconds + word.start_seconds
+            ),
+            end_seconds=min(window.end_seconds, window.start_seconds + word.end_seconds),
+            text=word.text,
+            probability=word.probability,
+            speaker_ref=word.speaker_ref,
+        )

--- a/src/echoflow/transcription/assembly.py
+++ b/src/echoflow/transcription/assembly.py
@@ -1,11 +1,8 @@
 import math
 from collections.abc import Sequence
+from dataclasses import replace
 
-from echoflow.transcription.alignment import (
-    AlignedRecognizedSegment,
-    AlignedWord,
-    aligned_words,
-)
+from echoflow.transcription.alignment import AlignedWord, aligned_words
 from echoflow.transcription.errors import TranscriptionError
 from echoflow.transcription.models import (
     AudioSegmentWindow,
@@ -122,24 +119,22 @@ class TranscriptAssembler:
                 end_seconds = window.start_seconds + segment.end_seconds
 
             words = tuple(cls._rebase_word(word, window) for word in aligned_words(segment))
-            segment_type = AlignedRecognizedSegment if words else RecognizedSegment
-            keyword_arguments = {
-                "index": len(output),
-                "start_seconds": start_seconds,
-                "end_seconds": end_seconds,
-                "text": segment.text,
-                "average_log_probability": segment.average_log_probability,
-                "no_speech_probability": segment.no_speech_probability,
-                "detected_language": segment.detected_language,
-                "language_probability": segment.language_probability,
-                "language": segment.language,
-                "language_spans": segment.language_spans,
-                "speaker_ref": segment.speaker_ref,
-            }
             if words:
-                output.append(segment_type(**keyword_arguments, words=words))
+                rebased = replace(
+                    segment,
+                    index=len(output),
+                    start_seconds=start_seconds,
+                    end_seconds=end_seconds,
+                    words=words,
+                )
             else:
-                output.append(segment_type(**keyword_arguments))
+                rebased = replace(
+                    segment,
+                    index=len(output),
+                    start_seconds=start_seconds,
+                    end_seconds=end_seconds,
+                )
+            output.append(rebased)
 
     @staticmethod
     def _rebase_word(word: AlignedWord, window: AudioSegmentWindow) -> AlignedWord:

--- a/src/echoflow/transcription/assembly.py
+++ b/src/echoflow/transcription/assembly.py
@@ -118,7 +118,9 @@ class TranscriptAssembler:
             else:
                 end_seconds = window.start_seconds + segment.end_seconds
 
-            words = tuple(cls._rebase_word(word, window) for word in aligned_words(segment))
+            words = tuple(
+                cls._rebase_word(word, window) for word in aligned_words(segment)
+            )
             if words:
                 rebased = replace(
                     segment,
@@ -142,7 +144,9 @@ class TranscriptAssembler:
             start_seconds=min(
                 window.end_seconds, window.start_seconds + word.start_seconds
             ),
-            end_seconds=min(window.end_seconds, window.start_seconds + word.end_seconds),
+            end_seconds=min(
+                window.end_seconds, window.start_seconds + word.end_seconds
+            ),
             text=word.text,
             probability=word.probability,
             speaker_ref=word.speaker_ref,

--- a/src/echoflow/transcription/backend.py
+++ b/src/echoflow/transcription/backend.py
@@ -3,6 +3,7 @@ from importlib import import_module, metadata
 from pathlib import Path
 from typing import Any
 
+from echoflow.transcription.alignment import AlignedRecognizedSegment, AlignedWord
 from echoflow.transcription.errors import (
     ModelUnavailableError,
     TranscriptionDependencyError,
@@ -39,7 +40,7 @@ class FasterWhisperSession:
                 str(audio_path),
                 beam_size=self.configuration.beam_size,
                 language=requested_language,
-                word_timestamps=False,
+                word_timestamps=True,
                 multilingual=multilingual,
                 chunk_length=(
                     _LANGUAGE_DETECTION_WINDOW_SECONDS if multilingual else None
@@ -148,7 +149,7 @@ class FasterWhisperTranscriber:
                 continue
             try:
                 recognized.append(
-                    RecognizedSegment(
+                    AlignedRecognizedSegment(
                         index=len(recognized),
                         start_seconds=float(raw.start),
                         end_seconds=float(raw.end),
@@ -161,6 +162,7 @@ class FasterWhisperTranscriber:
                         ),
                         detected_language=detected_language,
                         language_probability=language_probability,
+                        words=cls._words(getattr(raw, "words", None)),
                     )
                 )
             except (AttributeError, TypeError, ValueError) as exc:
@@ -168,6 +170,25 @@ class FasterWhisperTranscriber:
                     "The transcription engine returned invalid segment data", cause=exc
                 ) from exc
         return tuple(recognized)
+
+    @classmethod
+    def _words(cls, raw_words: Iterable[Any] | None) -> tuple[AlignedWord, ...]:
+        if raw_words is None:
+            return ()
+        words: list[AlignedWord] = []
+        for raw in raw_words:
+            text = str(getattr(raw, "word", "")).strip()
+            if not text:
+                continue
+            words.append(
+                AlignedWord(
+                    start_seconds=float(raw.start),
+                    end_seconds=float(raw.end),
+                    text=text,
+                    probability=cls._optional_float(getattr(raw, "probability", None)),
+                )
+            )
+        return tuple(words)
 
     @staticmethod
     def _optional_text(value: object) -> str | None:

--- a/src/echoflow/transcription/backend.py
+++ b/src/echoflow/transcription/backend.py
@@ -177,8 +177,8 @@ class FasterWhisperTranscriber:
             return ()
         words: list[AlignedWord] = []
         for raw in raw_words:
-            text = str(getattr(raw, "word", "")).strip()
-            if not text:
+            text = str(getattr(raw, "word", ""))
+            if not text.strip():
                 continue
             words.append(
                 AlignedWord(

--- a/src/echoflow/transcription/checkpoint.py
+++ b/src/echoflow/transcription/checkpoint.py
@@ -8,6 +8,7 @@ from typing import cast
 
 from echoflow.core.file_manager_facade import FileManagerFacade
 from echoflow.runner.models import ProcessingProfile
+from echoflow.transcription.alignment import AlignedRecognizedSegment, AlignedWord
 from echoflow.transcription.enhancement_models import (
     EnhancementConfiguration,
     EnhancementMode,
@@ -19,7 +20,6 @@ from echoflow.transcription.models import (
     DecodeConfiguration,
     DecodeStrategy,
     EngineTranscript,
-    RecognizedSegment,
     SegmentationConfiguration,
     TranscriptionJobPlan,
     TranscriptSource,
@@ -28,6 +28,7 @@ from echoflow.workspace.models import Job
 
 _CHECKPOINT_SCHEMA_VERSION = 1
 _JOB_PLAN_SCHEMA_VERSION = 1
+_ALIGNMENT_SCHEMA_VERSION = 1
 _MANIFEST_NAME = "manifest.json"
 _MAX_CHECKPOINT_BYTES = 16 * 1024 * 1024
 
@@ -250,6 +251,11 @@ class LocalCheckpointStore:
             "profile": plan.policy.profile.value,
             "provisional": plan.policy.provisional,
             "engine": engine,
+            "alignment": {
+                "schema_version": _ALIGNMENT_SCHEMA_VERSION,
+                "provider": plan.engine.engine,
+                "word_timestamps": True,
+            },
             "decoder": plan.decoder.to_dict(),
             "enhancement": plan.enhancement.to_dict(),
             "segmentation": plan.segmentation.to_dict(),
@@ -300,10 +306,17 @@ class LocalCheckpointStore:
                 raise ValueError("unsupported job-plan schema version")
             source = cast("dict[str, object]", contract["source"])
             engine = cast("dict[str, object]", contract["engine"])
+            alignment = cast("dict[str, object]", contract["alignment"])
             decoder = cast("dict[str, object]", contract["decoder"])
             enhancement = cast("dict[str, object]", contract["enhancement"])
             segmentation = cast("dict[str, object]", contract["segmentation"])
             resources = cast("dict[str, object]", contract["resources"])
+            if int(cast("int", alignment["schema_version"])) != _ALIGNMENT_SCHEMA_VERSION:
+                raise ValueError("unsupported word-alignment schema version")
+            if alignment["word_timestamps"] is not True:
+                raise ValueError("word alignment must remain enabled for resume")
+            if str(alignment["provider"]) != str(engine["engine"]):
+                raise ValueError("word-alignment provider does not match engine")
             return ResumeSettings(
                 source=TranscriptSource(
                     sha256=str(source["sha256"]),
@@ -427,39 +440,60 @@ class LocalCheckpointStore:
     def _result_from_dict(document: dict[str, object]) -> EngineTranscript:
         try:
             raw_segments = cast("list[dict[str, object]]", document["segments"])
-            segments = tuple(
-                RecognizedSegment(
-                    index=int(cast("int", raw["index"])),
-                    start_seconds=float(cast("float", raw["start_seconds"])),
-                    end_seconds=float(cast("float", raw["end_seconds"])),
-                    text=str(raw["text"]),
-                    average_log_probability=(
-                        None
-                        if raw.get("average_log_probability") is None
-                        else float(cast("float", raw["average_log_probability"]))
-                    ),
-                    no_speech_probability=(
-                        None
-                        if raw.get("no_speech_probability") is None
-                        else float(cast("float", raw["no_speech_probability"]))
-                    ),
-                    detected_language=(
-                        None
-                        if raw.get("detected_language") is None
-                        else str(raw["detected_language"])
-                    ),
-                    language_probability=(
-                        None
-                        if raw.get("language_probability") is None
-                        else float(cast("float", raw["language_probability"]))
-                    ),
+            segments = []
+            for raw in raw_segments:
+                raw_words = cast("list[dict[str, object]]", raw["words"])
+                words = tuple(
+                    AlignedWord(
+                        start_seconds=float(cast("float", word["start_seconds"])),
+                        end_seconds=float(cast("float", word["end_seconds"])),
+                        text=str(word["text"]),
+                        probability=(
+                            None
+                            if word.get("probability") is None
+                            else float(cast("float", word["probability"]))
+                        ),
+                        speaker_ref=(
+                            None
+                            if word.get("speaker_ref") is None
+                            else str(word["speaker_ref"])
+                        ),
+                    )
+                    for word in raw_words
                 )
-                for raw in raw_segments
-            )
+                segments.append(
+                    AlignedRecognizedSegment(
+                        index=int(cast("int", raw["index"])),
+                        start_seconds=float(cast("float", raw["start_seconds"])),
+                        end_seconds=float(cast("float", raw["end_seconds"])),
+                        text=str(raw["text"]),
+                        average_log_probability=(
+                            None
+                            if raw.get("average_log_probability") is None
+                            else float(cast("float", raw["average_log_probability"]))
+                        ),
+                        no_speech_probability=(
+                            None
+                            if raw.get("no_speech_probability") is None
+                            else float(cast("float", raw["no_speech_probability"]))
+                        ),
+                        detected_language=(
+                            None
+                            if raw.get("detected_language") is None
+                            else str(raw["detected_language"])
+                        ),
+                        language_probability=(
+                            None
+                            if raw.get("language_probability") is None
+                            else float(cast("float", raw["language_probability"]))
+                        ),
+                        words=words,
+                    )
+                )
             language_value = document.get("language")
             probability_value = document.get("language_probability")
             return EngineTranscript(
-                segments=segments,
+                segments=tuple(segments),
                 language=None if language_value is None else str(language_value),
                 language_probability=(
                     None

--- a/src/echoflow/transcription/checkpoint.py
+++ b/src/echoflow/transcription/checkpoint.py
@@ -311,7 +311,10 @@ class LocalCheckpointStore:
             enhancement = cast("dict[str, object]", contract["enhancement"])
             segmentation = cast("dict[str, object]", contract["segmentation"])
             resources = cast("dict[str, object]", contract["resources"])
-            if int(cast("int", alignment["schema_version"])) != _ALIGNMENT_SCHEMA_VERSION:
+            if (
+                int(cast("int", alignment["schema_version"]))
+                != _ALIGNMENT_SCHEMA_VERSION
+            ):
                 raise ValueError("unsupported word-alignment schema version")
             if alignment["word_timestamps"] is not True:
                 raise ValueError("word alignment must remain enabled for resume")

--- a/src/echoflow/transcription/diarization.py
+++ b/src/echoflow/transcription/diarization.py
@@ -8,6 +8,7 @@ from importlib import import_module, metadata
 from pathlib import Path
 from typing import Any, cast
 
+from echoflow.transcription.alignment import aligned_words
 from echoflow.transcription.errors import (
     DiarizationDependencyError,
     DiarizationError,
@@ -71,9 +72,6 @@ class PyannoteSpeakerDiarizer:
         request: SpeakerDiarizationRequest | None = None,
     ) -> SpeakerDiarizationResult:
         """Return deterministic anonymous turns for one canonical local audio file."""
-        # Prove the optional runtime is safe and installed before model resolution.
-        # This prevents both needless gated downloads and execution of a known
-        # vulnerable Lightning checkpoint loader.
         pyannote = self._load_pyannote()
         local_model = self._resolve_model(allow_model_download=allow_model_download)
         try:
@@ -133,8 +131,6 @@ class PyannoteSpeakerDiarizer:
             ) from exc
 
     def _load_pyannote(self) -> Any:
-        # Set the upstream-documented disable value before importing pyannote so
-        # EchoFlow never emits pyannote usage metrics by default.
         os.environ["PYANNOTE_METRICS_ENABLED"] = "0"
         self._require_safe_lightning()
         try:
@@ -193,27 +189,68 @@ def project_speaker_refs(
     segments: tuple[RecognizedSegment, ...],
     turns: tuple[SpeakerTurn, ...],
 ) -> tuple[RecognizedSegment, ...]:
-    """Attach a speaker only when one unique diarized speaker overlaps a segment.
+    """Project diarization onto the finest trustworthy timing evidence available.
 
-    The exact speaker-turn timeline remains the primary diarization evidence. A text
-    segment that crosses a speaker change or overlapping speech stays unattributed
-    until a finer alignment capability can split the text defensibly.
+    With aligned words, each word receives a speaker only when exactly one diarized
+    speaker overlaps that word. The enclosing ASR segment receives a speaker only when
+    every aligned word is attributed to the same speaker. Without word evidence, the
+    original conservative whole-segment behavior remains in place.
     """
     projected: list[RecognizedSegment] = []
     for segment in segments:
-        if segment.speaker_ref is not None:
+        words = aligned_words(segment)
+        if segment.speaker_ref is not None or any(
+            word.speaker_ref is not None for word in words
+        ):
             raise ValueError("speaker projection refuses to overwrite existing labels")
-        speakers = {
-            turn.speaker_ref for turn in turns if _overlap_seconds(segment, turn) > 0
-        }
-        speaker_ref = next(iter(speakers)) if len(speakers) == 1 else None
+
+        if words:
+            projected_words = tuple(
+                replace(
+                    word,
+                    speaker_ref=_speaker_for_interval(
+                        word.start_seconds, word.end_seconds, turns
+                    ),
+                )
+                for word in words
+            )
+            speaker_refs = {word.speaker_ref for word in projected_words}
+            speaker_ref = (
+                next(iter(speaker_refs))
+                if len(speaker_refs) == 1 and None not in speaker_refs
+                else None
+            )
+            projected.append(
+                replace(segment, words=projected_words, speaker_ref=speaker_ref)
+            )
+            continue
+
+        speaker_ref = _speaker_for_interval(
+            segment.start_seconds, segment.end_seconds, turns
+        )
         projected.append(replace(segment, speaker_ref=speaker_ref))
     return tuple(projected)
 
 
-def _overlap_seconds(segment: RecognizedSegment, turn: SpeakerTurn) -> float:
+def _speaker_for_interval(
+    start_seconds: float,
+    end_seconds: float,
+    turns: tuple[SpeakerTurn, ...],
+) -> str | None:
+    speakers = {
+        turn.speaker_ref
+        for turn in turns
+        if _overlap_seconds(start_seconds, end_seconds, turn) > 0
+    }
+    return next(iter(speakers)) if len(speakers) == 1 else None
+
+
+def _overlap_seconds(
+    start_seconds: float,
+    end_seconds: float,
+    turn: SpeakerTurn,
+) -> float:
     return max(
         0.0,
-        min(segment.end_seconds, turn.end_seconds)
-        - max(segment.start_seconds, turn.start_seconds),
+        min(end_seconds, turn.end_seconds) - max(start_seconds, turn.start_seconds),
     )

--- a/src/echoflow/transcription/tests/test_alignment.py
+++ b/src/echoflow/transcription/tests/test_alignment.py
@@ -1,0 +1,184 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from echoflow.transcription.alignment import (
+    AlignedRecognizedSegment,
+    AlignedWord,
+    aligned_words,
+)
+from echoflow.transcription.assembly import TranscriptAssembler
+from echoflow.transcription.diarization import project_speaker_refs
+from echoflow.transcription.models import AudioSegmentWindow, EngineTranscript
+from echoflow.transcription.speaker_models import SpeakerTurn
+
+
+def aligned_segment(
+    *,
+    index=0,
+    start=0.0,
+    end=2.0,
+    text="hello world",
+    words=None,
+):
+    return AlignedRecognizedSegment(
+        index=index,
+        start_seconds=start,
+        end_seconds=end,
+        text=text,
+        words=(
+            tuple(words)
+            if words is not None
+            else (
+                AlignedWord(start, start + 1.0, "hello", 0.9),
+                AlignedWord(start + 1.0, end, "world", 0.8),
+            )
+        ),
+    )
+
+
+def test_aligned_word_is_frozen_json_safe_and_allows_zero_duration():
+    word = AlignedWord(1.25, 1.25, "yes", 0.75)
+
+    assert word.to_dict() == {
+        "start_seconds": 1.25,
+        "end_seconds": 1.25,
+        "text": "yes",
+        "probability": 0.75,
+        "speaker_ref": None,
+    }
+    assert not hasattr(word, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        word.text = "changed"
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        ((-0.1, 0.1, "word"), "word timestamps must be finite and ordered"),
+        ((1.0, 0.5, "word"), "word timestamps must be finite and ordered"),
+        ((float("nan"), 1.0, "word"), "word timestamps must be finite and ordered"),
+        ((0.0, 1.0, " "), "word text cannot be empty"),
+        ((0.0, 1.0, "word", -0.1), "word probability must be between 0 and 1"),
+        ((0.0, 1.0, "word", 1.1), "word probability must be between 0 and 1"),
+    ],
+)
+def test_aligned_word_rejects_invalid_evidence(args, message):
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        AlignedWord(*args)
+
+
+def test_aligned_segment_serializes_words_without_changing_base_segment_contract():
+    segment = aligned_segment()
+
+    document = segment.to_dict()
+    assert document["segment_id"] == "segment-000000"
+    assert [word["text"] for word in document["words"]] == ["hello", "world"]
+    assert aligned_words(segment) == segment.words
+
+
+@pytest.mark.parametrize(
+    ("words", "message"),
+    [
+        ((AlignedWord(0.0, 1.1, "late"),), "word timestamp ends after its segment"),
+        (
+            (AlignedWord(0.0, 0.7, "one"), AlignedWord(0.6, 1.0, "two")),
+            "word timestamps must be ordered and non-overlapping",
+        ),
+    ],
+)
+def test_aligned_segment_rejects_words_outside_or_crossing_each_other(words, message):
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        aligned_segment(end=1.0, text="one two", words=words)
+
+
+def test_assembler_rebases_aligned_words_to_source_relative_timeline():
+    first_window = AudioSegmentWindow(0, 0, 100, 10)
+    second_window = AudioSegmentWindow(1, 100, 200, 10)
+    first = EngineTranscript(
+        (aligned_segment(start=1.0, end=3.0),),
+        "en",
+        0.9,
+        "1.2.1",
+    )
+    second = EngineTranscript(
+        (aligned_segment(start=2.0, end=4.0),),
+        "en",
+        0.8,
+        "1.2.1",
+    )
+
+    result = TranscriptAssembler().assemble(
+        ((first_window, first), (second_window, second))
+    )
+
+    assert [(segment.start_seconds, segment.end_seconds) for segment in result.segments] == [
+        (1.0, 3.0),
+        (12.0, 14.0),
+    ]
+    assert [
+        (word.start_seconds, word.end_seconds)
+        for word in aligned_words(result.segments[1])
+    ] == [(12.0, 13.0), (13.0, 14.0)]
+
+
+def test_word_alignment_makes_speaker_handoff_visible_without_false_segment_precision():
+    segment = aligned_segment(
+        start=0.0,
+        end=4.0,
+        text="one two three four",
+        words=(
+            AlignedWord(0.0, 1.0, "one"),
+            AlignedWord(1.0, 2.0, "two"),
+            AlignedWord(2.0, 3.0, "three"),
+            AlignedWord(3.0, 4.0, "four"),
+        ),
+    )
+    turns = (
+        SpeakerTurn(0.0, 2.0, "speaker-01"),
+        SpeakerTurn(2.0, 4.0, "speaker-02"),
+    )
+
+    projected = project_speaker_refs((segment,), turns)[0]
+
+    assert projected.speaker_ref is None
+    assert [word.speaker_ref for word in aligned_words(projected)] == [
+        "speaker-01",
+        "speaker-01",
+        "speaker-02",
+        "speaker-02",
+    ]
+
+
+def test_word_crossing_overlapping_speakers_stays_unattributed():
+    segment = aligned_segment(
+        start=0.0,
+        end=2.0,
+        text="hello there",
+        words=(
+            AlignedWord(0.0, 1.0, "hello"),
+            AlignedWord(1.0, 2.0, "there"),
+        ),
+    )
+    turns = (
+        SpeakerTurn(0.0, 1.5, "speaker-01"),
+        SpeakerTurn(1.5, 2.0, "speaker-02"),
+    )
+
+    projected = project_speaker_refs((segment,), turns)[0]
+
+    assert projected.speaker_ref is None
+    assert [word.speaker_ref for word in aligned_words(projected)] == [
+        "speaker-01",
+        None,
+    ]
+
+
+def test_uniform_word_speaker_projection_retains_segment_level_convenience_label():
+    segment = aligned_segment()
+    turns = (SpeakerTurn(0.0, 2.0, "speaker-01"),)
+
+    projected = project_speaker_refs((segment,), turns)[0]
+
+    assert projected.speaker_ref == "speaker-01"
+    assert {word.speaker_ref for word in aligned_words(projected)} == {"speaker-01"}

--- a/src/echoflow/transcription/tests/test_alignment.py
+++ b/src/echoflow/transcription/tests/test_alignment.py
@@ -1,4 +1,5 @@
 from dataclasses import FrozenInstanceError
+from typing import cast
 
 import pytest
 
@@ -81,7 +82,8 @@ def test_aligned_segment_serializes_words_without_changing_base_segment_contract
 
     document = segment.to_dict()
     assert document["segment_id"] == "segment-000000"
-    assert [word["text"] for word in document["words"]] == ["hello", "world"]
+    words = cast("list[dict[str, object]]", document["words"])
+    assert [word["text"] for word in words] == ["hello", "world"]
     assert aligned_words(segment) == segment.words
 
 
@@ -117,8 +119,9 @@ def test_canonical_transcript_serializes_source_relative_word_evidence():
     )
 
     document = transcript.to_dict()
+    segments = cast("list[dict[str, object]]", document["segments"])
+    words = cast("list[dict[str, object]]", segments[0]["words"])
 
-    words = document["segments"][0]["words"]
     assert words == [
         {
             "start_seconds": 12.4,

--- a/src/echoflow/transcription/tests/test_alignment.py
+++ b/src/echoflow/transcription/tests/test_alignment.py
@@ -193,7 +193,9 @@ def test_assembler_rebases_aligned_words_to_source_relative_timeline():
         ((first_window, first), (second_window, second))
     )
 
-    assert [(segment.start_seconds, segment.end_seconds) for segment in result.segments] == [
+    assert [
+        (segment.start_seconds, segment.end_seconds) for segment in result.segments
+    ] == [
         (1.0, 3.0),
         (12.0, 14.0),
     ]

--- a/src/echoflow/transcription/tests/test_alignment.py
+++ b/src/echoflow/transcription/tests/test_alignment.py
@@ -2,6 +2,7 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
+from echoflow.runner.models import ProcessingProfile
 from echoflow.transcription.alignment import (
     AlignedRecognizedSegment,
     AlignedWord,
@@ -9,7 +10,14 @@ from echoflow.transcription.alignment import (
 )
 from echoflow.transcription.assembly import TranscriptAssembler
 from echoflow.transcription.diarization import project_speaker_refs
-from echoflow.transcription.models import AudioSegmentWindow, EngineTranscript
+from echoflow.transcription.models import (
+    AudioSegmentWindow,
+    CanonicalTranscript,
+    DecodeStrategy,
+    EngineProvenance,
+    EngineTranscript,
+    TranscriptSource,
+)
 from echoflow.transcription.speaker_models import SpeakerTurn
 
 
@@ -77,6 +85,58 @@ def test_aligned_segment_serializes_words_without_changing_base_segment_contract
     assert aligned_words(segment) == segment.words
 
 
+def test_canonical_transcript_serializes_source_relative_word_evidence():
+    segment = aligned_segment(
+        start=12.4,
+        end=14.4,
+        words=(
+            AlignedWord(12.4, 13.1, " hello", 0.91),
+            AlignedWord(13.1, 14.4, " world", 0.87),
+        ),
+    )
+    transcript = CanonicalTranscript(
+        job_id="job-aligned",
+        source=TranscriptSource("0" * 64, 1, 0, "wav", 20.0, 0),
+        profile=ProcessingProfile.BALANCED,
+        provisional=False,
+        decode_strategy=DecodeStrategy.DIRECT,
+        engine=EngineProvenance(
+            name="faster-whisper",
+            package_version="1.2.1",
+            model="small",
+            model_revision="revision-1",
+            device="cpu",
+            compute_type="int8",
+            cpu_threads=2,
+            beam_size=5,
+            requested_language=None,
+        ),
+        detected_language="en",
+        language_probability=0.9,
+        segments=(segment,),
+    )
+
+    document = transcript.to_dict()
+
+    words = document["segments"][0]["words"]
+    assert words == [
+        {
+            "start_seconds": 12.4,
+            "end_seconds": 13.1,
+            "text": " hello",
+            "probability": 0.91,
+            "speaker_ref": None,
+        },
+        {
+            "start_seconds": 13.1,
+            "end_seconds": 14.4,
+            "text": " world",
+            "probability": 0.87,
+            "speaker_ref": None,
+        },
+    ]
+
+
 @pytest.mark.parametrize(
     ("words", "message"),
     [
@@ -90,6 +150,24 @@ def test_aligned_segment_serializes_words_without_changing_base_segment_contract
 def test_aligned_segment_rejects_words_outside_or_crossing_each_other(words, message):
     with pytest.raises(ValueError, match=f"^{message}$"):
         aligned_segment(end=1.0, text="one two", words=words)
+
+
+def test_segment_level_speaker_requires_uniform_word_attribution():
+    with pytest.raises(
+        ValueError,
+        match="^segment speaker_ref requires uniformly attributed aligned words$",
+    ):
+        AlignedRecognizedSegment(
+            index=0,
+            start_seconds=0.0,
+            end_seconds=2.0,
+            text="hello world",
+            speaker_ref="speaker-01",
+            words=(
+                AlignedWord(0.0, 1.0, "hello", speaker_ref="speaker-01"),
+                AlignedWord(1.0, 2.0, "world", speaker_ref="speaker-02"),
+            ),
+        )
 
 
 def test_assembler_rebases_aligned_words_to_source_relative_timeline():

--- a/src/echoflow/transcription/tests/test_backend.py
+++ b/src/echoflow/transcription/tests/test_backend.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from echoflow.transcription.alignment import aligned_words
 from echoflow.transcription.backend import FasterWhisperTranscriber
 from echoflow.transcription.errors import (
     ModelUnavailableError,
@@ -27,13 +28,30 @@ def configuration(tmp_path, *, revision="managed-revision", language=None):
     )
 
 
-def segment(start=0.0, end=1.0, text=" hello ", avg=-0.2, no_speech=0.1):
+def word(start=0.0, end=0.5, text=" hello", probability=0.9):
+    return SimpleNamespace(
+        start=start,
+        end=end,
+        word=text,
+        probability=probability,
+    )
+
+
+def segment(
+    start=0.0,
+    end=1.0,
+    text=" hello ",
+    avg=-0.2,
+    no_speech=0.1,
+    words=None,
+):
     return SimpleNamespace(
         start=start,
         end=end,
         text=text,
         avg_logprob=avg,
         no_speech_prob=no_speech,
+        words=words,
     )
 
 
@@ -57,9 +75,9 @@ def test_local_cpu_session_uses_exact_managed_plan_and_consumes_generator(tmp_pa
 
             def generated():
                 calls.append("iterated")
-                yield segment()
+                yield segment(words=(word(), word(0.5, 1.0, " world", 0.8)))
                 yield segment(1.0, 1.5, "   ")
-                yield segment(1.5, 2.0, "world", -0.4, 0.2)
+                yield segment(1.5, 2.0, "world", -0.4, 0.2, (word(1.5, 2.0, "world"),))
 
             return generated(), SimpleNamespace(
                 language=" en ", language_probability="0.95"
@@ -87,7 +105,7 @@ def test_local_cpu_session_uses_exact_managed_plan_and_consumes_generator(tmp_pa
         {
             "beam_size": 1,
             "language": None,
-            "word_timestamps": False,
+            "word_timestamps": True,
             "multilingual": True,
             "chunk_length": 8,
             "condition_on_previous_text": False,
@@ -100,6 +118,8 @@ def test_local_cpu_session_uses_exact_managed_plan_and_consumes_generator(tmp_pa
     assert [item.index for item in result.segments] == [0, 1]
     assert result.segments[0].average_log_probability == -0.2
     assert result.segments[1].no_speech_probability == 0.2
+    assert [item.text for item in aligned_words(result.segments[0])] == ["hello", "world"]
+    assert [item.probability for item in aligned_words(result.segments[0])] == [0.9, 0.8]
     assert result.language == "en"
     assert result.language_probability == 0.95
     assert result.engine_version == "1.2.1"
@@ -141,6 +161,7 @@ def test_explicit_language_disables_multilingual_detection_window(tmp_path):
     assert kwargs["multilingual"] is False
     assert kwargs["chunk_length"] is None
     assert kwargs["condition_on_previous_text"] is True
+    assert kwargs["word_timestamps"] is True
 
 
 @pytest.mark.parametrize(
@@ -204,11 +225,14 @@ def test_engine_iteration_failure_is_redacted(tmp_path):
 @pytest.mark.parametrize(
     "bad_segment",
     [
-        SimpleNamespace(text="words", start="bad", end=1),
-        SimpleNamespace(text="words", start=2, end=1),
+        SimpleNamespace(text="words", start="bad", end=1, words=None),
+        SimpleNamespace(text="words", start=2, end=1, words=None),
+        segment(words=(word(-1, 0.5, "bad"),)),
+        segment(words=(word(0.0, 1.1, "bad"),)),
+        segment(words=(word(0.0, 0.5, "one"), word(0.4, 0.8, "two"))),
     ],
 )
-def test_invalid_engine_segment_values_are_typed(tmp_path, bad_segment):
+def test_invalid_engine_segment_or_word_values_are_typed(tmp_path, bad_segment):
     class Model:
         def __init__(self, *_args, **_kwargs):
             pass

--- a/src/echoflow/transcription/tests/test_backend.py
+++ b/src/echoflow/transcription/tests/test_backend.py
@@ -122,7 +122,10 @@ def test_local_cpu_session_uses_exact_managed_plan_and_consumes_generator(tmp_pa
         " hello",
         " world",
     ]
-    assert [item.probability for item in aligned_words(result.segments[0])] == [0.9, 0.8]
+    assert [item.probability for item in aligned_words(result.segments[0])] == [
+        0.9,
+        0.8,
+    ]
     assert result.language == "en"
     assert result.language_probability == 0.95
     assert result.engine_version == "1.2.1"

--- a/src/echoflow/transcription/tests/test_backend.py
+++ b/src/echoflow/transcription/tests/test_backend.py
@@ -118,7 +118,10 @@ def test_local_cpu_session_uses_exact_managed_plan_and_consumes_generator(tmp_pa
     assert [item.index for item in result.segments] == [0, 1]
     assert result.segments[0].average_log_probability == -0.2
     assert result.segments[1].no_speech_probability == 0.2
-    assert [item.text for item in aligned_words(result.segments[0])] == ["hello", "world"]
+    assert [item.text for item in aligned_words(result.segments[0])] == [
+        " hello",
+        " world",
+    ]
     assert [item.probability for item in aligned_words(result.segments[0])] == [0.9, 0.8]
     assert result.language == "en"
     assert result.language_probability == 0.95

--- a/src/echoflow/transcription/tests/test_checkpoint.py
+++ b/src/echoflow/transcription/tests/test_checkpoint.py
@@ -10,6 +10,11 @@ from echoflow.core.performance_tracker import PerformanceTracker
 from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
 from echoflow.runner.models import ProcessingProfile
+from echoflow.transcription.alignment import (
+    AlignedRecognizedSegment,
+    AlignedWord,
+    aligned_words,
+)
 from echoflow.transcription.checkpoint import LocalCheckpointStore
 from echoflow.transcription.enhancement import ffmpeg_afftdn_configuration
 from echoflow.transcription.enhancement_models import EnhancementConfiguration
@@ -20,7 +25,6 @@ from echoflow.transcription.models import (
     DecodeConfiguration,
     DecodeStrategy,
     EngineTranscript,
-    RecognizedSegment,
     SegmentationConfiguration,
 )
 from echoflow.workspace.models import Job, JobId, WorkspacePaths
@@ -85,7 +89,7 @@ def context(tmp_path, *, profile=ProcessingProfile.BALANCED):
 def result(text, *, language="en"):
     return EngineTranscript(
         (
-            RecognizedSegment(
+            AlignedRecognizedSegment(
                 0,
                 0.0,
                 1.0,
@@ -94,6 +98,7 @@ def result(text, *, language="en"):
                 0.1,
                 detected_language=language,
                 language_probability=0.98,
+                words=(AlignedWord(0.0, 1.0, text, 0.91),),
             ),
         ),
         language,
@@ -117,6 +122,11 @@ def test_manifest_is_private_local_and_omits_source_and_model_paths(tmp_path):
     contract = json.loads(document)["contract"]
     assert contract["source"]["sha256"] == "a" * 64
     assert contract["enhancement"]["mode"] == "off"
+    assert contract["alignment"] == {
+        "provider": "faster-whisper",
+        "schema_version": 1,
+        "word_timestamps": True,
+    }
     if os.name != "nt":
         assert manifest.stat().st_mode & 0o777 == 0o600
         assert manifest.parent.stat().st_mode & 0o777 == 0o700
@@ -141,7 +151,7 @@ def test_manifest_restores_original_execution_settings_without_local_paths(tmp_p
     assert restored_engine.model_cache_path == (tmp_path / "new-model-cache").resolve()
 
 
-def test_completed_segment_round_trips_with_detected_language(tmp_path):
+def test_completed_segment_round_trips_with_detected_language_and_word_alignment(tmp_path):
     store, job, plan, windows, _ = context(tmp_path)
     store.initialize(job, plan, windows)
     store.save_segment(job, plan, windows, windows[0], result("sensitive words"))
@@ -151,9 +161,13 @@ def test_completed_segment_round_trips_with_detected_language(tmp_path):
     assert len(restored.completed) == 1
     assert restored.completed[0][0] == windows[0]
     restored_result = restored.completed[0][1]
-    assert restored_result.segments[0].text == "sensitive words"
-    assert restored_result.segments[0].detected_language == "en"
-    assert restored_result.segments[0].language_probability == 0.98
+    restored_segment = restored_result.segments[0]
+    assert restored_segment.text == "sensitive words"
+    assert restored_segment.detected_language == "en"
+    assert restored_segment.language_probability == 0.98
+    assert aligned_words(restored_segment) == (
+        AlignedWord(0.0, 1.0, "sensitive words", 0.91),
+    )
     assert restored.engine_version == "1.2.1"
 
 
@@ -167,6 +181,23 @@ def test_contract_change_refuses_resume(tmp_path):
         match="^Private checkpoint does not match the current transcription contract$",
     ):
         store.restore(job, plan, windows)
+
+
+def test_missing_alignment_contract_refuses_pre_alignment_checkpoint(tmp_path):
+    store, job, plan, windows, _ = context(tmp_path)
+    store.initialize(job, plan, windows)
+    manifest = job.workspace_dir / "checkpoints" / "manifest.json"
+    document = json.loads(manifest.read_text())
+    contract = document["contract"]
+    contract.pop("alignment")
+    document["contract_sha256"] = store._digest(contract)
+    manifest.write_bytes(store._canonical_bytes(document))
+
+    with pytest.raises(
+        CheckpointError,
+        match="^Private checkpoint contract is malformed$",
+    ):
+        store.resume_settings(job)
 
 
 def test_enhancement_change_refuses_resume(tmp_path):

--- a/src/echoflow/transcription/tests/test_checkpoint_process_acceptance.py
+++ b/src/echoflow/transcription/tests/test_checkpoint_process_acceptance.py
@@ -10,11 +10,8 @@ from dependency_injector import providers
 from echoflow.app.app_container import AppContainer
 from echoflow.core.config import AppConfig
 from echoflow.runner.models import ProcessingProfile
-from echoflow.transcription.models import (
-    AudioSegmentWindow,
-    EngineTranscript,
-    RecognizedSegment,
-)
+from echoflow.transcription.alignment import AlignedRecognizedSegment, AlignedWord
+from echoflow.transcription.models import AudioSegmentWindow, EngineTranscript
 from echoflow.workspace.models import JobId
 
 _EXIT_AFTER_CHECKPOINT = 73
@@ -86,11 +83,19 @@ def _crash_after_checkpoint(root_text: str) -> None:
         _WINDOW,
         EngineTranscript(
             segments=(
-                RecognizedSegment(
+                AlignedRecognizedSegment(
                     index=0,
                     start_seconds=0.0,
                     end_seconds=1.0,
                     text="Durable checkpoint.",
+                    words=(
+                        AlignedWord(
+                            start_seconds=0.0,
+                            end_seconds=1.0,
+                            text=" Durable checkpoint.",
+                            probability=0.99,
+                        ),
+                    ),
                 ),
             ),
             language="en",
@@ -129,6 +134,15 @@ def test_completed_checkpoint_survives_unceremonious_process_exit(tmp_path):
     window, transcript = restored.completed[0]
     assert window == _WINDOW
     assert transcript.segments[0].text == "Durable checkpoint."
+    assert transcript.segments[0].to_dict()["words"] == [
+        {
+            "start_seconds": 0.0,
+            "end_seconds": 1.0,
+            "text": " Durable checkpoint.",
+            "probability": 0.99,
+            "speaker_ref": None,
+        }
+    ]
     assert transcript.language == "en"
     assert restored.engine_version == "crash-acceptance-engine"
 

--- a/src/echoflow/transcription/tests/test_resume.py
+++ b/src/echoflow/transcription/tests/test_resume.py
@@ -2,9 +2,30 @@ from unittest.mock import call
 
 import pytest
 
+from echoflow.transcription.alignment import AlignedRecognizedSegment, AlignedWord
 from echoflow.transcription.checkpoint import LocalCheckpointStore
 from echoflow.transcription.errors import CheckpointError, TranscriptionError
-from echoflow.transcription.tests.test_executor import executor, local_result, plan
+from echoflow.transcription.models import EngineTranscript
+from echoflow.transcription.tests.test_executor import executor, plan
+
+
+def local_result(text, *, language="en", probability=0.98):
+    return EngineTranscript(
+        (
+            AlignedRecognizedSegment(
+                0,
+                0.0,
+                1.0,
+                text,
+                -0.2,
+                0.1,
+                words=(AlignedWord(0.0, 1.0, text, 0.9),),
+            ),
+        ),
+        language,
+        probability,
+        "1.2.1",
+    )
 
 
 def _with_real_checkpoints(service):


### PR DESCRIPTION
## What changed

This tranche adds EchoFlow's first word/timestamp alignment layer without adding another ML model or changing the canonical source timeline. It retains faster-whisper's native per-word timing evidence, validates it, rebases it through EchoFlow's deterministic segmentation timeline, persists it through checkpoints/resume, and uses it for finer anonymous-speaker projection.

### Word evidence

- add frozen/slotted `AlignedWord` and `AlignedRecognizedSegment` values
- enable faster-whisper `word_timestamps=True`
- retain engine word start/end, **exact token text** (including meaningful leading whitespace), probability, and optional speaker ref
- validate finite/ordered timestamps, segment bounds, non-overlap, and probability bounds
- tolerate small engine boundary/rounding differences without rewriting stored timing values
- allow zero-duration engine observations instead of fabricating duration

### Source-relative assembly

- rebase word intervals from each materialized work window onto EchoFlow's source-relative canonical timeline
- preserve immutable segment enrichments with `dataclasses.replace`
- keep segmentation/checkpoint boundaries from leaking into published word timestamps
- serialize nested word timing into canonical JSON

### Speaker attribution

- project diarization onto aligned words when word evidence exists
- assign a word only when exactly one diarized speaker overlaps that word interval
- retain a segment-level speaker convenience label only when every aligned word is attributed to the same speaker
- keep mixed handoffs and ambiguous/overlapping words unlabeled at the segment level rather than inventing precision
- preserve the existing conservative whole-segment behavior when word evidence is absent

### Checkpoint/resume contract

- persist aligned words in private per-window checkpoints
- record an explicit alignment contract (`schema_version`, provider, `word_timestamps`)
- require the alignment contract on resume so pre-alignment checkpoints cannot silently mix with newly aligned work
- round-trip word timing evidence through interrupted/resumed jobs
- update the abrupt-process acceptance worker so a checkpoint written immediately before `os._exit(...)` proves aligned word evidence survives the crash boundary

### Transcript library compatibility

- canonical aligned segments add nested `words` evidence
- the existing search projection intentionally ignores that extra nested detail and continues indexing canonical segment text once
- add a regression test proving aligned canonical JSON remains compatible with lexical/semantic projection

### Documentation / product sequencing

- add `docs/architecture/word-alignment.md`
- update diarization and processing-capability docs for word-level speaker projection
- update README so word timing is a current product capability rather than hidden backend detail
- advance `ROADMAP.md`: original-media timecode/capture provenance is now next, then better speaker overlap/display-label UX, then richer aligned research-navigation UX, with source separation later

## Why

Segment-level ASR timestamps are too coarse for precise speaker handoffs, future search highlighting, jump-to-audio, and durable annotations. Faster-whisper already exposes native word timing evidence, so EchoFlow can preserve it locally instead of introducing a separate alignment model and second inference pass.

This is intentionally described as **engine-produced/native word timing**, not independent forced alignment. A future forced-alignment provider can be qualified separately if native timing proves insufficient for a real use case.

The product rule remains conservative: finer timing is additional evidence, not permission to claim speaker certainty where multiple diarized speakers overlap the same word.

## Qualification added

- word model boundary/serialization tests
- invalid/NaN/reversed/out-of-segment/overlapping word timing cases
- segment/word speaker consistency validation
- canonical JSON word-evidence serialization
- multi-window source-relative rebasing
- speaker handoff and ambiguous-overlap cases
- checkpoint manifest alignment identity
- aligned checkpoint round-trip and resume
- pre-alignment checkpoint rejection
- abrupt-process aligned-checkpoint acceptance
- transcript-library projection compatibility

One earlier macOS run exposed the crash-acceptance fixture still fabricating the old base segment shape. That fixture was updated to fabricate the current aligned engine result rather than weakening checkpoint restore. A subsequent current-head macOS lane completed successfully; Linux quality and Windows remain governed by the normal PR workflow.

## Deliberately not included

- original-media SMPTE/container/capture-time provenance
- user-assigned speaker display labels
- special word-level TXT/SRT/VTT rendering
- speech/source separation
- a separate forced-alignment model
- phoneme-level timing or fabricated character offsets

Those remain later tranches in the agreed sequence.