### PR TITLE
feat(library): add durable speaker display labels

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ searchable evidence corpus.
 | Clean up a noisy recording | optionally applies deterministic local noise suppression with provenance and timeline checks |
 | Work with multiple languages | supports multilingual decoding plus conservative local language attribution |
 | Distinguish speakers | has optional anonymous recording-scoped diarization, currently held behind a dependency security gate |
+| Give anonymous speakers useful names | stores user-assigned display labels separately from canonical diarization evidence and rebuildable search state |
 | Publish useful transcript formats | produces canonical JSON plus rebuildable TXT, SRT, and WebVTT views |
 | Find an exact phrase later | builds a private local lexical/BM25 transcript library |
 | Find an idea even when the wording changed | supports optional local semantic retrieval |
@@ -61,6 +62,14 @@ Read **[Transcript time without calculator gymnastics](time-navigation.md)**.
 It explains what word timestamps buy you, why `4788.37` seconds becomes
 `01:19:48.370`, how future click-to-seek and notes should anchor to evidence, and why a
 camera's embedded timecode is a different clock.
+
+### 👥 I want `speaker-02` to have a human name
+
+Read **[Give the anonymous speakers names](speaker-names.md)**.
+
+It explains why `speaker-02` remains evidence while `Dr. Chen` is your durable display
+label, how to name or un-name a speaker, and why labels do not silently jump across a
+changed transcript generation.
 
 ### 🔎 I want to search my transcripts
 
@@ -126,7 +135,8 @@ EchoFlow uses different custody rules for different kinds of data.
 |---|---|---|
 | Original recording | source evidence | **No** |
 | Canonical transcript JSON | authoritative transcript artifact | **No** |
-| Future notes, tags, labels, annotations | user-authored knowledge | **No** |
+| Speaker display labels | user-authored knowledge | **No** |
+| Future notes, tags, annotations | user-authored knowledge | **No** |
 | TXT / SRT / WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
 | Checkpoint machinery after successful publication | execution/recovery state | Usually disposable after completion |
@@ -159,15 +169,14 @@ easier to enter.
 
 The evidence-navigation sequence has advanced:
 
-1. **word/timestamp alignment** is now in the foundation, so canonical evidence has
-   finer word coordinates;
-2. **human elapsed time + original-media temporal provenance** now makes those
-   coordinates readable and preserves source-declared time clues without conflating
-   clocks;
-3. **better speaker UX** is next, including user-assigned display labels for anonymous
-   speakers and better presentation of overlap;
-4. **aligned research-navigation UX** can then exploit the same coordinates for
-   highlighting, click-to-audio, durable notes, and annotations; and
+1. **word/timestamp alignment** is in the foundation, so canonical evidence has finer
+   word coordinates;
+2. **human elapsed time + original-media temporal provenance** makes those coordinates
+   readable and preserves source-declared time clues without conflating clocks;
+3. **user-assigned speaker display labels** now keep human naming separate from anonymous
+   diarization evidence and rebuildable indexes;
+4. **better overlap presentation and aligned research-navigation UX** can exploit the
+   same coordinates for highlighting, click-to-audio, durable notes, and annotations;
 5. **later, source separation for overlapping speech** remains a measured capability,
    not a premature checkbox.
 

--- a/docs/architecture/diarization.md
+++ b/docs/architecture/diarization.md
@@ -173,13 +173,13 @@ text coordinate.
 The first payoff is already structural: a speaker handoff can be represented inside one
 recognized segment without assigning the entire segment to either person.
 
-The same evidence seam can later support:
+The same evidence seam can support:
 
 - precise transcript highlighting;
 - more exact jump-to-audio behavior;
 - durable annotations anchored to smaller evidence spans;
 - clearer overlap presentation; and
-- cleaner future speaker-label UX.
+- user-authored names over anonymous speaker evidence.
 
 Alignment does **not** solve simultaneous speech. If two active speakers overlap the same
 word interval, the word remains unattributed. Later source separation may provide more
@@ -187,43 +187,65 @@ evidence, but EchoFlow does not manufacture certainty in the meantime.
 
 ## User-assigned display labels without biometric identity
 
-A useful future feature is allowing the user to say:
+EchoFlow now lets the user say:
 
 ```text
 speaker-01 → Dr. Chen
 speaker-02 → Interviewer
 ```
 
-The important design rule is that this should be **display/user-authored state**, not a
-rewrite of the underlying anonymous diarization evidence.
+through the local transcript library:
 
-Conceptually:
+```bash
+echoflow library speakers list TRANSCRIPT_ID
+echoflow library speakers name TRANSCRIPT_ID speaker-01 "Dr. Chen"
+echoflow library speakers forget-name TRANSCRIPT_ID speaker-01
+```
+
+The design rule is that this is **display/user-authored state**, not a rewrite of the
+underlying anonymous diarization evidence.
 
 ```mermaid
 flowchart LR
     A[speaker-01 evidence] --> B[User-authored display label: Dr. Chen]
-    A --> C[Canonical speaker-turn coordinates]
+    A --> C[Canonical speaker coordinates]
+    B --> D[Dr. Chen (speaker-01)]
 
     classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
     classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
 
     class A,C evidence
     class B user
+    class D view
 ```
 
-The label is meaningful user knowledge and must **not** share the deletion semantics of
-a rebuildable search index.
+The label is meaningful user knowledge and does **not** share the deletion semantics of
+a rebuildable search index. It is written to private user state separately from lexical
+and semantic indexes.
 
-EchoFlow can remain anonymous-by-default while still letting a researcher make their own
-recording understandable.
+A label is bound to the transcript ID, exact canonical transcript SHA-256, and anonymous
+speaker reference. If the canonical transcript changes, the old label is retained as
+user-authored state but is treated as stale and is not silently applied to the new
+speaker generation.
+
+Before accepting a new label, EchoFlow verifies that the current canonical bytes still
+match the hash recorded in the library and that the anonymous speaker actually appears
+in canonical evidence. Both segment-level refs and aligned word-level refs count, so a
+speaker involved only in a mixed-speaker handoff remains nameable.
+
+EchoFlow can therefore stay anonymous-by-default while still letting a researcher make
+their own recording understandable.
+
+See [Give the anonymous speakers names](../speaker-names.md) for the human-facing guide.
 
 ## Better overlap handling before source separation
 
 Overlap still deserves two distinct product steps.
 
 First, EchoFlow improves **representation and presentation** using finer word timing,
-explicit multi-speaker turn evidence, and UI/export behavior that does not force one
-speaker when multiple voices are active.
+explicit multi-speaker turn evidence, user-controlled display labels, and UI/export
+behavior that does not force one speaker when multiple voices are active.
 
 Only later should EchoFlow consider **speech/source separation**, where the audio itself
 is decomposed into estimated sources before or during recognition.
@@ -244,8 +266,9 @@ Mixed or ambiguous segments remain unlabeled at the segment level even when some
 have useful speaker evidence. Export rendering never changes timestamps or becomes
 canonical custody.
 
-Future user-assigned display labels should remain a presentation layer over stable
-anonymous speaker references and durable transcript coordinates.
+User-assigned display labels remain a presentation layer over stable anonymous speaker
+references and durable transcript coordinates. The current naming commands do not bake
+the human label into canonical JSON or derived transcript exports.
 
 ## Qualification boundary
 
@@ -253,11 +276,14 @@ The deterministic test surface covers:
 
 - adapter/cache-only versus download policy;
 - telemetry-disable behavior;
-- deterministic label normalization;
+- deterministic anonymous-label normalization;
 - canonical schema integration;
 - executor integration;
 - conservative word/segment speaker projection;
 - mixed-speaker handoffs and ambiguous word overlap;
+- durable user display-label binding to exact canonical hashes;
+- word-only speaker discovery for mixed handoffs;
+- stale-generation isolation and corrupted-state rejection;
 - derived exports; and
 - the fail-closed Lightning security gate.
 
@@ -275,9 +301,10 @@ This capability does not currently provide:
 
 - biometric speaker identification;
 - cross-recording speaker linking;
-- user-assigned display labels;
+- automatic inference of a human speaker's real name;
 - a guarantee that engine word timing or diarization is always correct;
 - polished overlap presentation;
+- display labels baked into canonical or derived transcript artifacts;
 - simultaneous-speaker/source separation; or
 - a claim that the dependency footprint is suitable for every low-memory device.
 

--- a/docs/speaker-names.md
+++ b/docs/speaker-names.md
@@ -1,0 +1,147 @@
+# Give the anonymous speakers names 👥✨
+
+Diarization gives EchoFlow useful but intentionally anonymous evidence:
+
+```text
+speaker-01
+speaker-02
+speaker-03
+```
+
+That is excellent for provenance and terrible for remembering which person was Dr. Chen.
+
+EchoFlow therefore keeps **two different facts** instead of pretending they are the same thing:
+
+- `speaker-02` is machine-produced diarization evidence;
+- `Dr. Chen` is a name **you** assigned to that anonymous speaker in this transcript generation.
+
+The friendly label never rewrites the evidence underneath it.
+
+```mermaid
+flowchart LR
+    D[Anonymous diarization evidence] --> R[speaker-02]
+    R --> C[Canonical transcript coordinates]
+    R --> U[User-authored display label]
+    U --> V[Dr. Chen (speaker-02)]
+
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class D,R,C evidence
+    class U user
+    class V view
+```
+
+🦝 **The raccoon may rebuild the search index. The raccoon may not eat your names.**
+
+## Naming a speaker
+
+First make sure the transcript is present in the local library, then inspect its anonymous speaker refs:
+
+```bash
+echoflow library speakers list TRANSCRIPT_ID
+```
+
+Assign a human-readable display label:
+
+```bash
+echoflow library speakers name TRANSCRIPT_ID speaker-02 "Dr. Chen"
+```
+
+EchoFlow will continue to retain `speaker-02` as the evidence reference and can present the friendly form as:
+
+```text
+Dr. Chen (speaker-02)
+```
+
+If you change your mind:
+
+```bash
+echoflow library speakers forget-name TRANSCRIPT_ID speaker-02
+```
+
+Every command also supports `--json` for machine-readable output.
+
+## Why not just replace `speaker-02` with the name?
+
+Because those statements come from different authorities.
+
+Diarization says:
+
+> this voice cluster received the recording-scoped anonymous reference `speaker-02`.
+
+You say:
+
+> I know this person is Dr. Chen, so show me that name while I work.
+
+If EchoFlow overwrote one with the other, it would destroy the distinction between **derived evidence** and **human knowledge**. That distinction matters for reproducibility, correction, auditing, and future annotations.
+
+## What if the transcript changes?
+
+Speaker numbering is meaningful only inside the canonical transcript generation that produced it.
+
+A re-transcription could change where speaker boundaries fall. It could even make tomorrow's `speaker-02` represent somebody different from today's `speaker-02`.
+
+So a display label is bound to:
+
+```text
+transcript ID
++ exact canonical transcript SHA-256
++ anonymous speaker ref
+```
+
+If the canonical transcript changes, EchoFlow **keeps the old user-authored label** but refuses to silently apply it to the new generation.
+
+```mermaid
+flowchart TD
+    A[Canonical transcript generation A] --> B[speaker-02]
+    B --> C[User label: Dr. Chen]
+    A -->|transcript changes| D[Canonical transcript generation B]
+    D --> E[speaker-02]
+    C -. retained but stale .-> F[User-authored state]
+    C -. not silently reused .-> E
+
+    classDef old fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef current fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+
+    class A,B old
+    class D,E current
+    class C,F user
+```
+
+That is slightly fussy on purpose. EchoFlow would rather ask you to confirm a name than confidently attach Dr. Chen to the wrong human.
+
+## What about speaker handoffs inside one transcript segment?
+
+Word-level timing matters here.
+
+A mixed ASR segment may have no single segment-level `speaker_ref` because the speaker changes halfway through. Its individual aligned words can still carry `speaker-01` and `speaker-02` evidence.
+
+The speaker-label service inspects **both segment-level and aligned-word speaker evidence**, so those speakers remain available to name even when the enclosing sentence cannot honestly be assigned to one person.
+
+💃 Finer evidence, less lying. A useful trade.
+
+## Where are these labels stored?
+
+Speaker names are **private user-authored state**, not rebuildable search state.
+
+They live under EchoFlow's private application state, separate from:
+
+- the canonical transcript;
+- the lexical DuckDB index;
+- semantic chunks and vectors; and
+- checkpoint/recovery machinery.
+
+Writes use EchoFlow's existing atomic private-file boundary.
+
+This means rebuilding lexical or semantic search must not erase the names you assigned.
+
+## What this does not do
+
+Speaker display labels are not biometric identification. EchoFlow does not infer that `speaker-01` in two different recordings is the same person, and it does not search for somebody's identity from their voice.
+
+This feature also does not solve simultaneous speech. Word-level diarization can preserve ambiguity honestly, but source separation remains a later and materially heavier capability.
+
+For the underlying diarization evidence model, security gate, and overlap rules, see **[Anonymous speaker diarization](architecture/diarization.md)**.

--- a/src/echoflow/app/app_container.py
+++ b/src/echoflow/app/app_container.py
@@ -20,6 +20,8 @@ from echoflow.library.duckdb_index import DuckDbTranscriptIndex
 from echoflow.library.duckdb_semantic import DuckDbSemanticIndex
 from echoflow.library.semantic import EmbeddingProfile, SentenceTransformersE5Provider
 from echoflow.library.service import TranscriptLibraryService
+from echoflow.library.speaker_label_service import SpeakerLabelService
+from echoflow.library.speaker_labels import SpeakerLabelStore
 from echoflow.media.probe import FfprobeMediaProbe
 from echoflow.media.selection import AudioStreamSelector
 from echoflow.model_management.catalog import faster_whisper_model_catalog
@@ -136,6 +138,15 @@ def _create_semantic_index(
     )
 
 
+def _create_speaker_label_store(
+    config: AppConfig, file_manager: FileManagerFacade
+) -> SpeakerLabelStore:
+    return SpeakerLabelStore(
+        config.STATE_DIR / "library" / "user-state" / "speaker-labels.json",
+        file_manager,
+    )
+
+
 def _restore_embedding_provider(
     profile: EmbeddingProfile,
 ) -> SentenceTransformersE5Provider:
@@ -225,6 +236,17 @@ class AppContainer(containers.DeclarativeContainer):
     semantic_index = providers.Singleton(
         _create_semantic_index,
         config=config,
+        file_manager=file_manager,
+    )
+    speaker_label_store = providers.Singleton(
+        _create_speaker_label_store,
+        config=config,
+        file_manager=file_manager,
+    )
+    speaker_labels = providers.Singleton(
+        SpeakerLabelService,
+        index=transcript_index,
+        store=speaker_label_store,
         file_manager=file_manager,
     )
     semantic_embedding_provider = providers.Factory(SentenceTransformersE5Provider)

--- a/src/echoflow/cli_library.py
+++ b/src/echoflow/cli_library.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from echoflow.app.app_container import AppContainer
+from echoflow.cli_speakers import register_speaker_commands
 from echoflow.core.errors import EchoFlowError
 from echoflow.library.index import (
     IndexedDocument,
@@ -575,4 +576,5 @@ def register_library_commands(
         )
 
     library_app.add_typer(embeddings_app, name="embeddings")
+    register_speaker_commands(library_app, container_factory)
     app.add_typer(library_app, name="library")

--- a/src/echoflow/cli_speakers.py
+++ b/src/echoflow/cli_speakers.py
@@ -1,0 +1,151 @@
+"""CLI for durable human display names over anonymous speaker evidence."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import cast
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from echoflow.app.app_container import AppContainer
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.speaker_label_service import SpeakerRosterEntry
+
+ContainerFactory = Callable[[typer.Context], AppContainer]
+
+
+def _root_context(context: typer.Context) -> typer.Context:
+    return cast("typer.Context", context.find_root())
+
+
+def _handle_error(exc: Exception) -> None:
+    if isinstance(exc, EchoFlowError):
+        typer.echo(exc.public_message, err=True)
+        raise typer.Exit(code=exc.exit_code) from None
+    if isinstance(exc, ValueError):
+        raise typer.BadParameter(str(exc)) from exc
+    typer.echo(
+        f"EchoFlow speaker labels failed internally ({type(exc).__name__})",
+        err=True,
+    )
+    raise typer.Exit(code=3) from None
+
+
+def _roster_dict(entry: SpeakerRosterEntry) -> dict[str, object]:
+    return {
+        "speaker_ref": entry.speaker_ref,
+        "display_label": entry.display_label,
+        "display_name": entry.display_name,
+    }
+
+
+def _render_roster(
+    document_id: str,
+    roster: tuple[SpeakerRosterEntry, ...],
+    console: Console,
+) -> None:
+    table = Table(title=f"EchoFlow speakers: {document_id}")
+    table.add_column("Evidence ref")
+    table.add_column("Your label")
+    table.add_column("Shown as")
+    for entry in roster:
+        table.add_row(
+            entry.speaker_ref,
+            entry.display_label or "not named",
+            entry.display_name,
+        )
+    console.print(table)
+
+
+def register_speaker_commands(
+    app: typer.Typer,
+    container_factory: ContainerFactory,
+) -> None:
+    speakers_app = typer.Typer(
+        help="Give anonymous transcript speakers durable human display names.",
+        no_args_is_help=True,
+    )
+
+    @speakers_app.command("list")
+    def list_speakers(
+        context: typer.Context,
+        transcript_id: str = typer.Argument(..., metavar="TRANSCRIPT_ID"),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        try:
+            roster = (
+                container_factory(_root_context(context))
+                .speaker_labels()
+                .roster(transcript_id)
+            )
+        except Exception as exc:
+            _handle_error(exc)
+            return
+        if json_output:
+            typer.echo(json.dumps([_roster_dict(item) for item in roster], sort_keys=True))
+            return
+        _render_roster(transcript_id, roster, Console())
+
+    @speakers_app.command("name")
+    def name_speaker(
+        context: typer.Context,
+        transcript_id: str = typer.Argument(..., metavar="TRANSCRIPT_ID"),
+        speaker_ref: str = typer.Argument(..., metavar="SPEAKER_REF"),
+        label: str = typer.Argument(..., metavar="DISPLAY_LABEL"),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        try:
+            service = container_factory(_root_context(context)).speaker_labels()
+            binding = service.set_label(
+                transcript_id,
+                speaker_ref=speaker_ref,
+                label=label,
+            )
+        except Exception as exc:
+            _handle_error(exc)
+            return
+        if json_output:
+            typer.echo(json.dumps(binding.to_dict(), sort_keys=True))
+            return
+        typer.echo(
+            f"{binding.speaker_ref} will be shown as "
+            f"{binding.label} ({binding.speaker_ref})."
+        )
+
+    @speakers_app.command("forget-name")
+    def forget_speaker_name(
+        context: typer.Context,
+        transcript_id: str = typer.Argument(..., metavar="TRANSCRIPT_ID"),
+        speaker_ref: str = typer.Argument(..., metavar="SPEAKER_REF"),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        try:
+            removed = (
+                container_factory(_root_context(context))
+                .speaker_labels()
+                .remove_label(transcript_id, speaker_ref=speaker_ref)
+            )
+        except Exception as exc:
+            _handle_error(exc)
+            return
+        if json_output:
+            typer.echo(
+                json.dumps(
+                    {
+                        "transcript_id": transcript_id,
+                        "speaker_ref": speaker_ref,
+                        "removed": removed,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return
+        if removed:
+            typer.echo(f"Forgot the display name for {speaker_ref}.")
+        else:
+            typer.echo(f"{speaker_ref} did not have a current display name.")
+
+    app.add_typer(speakers_app, name="speakers")

--- a/src/echoflow/cli_speakers.py
+++ b/src/echoflow/cli_speakers.py
@@ -60,6 +60,91 @@ def _render_roster(
     console.print(table)
 
 
+def _list_speakers(
+    context: typer.Context,
+    transcript_id: str,
+    *,
+    json_output: bool,
+    container_factory: ContainerFactory,
+) -> None:
+    try:
+        roster = (
+            container_factory(_root_context(context)).speaker_labels().roster(transcript_id)
+        )
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(
+            json.dumps([_roster_dict(item) for item in roster], sort_keys=True)
+        )
+        return
+    _render_roster(transcript_id, roster, Console())
+
+
+def _name_speaker(
+    context: typer.Context,
+    transcript_id: str,
+    speaker_ref: str,
+    label: str,
+    *,
+    json_output: bool,
+    container_factory: ContainerFactory,
+) -> None:
+    try:
+        service = container_factory(_root_context(context)).speaker_labels()
+        binding = service.set_label(
+            transcript_id,
+            speaker_ref=speaker_ref,
+            label=label,
+        )
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps(binding.to_dict(), sort_keys=True))
+        return
+    typer.echo(
+        f"{binding.speaker_ref} will be shown as "
+        f"{binding.label} ({binding.speaker_ref})."
+    )
+
+
+def _forget_speaker_name(
+    context: typer.Context,
+    transcript_id: str,
+    speaker_ref: str,
+    *,
+    json_output: bool,
+    container_factory: ContainerFactory,
+) -> None:
+    try:
+        removed = (
+            container_factory(_root_context(context))
+            .speaker_labels()
+            .remove_label(transcript_id, speaker_ref=speaker_ref)
+        )
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "transcript_id": transcript_id,
+                    "speaker_ref": speaker_ref,
+                    "removed": removed,
+                },
+                sort_keys=True,
+            )
+        )
+        return
+    if removed:
+        typer.echo(f"Forgot the display name for {speaker_ref}.")
+    else:
+        typer.echo(f"{speaker_ref} did not have a current display name.")
+
+
 def register_speaker_commands(
     app: typer.Typer,
     container_factory: ContainerFactory,
@@ -75,19 +160,12 @@ def register_speaker_commands(
         transcript_id: str = typer.Argument(..., metavar="TRANSCRIPT_ID"),
         json_output: bool = typer.Option(False, "--json"),
     ) -> None:
-        try:
-            roster = (
-                container_factory(_root_context(context))
-                .speaker_labels()
-                .roster(transcript_id)
-            )
-        except Exception as exc:
-            _handle_error(exc)
-            return
-        if json_output:
-            typer.echo(json.dumps([_roster_dict(item) for item in roster], sort_keys=True))
-            return
-        _render_roster(transcript_id, roster, Console())
+        _list_speakers(
+            context,
+            transcript_id,
+            json_output=json_output,
+            container_factory=container_factory,
+        )
 
     @speakers_app.command("name")
     def name_speaker(
@@ -97,22 +175,13 @@ def register_speaker_commands(
         label: str = typer.Argument(..., metavar="DISPLAY_LABEL"),
         json_output: bool = typer.Option(False, "--json"),
     ) -> None:
-        try:
-            service = container_factory(_root_context(context)).speaker_labels()
-            binding = service.set_label(
-                transcript_id,
-                speaker_ref=speaker_ref,
-                label=label,
-            )
-        except Exception as exc:
-            _handle_error(exc)
-            return
-        if json_output:
-            typer.echo(json.dumps(binding.to_dict(), sort_keys=True))
-            return
-        typer.echo(
-            f"{binding.speaker_ref} will be shown as "
-            f"{binding.label} ({binding.speaker_ref})."
+        _name_speaker(
+            context,
+            transcript_id,
+            speaker_ref,
+            label,
+            json_output=json_output,
+            container_factory=container_factory,
         )
 
     @speakers_app.command("forget-name")
@@ -122,30 +191,12 @@ def register_speaker_commands(
         speaker_ref: str = typer.Argument(..., metavar="SPEAKER_REF"),
         json_output: bool = typer.Option(False, "--json"),
     ) -> None:
-        try:
-            removed = (
-                container_factory(_root_context(context))
-                .speaker_labels()
-                .remove_label(transcript_id, speaker_ref=speaker_ref)
-            )
-        except Exception as exc:
-            _handle_error(exc)
-            return
-        if json_output:
-            typer.echo(
-                json.dumps(
-                    {
-                        "transcript_id": transcript_id,
-                        "speaker_ref": speaker_ref,
-                        "removed": removed,
-                    },
-                    sort_keys=True,
-                )
-            )
-            return
-        if removed:
-            typer.echo(f"Forgot the display name for {speaker_ref}.")
-        else:
-            typer.echo(f"{speaker_ref} did not have a current display name.")
+        _forget_speaker_name(
+            context,
+            transcript_id,
+            speaker_ref,
+            json_output=json_output,
+            container_factory=container_factory,
+        )
 
     app.add_typer(speakers_app, name="speakers")

--- a/src/echoflow/cli_speakers.py
+++ b/src/echoflow/cli_speakers.py
@@ -69,15 +69,15 @@ def _list_speakers(
 ) -> None:
     try:
         roster = (
-            container_factory(_root_context(context)).speaker_labels().roster(transcript_id)
+            container_factory(_root_context(context))
+            .speaker_labels()
+            .roster(transcript_id)
         )
     except Exception as exc:
         _handle_error(exc)
         return
     if json_output:
-        typer.echo(
-            json.dumps([_roster_dict(item) for item in roster], sort_keys=True)
-        )
+        typer.echo(json.dumps([_roster_dict(item) for item in roster], sort_keys=True))
         return
     _render_roster(transcript_id, roster, Console())
 

--- a/src/echoflow/library/errors.py
+++ b/src/echoflow/library/errors.py
@@ -17,3 +17,9 @@ class SemanticSearchUnavailableError(TranscriptLibraryError):
     """Semantic capability is absent, unbuilt, stale, or cannot load locally."""
 
     exit_code = 2
+
+
+class SpeakerLabelStateError(TranscriptLibraryError):
+    """User-authored speaker label state is invalid, stale, or unavailable."""
+
+    exit_code = 2

--- a/src/echoflow/library/speaker_label_service.py
+++ b/src/echoflow/library/speaker_label_service.py
@@ -97,7 +97,11 @@ class SpeakerLabelService:
 
     def _document(self, document_id: str) -> IndexedDocument:
         document = next(
-            (item for item in self.index.documents() if item.document_id == document_id),
+            (
+                item
+                for item in self.index.documents()
+                if item.document_id == document_id
+            ),
             None,
         )
         if document is None:

--- a/src/echoflow/library/speaker_label_service.py
+++ b/src/echoflow/library/speaker_label_service.py
@@ -84,18 +84,16 @@ class SpeakerLabelService:
         speaker_refs: tuple[str, ...],
     ) -> dict[str, str]:
         """Resolve only labels bound to the exact evidence generation in a result."""
-        return {
-            speaker_ref: label
-            for speaker_ref in speaker_refs
-            if (
-                label := self.store.resolve(
-                    document_id=document_id,
-                    canonical_sha256=canonical_sha256,
-                    speaker_ref=speaker_ref,
-                )
+        resolved: dict[str, str] = {}
+        for speaker_ref in speaker_refs:
+            label = self.store.resolve(
+                document_id=document_id,
+                canonical_sha256=canonical_sha256,
+                speaker_ref=speaker_ref,
             )
-            is not None
-        }
+            if label is not None:
+                resolved[speaker_ref] = label
+        return resolved
 
     def _document(self, document_id: str) -> IndexedDocument:
         document = next(

--- a/src/echoflow/library/speaker_label_service.py
+++ b/src/echoflow/library/speaker_label_service.py
@@ -1,0 +1,109 @@
+"""Application service for human-readable names over anonymous speaker evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.errors import SpeakerLabelStateError
+from echoflow.library.index import IndexedDocument, TranscriptIndex
+from echoflow.library.speaker_labels import (
+    SpeakerDisplayLabel,
+    SpeakerLabelStore,
+    SpeakerLabelView,
+    canonical_speaker_refs,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SpeakerRosterEntry:
+    """One current anonymous speaker plus an optional user-authored display name."""
+
+    speaker_ref: str
+    display_label: str | None
+
+    @property
+    def display_name(self) -> str:
+        if self.display_label is None:
+            return self.speaker_ref
+        return f"{self.display_label} ({self.speaker_ref})"
+
+
+class SpeakerLabelService:
+    """Keep user naming separate from diarization and rebuildable search state."""
+
+    def __init__(
+        self,
+        index: TranscriptIndex,
+        store: SpeakerLabelStore,
+        file_manager: FileManagerFacade,
+    ) -> None:
+        self.index = index
+        self.store = store
+        self.file_manager = file_manager
+
+    def roster(self, document_id: str) -> tuple[SpeakerRosterEntry, ...]:
+        document = self._document(document_id)
+        refs = canonical_speaker_refs(document, self.file_manager)
+        labels = {
+            item.speaker_ref: item.label for item in self.store.current_labels(document)
+        }
+        return tuple(
+            SpeakerRosterEntry(speaker_ref=ref, display_label=labels.get(ref))
+            for ref in refs
+        )
+
+    def views(self, document_id: str) -> tuple[SpeakerLabelView, ...]:
+        return self.store.views(self._document(document_id))
+
+    def set_label(
+        self,
+        document_id: str,
+        *,
+        speaker_ref: str,
+        label: str,
+    ) -> SpeakerDisplayLabel:
+        document = self._document(document_id)
+        refs = canonical_speaker_refs(document, self.file_manager)
+        if speaker_ref not in refs:
+            raise SpeakerLabelStateError(
+                "Speaker reference is not present in the current canonical transcript"
+            )
+        return self.store.set_label(document, speaker_ref=speaker_ref, label=label)
+
+    def remove_label(self, document_id: str, *, speaker_ref: str) -> bool:
+        return self.store.remove_label(
+            self._document(document_id), speaker_ref=speaker_ref
+        )
+
+    def display_labels(
+        self,
+        *,
+        document_id: str,
+        canonical_sha256: str | None,
+        speaker_refs: tuple[str, ...],
+    ) -> dict[str, str]:
+        """Resolve only labels bound to the exact evidence generation in a result."""
+        return {
+            speaker_ref: label
+            for speaker_ref in speaker_refs
+            if (
+                label := self.store.resolve(
+                    document_id=document_id,
+                    canonical_sha256=canonical_sha256,
+                    speaker_ref=speaker_ref,
+                )
+            )
+            is not None
+        }
+
+    def _document(self, document_id: str) -> IndexedDocument:
+        document = next(
+            (item for item in self.index.documents() if item.document_id == document_id),
+            None,
+        )
+        if document is None:
+            raise SpeakerLabelStateError(
+                "Transcript is not present in the local library; rebuild the library first"
+            )
+        return document

--- a/src/echoflow/library/speaker_labels.py
+++ b/src/echoflow/library/speaker_labels.py
@@ -1,0 +1,233 @@
+"""Durable user-authored display labels for anonymous transcript speakers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.errors import SpeakerLabelStateError
+from echoflow.library.index import IndexedDocument
+
+_STATE_SCHEMA_VERSION = 1
+_MAX_LABEL_LENGTH = 200
+
+
+def _validate_sha256(value: str) -> None:
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError("canonical_sha256 must be a lowercase 64-character digest")
+
+
+@dataclass(frozen=True, slots=True)
+class SpeakerDisplayLabel:
+    """One human-authored name bound to one anonymous speaker evidence generation."""
+
+    document_id: str
+    canonical_sha256: str
+    speaker_ref: str
+    label: str
+
+    def __post_init__(self) -> None:
+        if not self.document_id.strip():
+            raise ValueError("document_id cannot be empty")
+        _validate_sha256(self.canonical_sha256)
+        if not self.speaker_ref.strip():
+            raise ValueError("speaker_ref cannot be empty")
+        normalized = self.label.strip()
+        if not normalized:
+            raise ValueError("speaker display label cannot be empty")
+        if len(normalized) > _MAX_LABEL_LENGTH:
+            raise ValueError(
+                f"speaker display label cannot exceed {_MAX_LABEL_LENGTH} characters"
+            )
+        if any(character in "\r\n\x00" for character in normalized):
+            raise ValueError("speaker display label cannot contain line breaks or NUL")
+        object.__setattr__(self, "label", normalized)
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "document_id": self.document_id,
+            "canonical_sha256": self.canonical_sha256,
+            "speaker_ref": self.speaker_ref,
+            "label": self.label,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SpeakerLabelView:
+    """A stored label plus whether it still matches the current canonical evidence."""
+
+    binding: SpeakerDisplayLabel
+    current: bool
+
+
+class _StoredLabel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    document_id: str
+    canonical_sha256: str
+    speaker_ref: str
+    label: str
+
+
+class _StoredState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int
+    labels: list[_StoredLabel]
+
+
+class SpeakerLabelStore:
+    """Own non-rebuildable speaker display labels separately from search indexes."""
+
+    def __init__(self, path: Path, file_manager: FileManagerFacade) -> None:
+        self.path = path.expanduser().resolve(strict=False)
+        self.file_manager = file_manager
+
+    def set_label(
+        self,
+        document: IndexedDocument,
+        *,
+        speaker_ref: str,
+        label: str,
+    ) -> SpeakerDisplayLabel:
+        canonical_sha256 = self._require_canonical_hash(document)
+        binding = SpeakerDisplayLabel(
+            document_id=document.document_id,
+            canonical_sha256=canonical_sha256,
+            speaker_ref=speaker_ref,
+            label=label,
+        )
+        state = self._load()
+        keyed = {
+            (item.document_id, item.canonical_sha256, item.speaker_ref): item
+            for item in state
+        }
+        keyed[
+            (binding.document_id, binding.canonical_sha256, binding.speaker_ref)
+        ] = binding
+        self._save(tuple(sorted(keyed.values(), key=self._sort_key)))
+        return binding
+
+    def remove_label(self, document: IndexedDocument, *, speaker_ref: str) -> bool:
+        canonical_sha256 = self._require_canonical_hash(document)
+        state = self._load()
+        retained = tuple(
+            item
+            for item in state
+            if not (
+                item.document_id == document.document_id
+                and item.canonical_sha256 == canonical_sha256
+                and item.speaker_ref == speaker_ref
+            )
+        )
+        if len(retained) == len(state):
+            return False
+        self._save(retained)
+        return True
+
+    def current_labels(self, document: IndexedDocument) -> tuple[SpeakerDisplayLabel, ...]:
+        canonical_sha256 = self._require_canonical_hash(document)
+        return tuple(
+            item
+            for item in self._load()
+            if item.document_id == document.document_id
+            and item.canonical_sha256 == canonical_sha256
+        )
+
+    def views(self, document: IndexedDocument) -> tuple[SpeakerLabelView, ...]:
+        canonical_sha256 = self._require_canonical_hash(document)
+        return tuple(
+            SpeakerLabelView(
+                binding=item,
+                current=item.canonical_sha256 == canonical_sha256,
+            )
+            for item in self._load()
+            if item.document_id == document.document_id
+        )
+
+    def resolve(
+        self,
+        *,
+        document_id: str,
+        canonical_sha256: str | None,
+        speaker_ref: str,
+    ) -> str | None:
+        if canonical_sha256 is None:
+            return None
+        for item in self._load():
+            if (
+                item.document_id == document_id
+                and item.canonical_sha256 == canonical_sha256
+                and item.speaker_ref == speaker_ref
+            ):
+                return item.label
+        return None
+
+    def _load(self) -> tuple[SpeakerDisplayLabel, ...]:
+        if not self.file_manager.file_exists(self.path):
+            return ()
+        try:
+            payload = json.loads(self.file_manager.read_file(self.path))
+            state = _StoredState.model_validate(payload)
+            if state.schema_version != _STATE_SCHEMA_VERSION:
+                raise SpeakerLabelStateError(
+                    "Speaker label state was written by an unsupported EchoFlow schema"
+                )
+            labels = tuple(
+                SpeakerDisplayLabel(
+                    document_id=item.document_id,
+                    canonical_sha256=item.canonical_sha256,
+                    speaker_ref=item.speaker_ref,
+                    label=item.label,
+                )
+                for item in state.labels
+            )
+            keys = tuple(
+                (item.document_id, item.canonical_sha256, item.speaker_ref)
+                for item in labels
+            )
+            if len(keys) != len(set(keys)):
+                raise SpeakerLabelStateError(
+                    "Speaker label state contains duplicate evidence bindings"
+                )
+            return tuple(sorted(labels, key=self._sort_key))
+        except SpeakerLabelStateError:
+            raise
+        except (
+            OSError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValidationError,
+            ValueError,
+        ) as exc:
+            raise SpeakerLabelStateError(
+                "Speaker label state could not be validated safely",
+                cause=exc,
+            ) from exc
+
+    def _save(self, labels: tuple[SpeakerDisplayLabel, ...]) -> None:
+        self.file_manager.ensure_directory_exists(self.path.parent, private=True)
+        document = {
+            "schema_version": _STATE_SCHEMA_VERSION,
+            "labels": [item.to_dict() for item in labels],
+        }
+        payload = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        self.file_manager.save_file(payload, self.path, private=True)
+
+    @staticmethod
+    def _require_canonical_hash(document: IndexedDocument) -> str:
+        if document.canonical_sha256 is None:
+            raise SpeakerLabelStateError(
+                "Transcript index predates canonical hashing; rebuild the library first"
+            )
+        return document.canonical_sha256
+
+    @staticmethod
+    def _sort_key(item: SpeakerDisplayLabel) -> tuple[str, str, str]:
+        return (item.document_id, item.canonical_sha256, item.speaker_ref)

--- a/src/echoflow/library/speaker_labels.py
+++ b/src/echoflow/library/speaker_labels.py
@@ -172,9 +172,9 @@ class SpeakerLabelStore:
             (item.document_id, item.canonical_sha256, item.speaker_ref): item
             for item in state
         }
-        keyed[
-            (binding.document_id, binding.canonical_sha256, binding.speaker_ref)
-        ] = binding
+        keyed[(binding.document_id, binding.canonical_sha256, binding.speaker_ref)] = (
+            binding
+        )
         self._save(tuple(sorted(keyed.values(), key=self._sort_key)))
         return binding
 
@@ -195,7 +195,9 @@ class SpeakerLabelStore:
         self._save(retained)
         return True
 
-    def current_labels(self, document: IndexedDocument) -> tuple[SpeakerDisplayLabel, ...]:
+    def current_labels(
+        self, document: IndexedDocument
+    ) -> tuple[SpeakerDisplayLabel, ...]:
         canonical_sha256 = self._require_canonical_hash(document)
         return tuple(
             item
@@ -281,7 +283,9 @@ class SpeakerLabelStore:
             "schema_version": _STATE_SCHEMA_VERSION,
             "labels": [item.to_dict() for item in labels],
         }
-        payload = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        payload = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode(
+            "utf-8"
+        )
         self.file_manager.save_file(payload, self.path, private=True)
 
     @staticmethod

--- a/src/echoflow/library/speaker_labels.py
+++ b/src/echoflow/library/speaker_labels.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from echoflow.core.file_manager_facade import FileManagerFacade
 from echoflow.library.errors import SpeakerLabelStateError
@@ -80,6 +81,69 @@ class _StoredState(BaseModel):
 
     schema_version: int
     labels: list[_StoredLabel]
+
+
+class _CanonicalWordSpeaker(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    speaker_ref: str | None = None
+
+
+class _CanonicalSegmentSpeaker(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    speaker_ref: str | None = None
+    words: list[_CanonicalWordSpeaker] = Field(default_factory=list)
+
+
+class _CanonicalSpeakerProjection(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    segments: list[_CanonicalSegmentSpeaker]
+
+
+def canonical_speaker_refs(
+    document: IndexedDocument,
+    file_manager: FileManagerFacade,
+) -> tuple[str, ...]:
+    """Return anonymous refs from the exact canonical generation in the index.
+
+    Mixed-speaker ASR segments may have no segment-level label while their aligned
+    words do, so both evidence levels are inspected. The canonical hash is checked
+    before accepting a human label to avoid binding a name to stale speaker numbering.
+    """
+    canonical_sha256 = SpeakerLabelStore._require_canonical_hash(document)
+    try:
+        payload = file_manager.read_file(Path(document.canonical_path))
+        if hashlib.sha256(payload).hexdigest() != canonical_sha256:
+            raise SpeakerLabelStateError(
+                "Canonical transcript changed; rebuild the library before editing speaker labels"
+            )
+        projection = _CanonicalSpeakerProjection.model_validate(json.loads(payload))
+    except SpeakerLabelStateError:
+        raise
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValidationError,
+        ValueError,
+    ) as exc:
+        raise SpeakerLabelStateError(
+            "Canonical speaker evidence could not be validated safely",
+            cause=exc,
+        ) from exc
+
+    refs: set[str] = set()
+    for segment in projection.segments:
+        if segment.speaker_ref is not None and segment.speaker_ref.strip():
+            refs.add(segment.speaker_ref)
+        refs.update(
+            word.speaker_ref
+            for word in segment.words
+            if word.speaker_ref is not None and word.speaker_ref.strip()
+        )
+    return tuple(sorted(refs))
 
 
 class SpeakerLabelStore:

--- a/src/echoflow/library/tests/test_speaker_labels.py
+++ b/src/echoflow/library/tests/test_speaker_labels.py
@@ -1,0 +1,198 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.library.errors import SpeakerLabelStateError
+from echoflow.library.index import IndexedDocument
+from echoflow.library.speaker_label_service import SpeakerLabelService
+from echoflow.library.speaker_labels import SpeakerDisplayLabel, SpeakerLabelStore
+
+
+class DocumentIndex:
+    def __init__(self, documents: tuple[IndexedDocument, ...]) -> None:
+        self._documents = documents
+
+    def documents(self) -> tuple[IndexedDocument, ...]:
+        return self._documents
+
+
+def _canonical(path: Path, *, second_word_speaker: str = "speaker-02") -> str:
+    document = {
+        "schema_version": 1,
+        "job_id": "job-1",
+        "source": {
+            "sha256": "a" * 64,
+            "size_bytes": 100,
+            "modified_ns": 1,
+        },
+        "segments": [
+            {
+                "segment_id": "segment-000000",
+                "start_seconds": 1.0,
+                "end_seconds": 3.0,
+                "text": "Hello there",
+                "speaker_ref": "speaker-01",
+                "words": [
+                    {
+                        "start_seconds": 1.0,
+                        "end_seconds": 1.5,
+                        "text": "Hello",
+                        "speaker_ref": "speaker-01",
+                    },
+                    {
+                        "start_seconds": 2.0,
+                        "end_seconds": 2.5,
+                        "text": " there",
+                        "speaker_ref": second_word_speaker,
+                    },
+                ],
+            }
+        ],
+    }
+    payload = json.dumps(document, sort_keys=True).encode()
+    path.write_bytes(payload)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _document(path: Path, digest: str) -> IndexedDocument:
+    return IndexedDocument(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        detected_language="en",
+        canonical_path=str(path.resolve()),
+        source_path=None,
+        segment_count=1,
+        canonical_sha256=digest,
+    )
+
+
+def _service(
+    tmp_path: Path,
+    document: IndexedDocument,
+) -> SpeakerLabelService:
+    file_manager = LocalFileManager()
+    store = SpeakerLabelStore(
+        tmp_path / "state" / "library" / "user-state" / "speaker-labels.json",
+        file_manager,  # type: ignore[arg-type]
+    )
+    return SpeakerLabelService(
+        index=DocumentIndex((document,)),  # type: ignore[arg-type]
+        store=store,
+        file_manager=file_manager,  # type: ignore[arg-type]
+    )
+
+
+def test_roster_reads_segment_and_word_only_speaker_evidence(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    document = _document(canonical, _canonical(canonical))
+    service = _service(tmp_path, document)
+
+    roster = service.roster("job-1")
+
+    assert [item.speaker_ref for item in roster] == ["speaker-01", "speaker-02"]
+    assert [item.display_name for item in roster] == ["speaker-01", "speaker-02"]
+
+
+def test_label_is_user_state_without_replacing_anonymous_evidence(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _canonical(canonical)
+    document = _document(canonical, digest)
+    service = _service(tmp_path, document)
+
+    binding = service.set_label("job-1", speaker_ref="speaker-02", label="  Dr. Chen  ")
+    roster = service.roster("job-1")
+
+    assert binding.label == "Dr. Chen"
+    assert roster[1].speaker_ref == "speaker-02"
+    assert roster[1].display_label == "Dr. Chen"
+    assert roster[1].display_name == "Dr. Chen (speaker-02)"
+    assert service.display_labels(
+        document_id="job-1",
+        canonical_sha256=digest,
+        speaker_refs=("speaker-01", "speaker-02"),
+    ) == {"speaker-02": "Dr. Chen"}
+
+
+def test_unknown_speaker_reference_is_rejected(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    document = _document(canonical, _canonical(canonical))
+    service = _service(tmp_path, document)
+
+    with pytest.raises(SpeakerLabelStateError, match="not present"):
+        service.set_label("job-1", speaker_ref="speaker-99", label="Mystery Guest")
+
+
+def test_label_does_not_follow_changed_canonical_generation(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    first_digest = _canonical(canonical)
+    first = _document(canonical, first_digest)
+    service = _service(tmp_path, first)
+    service.set_label("job-1", speaker_ref="speaker-02", label="Dr. Chen")
+
+    second_digest = _canonical(canonical, second_word_speaker="speaker-03")
+    second = _document(canonical, second_digest)
+    current = _service(tmp_path, second)
+
+    assert current.display_labels(
+        document_id="job-1",
+        canonical_sha256=second_digest,
+        speaker_refs=("speaker-02",),
+    ) == {}
+    views = current.views("job-1")
+    assert len(views) == 1
+    assert views[0].binding.canonical_sha256 == first_digest
+    assert not views[0].current
+    assert [item.speaker_ref for item in current.roster("job-1")] == [
+        "speaker-01",
+        "speaker-03",
+    ]
+
+
+def test_canonical_change_requires_library_rebuild_before_edit(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    document = _document(canonical, _canonical(canonical))
+    service = _service(tmp_path, document)
+    canonical.write_text('{"segments": []}')
+
+    with pytest.raises(SpeakerLabelStateError, match="rebuild the library"):
+        service.set_label("job-1", speaker_ref="speaker-01", label="Interviewer")
+
+
+def test_replacing_and_removing_label_is_deterministic(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    document = _document(canonical, _canonical(canonical))
+    service = _service(tmp_path, document)
+
+    service.set_label("job-1", speaker_ref="speaker-01", label="Interviewer")
+    service.set_label("job-1", speaker_ref="speaker-01", label="Host")
+
+    assert service.roster("job-1")[0].display_label == "Host"
+    assert service.remove_label("job-1", speaker_ref="speaker-01")
+    assert service.roster("job-1")[0].display_label is None
+    assert not service.remove_label("job-1", speaker_ref="speaker-01")
+
+
+def test_corrupt_user_state_fails_closed(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    document = _document(canonical, _canonical(canonical))
+    service = _service(tmp_path, document)
+    state = tmp_path / "state" / "library" / "user-state" / "speaker-labels.json"
+    state.parent.mkdir(parents=True)
+    state.write_text("not json")
+
+    with pytest.raises(SpeakerLabelStateError, match="could not be validated"):
+        service.roster("job-1")
+
+
+@pytest.mark.parametrize("label", ["", "   ", "bad\nlabel", "bad\x00label"])
+def test_invalid_display_labels_are_rejected(label: str) -> None:
+    with pytest.raises(ValueError, match="label"):
+        SpeakerDisplayLabel(
+            document_id="job-1",
+            canonical_sha256="a" * 64,
+            speaker_ref="speaker-01",
+            label=label,
+        )

--- a/src/echoflow/library/tests/test_speaker_labels.py
+++ b/src/echoflow/library/tests/test_speaker_labels.py
@@ -96,7 +96,9 @@ def test_roster_reads_segment_and_word_only_speaker_evidence(tmp_path: Path) -> 
     assert [item.display_name for item in roster] == ["speaker-01", "speaker-02"]
 
 
-def test_label_is_user_state_without_replacing_anonymous_evidence(tmp_path: Path) -> None:
+def test_label_is_user_state_without_replacing_anonymous_evidence(
+    tmp_path: Path,
+) -> None:
     canonical = tmp_path / "transcript.json"
     digest = _canonical(canonical)
     document = _document(canonical, digest)
@@ -136,11 +138,14 @@ def test_label_does_not_follow_changed_canonical_generation(tmp_path: Path) -> N
     second = _document(canonical, second_digest)
     current = _service(tmp_path, second)
 
-    assert current.display_labels(
-        document_id="job-1",
-        canonical_sha256=second_digest,
-        speaker_refs=("speaker-02",),
-    ) == {}
+    assert (
+        current.display_labels(
+            document_id="job-1",
+            canonical_sha256=second_digest,
+            speaker_refs=("speaker-02",),
+        )
+        == {}
+    )
     views = current.views("job-1")
     assert len(views) == 1
     assert views[0].binding.canonical_sha256 == first_digest

--- a/src/echoflow/tests/test_cli_speakers.py
+++ b/src/echoflow/tests/test_cli_speakers.py
@@ -1,0 +1,140 @@
+import json
+from unittest.mock import Mock
+
+import typer
+from typer.testing import CliRunner
+
+from echoflow.cli_library import register_library_commands
+from echoflow.library.speaker_label_service import SpeakerRosterEntry
+from echoflow.library.speaker_labels import SpeakerDisplayLabel
+
+
+def _app_with_speakers(service: Mock) -> typer.Typer:
+    app = typer.Typer()
+    container = Mock()
+    container.speaker_labels.return_value = service
+    register_library_commands(app, lambda context: container)
+    return app
+
+
+def test_speaker_list_preserves_evidence_ref_and_human_label() -> None:
+    service = Mock()
+    service.roster.return_value = (
+        SpeakerRosterEntry("speaker-01", "Interviewer"),
+        SpeakerRosterEntry("speaker-02", None),
+    )
+    app = _app_with_speakers(service)
+    runner = CliRunner()
+
+    human = runner.invoke(app, ["library", "speakers", "list", "job-1"])
+    machine = runner.invoke(
+        app, ["library", "speakers", "list", "job-1", "--json"]
+    )
+
+    assert human.exit_code == 0
+    assert "Interviewer (speaker-01)" in human.stdout
+    assert "speaker-02" in human.stdout
+    assert machine.exit_code == 0
+    payload = json.loads(machine.stdout)
+    assert payload == [
+        {
+            "display_label": "Interviewer",
+            "display_name": "Interviewer (speaker-01)",
+            "speaker_ref": "speaker-01",
+        },
+        {
+            "display_label": None,
+            "display_name": "speaker-02",
+            "speaker_ref": "speaker-02",
+        },
+    ]
+
+
+def test_speaker_name_writes_user_label_without_replacing_ref() -> None:
+    service = Mock()
+    service.set_label.return_value = SpeakerDisplayLabel(
+        document_id="job-1",
+        canonical_sha256="a" * 64,
+        speaker_ref="speaker-02",
+        label="Dr. Chen",
+    )
+    app = _app_with_speakers(service)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "library",
+            "speakers",
+            "name",
+            "job-1",
+            "speaker-02",
+            "Dr. Chen",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Dr. Chen (speaker-02)" in result.stdout
+    service.set_label.assert_called_once_with(
+        "job-1", speaker_ref="speaker-02", label="Dr. Chen"
+    )
+
+
+def test_speaker_name_json_keeps_binding_provenance() -> None:
+    service = Mock()
+    service.set_label.return_value = SpeakerDisplayLabel(
+        document_id="job-1",
+        canonical_sha256="b" * 64,
+        speaker_ref="speaker-01",
+        label="Host",
+    )
+    app = _app_with_speakers(service)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "library",
+            "speakers",
+            "name",
+            "job-1",
+            "speaker-01",
+            "Host",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "canonical_sha256": "b" * 64,
+        "document_id": "job-1",
+        "label": "Host",
+        "speaker_ref": "speaker-01",
+    }
+
+
+def test_forget_speaker_name_reports_whether_current_binding_existed() -> None:
+    service = Mock()
+    service.remove_label.return_value = True
+    app = _app_with_speakers(service)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "library",
+            "speakers",
+            "forget-name",
+            "job-1",
+            "speaker-01",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "removed": True,
+        "speaker_ref": "speaker-01",
+        "transcript_id": "job-1",
+    }
+    service.remove_label.assert_called_once_with("job-1", speaker_ref="speaker-01")

--- a/src/echoflow/tests/test_cli_speakers.py
+++ b/src/echoflow/tests/test_cli_speakers.py
@@ -27,9 +27,7 @@ def test_speaker_list_preserves_evidence_ref_and_human_label() -> None:
     runner = CliRunner()
 
     human = runner.invoke(app, ["library", "speakers", "list", "job-1"])
-    machine = runner.invoke(
-        app, ["library", "speakers", "list", "job-1", "--json"]
-    )
+    machine = runner.invoke(app, ["library", "speakers", "list", "job-1", "--json"])
 
     assert human.exit_code == 0
     assert "Interviewer (speaker-01)" in human.stdout


### PR DESCRIPTION
## What changed

This tranche adds the first durable human-facing speaker naming layer on top of EchoFlow's anonymous diarization evidence.

### Evidence stays evidence

- anonymous `speaker-01`, `speaker-02`, ... values remain recording-scoped diarization evidence
- a human name such as `speaker-02 -> Dr. Chen` is separate user-authored state
- display labels never rewrite canonical transcript JSON or the diarization turn timeline
- the friendly form remains additive, e.g. `Dr. Chen (speaker-02)`

### Durable user state

- add a private `SpeakerLabelStore` under `STATE_DIR/library/user-state/speaker-labels.json`
- use EchoFlow's existing atomic/private file boundary for writes
- keep label state physically separate from lexical and semantic indexes
- bind each label to `(document_id, canonical_sha256, speaker_ref)`
- preserve stale historical bindings when canonical transcript bytes change, but never silently apply them to the new generation
- validate the current canonical SHA before accepting edits
- reject unknown speaker refs

### Word-level speaker discovery

Mixed-speaker ASR segments can have no segment-level `speaker_ref` while aligned words carry different anonymous refs. The label service therefore inspects both segment-level and nested word-level canonical evidence so speakers involved only in an intra-segment handoff remain nameable.

### Service + CLI

- add a dedicated `SpeakerLabelService` rather than making `TranscriptLibraryService` own human-authored metadata
- wire store/service through Dependency Injector
- add:
  - `echoflow library speakers list TRANSCRIPT_ID`
  - `echoflow library speakers name TRANSCRIPT_ID SPEAKER_REF DISPLAY_LABEL`
  - `echoflow library speakers forget-name TRANSCRIPT_ID SPEAKER_REF`
- support `--json` while retaining anonymous refs and canonical hash binding provenance

### Qualification

- segment and word-only speaker discovery
- display labels preserve raw anonymous refs
- exact-generation resolution
- unknown speaker rejection
- stale canonical-generation isolation
- canonical-change fail-closed behavior
- deterministic replacement/removal
- corrupted user-state rejection
- display-label validation
- CLI human and JSON contracts

### Documentation

- add `docs/speaker-names.md` with the human-facing custody and stale-generation model
- update the docs lobby with a dedicated speaker naming doorway
- update the diarization architecture doc from future-state language to the implemented display-label contract

## Why

Diarization evidence answers `which anonymous voice cluster spoke here?` A researcher may additionally know that `speaker-02` is Dr. Chen. Those facts have different authorities and different deletion semantics.

EchoFlow therefore keeps the anonymous evidence stable while storing the researcher's naming decision as non-rebuildable private user state. Rebuilding BM25 or semantic embeddings must never eat a human-authored name, and a changed transcript generation must never cause a stale name to jump onto a newly numbered speaker.

## Deliberately not included

- biometric identity inference
- cross-recording speaker linking
- automatic inference of real-world names
- source separation for simultaneous speech
- display names baked into canonical JSON or derived TXT/SRT/WebVTT
- notes/annotation editing

Those remain separate product layers with different evidence and custody requirements.
