### PR TITLE
feat(media): add source time references and human timestamps

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,6 +63,12 @@ The current media foundation includes:
 - exact integer-frame work windows and source-relative segment timestamps;
 - faster-whisper native per-word timestamp evidence rebased onto that same source
   timeline;
+- deterministic human elapsed presentation as unwrapped `HH:MM:SS.mmm` while numeric
+  source-relative seconds remain authoritative;
+- preservation of source-declared `timecode` and `creation_time` metadata at format and
+  stream scope when FFprobe reports it;
+- explicit provenance for conflicting source time declarations instead of silently
+  choosing one;
 - optional deterministic FFmpeg noise suppression;
 - timeline-preservation checks around enhanced audio; and
 - provenance recording for preprocessing that affected ASR input.
@@ -70,6 +76,15 @@ The current media foundation includes:
 Word alignment is part of the current faster-whisper execution/checkpoint contract. It
 preserves engine-produced timing rather than claiming an independent forced-alignment
 pass.
+
+Human elapsed strings are derived views, not durable evidence anchors. Source-declared
+timecode/capture metadata is parallel provenance, not a replacement for canonical
+elapsed time and not part of checkpoint source identity.
+
+The current time-provenance implementation deliberately does **not** perform SMPTE frame
+arithmetic, resolve drop-frame semantics, preserve every PTS/DTS origin, or infer
+cross-device synchronization. Those require qualified source semantics rather than
+optimistic string arithmetic.
 
 The original recording remains read-only evidence. Normalized/enhanced WAV files remain
 private derived processing material.
@@ -123,13 +138,13 @@ EchoFlow fails closed before pyannote execution/acquisition while that gate is a
 Canonical JSON is authoritative transcript evidence.
 
 It carries source and execution provenance, source-relative segment and word timestamps,
-language evidence, optional enhancement provenance, and optional speaker-turn/word
-speaker evidence.
+source-declared temporal tags when present, language evidence, optional enhancement
+provenance, and optional speaker-turn/word speaker evidence.
 
 TXT, SRT, and WebVTT remain deterministic segment-oriented publication views that can be
 regenerated without rerunning recognition. More expressive intra-segment speaker
-presentation belongs to the later speaker-UX tranche rather than being smuggled into the
-alignment work.
+presentation belongs to the speaker-UX tranche rather than being smuggled into timing
+work.
 
 ### Transcript library and retrieval
 
@@ -147,7 +162,9 @@ The local library now includes:
 - private numeric semantic vectors;
 - exact local dense similarity with hard filters before top-K;
 - reciprocal-rank hybrid BM25 + dense retrieval;
-- one evidence-bearing `SearchResponse` with lexical/semantic/fused ranks; and
+- one evidence-bearing `SearchResponse` with lexical/semantic/fused ranks;
+- human search-result time ranges such as `01:19:48.370–01:19:51.125` while JSON keeps
+  numeric seconds and exposes derived timestamp conveniences; and
 - corpus-fingerprint stale-vector refusal when canonical transcript bytes change.
 
 Nested word timing is additional canonical evidence. Current lexical/semantic projection
@@ -193,37 +210,12 @@ into a research library.
 
 # Near-term product sequence
 
-Word timing now gives EchoFlow a finer canonical evidence coordinate below the ASR
-segment. The next features should **add source clocks, improve how humans see speaker
-evidence, and then exploit those coordinates in the research workspace** before heavier
-source-separation machinery arrives.
+Word timing and human/source time provenance now give EchoFlow a finer canonical evidence
+coordinate and a sane way to present it. The next work should make speaker evidence
+legible to humans, then exploit the same coordinates in the research workspace before
+heavier source-separation machinery arrives.
 
-## 1. Original-media timecode and capture-time provenance
-
-EchoFlow currently exposes one clear canonical clock: elapsed source-relative seconds
-from the selected audio origin.
-
-That should remain stable.
-
-The next provenance layer should preserve additional clocks when the input actually
-contains them:
-
-- non-zero container/stream presentation origins;
-- SMPTE timecode;
-- stream start-time offsets;
-- camera/device capture timestamps;
-- timezone/offset metadata when trustworthy; and
-- explicit synchronization relationships between sources when known.
-
-These should be typed parallel provenance, not collapsed into an ambiguous `timestamp`
-field.
-
-The design should distinguish “metadata exists” from “metadata is trustworthy enough to
-map onto the transcript.” Word timing should remain expressed in canonical elapsed time,
-with additional media clocks providing mappings rather than replacing that coordinate
-system.
-
-## 2. Better speaker UX: overlap + user-assigned display labels
+## 1. Better speaker UX: overlap + user-assigned display labels
 
 Anonymous diarization evidence should remain anonymous-by-default and recording-scoped.
 
@@ -248,24 +240,29 @@ to a human:
 - let users assign display labels over stable anonymous refs; and
 - keep those labels durable and separate from rebuildable indexes.
 
-## 3. Search/research workspace UX over aligned coordinates
+## 2. Search/research workspace UX over aligned coordinates
 
-The retrieval engine now supports lexical, semantic, and hybrid ranking, while canonical
-transcripts now have finer word timing coordinates. Real corpus use should drive the next
-interface layer:
+The retrieval engine supports lexical, semantic, and hybrid ranking, while canonical
+transcripts now have word timing and human elapsed coordinates. Real corpus use should
+drive the next interface layer:
 
 - exact phrase/word highlighting inside a retrieved passage;
 - result-context expansion;
 - facets;
 - exportable result sets;
-- precise jump-to-audio;
+- precise jump-to-audio/video using numeric source-relative seconds;
 - saved searches/collections; and
-- durable tags, notes, and annotations anchored to durable evidence coordinates.
+- durable tags, notes, and annotations anchored to source identity plus durable canonical
+  evidence coordinates.
 
 The ownership rule is non-negotiable: user-authored state does not share deletion
 semantics with rebuildable indexes.
 
-## 4. Qualify semantic dependency and managed embedding custody
+A display string such as `01:19:48.370` is a convenience, not the annotation anchor.
+Likewise, a semantic chunk ID is rebuildable and must not become the only location of a
+user note.
+
+## 3. Qualify semantic dependency and managed embedding custody
 
 Before semantic search is advertised as a normal source install, qualify a locked
 optional semantic dependency set.
@@ -283,7 +280,7 @@ Target direction:
 
 Do not bypass `uv.lock` coherence to make the feature look more finished.
 
-## 5. Representative-device and enhancement qualification
+## 4. Representative-device and enhancement qualification
 
 Collect repeated benchmark evidence from at least:
 
@@ -299,18 +296,36 @@ embedding build cost, and semantic-query latency.
 
 Calibrate from measurements, not hardware marketing names.
 
+## 5. Deeper original-media clock qualification only when needed
+
+The current implementation preserves source-declared format/stream `timecode` and
+`creation_time` tags and keeps them distinct from canonical elapsed seconds.
+
+If real recordings require deterministic mapping to production/media clocks, extend that
+foundation with qualified evidence rather than guessing. Candidate work includes:
+
+- non-zero stream/container start-time or PTS/DTS origins;
+- exact rational frame rates and nominal timecode rates;
+- drop-frame/non-drop-frame semantics;
+- deterministic SMPTE-to-elapsed mappings;
+- timezone/offset normalization only when actually encoded; and
+- explicit synchronization relationships between independently recorded sources.
+
+“Metadata exists” and “metadata is trustworthy enough to map onto transcript evidence”
+remain different states.
+
 # Beginner-ready milestone
 
 The backend is already beginner-oriented in many internal decisions: resource discovery,
-model custody, recovery, provenance, alignment, and search are designed so the user does
-**not** need to manually operate those systems.
+model custody, recovery, provenance, alignment, time navigation, and search are designed
+so the user does **not** need to manually operate those systems.
 
 But a beginner-friendly product also needs a beginner-friendly delivery surface.
 
 A reasonable pre-1.0 usability milestone is:
 
-1. richer original-media time provenance;
-2. clearer speaker labels/overlap behavior over aligned evidence;
+1. clearer speaker labels/overlap behavior over aligned evidence;
+2. precise transcript navigation and durable note/annotation anchors;
 3. semantic dependency/model setup that no longer requires advanced manual environment
    preparation;
 4. representative qualification on ordinary hardware;
@@ -319,7 +334,7 @@ A reasonable pre-1.0 usability milestone is:
 7. a thin graphical shell over the existing application services.
 
 The GUI should be a presentation adapter, not a second implementation of transcription,
-search, or model policy.
+search, time mapping, or model policy.
 
 # Later capability: speech/source separation for overlapping speakers
 
@@ -350,6 +365,8 @@ but unqualified checkbox.
 Use real multi-recording corpora to exercise:
 
 - interruption/resume with aligned word evidence;
+- long-duration human time rendering across hour and 24-hour boundaries;
+- conflicting or absent source temporal metadata;
 - stale-process reconciliation;
 - progress rendering;
 - accelerator re-admission;
@@ -402,6 +419,7 @@ Interesting later investigations include:
   insufficient for a real use case;
 - finer intra-clause/romanized language attribution;
 - improved overlap rendering and source separation;
+- richer PTS/SMPTE synchronization only when real media requires it;
 - alternative qualified multilingual embedding models;
 - character n-gram/fuzzy retrieval for ASR names/acronyms/misspellings;
 - a small local cross-encoder reranker if measured benefit justifies it;

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@ searchable evidence corpus.
 | Find an exact phrase later | builds a private local lexical/BM25 transcript library |
 | Find an idea even when the wording changed | supports optional local semantic retrieval |
 | Get the best of both search styles | combines lexical and semantic results with inspectable reciprocal-rank fusion |
+| Stop calculating giant second counts | renders source-relative evidence as human `HH:MM:SS.mmm` coordinates while keeping numeric seconds authoritative |
+| Preserve camera/container time clues | records source-declared `timecode` and `creation_time` tags with format/stream provenance when present |
 | Verify where a result came from | carries timestamps, speakers/languages, hashes, canonical coordinates, and retrieval provenance |
 
 That is a lot of machinery. The point is not to make you operate the machinery. The
@@ -51,6 +53,14 @@ Start with **[Getting started](getting-started.md)**.
 
 It walks through installation, model setup, transcription, resume, exports, and search
 without requiring an architecture degree.
+
+### 🕰️ I want to understand transcript time and jumping around
+
+Read **[Transcript time without calculator gymnastics](time-navigation.md)**.
+
+It explains what word timestamps buy you, why `4788.37` seconds becomes
+`01:19:48.370`, how future click-to-seek and notes should anchor to evidence, and why a
+camera's embedded timecode is a different clock.
 
 ### 🔎 I want to search my transcripts
 
@@ -147,16 +157,19 @@ The backend is now broad enough that the next work is less about inventing a
 transcription engine and more about making evidence easier to navigate and the product
 easier to enter.
 
-The likely evidence-navigation sequence is:
+The evidence-navigation sequence has advanced:
 
-1. **word/timestamp alignment**, so highlighting, speaker attribution, annotations, and
-   jump-to-audio can use finer coordinates;
-2. **original-media timecode and capture-time provenance**, so source-relative seconds
-   can coexist with container/SMPTE/device time when the source provides it;
-3. **better speaker UX**, including user-assigned display labels for anonymous speakers
-   and better presentation of overlap; and
-4. **later, source separation for overlapping speech**, only after the simpler temporal
-   evidence model is strong enough to justify the additional compute and uncertainty.
+1. **word/timestamp alignment** is now in the foundation, so canonical evidence has
+   finer word coordinates;
+2. **human elapsed time + original-media temporal provenance** now makes those
+   coordinates readable and preserves source-declared time clues without conflating
+   clocks;
+3. **better speaker UX** is next, including user-assigned display labels for anonymous
+   speakers and better presentation of overlap;
+4. **aligned research-navigation UX** can then exploit the same coordinates for
+   highlighting, click-to-audio, durable notes, and annotations; and
+5. **later, source separation for overlapping speech** remains a measured capability,
+   not a premature checkbox.
 
 Packaging, installers, and a thin graphical interface remain important for ordinary
 non-developer use. The architecture is already intentionally arranged so those can sit

--- a/docs/architecture/media-and-timeline.md
+++ b/docs/architecture/media-and-timeline.md
@@ -1,54 +1,72 @@
 # Media normalization and transcript timeline 🎙️🕰️
 
-EchoFlow has to answer two deceptively simple questions before it can produce a useful
-transcript:
+EchoFlow has to answer three deceptively simple questions before recorded evidence is
+useful:
 
 1. **What exactly did we transcribe?**
-2. **What does a timestamp in the transcript actually mean?**
+2. **Where is a transcript span inside that recording?**
+3. **What other clocks did the original media claim to have?**
 
-Those questions get complicated quickly when the input is a video with multiple audio
-streams, a container with a non-zero presentation timestamp, or a camera file carrying
-capture-time metadata.
+Those are different questions. The architecture now keeps their answers separate.
 
-The current implementation solves the first layer rigorously: deterministic stream
-selection, source fingerprinting, canonical audio, exact frame windows, and one
-source-relative elapsed-time transcript.
+The canonical transcript timeline is always **elapsed source-relative seconds from the
+selected audio origin**. Humans can view that coordinate as `HH:MM:SS.mmm`. Original
+container/stream `timecode` and `creation_time` tags are preserved in parallel as
+source-declared provenance when FFprobe reports them.
 
-The next provenance step is to preserve **original-media timecode/capture-time evidence**
-without overloading that existing source-relative timeline.
+Nothing rewrites the meaning of the canonical elapsed coordinate.
+
+For the plain-language navigation guide, see
+**[Transcript time without calculator gymnastics](../time-navigation.md)**.
 
 ## The human version
 
-Today, if EchoFlow says a passage begins at `4221.7` seconds, it means:
+If EchoFlow says a passage begins at `4788.37` seconds, it means:
 
-> **4221.7 seconds after the beginning of the selected recording audio.**
+> **4788.37 seconds after the beginning of the selected recording audio.**
 
-That timeline survives normalization, segmentation, checkpoints, enhancement, and
-assembly.
+The human presentation is:
 
-It does **not yet** mean “camera wall-clock time 14:32:08,” “SMPTE 01:10:21:17,” or “the
-container's original PTS value.” Those are distinct pieces of provenance and should stay
-distinct.
+```text
+01:19:48.370
+```
+
+That timeline survives normalization, segmentation, checkpoints, enhancement, word
+alignment, and assembly.
+
+A file may also declare something like:
+
+```text
+timecode:      10:00:00:00
+creation_time: 2026-04-05T12:34:56Z
+```
+
+EchoFlow preserves those declarations with their format/stream origin. It does not treat
+them as interchangeable with `4788.37` seconds, and it does not claim that a device clock
+was historically correct merely because a tag exists.
 
 ```mermaid
 flowchart LR
-    A[Local media file] --> B[FFprobe inspection + fingerprint]
-    B --> C[Choose one audio stream]
-    C --> D[Canonical PCM timeline]
-    D --> E[Optional enhancement]
-    E --> F[Exact frame windows]
-    F --> G[Local ASR]
-    G --> H[Source-relative canonical transcript]
+    A[🎙️ Local media file] --> B[FFprobe + SHA-256]
+    B --> R[Canonical elapsed timeline<br/>0.000 s → ...]
+    B --> T[Declared timecode tags]
+    B --> C[Declared creation-time tags]
+    R --> W[Word + segment evidence]
+    W --> H[✨ Human display<br/>HH:MM:SS.mmm]
+    T --> P[Canonical source provenance]
+    C --> P
+    W --> X[📜 Canonical transcript]
+    P --> X
 
     classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef inspect fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef canonical fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef provenance fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
 
     class A source
-    class B,C inspect
-    class D,E,F,G process
-    class H evidence
+    class R,W,X canonical
+    class B,T,C,P provenance
+    class H view
 ```
 
 ## One input boundary for audio and video
@@ -56,11 +74,14 @@ flowchart LR
 EchoFlow treats every supported input as **audio-bearing local media**.
 
 Video is not a second downstream pipeline. FFprobe discovers the streams, EchoFlow
-selects one audio stream, and later processing discards video/subtitle/attachment/data
-streams.
+selects one audio stream, and transcription later discards unrelated video/subtitle/
+attachment/data streams from the working audio path.
 
 That means `interview.m4a`, `lecture.wav`, and `meeting.mp4` all converge on the same
 transcription contract once one audio stream has been selected.
+
+Temporal metadata discovery remains attached to the original media evidence, not to a
+normalized WAV derivative.
 
 ## What media inspection owns
 
@@ -72,6 +93,7 @@ For one local source it:
 - snapshots filesystem identity before inspection;
 - invokes FFprobe with a file-only protocol whitelist;
 - reads bounded container/stream metadata;
+- requests format/stream `timecode` and `creation_time` tags;
 - validates that at least one audio stream exists;
 - fingerprints the complete source with SHA-256;
 - snapshots filesystem identity again; and
@@ -81,6 +103,42 @@ The result is immutable `MediaInfo` evidence.
 
 Routine logs omit local paths by default because recording names and directory layouts
 may themselves be sensitive.
+
+## Source-declared temporal tags
+
+`MediaTemporalTag` records four things:
+
+| Field | Meaning |
+|---|---|
+| `kind` | currently `timecode` or `creation_time` |
+| `value` | the source-declared string |
+| `source` | `format` or `stream` |
+| `stream_index` | required for stream-scoped declarations, absent for format scope |
+
+A stream-scoped tag must reference a stream that FFprobe actually discovered.
+
+Conflicting values are intentionally preserved rather than silently resolved. For
+example, a format-level timecode and a video-stream timecode may disagree. EchoFlow's
+current job is to retain that evidence with enough provenance for a later qualified
+mapping decision.
+
+```mermaid
+flowchart TD
+    M[Original MOV file] --> F[Format tags]
+    M --> V[Video stream 0 tags]
+    M --> A[Audio stream 1 tags]
+    F --> E[Temporal provenance tuple]
+    V --> E
+    A --> E
+    E --> C[Canonical transcript source provenance]
+
+    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    class M source
+    class F,V,A,E,C evidence
+```
+
+The values are *declarations*, not trusted wall-clock facts.
 
 ## Deterministic audio-stream selection
 
@@ -98,8 +156,9 @@ the job/source contract.
 Resume restores the same selected stream. It does not decide that a different track is
 close enough.
 
-Selection returns new immutable metadata rather than mutating the FFprobe discovery
-record.
+Selection uses `dataclasses.replace`, so temporal provenance discovered from the original
+container survives a user-selected audio-stream change without being rediscovered or
+mutated.
 
 ## Canonical working audio
 
@@ -159,133 +218,148 @@ Application-owned work units are represented by integer PCM frame intervals:
 
 Seconds are derived from those exact frames and the canonical sample rate.
 
-Faster-whisper returns timestamps relative to the materialized work interval. Assembly
-adds the interval's source-relative offset:
+Faster-whisper returns segment and native word timestamps relative to the materialized
+work interval. Assembly adds the interval's source-relative offset:
 
 ```text
 work interval 0 starts at 0 s
-engine timestamp 12.4 s   → canonical timestamp 12.4 s
+engine word at 12.4 s      → canonical word at 12.4 s
 
 work interval 7 starts at 4200 s
-engine timestamp 21.7 s   → canonical timestamp 4221.7 s
+engine word at 588.37 s    → canonical word at 4788.37 s
+                              → display 01:19:48.370
 ```
 
-SRT and WebVTT render from canonical timestamps. Segment/checkpoint boundaries therefore
-do not reset subtitle time to zero.
+The default work-window duration is currently 600 seconds (10 minutes). Those work
+windows are an execution/checkpoint detail, not a user-facing time coordinate. They
+never reset the published transcript timeline.
+
+SRT and WebVTT also render from canonical timestamps. Segment/checkpoint boundaries
+therefore do not reset subtitle time to zero.
 
 💃 The timeline survives the choreography.
 
-## Current source/provenance record
+## Human elapsed timestamps are derived views
+
+`format_elapsed_timestamp()` renders canonical seconds as unwrapped `HH:MM:SS.mmm`.
+
+Examples:
+
+| Numeric evidence | Human display |
+|---:|---|
+| `0.0` | `00:00:00.000` |
+| `60.0` | `00:01:00.000` |
+| `3600.0` | `01:00:00.000` |
+| `4788.37` | `01:19:48.370` |
+| `86400.0` | `24:00:00.000` |
+
+Hours intentionally do not wrap at 24. A 30-hour oral-history corpus item is elapsed
+media, not a wall clock.
+
+The formatter rounds to milliseconds deterministically and handles rollover, so
+`59.9996` becomes `00:01:00.000` rather than producing an impossible `00:00:60.000`.
+
+Search JSON retains numeric `start_seconds`/`end_seconds` and adds derived
+`start_timestamp`/`end_timestamp` conveniences. The human table shows the formatted
+range.
+
+Formatted strings are not durable anchors.
+
+## Canonical source provenance
 
 The original local media file remains authoritative.
 
-EchoFlow separately records enough execution context to explain how canonical text was
-produced, including:
+EchoFlow records enough execution context to explain how canonical text was produced,
+including:
 
 - source fingerprint/media identity;
 - selected audio stream;
+- source-declared temporal tags when present;
 - decode strategy;
 - managed ASR engine/model/revision and execution target;
 - enhancement provider/version/operation/parameters when used;
 - language and optional speaker evidence; and
-- source-relative segment timestamps.
+- source-relative segment and word timestamps.
 
-Derived audio can therefore disappear without erasing the description of the path from
-source to transcript.
+Temporal tags are included in canonical source provenance only when they exist, so files
+without them retain the previous wire shape.
 
-## ✨ Next provenance layer: original media timecode and capture time
+Temporal tags deliberately do **not** participate in checkpoint source equality. Source
+identity remains the cryptographic/file/media identity contract. A camera clock changing
+its story is provenance drift, not a new SHA-256 source.
 
-Source-relative seconds are useful but incomplete for some research, documentary,
-forensic, archival, and multi-device recordings.
+## Why EchoFlow does not add elapsed time to SMPTE yet
 
-A future timeline provenance model should be able to preserve **additional clocks** when
-the media exposes them, without redefining the canonical elapsed-time coordinate.
+A source string such as:
 
-Potential evidence includes:
-
-- non-zero container or stream PTS/DTS origins;
-- SMPTE timecode tracks or tags;
-- camera/device creation or capture timestamps;
-- timezone/offset information when it is actually encoded and trustworthy;
-- stream start-time offsets; and
-- synchronization relationships between independently recorded sources when explicitly
-  known.
-
-The key design rule is **parallel provenance, not timeline mutation**.
-
-Conceptually:
-
-```mermaid
-flowchart TD
-    S[Selected audio stream] --> R[Canonical source-relative timeline]
-    S --> P[Original presentation-time evidence]
-    S --> T[SMPTE / embedded timecode evidence]
-    S --> C[Capture-time metadata]
-    R --> X[Canonical transcript segments]
-    P --> X
-    T --> X
-    C --> X
-
-    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef canonical fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef provenance fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-
-    class S source
-    class R,X canonical
-    class P,T,C provenance
+```text
+10:00:00:00
 ```
 
-A transcript segment could then say, in effect:
+looks temptingly like a clock. It is not enough information for safe arithmetic.
 
-> This passage begins 4221.7 seconds into the selected audio **and**, where trustworthy
-> source metadata exists, corresponds to original media timecode/capture coordinates X.
+SMPTE-style timecode can depend on frame rate and drop-frame/non-drop-frame semantics.
+Container/device metadata may also be missing, stale, copied, or contradictory.
 
-Those values should be typed and qualified, not collapsed into a single ambiguous
-`timestamp` field.
+This tranche therefore preserves source-declared values but **does not invent a mapping
+from canonical seconds to SMPTE frames** without qualified frame semantics.
 
-## Why this should be its own model
+That limitation does not block ordinary click-to-audio navigation. A local player can
+seek directly to canonical `start_seconds`.
 
-Container/media time is messy.
+Future SMPTE mapping, if product use requires it, should qualify:
 
-A creation timestamp may represent file creation rather than acoustic capture. A stream
-can begin at a non-zero presentation timestamp. Timecode may have frame-rate/drop-frame
-semantics. Device clocks may be wrong. Some metadata may be missing, malformed, or
-contradictory.
+- exact/rational frame rate;
+- nominal frame-numbering rate;
+- drop-frame semantics;
+- source of the timecode declaration;
+- conflict-resolution policy; and
+- deterministic mapping tests around minute/hour/day rollover.
 
-EchoFlow should therefore preserve:
+## Relationship to word timing
 
-- the **kind** of time evidence;
-- its raw/normalized representation;
-- the stream/container it came from;
-- confidence/qualification rules where needed; and
-- whether it can be deterministically mapped to source-relative seconds.
+Word timing and media temporal provenance solve different problems.
 
-It should not pretend every media timestamp is interchangeable.
+**Word timing** answers:
 
-## Relationship to word/timestamp alignment
+> Where does this word live inside the canonical elapsed timeline?
 
-Original-media timecode and word alignment solve different problems.
+**Human elapsed formatting** answers:
 
-**Word/timestamp alignment** gives finer coordinates *within the canonical source-relative
-timeline*.
+> How do I show that coordinate without making a person calculate 4788 seconds?
 
-**Original-media timecode/capture provenance** gives additional clocks or source metadata
-that can be mapped alongside that timeline.
+**Original-media temporal metadata** answers:
 
-Together they eventually make very precise evidence receipts possible:
+> What other clock information did the source itself declare?
+
+Together they support richer evidence receipts without pretending every clock is the
+same clock.
 
 ```text
 word "budget"
-  canonical elapsed time: 01:10:21.700
-  original media timecode: 02:14:03:17   (if available/qualified)
-  capture timestamp: 2026-07-04T14:32:08-04:00   (if present/qualified)
+  canonical elapsed seconds: 4788.370
+  human elapsed display:     01:19:48.370
+  declared source timecode:  10:00:00:00   (if present; not yet mapped)
+  declared creation time:    2026-04-05T12:34:56Z   (if present)
 ```
 
-Neither should be invented when the source does not provide trustworthy evidence.
+## Relationship to future notes and click-to-seek
+
+A graphical player does not exist yet, and neither does the durable notes editor/store.
+The coordinate contract they need now does.
+
+A future player should seek by numeric canonical seconds.
+
+A future annotation should anchor to durable evidence such as source SHA-256 plus a
+canonical word/segment time span. It should not anchor only to a pretty timestamp string
+or rebuildable search-chunk ID.
+
+That keeps user-authored knowledge attached even when search indexes are rebuilt or time
+display formatting changes.
 
 ## Why the stages remain separate
 
-Inspection answers **what source and streams exist?**
+Inspection answers **what source, streams, and declared metadata exist?**
 
 Selection answers **which audio stream are we using?**
 
@@ -293,10 +367,11 @@ Normalization answers **what deterministic representation will local processing 
 
 Enhancement answers **did the user request a provenance-bearing acoustic transform?**
 
-Alignment will answer **where do finer text units sit on the canonical timeline?**
+Word alignment answers **where do finer text units sit on the canonical timeline?**
 
-Original timecode/capture provenance will answer **what other source clocks can be
-preserved alongside that timeline?**
+Human timestamp formatting answers **how should a person read that elapsed coordinate?**
+
+Temporal provenance answers **what other source clocks were declared alongside it?**
 
 Keeping these responsibilities separate makes metadata discovery side-effect free,
 keeps source authority explicit, and leaves room for richer evidence without rewriting

--- a/docs/time-navigation.md
+++ b/docs/time-navigation.md
@@ -98,7 +98,7 @@ It should **not** anchor only to:
 ```
 
 Why? Because `01:19:48.370` is presentation. We may later offer a different visual
-format, but Susan's metaphorical sticky note should not fall off the transcript because
+format, but a researcher's sticky note should not fall off the transcript because
 someone changed the clock typography.
 
 It also should not anchor only to a semantic-search chunk ID. Search chunks and indexes

--- a/docs/time-navigation.md
+++ b/docs/time-navigation.md
@@ -1,0 +1,230 @@
+# 🕰️ Transcript time without calculator gymnastics
+
+A transcript is much more useful when “where did they say that?” has an answer that a
+human can actually use.
+
+EchoFlow therefore keeps **one durable numeric timeline** and can present it as a familiar
+clock-style coordinate.
+
+If a passage begins `4788.37` seconds into a recording, you should not have to divide by
+60 twice in your head.
+
+EchoFlow can present that as:
+
+```text
+01:19:48.370
+```
+
+That means **1 hour, 19 minutes, 48 seconds, and 370 milliseconds after the beginning of
+the selected recording audio**.
+
+🦝 The raccoon has been relieved of manual base-60 arithmetic duties.
+
+## What did word timestamps add?
+
+Before word timing, a transcript segment might say:
+
+```text
+01:19:40.000 → 01:20:02.000
+"We eventually realized the housing cost was the real problem."
+```
+
+That tells you where the sentence-sized segment lives, but not where a particular phrase
+inside it begins.
+
+With native word timing, the canonical transcript can retain finer evidence:
+
+```text
+"housing"  → 4788.370 s
+"cost"     → 4788.910 s
+"problem"  → 4791.125 s
+```
+
+The pretty display is derived from those numeric coordinates:
+
+```text
+"housing"  → 01:19:48.370
+"cost"     → 01:19:48.910
+"problem"  → 01:19:51.125
+```
+
+The numbers are the anchor. The clock-style strings are the label on the drawer.
+
+```mermaid
+flowchart LR
+    W[📜 Canonical word evidence<br/>4788.370 seconds] --> H[✨ Human display<br/>01:19:48.370]
+    W --> P[▶️ Future player seek<br/>seek to 4788.370]
+    W --> N[📝 Future note anchor<br/>source + evidence span]
+    W --> S[🔎 Search result<br/>show the useful time]
+
+    classDef truth fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+    class W truth
+    class H,P,N,S view
+```
+
+## Can I click a word and jump to that exact place in the recording?
+
+**The evidence coordinate needed for that now exists.**
+
+A future local player can take a word's `start_seconds` and seek the original recording
+to that point. Search results already carry source-relative start/end seconds, and the
+human CLI view now renders them as `HH:MM:SS.mmm` instead of asking you to interpret a
+large decimal number.
+
+EchoFlow does **not yet ship the graphical media-player click handler**. The important
+part is that the UI will not need to guess where a phrase lives when that layer arrives.
+It can consume canonical evidence that already has the coordinate.
+
+## What about notes and annotations? 📝
+
+Notes are planned as **durable user-authored knowledge**, not search-index metadata.
+There is not yet a finished notes editor or annotation store.
+
+When that feature arrives, a note should anchor to durable evidence, conceptually:
+
+```text
+source SHA-256:   <recording fingerprint>
+start:            4788.370 s
+end:              4791.125 s
+canonical span:   the relevant segment/word evidence
+note:             "Participant connects housing cost to the decision to leave."
+```
+
+It should **not** anchor only to:
+
+```text
+"01:19:48.370"
+```
+
+Why? Because `01:19:48.370` is presentation. We may later offer a different visual
+format, but Susan's metaphorical sticky note should not fall off the transcript because
+someone changed the clock typography.
+
+It also should not anchor only to a semantic-search chunk ID. Search chunks and indexes
+are rebuildable. Notes are not.
+
+```mermaid
+flowchart TD
+    A[🎙️ Original recording<br/>read-only evidence] --> C[📜 Canonical transcript]
+    C --> W[Word / segment coordinates]
+    W --> N[📝 Future user note]
+    C --> I[🔎 Rebuildable search index]
+    I --> R[Search result]
+    R -. points back to .-> W
+
+    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef durable fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef rebuild fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    class A source
+    class C,W,N durable
+    class I,R rebuild
+```
+
+If the librarian rebuilds the index, the note remains attached to the evidence. This is
+one of EchoFlow's custody rules, not a decorative preference.
+
+## Do internal work chunks reset the clock?
+
+No.
+
+EchoFlow currently uses application-owned work windows that are **10 minutes by default**
+(`600` seconds), not hour-long user-visible transcript sections. Those windows exist so
+long recordings can be processed and checkpointed safely.
+
+They are an implementation detail.
+
+When a work window starts at `4200` seconds and faster-whisper reports a word at `588.37`
+seconds inside that work window, assembly rebases it onto the source timeline:
+
+```text
+4200.000 + 588.370 = 4788.370 seconds
+                       ↓
+                 01:19:48.370
+```
+
+The published coordinate never resets to zero because EchoFlow happened to create a new
+work file.
+
+💃 Internal segmentation may change costumes. The source timeline does not.
+
+## What if the camera or media file already has a timecode?
+
+That is a **different clock**.
+
+Some MOV/MP4/camera files may declare metadata such as:
+
+```text
+timecode:      10:00:00:00
+creation_time: 2026-04-05T12:34:56Z
+```
+
+EchoFlow now asks FFprobe for `timecode` and `creation_time` at both container and stream
+scope. When present, those declarations are preserved in canonical source provenance,
+including where they came from.
+
+EchoFlow does **not** silently decide that a camera tag is true. Devices can have wrong
+clocks, copied metadata, conflicting stream tags, or timecode with frame-rate/drop-frame
+semantics that require more information before arithmetic is safe.
+
+So the model stays parallel:
+
+```mermaid
+flowchart LR
+    M[🎥 Original media] --> E[Canonical elapsed time<br/>0.000 s → ...]
+    M --> T[Declared timecode<br/>if source provides it]
+    M --> C[Declared creation time<br/>if source provides it]
+
+    E --> X[📜 Transcript evidence]
+    T --> X
+    C --> X
+
+    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef canonical fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef provenance fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    class M source
+    class E,X canonical
+    class T,C provenance
+```
+
+**Elapsed time answers:** “where is this inside the selected recording?”
+
+**Declared media metadata answers:** “what other clock information did the source claim
+to have?”
+
+Those are useful together. They are dangerous when collapsed into one mystery field
+called `timestamp`.
+
+## Why not immediately add 1:19:48 to `10:00:00:00`?
+
+Because SMPTE-style timecode is not just wall-clock `HH:MM:SS` with two extra digits.
+Frame rate and drop-frame/non-drop-frame semantics can change the arithmetic.
+
+This tranche deliberately preserves source declarations **without inventing a mapping it
+cannot yet qualify**.
+
+For ordinary transcript navigation, no such mapping is necessary. Canonical elapsed time
+already gives a local player an exact seek coordinate.
+
+## What you get now
+
+| Need | Current behavior |
+|---|---|
+| “Where is 4788 seconds?” | rendered as `01:19:48.000` |
+| Search result navigation | human elapsed start/end plus numeric seconds in JSON |
+| Word-level position | native faster-whisper word start/end retained in canonical evidence |
+| Speaker handoff inside one ASR segment | word evidence can carry the handoff without inventing one segment speaker |
+| Original `timecode` metadata | preserved when FFprobe reports it, with source scope |
+| Original `creation_time` metadata | preserved when FFprobe reports it, with source scope |
+| Click word to play source | coordinate is ready; graphical player interaction is still future UI work |
+| Durable notes/annotations | architecture is ready for canonical anchors; editor/storage is still future work |
+| SMPTE frame arithmetic | intentionally not inferred without qualified frame semantics |
+
+## The small rule underneath all of this
+
+**Store evidence coordinates. Derive pretty clocks. Preserve source claims. Do not
+confuse the three.** ✨
+
+For the exact implementation contract, see
+**[Media normalization and transcript timeline](architecture/media-and-timeline.md)** and
+**[Word-level timestamp alignment](architecture/word-alignment.md)**.

--- a/src/echoflow/cli_library.py
+++ b/src/echoflow/cli_library.py
@@ -185,7 +185,7 @@ def _render_response(response: SearchResponse, console: Console) -> None:
         )
     )
     table.add_column("Recording")
-    table.add_column("Time")
+    table.add_column("Time", min_width=12, no_wrap=True)
     table.add_column("Speaker")
     table.add_column("Language")
     table.add_column("Ranks")
@@ -202,7 +202,7 @@ def _render_response(response: SearchResponse, console: Console) -> None:
             f"F:{result.fused_rank}"
         )
         time_range = (
-            f"{format_elapsed_timestamp(result.start_seconds)}–"
+            f"{format_elapsed_timestamp(result.start_seconds)}\n"
             f"{format_elapsed_timestamp(result.end_seconds)}"
         )
         table.add_row(

--- a/src/echoflow/cli_library.py
+++ b/src/echoflow/cli_library.py
@@ -24,6 +24,7 @@ from echoflow.library.service import (
     LibraryRebuildReport,
     SemanticRebuildReport,
 )
+from echoflow.media.time_coordinates import format_elapsed_timestamp
 
 ContainerFactory = Callable[[typer.Context], AppContainer]
 
@@ -82,6 +83,8 @@ def _passage_dict(passage: SearchPassage) -> dict[str, object]:
         "matched_segment_ids": list(passage.matched_segment_ids),
         "start_seconds": passage.start_seconds,
         "end_seconds": passage.end_seconds,
+        "start_timestamp": format_elapsed_timestamp(passage.start_seconds),
+        "end_timestamp": format_elapsed_timestamp(passage.end_seconds),
         "text": passage.text,
         "languages": list(passage.languages),
         "speaker_refs": list(passage.speaker_refs),
@@ -198,9 +201,13 @@ def _render_response(response: SearchResponse, console: Console) -> None:
             f"S:{result.semantic_rank or '-'} "
             f"F:{result.fused_rank}"
         )
+        time_range = (
+            f"{format_elapsed_timestamp(result.start_seconds)}–"
+            f"{format_elapsed_timestamp(result.end_seconds)}"
+        )
         table.add_row(
             recording,
-            f"{result.start_seconds:.2f}-{result.end_seconds:.2f}s",
+            time_range,
             ", ".join(result.speaker_refs) or "unknown",
             ", ".join(result.languages) or "unknown",
             ranks,

--- a/src/echoflow/media/__init__.py
+++ b/src/echoflow/media/__init__.py
@@ -2,17 +2,29 @@
 
 The media package owns facts about the original container before transcription:
 input identity/fingerprint, container duration, discovered streams, codec metadata,
-and the selected audio-stream index. ``FfprobeMediaProbe`` is read-only inspection;
-it does not transcode or normalize media. ``AudioStreamSelector`` chooses one of the
-already-discovered audio streams without rewriting the probe result in place.
+source-declared temporal metadata, and the selected audio-stream index.
+``FfprobeMediaProbe`` is read-only inspection; it does not transcode or normalize media.
+``AudioStreamSelector`` chooses one of the already-discovered audio streams without
+rewriting the probe result in place.
 
 Actual extraction and canonical-audio normalization live at the transcription audio
-boundary because they are execution work, not media discovery.
+boundary because they are execution work, not media discovery. Human elapsed timestamp
+formatting is presentation-only; canonical evidence remains numeric source-relative
+seconds.
 """
 
-from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
+from echoflow.media.models import (
+    InputIdentity,
+    MediaInfo,
+    MediaStream,
+    MediaTemporalTag,
+    StreamKind,
+    TemporalTagKind,
+    TemporalTagSource,
+)
 from echoflow.media.probe import FfprobeMediaProbe
 from echoflow.media.selection import AudioStreamSelector
+from echoflow.media.time_coordinates import format_elapsed_timestamp
 
 __all__ = [
     "AudioStreamSelector",
@@ -20,5 +32,9 @@ __all__ = [
     "InputIdentity",
     "MediaInfo",
     "MediaStream",
+    "MediaTemporalTag",
     "StreamKind",
+    "TemporalTagKind",
+    "TemporalTagSource",
+    "format_elapsed_timestamp",
 ]

--- a/src/echoflow/media/models.py
+++ b/src/echoflow/media/models.py
@@ -16,6 +16,50 @@ class StreamKind(StrEnum):
     UNKNOWN = "unknown"
 
 
+class TemporalTagKind(StrEnum):
+    """Kinds of original-container temporal metadata EchoFlow preserves verbatim."""
+
+    TIMECODE = "timecode"
+    CREATION_TIME = "creation_time"
+
+
+class TemporalTagSource(StrEnum):
+    """Where FFprobe reported one original-media temporal tag."""
+
+    FORMAT = "format"
+    STREAM = "stream"
+
+
+@dataclass(frozen=True, slots=True)
+class MediaTemporalTag:
+    """One source-declared temporal fact, preserved without claiming it is true."""
+
+    kind: TemporalTagKind
+    value: str
+    source: TemporalTagSource
+    stream_index: int | None = None
+
+    def __post_init__(self) -> None:
+        normalized = self.value.strip()
+        if not normalized:
+            raise ValueError("temporal tag value cannot be empty")
+        object.__setattr__(self, "value", normalized)
+        if self.source is TemporalTagSource.FORMAT and self.stream_index is not None:
+            raise ValueError("format temporal tags cannot have a stream index")
+        if self.source is TemporalTagSource.STREAM and (
+            self.stream_index is None or self.stream_index < 0
+        ):
+            raise ValueError("stream temporal tags require a nonnegative stream index")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "value": self.value,
+            "source": self.source.value,
+            "stream_index": self.stream_index,
+        }
+
+
 @dataclass(frozen=True, slots=True)
 class InputIdentity:
     path: Path
@@ -86,6 +130,7 @@ class MediaInfo:
     duration_seconds: float
     streams: tuple[MediaStream, ...]
     primary_audio_stream_index: int
+    temporal_tags: tuple[MediaTemporalTag, ...] = ()
 
     def __post_init__(self) -> None:
         if not self.container_format:
@@ -118,4 +163,5 @@ class MediaInfo:
             "duration_seconds": self.duration_seconds,
             "streams": [stream.to_dict() for stream in self.streams],
             "primary_audio_stream_index": self.primary_audio_stream_index,
+            "temporal_tags": [tag.to_dict() for tag in self.temporal_tags],
         }

--- a/src/echoflow/media/models.py
+++ b/src/echoflow/media/models.py
@@ -157,11 +157,13 @@ class MediaInfo:
         )
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        document: dict[str, object] = {
             "input": self.input.to_dict(),
             "container_format": self.container_format,
             "duration_seconds": self.duration_seconds,
             "streams": [stream.to_dict() for stream in self.streams],
             "primary_audio_stream_index": self.primary_audio_stream_index,
-            "temporal_tags": [tag.to_dict() for tag in self.temporal_tags],
         }
+        if self.temporal_tags:
+            document["temporal_tags"] = [tag.to_dict() for tag in self.temporal_tags]
+        return document

--- a/src/echoflow/media/models.py
+++ b/src/echoflow/media/models.py
@@ -147,6 +147,13 @@ class MediaInfo:
         ]
         if len(selected) != 1:
             raise ValueError("primary_audio_stream_index must select one audio stream")
+        stream_indices = {stream.index for stream in self.streams}
+        if any(
+            tag.source is TemporalTagSource.STREAM
+            and tag.stream_index not in stream_indices
+            for tag in self.temporal_tags
+        ):
+            raise ValueError("stream temporal tag must reference a discovered stream")
 
     @property
     def primary_audio_stream(self) -> MediaStream:

--- a/src/echoflow/media/probe.py
+++ b/src/echoflow/media/probe.py
@@ -13,14 +13,22 @@ from echoflow.media.errors import (
     MediaToolUnavailableError,
     UnsupportedMediaError,
 )
-from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
+from echoflow.media.models import (
+    InputIdentity,
+    MediaInfo,
+    MediaStream,
+    MediaTemporalTag,
+    StreamKind,
+    TemporalTagKind,
+    TemporalTagSource,
+)
 
 _HASH_BLOCK_SIZE = 1024 * 1024
 _MAX_PROBE_OUTPUT_BYTES = 1024 * 1024
 _FFPROBE_ENTRIES = (
-    "format=format_name,duration:"
+    "format=format_name,duration:format_tags=timecode,creation_time:"
     "stream=index,codec_type,codec_name,duration,sample_rate,channels,"
-    "channel_layout,bit_rate"
+    "channel_layout,bit_rate:stream_tags=timecode,creation_time"
 )
 
 
@@ -65,6 +73,8 @@ def _parse_stream(raw_stream: object) -> MediaStream:
         raise MediaProbeError("FFprobe stream metadata is invalid")
     index = raw_stream.get("index")
     try:
+        if isinstance(index, bool):
+            raise ValueError("boolean stream index")
         parsed_index = int(str(index))
     except (TypeError, ValueError) as exc:
         raise MediaProbeError("FFprobe stream index is invalid", cause=exc) from exc
@@ -103,6 +113,58 @@ def _audio_duration(
     if duration <= 0:
         raise UnsupportedMediaError("Input audio duration could not be determined")
     return duration
+
+
+def _tag_value(raw_tags: object, key: str) -> str | None:
+    if not isinstance(raw_tags, dict):
+        return None
+    value = raw_tags.get(key)
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _temporal_tags(
+    raw_format: Mapping[str, Any],
+    raw_streams: list[object],
+    streams: list[MediaStream],
+) -> tuple[MediaTemporalTag, ...]:
+    """Preserve temporal declarations without resolving conflicts or asserting truth."""
+    tags: list[MediaTemporalTag] = []
+    kinds = (
+        (TemporalTagKind.TIMECODE, "timecode"),
+        (TemporalTagKind.CREATION_TIME, "creation_time"),
+    )
+
+    format_tags = raw_format.get("tags")
+    for kind, key in kinds:
+        value = _tag_value(format_tags, key)
+        if value is not None:
+            tags.append(
+                MediaTemporalTag(
+                    kind=kind,
+                    value=value,
+                    source=TemporalTagSource.FORMAT,
+                )
+            )
+
+    for raw_stream, stream in zip(raw_streams, streams, strict=True):
+        if not isinstance(raw_stream, dict):
+            continue
+        stream_tags = raw_stream.get("tags")
+        for kind, key in kinds:
+            value = _tag_value(stream_tags, key)
+            if value is not None:
+                tags.append(
+                    MediaTemporalTag(
+                        kind=kind,
+                        value=value,
+                        source=TemporalTagSource.STREAM,
+                        stream_index=stream.index,
+                    )
+                )
+    return tuple(tags)
 
 
 class FfprobeMediaProbe:
@@ -228,6 +290,7 @@ class FfprobeMediaProbe:
                 duration_seconds=_audio_duration(raw_format, audio_streams),
                 streams=tuple(streams),
                 primary_audio_stream_index=audio_streams[0].index,
+                temporal_tags=_temporal_tags(raw_format, raw_streams, streams),
             )
         except ValueError as exc:
             raise MediaProbeError(

--- a/src/echoflow/media/tests/test_models.py
+++ b/src/echoflow/media/tests/test_models.py
@@ -215,6 +215,19 @@ def test_media_info_selects_primary_audio_and_serializes_all_streams(tmp_path):
             {"primary_audio_stream_index": 7},
             "primary_audio_stream_index must select one audio stream",
         ),
+        (
+            {
+                "temporal_tags": (
+                    MediaTemporalTag(
+                        TemporalTagKind.TIMECODE,
+                        "10:00:00:00",
+                        TemporalTagSource.STREAM,
+                        stream_index=7,
+                    ),
+                )
+            },
+            "stream temporal tag must reference a discovered stream",
+        ),
     ],
 )
 def test_media_info_rejects_incomplete_or_inconsistent_values(

--- a/src/echoflow/media/tests/test_models.py
+++ b/src/echoflow/media/tests/test_models.py
@@ -2,7 +2,15 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
+from echoflow.media.models import (
+    InputIdentity,
+    MediaInfo,
+    MediaStream,
+    MediaTemporalTag,
+    StreamKind,
+    TemporalTagKind,
+    TemporalTagSource,
+)
 
 
 def identity(tmp_path) -> InputIdentity:
@@ -118,15 +126,67 @@ def test_media_stream_rejects_invalid_values(overrides, message):
         audio_stream(**overrides)
 
 
+def test_temporal_tag_is_source_explicit_frozen_and_serializable():
+    tag = MediaTemporalTag(
+        TemporalTagKind.TIMECODE,
+        " 10:00:00:00 ",
+        TemporalTagSource.STREAM,
+        stream_index=2,
+    )
+
+    assert tag.value == "10:00:00:00"
+    assert tag.to_dict() == {
+        "kind": "timecode",
+        "value": "10:00:00:00",
+        "source": "stream",
+        "stream_index": 2,
+    }
+    assert not hasattr(tag, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        tag.value = "changed"
+
+
+@pytest.mark.parametrize(
+    ("tag", "message"),
+    [
+        (
+            (TemporalTagKind.TIMECODE, " ", TemporalTagSource.FORMAT, None),
+            "temporal tag value cannot be empty",
+        ),
+        (
+            (TemporalTagKind.TIMECODE, "1", TemporalTagSource.FORMAT, 0),
+            "format temporal tags cannot have a stream index",
+        ),
+        (
+            (TemporalTagKind.CREATION_TIME, "1", TemporalTagSource.STREAM, None),
+            "stream temporal tags require a nonnegative stream index",
+        ),
+        (
+            (TemporalTagKind.CREATION_TIME, "1", TemporalTagSource.STREAM, -1),
+            "stream temporal tags require a nonnegative stream index",
+        ),
+    ],
+)
+def test_temporal_tag_rejects_ambiguous_source_coordinates(tag, message):
+    with pytest.raises(ValueError, match=f"^{message}$"):
+        MediaTemporalTag(*tag)
+
+
 def test_media_info_selects_primary_audio_and_serializes_all_streams(tmp_path):
     video = MediaStream(index=0, kind=StreamKind.VIDEO, codec="h264")
     audio = audio_stream(index=1)
+    temporal = MediaTemporalTag(
+        TemporalTagKind.CREATION_TIME,
+        "2026-04-05T12:34:56Z",
+        TemporalTagSource.FORMAT,
+    )
     media = MediaInfo(
         input=identity(tmp_path),
         container_format="mov,mp4,m4a,3gp,3g2,mj2",
         duration_seconds=2.5,
         streams=(video, audio),
         primary_audio_stream_index=1,
+        temporal_tags=(temporal,),
     )
     payload = media.to_dict()
     assert media.primary_audio_stream is audio
@@ -134,6 +194,7 @@ def test_media_info_selects_primary_audio_and_serializes_all_streams(tmp_path):
     assert payload["duration_seconds"] == 2.5
     assert payload["primary_audio_stream_index"] == 1
     assert payload["streams"] == [video.to_dict(), audio.to_dict()]
+    assert payload["temporal_tags"] == [temporal.to_dict()]
     assert payload["input"] == identity(tmp_path).to_dict()
     assert not hasattr(media, "__dict__")
     with pytest.raises(FrozenInstanceError):

--- a/src/echoflow/media/tests/test_probe.py
+++ b/src/echoflow/media/tests/test_probe.py
@@ -11,7 +11,12 @@ from echoflow.media.errors import (
     MediaToolUnavailableError,
     UnsupportedMediaError,
 )
-from echoflow.media.models import InputIdentity, StreamKind
+from echoflow.media.models import (
+    InputIdentity,
+    StreamKind,
+    TemporalTagKind,
+    TemporalTagSource,
+)
 from echoflow.media.probe import FfprobeMediaProbe
 
 
@@ -76,6 +81,7 @@ def test_probe_fingerprints_and_parses_local_media_without_network_protocols(
     assert result.primary_audio_stream.channels == 1
     assert result.primary_audio_stream.channel_layout == "mono"
     assert result.primary_audio_stream.bit_rate_bps == 256_000
+    assert result.temporal_tags == ()
     assert captured["lookup"] == "ffprobe"
     assert captured["command"] == [
         "/tools/ffprobe",
@@ -84,8 +90,9 @@ def test_probe_fingerprints_and_parses_local_media_without_network_protocols(
         "-protocol_whitelist",
         "file",
         "-show_entries",
-        "format=format_name,duration:stream=index,codec_type,codec_name,duration,"
-        "sample_rate,channels,channel_layout,bit_rate",
+        "format=format_name,duration:format_tags=timecode,creation_time:"
+        "stream=index,codec_type,codec_name,duration,sample_rate,channels,"
+        "channel_layout,bit_rate:stream_tags=timecode,creation_time",
         "-of",
         "json",
         str(source.resolve()),
@@ -121,13 +128,88 @@ def test_probe_preserves_all_streams_and_uses_first_audio_as_primary(
     assert result.streams[1].channels is None
 
 
+def test_probe_preserves_conflicting_temporal_tags_with_explicit_sources(tmp_path):
+    identity = InputIdentity(tmp_path / "media", 1, 0, "0" * 64)
+    document = payload(
+        streams=[
+            {
+                "index": 0,
+                "codec_type": "video",
+                "codec_name": "h264",
+                "tags": {
+                    "timecode": "10:00:00:00",
+                    "creation_time": "2026-04-05T12:34:56Z",
+                },
+            },
+            {
+                "index": 1,
+                "codec_type": "audio",
+                "codec_name": "aac",
+                "duration": "1.250",
+                "tags": {"timecode": "10:00:00:01"},
+            },
+        ]
+    )
+    document["format"]["tags"] = {
+        "timecode": "09:59:59:29",
+        "creation_time": "2026-04-05T12:30:00Z",
+    }
+
+    result = FfprobeMediaProbe._parse(document, identity)
+
+    assert [tag.to_dict() for tag in result.temporal_tags] == [
+        {
+            "kind": "timecode",
+            "value": "09:59:59:29",
+            "source": "format",
+            "stream_index": None,
+        },
+        {
+            "kind": "creation_time",
+            "value": "2026-04-05T12:30:00Z",
+            "source": "format",
+            "stream_index": None,
+        },
+        {
+            "kind": "timecode",
+            "value": "10:00:00:00",
+            "source": "stream",
+            "stream_index": 0,
+        },
+        {
+            "kind": "creation_time",
+            "value": "2026-04-05T12:34:56Z",
+            "source": "stream",
+            "stream_index": 0,
+        },
+        {
+            "kind": "timecode",
+            "value": "10:00:00:01",
+            "source": "stream",
+            "stream_index": 1,
+        },
+    ]
+    assert result.temporal_tags[0].kind is TemporalTagKind.TIMECODE
+    assert result.temporal_tags[0].source is TemporalTagSource.FORMAT
+
+
+def test_probe_ignores_empty_or_nonstring_temporal_tags(tmp_path):
+    identity = InputIdentity(tmp_path / "media", 1, 0, "0" * 64)
+    document = payload()
+    document["format"]["tags"] = {"timecode": "   ", "creation_time": 123}
+    document["streams"][0]["tags"] = {"timecode": None, "creation_time": False}
+
+    assert FfprobeMediaProbe._parse(document, identity).temporal_tags == ()
+
+
 def test_probe_security_limits_and_defaults_are_stable():
     probe = FfprobeMediaProbe()
     assert probe_module._HASH_BLOCK_SIZE == 1_048_576
     assert probe_module._MAX_PROBE_OUTPUT_BYTES == 1_048_576
     assert probe_module._FFPROBE_ENTRIES == (
-        "format=format_name,duration:stream=index,codec_type,codec_name,duration,"
-        "sample_rate,channels,channel_layout,bit_rate"
+        "format=format_name,duration:format_tags=timecode,creation_time:"
+        "stream=index,codec_type,codec_name,duration,sample_rate,channels,"
+        "channel_layout,bit_rate:stream_tags=timecode,creation_time"
     )
     assert probe.timeout_seconds == 10.0
     assert probe.max_output_bytes == 1_048_576

--- a/src/echoflow/media/tests/test_time_coordinates.py
+++ b/src/echoflow/media/tests/test_time_coordinates.py
@@ -1,0 +1,48 @@
+import math
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from echoflow.media.time_coordinates import format_elapsed_timestamp
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0.0, "00:00:00.000"),
+        (0.001, "00:00:00.001"),
+        (59.999, "00:00:59.999"),
+        (60.0, "00:01:00.000"),
+        (3_600.0, "01:00:00.000"),
+        (4_788.37, "01:19:48.370"),
+        (86_400.0, "24:00:00.000"),
+        (360_000.0, "100:00:00.000"),
+        (59.9996, "00:01:00.000"),
+    ],
+)
+def test_elapsed_timestamp_is_human_readable_unwrapped_and_rounds_safely(
+    seconds, expected
+):
+    assert format_elapsed_timestamp(seconds) == expected
+
+
+@pytest.mark.parametrize("seconds", [-0.001, math.inf, -math.inf, math.nan])
+def test_elapsed_timestamp_rejects_noncanonical_coordinates(seconds):
+    with pytest.raises(
+        ValueError,
+        match="^elapsed seconds must be finite and nonnegative$",
+    ):
+        format_elapsed_timestamp(seconds)
+
+
+@given(st.integers(min_value=0, max_value=500 * 60 * 60 * 1_000))
+def test_elapsed_timestamp_never_emits_sixty_for_minutes_or_seconds(total_ms):
+    rendered = format_elapsed_timestamp(total_ms / 1_000)
+    hours, minutes, rest = rendered.split(":")
+    seconds, milliseconds = rest.split(".")
+
+    assert int(hours) >= 0
+    assert 0 <= int(minutes) < 60
+    assert 0 <= int(seconds) < 60
+    assert 0 <= int(milliseconds) < 1_000

--- a/src/echoflow/media/time_coordinates.py
+++ b/src/echoflow/media/time_coordinates.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import ROUND_HALF_UP, Decimal
 
 _MILLISECONDS_PER_SECOND = 1_000
 _MILLISECONDS_PER_MINUTE = 60 * _MILLISECONDS_PER_SECOND

--- a/src/echoflow/media/time_coordinates.py
+++ b/src/echoflow/media/time_coordinates.py
@@ -1,0 +1,31 @@
+"""Human presentation helpers for canonical source-relative media time."""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal, ROUND_HALF_UP
+
+_MILLISECONDS_PER_SECOND = 1_000
+_MILLISECONDS_PER_MINUTE = 60 * _MILLISECONDS_PER_SECOND
+_MILLISECONDS_PER_HOUR = 60 * _MILLISECONDS_PER_MINUTE
+
+
+def format_elapsed_timestamp(seconds: float) -> str:
+    """Render source-relative seconds as an unwrapped ``HH:MM:SS.mmm`` coordinate.
+
+    Canonical evidence remains numeric seconds. This representation is deliberately a
+    presentation value so UI formatting can evolve without changing durable anchors.
+    Hours do not wrap at 24 because long recordings are elapsed timelines, not clocks.
+    """
+    if not math.isfinite(seconds) or seconds < 0:
+        raise ValueError("elapsed seconds must be finite and nonnegative")
+
+    total_milliseconds = int(
+        (Decimal(str(seconds)) * _MILLISECONDS_PER_SECOND).quantize(
+            Decimal("1"), rounding=ROUND_HALF_UP
+        )
+    )
+    hours, remainder = divmod(total_milliseconds, _MILLISECONDS_PER_HOUR)
+    minutes, remainder = divmod(remainder, _MILLISECONDS_PER_MINUTE)
+    whole_seconds, milliseconds = divmod(remainder, _MILLISECONDS_PER_SECOND)
+    return f"{hours:02d}:{minutes:02d}:{whole_seconds:02d}.{milliseconds:03d}"

--- a/src/echoflow/tests/test_cli_library.py
+++ b/src/echoflow/tests/test_cli_library.py
@@ -244,6 +244,9 @@ def test_library_search_compiles_cli_options_to_unified_retrieval_contract() -> 
     assert payload["results"][0]["lexical_rank"] == 2
     assert payload["results"][0]["semantic_rank"] == 1
     assert payload["results"][0]["fused_rank"] == 1
+    assert payload["results"][0]["start_seconds"] == 1.5
+    assert payload["results"][0]["start_timestamp"] == "00:00:01.500"
+    assert payload["results"][0]["end_timestamp"] == "00:00:04.000"
     query, mode = captured[0]
     assert mode is RetrievalMode.HYBRID
     assert query.text == "housing affordability"
@@ -264,7 +267,8 @@ def test_library_search_human_view_keeps_evidence_and_ranks_visible() -> None:
 
     assert result.exit_code == 0
     assert "interview" in result.stdout
-    assert "1.50-2.50s" in result.stdout
+    assert "00:00:01.500" in result.stdout
+    assert "00:00:02.500" in result.stdout
     assert "speaker-02" in result.stdout
     assert "L:1" in result.stdout
     assert "housing" in result.stdout

--- a/src/echoflow/transcription/assembly.py
+++ b/src/echoflow/transcription/assembly.py
@@ -123,7 +123,7 @@ class TranscriptAssembler:
                 end_seconds = window.start_seconds + segment.end_seconds
 
             if isinstance(segment, AlignedRecognizedSegment):
-                rebased = replace(
+                aligned_rebased = replace(
                     segment,
                     index=len(output),
                     start_seconds=start_seconds,
@@ -133,14 +133,16 @@ class TranscriptAssembler:
                         for word in aligned_words(segment)
                     ),
                 )
-            else:
-                rebased = replace(
-                    segment,
-                    index=len(output),
-                    start_seconds=start_seconds,
-                    end_seconds=end_seconds,
-                )
-            output.append(rebased)
+                output.append(aligned_rebased)
+                continue
+
+            base_rebased = replace(
+                segment,
+                index=len(output),
+                start_seconds=start_seconds,
+                end_seconds=end_seconds,
+            )
+            output.append(base_rebased)
 
     @staticmethod
     def _rebase_word(word: AlignedWord, window: AudioSegmentWindow) -> AlignedWord:

--- a/src/echoflow/transcription/assembly.py
+++ b/src/echoflow/transcription/assembly.py
@@ -2,7 +2,11 @@ import math
 from collections.abc import Sequence
 from dataclasses import replace
 
-from echoflow.transcription.alignment import AlignedWord, aligned_words
+from echoflow.transcription.alignment import (
+    AlignedRecognizedSegment,
+    AlignedWord,
+    aligned_words,
+)
 from echoflow.transcription.errors import TranscriptionError
 from echoflow.transcription.models import (
     AudioSegmentWindow,
@@ -118,16 +122,16 @@ class TranscriptAssembler:
             else:
                 end_seconds = window.start_seconds + segment.end_seconds
 
-            words = tuple(
-                cls._rebase_word(word, window) for word in aligned_words(segment)
-            )
-            if words:
+            if isinstance(segment, AlignedRecognizedSegment):
                 rebased = replace(
                     segment,
                     index=len(output),
                     start_seconds=start_seconds,
                     end_seconds=end_seconds,
-                    words=words,
+                    words=tuple(
+                        cls._rebase_word(word, window)
+                        for word in aligned_words(segment)
+                    ),
                 )
             else:
                 rebased = replace(

--- a/src/echoflow/transcription/diarization.py
+++ b/src/echoflow/transcription/diarization.py
@@ -8,7 +8,7 @@ from importlib import import_module, metadata
 from pathlib import Path
 from typing import Any, cast
 
-from echoflow.transcription.alignment import aligned_words
+from echoflow.transcription.alignment import AlignedRecognizedSegment, aligned_words
 from echoflow.transcription.errors import (
     DiarizationDependencyError,
     DiarizationError,
@@ -204,7 +204,7 @@ def project_speaker_refs(
         ):
             raise ValueError("speaker projection refuses to overwrite existing labels")
 
-        if words:
+        if isinstance(segment, AlignedRecognizedSegment) and words:
             projected_words = tuple(
                 replace(
                     word,

--- a/src/echoflow/transcription/models.py
+++ b/src/echoflow/transcription/models.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 
-from echoflow.media.models import MediaInfo
+from echoflow.media.models import MediaInfo, MediaTemporalTag
 from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 from echoflow.transcription.enhancement_models import (
     EnhancementConfiguration,
@@ -425,6 +425,7 @@ class TranscriptSource:
     container_format: str
     duration_seconds: float
     audio_stream_index: int
+    temporal_tags: tuple[MediaTemporalTag, ...] = field(default=(), compare=False)
 
     def __post_init__(self) -> None:
         if len(self.sha256) != 64 or any(
@@ -451,9 +452,11 @@ class TranscriptSource:
             container_format=media.container_format,
             duration_seconds=media.duration_seconds,
             audio_stream_index=media.primary_audio_stream_index,
+            temporal_tags=media.temporal_tags,
         )
 
     def to_dict(self) -> dict[str, object]:
+        """Return source identity facts used by checkpoint/resume contracts."""
         return {
             "sha256": self.sha256,
             "size_bytes": self.size_bytes,
@@ -462,6 +465,13 @@ class TranscriptSource:
             "duration_seconds": self.duration_seconds,
             "audio_stream_index": self.audio_stream_index,
         }
+
+    def canonical_dict(self) -> dict[str, object]:
+        """Return source identity plus non-identity temporal provenance."""
+        document = self.to_dict()
+        if self.temporal_tags:
+            document["temporal_tags"] = [tag.to_dict() for tag in self.temporal_tags]
+        return document
 
 
 @dataclass(frozen=True, slots=True)
@@ -631,7 +641,7 @@ class CanonicalTranscript:
         return {
             "schema_version": self.schema_version,
             "job_id": self.job_id,
-            "source": self.source.to_dict(),
+            "source": self.source.canonical_dict(),
             "profile": self.profile.value,
             "provisional": self.provisional,
             "decode_strategy": self.decode_strategy.value,

--- a/src/echoflow/transcription/tests/test_checkpoint.py
+++ b/src/echoflow/transcription/tests/test_checkpoint.py
@@ -151,7 +151,9 @@ def test_manifest_restores_original_execution_settings_without_local_paths(tmp_p
     assert restored_engine.model_cache_path == (tmp_path / "new-model-cache").resolve()
 
 
-def test_completed_segment_round_trips_with_detected_language_and_word_alignment(tmp_path):
+def test_completed_segment_round_trips_with_detected_language_and_word_alignment(
+    tmp_path,
+):
     store, job, plan, windows, _ = context(tmp_path)
     store.initialize(job, plan, windows)
     store.save_segment(job, plan, windows, windows[0], result("sensitive words"))

--- a/src/echoflow/transcription/tests/test_source_time_provenance.py
+++ b/src/echoflow/transcription/tests/test_source_time_provenance.py
@@ -1,0 +1,114 @@
+from echoflow.media.models import (
+    InputIdentity,
+    MediaInfo,
+    MediaStream,
+    MediaTemporalTag,
+    StreamKind,
+    TemporalTagKind,
+    TemporalTagSource,
+)
+from echoflow.runner.models import ProcessingProfile
+from echoflow.transcription.models import (
+    CanonicalTranscript,
+    DecodeStrategy,
+    EngineProvenance,
+    TranscriptSource,
+)
+
+
+def media(tmp_path, *, temporal_tags=()):
+    source = tmp_path / "interview.mov"
+    return MediaInfo(
+        input=InputIdentity(source, 42, 7, "a" * 64),
+        container_format="mov,mp4,m4a,3gp,3g2,mj2",
+        duration_seconds=5_000.0,
+        streams=(MediaStream(1, StreamKind.AUDIO, "aac", 5_000.0),),
+        primary_audio_stream_index=1,
+        temporal_tags=temporal_tags,
+    )
+
+
+def test_temporal_metadata_is_provenance_not_checkpoint_source_identity(tmp_path):
+    tag = MediaTemporalTag(
+        TemporalTagKind.TIMECODE,
+        "10:00:00:00",
+        TemporalTagSource.STREAM,
+        stream_index=0,
+    )
+    plain = TranscriptSource.from_media(media(tmp_path))
+    tagged = TranscriptSource.from_media(media(tmp_path, temporal_tags=(tag,)))
+
+    assert plain == tagged
+    assert plain.to_dict() == tagged.to_dict()
+    assert "temporal_tags" not in tagged.to_dict()
+
+
+def test_canonical_transcript_preserves_source_declared_temporal_metadata(tmp_path):
+    tags = (
+        MediaTemporalTag(
+            TemporalTagKind.TIMECODE,
+            "10:00:00:00",
+            TemporalTagSource.STREAM,
+            stream_index=0,
+        ),
+        MediaTemporalTag(
+            TemporalTagKind.CREATION_TIME,
+            "2026-04-05T12:34:56Z",
+            TemporalTagSource.FORMAT,
+        ),
+    )
+    transcript = CanonicalTranscript(
+        job_id="job-time",
+        source=TranscriptSource.from_media(media(tmp_path, temporal_tags=tags)),
+        profile=ProcessingProfile.BALANCED,
+        provisional=False,
+        decode_strategy=DecodeStrategy.DIRECT,
+        engine=EngineProvenance(
+            name="faster-whisper",
+            package_version="1.2.1",
+            model="small",
+            model_revision="revision-1",
+            device="cpu",
+            compute_type="int8",
+            cpu_threads=2,
+            beam_size=5,
+            requested_language=None,
+        ),
+        detected_language=None,
+        language_probability=None,
+        segments=(),
+    )
+
+    source = transcript.to_dict()["source"]
+    assert isinstance(source, dict)
+    assert source["temporal_tags"] == [tag.to_dict() for tag in tags]
+
+
+def test_canonical_transcript_omits_empty_temporal_metadata_for_wire_compatibility(
+    tmp_path,
+):
+    transcript = CanonicalTranscript(
+        job_id="job-time",
+        source=TranscriptSource.from_media(media(tmp_path)),
+        profile=ProcessingProfile.BALANCED,
+        provisional=False,
+        decode_strategy=DecodeStrategy.DIRECT,
+        engine=EngineProvenance(
+            name="faster-whisper",
+            package_version="1.2.1",
+            model="small",
+            model_revision="revision-1",
+            device="cpu",
+            compute_type="int8",
+            cpu_threads=2,
+            beam_size=5,
+            requested_language=None,
+        ),
+        detected_language=None,
+        language_probability=None,
+        segments=(),
+    )
+
+    source = transcript.to_dict()["source"]
+    assert isinstance(source, dict)
+    assert "temporal_tags" not in source

--- a/src/echoflow/transcription/tests/test_source_time_provenance.py
+++ b/src/echoflow/transcription/tests/test_source_time_provenance.py
@@ -33,7 +33,7 @@ def test_temporal_metadata_is_provenance_not_checkpoint_source_identity(tmp_path
         TemporalTagKind.TIMECODE,
         "10:00:00:00",
         TemporalTagSource.STREAM,
-        stream_index=0,
+        stream_index=1,
     )
     plain = TranscriptSource.from_media(media(tmp_path))
     tagged = TranscriptSource.from_media(media(tmp_path, temporal_tags=(tag,)))
@@ -49,7 +49,7 @@ def test_canonical_transcript_preserves_source_declared_temporal_metadata(tmp_pa
             TemporalTagKind.TIMECODE,
             "10:00:00:00",
             TemporalTagSource.STREAM,
-            stream_index=0,
+            stream_index=1,
         ),
         MediaTemporalTag(
             TemporalTagKind.CREATION_TIME,


### PR DESCRIPTION
## What changed

This tranche builds on word-level source-relative timing by adding human-readable elapsed coordinates and preserving original-container temporal metadata without conflating the two.

### Human elapsed coordinates

- add deterministic `HH:MM:SS.mmm` formatting for canonical source-relative seconds
- do not wrap hours at 24, because recordings are elapsed timelines rather than wall clocks
- round safely at millisecond boundaries
- keep numeric seconds authoritative; formatted timestamps are presentation values
- show human timestamp ranges in transcript-library search
- retain numeric seconds in JSON and add derived `start_timestamp` / `end_timestamp` conveniences

### Original-media temporal provenance

- ask FFprobe for source-declared `timecode` and `creation_time` tags at format and stream scope
- preserve every reported declaration with explicit source scope and stream index
- validate stream-scoped temporal tags against discovered streams
- do not resolve conflicting tags or claim source metadata is historically true
- carry temporal tags through `MediaInfo` into canonical transcript source provenance
- keep temporal tags out of checkpoint source identity/equality so stale camera metadata cannot redefine source identity
- preserve the previous JSON shape when no temporal metadata exists

### Product and navigation behavior

- `4788.37` seconds can be presented as `01:19:48.370`
- internal 600-second work windows remain execution details and never reset published time
- word coordinates now form the future seek/highlight/note anchor; pretty timestamp strings do not become durable identity
- a future player can seek the original media using canonical numeric seconds without reverse-engineering ASR work chunks
- future notes/annotations should bind to durable source/canonical evidence, never only to a rebuildable search chunk or formatted clock string

### Documentation

- add `docs/time-navigation.md`, a plain-language guide with Mermaid diagrams for word timing, click-to-media, durable future annotations, and multiple clock types
- rewrite `docs/architecture/media-and-timeline.md` around the implemented elapsed/source-provenance contract
- update `docs/README.md` with a dedicated time-navigation doorway and current product capabilities
- advance `ROADMAP.md`: better speaker UX is now next, aligned research-navigation UX follows, and deeper SMPTE/PTS mapping remains evidence-driven future qualification

### Qualification

- boundary and Hypothesis tests for elapsed timestamp rendering
- temporal tag validation and serialization tests
- FFprobe extraction tests including conflicting declarations and malformed optional tags
- reject temporal tags that reference undiscovered streams
- canonical-transcript provenance and wire-compatibility tests
- search CLI human/JSON timestamp tests
- also applies the Ruff formatter correction left behind by merged PR #59
- current qualification is additionally enforcing explicit `AlignedRecognizedSegment` narrowing before subclass-only `words` replacements, so mypy can prove the alignment path rather than relying on runtime dataclass behavior

## Why

A user should never have to turn `4788.37` seconds into hours and minutes in their head. Word timing tells EchoFlow where evidence lives; this tranche gives that coordinate a human presentation (`01:19:48.370`) and preserves any time metadata declared by the original media.

These are deliberately separate coordinate systems. Canonical source-relative seconds remain the durable anchor for future click-to-seek and annotations. Container timecode and capture metadata remain source-declared provenance.

## Deliberately not included

- a GUI/media-player click handler
- notes/annotation storage or editing UI
- arithmetic on SMPTE frame timecodes without qualified frame-rate/drop-frame semantics
- full PTS/DTS/start-time normalization
- cross-device clock synchronization
- user-assigned speaker display names
- source separation for overlapping speech

Those remain later product layers on top of the canonical evidence coordinates.

## CI note

PR #59 was merged with its Linux Quality lane stopped at Ruff formatting even though macOS and Windows passed. The exact outstanding formatter diff from that merged head is corrected in this branch. On PR #60, macOS and Windows full platform-smoke lanes passed on head `0d775acd...`; Linux progressed through dependency audit, lint, and formatting, then exposed two mypy errors where subclass-only `words` fields were passed through a base `RecognizedSegment` type. Those call sites are being narrowed explicitly rather than ignored. PR #60 remains draft until the resulting current head is fully qualified.