### PR TITLE
feat(library): add overlap-aware speaker presentation

### DIFF
--- a/docs/speaker-names.md
+++ b/docs/speaker-names.md
@@ -123,6 +123,55 @@ The speaker-label service inspects **both segment-level and aligned-word speaker
 
 💃 Finer evidence, less lying. A useful trade.
 
+## Reading handoffs and overlap without flattening them
+
+A speaker name is only useful if EchoFlow can show it where the evidence actually belongs.
+
+The derived speaker transcript view combines canonical word timing with the preserved speaker-turn timeline:
+
+```bash
+echoflow library speakers transcript TRANSCRIPT_ID
+```
+
+A clean handoff can become two readable spans:
+
+```text
+00:00:04.100  Interviewer (speaker-01)       single-speaker  What happened next?
+00:00:05.900  Dr. Chen (speaker-02)          single-speaker  We moved the samples.
+```
+
+If two diarized speakers are simultaneously active over the same aligned word interval, EchoFlow does not choose a winner:
+
+```text
+00:00:12.200  Interviewer (speaker-01)
+              + Dr. Chen (speaker-02)         overlap         Sorry—
+```
+
+And if a coarse segment contains more than one speaker but lacks word timing precise enough to assign its text, the view says `mixed-unresolved` rather than pretending the whole sentence belongs to either person.
+
+```mermaid
+flowchart LR
+    W[Canonical word timing] --> P[Derived speaker presentation]
+    T[Speaker-turn timeline] --> P
+    N[Your display labels] --> P
+    P --> S[single-speaker]
+    P --> O[overlap]
+    P --> M[mixed-unresolved]
+    P --> U[unattributed]
+
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class W,T evidence
+    class N user
+    class P,S,O,M,U view
+```
+
+This view is **derived presentation**, not a new canonical transcript. Numeric source-relative seconds and the original anonymous refs remain visible in JSON, along with the canonical transcript SHA-256 that the view came from.
+
+One conservative rule matters: if a canonical aligned word is unattributed, the presentation layer will not promote it to a single named speaker merely because one diarization turn happens to overlap. Presentation may expose additional **multi-speaker overlap**, but it does not manufacture a stronger single-speaker claim than canonical evidence already made.
+
 ## Where are these labels stored?
 
 Speaker names are **private user-authored state**, not rebuildable search state.
@@ -142,6 +191,6 @@ This means rebuilding lexical or semantic search must not erase the names you as
 
 Speaker display labels are not biometric identification. EchoFlow does not infer that `speaker-01` in two different recordings is the same person, and it does not search for somebody's identity from their voice.
 
-This feature also does not solve simultaneous speech. Word-level diarization can preserve ambiguity honestly, but source separation remains a later and materially heavier capability.
+Overlap-aware presentation also does not perform source separation. It represents simultaneous speaker evidence honestly using the timeline EchoFlow already has. Separating overlapping audio into estimated sources remains a later and materially heavier capability with its own compute, model-custody, and provenance requirements.
 
 For the underlying diarization evidence model, security gate, and overlap rules, see **[Anonymous speaker diarization](architecture/diarization.md)**.

--- a/src/echoflow/cli_speakers.py
+++ b/src/echoflow/cli_speakers.py
@@ -13,6 +13,11 @@ from rich.table import Table
 from echoflow.app.app_container import AppContainer
 from echoflow.core.errors import EchoFlowError
 from echoflow.library.speaker_label_service import SpeakerRosterEntry
+from echoflow.library.speaker_presentation import (
+    SpeakerPresentationService,
+    SpeakerPresentationSpan,
+)
+from echoflow.media.time_coordinates import format_elapsed_timestamp
 
 ContainerFactory = Callable[[typer.Context], AppContainer]
 
@@ -42,6 +47,14 @@ def _roster_dict(entry: SpeakerRosterEntry) -> dict[str, object]:
     }
 
 
+def _span_dict(span: SpeakerPresentationSpan) -> dict[str, object]:
+    return {
+        **span.to_dict(),
+        "start_timestamp": format_elapsed_timestamp(span.start_seconds),
+        "end_timestamp": format_elapsed_timestamp(span.end_seconds),
+    }
+
+
 def _render_roster(
     document_id: str,
     roster: tuple[SpeakerRosterEntry, ...],
@@ -58,6 +71,36 @@ def _render_roster(
             entry.display_name,
         )
     console.print(table)
+
+
+def _render_transcript(
+    document_id: str,
+    spans: tuple[SpeakerPresentationSpan, ...],
+    console: Console,
+) -> None:
+    table = Table(title=f"EchoFlow speaker transcript: {document_id}")
+    table.add_column("Time", min_width=12, no_wrap=True)
+    table.add_column("Speaker evidence")
+    table.add_column("State")
+    table.add_column("Transcript")
+    for span in spans:
+        time_range = (
+            f"{format_elapsed_timestamp(span.start_seconds)}\n"
+            f"{format_elapsed_timestamp(span.end_seconds)}"
+        )
+        speakers = " + ".join(
+            speaker.display_name for speaker in span.speakers
+        ) or "unknown"
+        table.add_row(time_range, speakers, span.kind.value, span.text)
+    console.print(table)
+
+
+def _presentation_service(container: AppContainer) -> SpeakerPresentationService:
+    return SpeakerPresentationService(
+        index=container.transcript_index(),
+        label_store=container.speaker_label_store(),
+        file_manager=container.file_manager(),
+    )
 
 
 def _list_speakers(
@@ -80,6 +123,25 @@ def _list_speakers(
         typer.echo(json.dumps([_roster_dict(item) for item in roster], sort_keys=True))
         return
     _render_roster(transcript_id, roster, Console())
+
+
+def _show_speaker_transcript(
+    context: typer.Context,
+    transcript_id: str,
+    *,
+    json_output: bool,
+    container_factory: ContainerFactory,
+) -> None:
+    try:
+        container = container_factory(_root_context(context))
+        spans = _presentation_service(container).spans(transcript_id)
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps([_span_dict(item) for item in spans], sort_keys=True))
+        return
+    _render_transcript(transcript_id, spans, Console())
 
 
 def _name_speaker(
@@ -150,7 +212,7 @@ def register_speaker_commands(
     container_factory: ContainerFactory,
 ) -> None:
     speakers_app = typer.Typer(
-        help="Give anonymous transcript speakers durable human display names.",
+        help="Name and inspect anonymous transcript speaker evidence.",
         no_args_is_help=True,
     )
 
@@ -161,6 +223,19 @@ def register_speaker_commands(
         json_output: bool = typer.Option(False, "--json"),
     ) -> None:
         _list_speakers(
+            context,
+            transcript_id,
+            json_output=json_output,
+            container_factory=container_factory,
+        )
+
+    @speakers_app.command("transcript")
+    def speaker_transcript(
+        context: typer.Context,
+        transcript_id: str = typer.Argument(..., metavar="TRANSCRIPT_ID"),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _show_speaker_transcript(
             context,
             transcript_id,
             json_output=json_output,

--- a/src/echoflow/cli_speakers.py
+++ b/src/echoflow/cli_speakers.py
@@ -88,9 +88,9 @@ def _render_transcript(
             f"{format_elapsed_timestamp(span.start_seconds)}\n"
             f"{format_elapsed_timestamp(span.end_seconds)}"
         )
-        speakers = " + ".join(
-            speaker.display_name for speaker in span.speakers
-        ) or "unknown"
+        speakers = (
+            " + ".join(speaker.display_name for speaker in span.speakers) or "unknown"
+        )
         table.add_row(time_range, speakers, span.kind.value, span.text)
     console.print(table)
 

--- a/src/echoflow/library/speaker_presentation.py
+++ b/src/echoflow/library/speaker_presentation.py
@@ -267,6 +267,8 @@ class SpeakerPresentationService:
         turns: list[_Turn],
         labels: dict[str, str],
     ) -> SpeakerPresentationSpan:
+        refs: tuple[str, ...]
+        kind: SpeakerPresentationKind
         if segment.speaker_ref is not None and segment.speaker_ref.strip():
             refs = (segment.speaker_ref,)
             kind = SpeakerPresentationKind.SINGLE

--- a/src/echoflow/library/speaker_presentation.py
+++ b/src/echoflow/library/speaker_presentation.py
@@ -1,0 +1,416 @@
+"""Derived human presentation over canonical anonymous speaker evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.errors import SpeakerLabelStateError
+from echoflow.library.index import IndexedDocument, TranscriptIndex
+from echoflow.library.speaker_labels import SpeakerLabelStore
+
+
+class SpeakerPresentationKind(StrEnum):
+    """How confidently a derived text span can be presented with speaker evidence."""
+
+    SINGLE = "single-speaker"
+    OVERLAP = "overlap"
+    MIXED_UNRESOLVED = "mixed-unresolved"
+    UNATTRIBUTED = "unattributed"
+
+
+@dataclass(frozen=True, slots=True)
+class PresentedSpeaker:
+    """Anonymous evidence ref plus optional human-authored display label."""
+
+    speaker_ref: str
+    display_label: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.speaker_ref.strip():
+            raise ValueError("speaker_ref cannot be empty")
+        if self.display_label is not None and not self.display_label.strip():
+            raise ValueError("display_label cannot be empty")
+
+    @property
+    def display_name(self) -> str:
+        if self.display_label is None:
+            return self.speaker_ref
+        return f"{self.display_label} ({self.speaker_ref})"
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "speaker_ref": self.speaker_ref,
+            "display_label": self.display_label,
+            "display_name": self.display_name,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SpeakerPresentationSpan:
+    """One source-relative derived text span for speaker-aware reading."""
+
+    document_id: str
+    canonical_sha256: str
+    segment_id: str
+    start_seconds: float
+    end_seconds: float
+    text: str
+    speakers: tuple[PresentedSpeaker, ...]
+    kind: SpeakerPresentationKind
+
+    def __post_init__(self) -> None:
+        if not self.document_id.strip() or not self.segment_id.strip():
+            raise ValueError("presentation identity cannot be empty")
+        if len(self.canonical_sha256) != 64 or any(
+            character not in "0123456789abcdef"
+            for character in self.canonical_sha256
+        ):
+            raise ValueError("canonical_sha256 must be a lowercase 64-character digest")
+        if (
+            not math.isfinite(self.start_seconds)
+            or not math.isfinite(self.end_seconds)
+            or self.start_seconds < 0
+            or self.end_seconds < self.start_seconds
+        ):
+            raise ValueError("presentation timestamps must be finite and ordered")
+        if not self.text.strip():
+            raise ValueError("presentation text cannot be empty")
+        refs = tuple(speaker.speaker_ref for speaker in self.speakers)
+        if refs != tuple(sorted(set(refs))):
+            raise ValueError("presentation speakers must be unique and sorted")
+        if self.kind is SpeakerPresentationKind.SINGLE and len(self.speakers) != 1:
+            raise ValueError("single-speaker presentation requires exactly one speaker")
+        if self.kind is SpeakerPresentationKind.OVERLAP and len(self.speakers) < 2:
+            raise ValueError("overlap presentation requires multiple speakers")
+        if self.kind is SpeakerPresentationKind.UNATTRIBUTED and self.speakers:
+            raise ValueError("unattributed presentation cannot name speakers")
+
+    @property
+    def overlap(self) -> bool:
+        return self.kind is SpeakerPresentationKind.OVERLAP
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "document_id": self.document_id,
+            "canonical_sha256": self.canonical_sha256,
+            "segment_id": self.segment_id,
+            "start_seconds": self.start_seconds,
+            "end_seconds": self.end_seconds,
+            "text": self.text,
+            "kind": self.kind.value,
+            "overlap": self.overlap,
+            "speakers": [speaker.to_dict() for speaker in self.speakers],
+        }
+
+
+class _Word(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    start_seconds: float
+    end_seconds: float
+    text: str
+    speaker_ref: str | None = None
+
+
+class _Segment(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    segment_id: str
+    start_seconds: float
+    end_seconds: float
+    text: str
+    speaker_ref: str | None = None
+    words: list[_Word] = Field(default_factory=list)
+
+
+class _Turn(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    start_seconds: float
+    end_seconds: float
+    speaker_ref: str
+
+
+class _CanonicalPresentationProjection(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    segments: list[_Segment]
+    speaker_turns: list[_Turn] = Field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class _WordEvidence:
+    start_seconds: float
+    end_seconds: float
+    text: str
+    speaker_refs: tuple[str, ...]
+    kind: SpeakerPresentationKind
+
+
+class SpeakerPresentationService:
+    """Build readable handoff/overlap spans without changing canonical evidence."""
+
+    def __init__(
+        self,
+        index: TranscriptIndex,
+        label_store: SpeakerLabelStore,
+        file_manager: FileManagerFacade,
+    ) -> None:
+        self.index = index
+        self.label_store = label_store
+        self.file_manager = file_manager
+
+    def spans(self, document_id: str) -> tuple[SpeakerPresentationSpan, ...]:
+        document = self._document(document_id)
+        canonical_sha256 = self._require_canonical_hash(document)
+        projection = self._load_projection(document, canonical_sha256)
+        labels = {
+            item.speaker_ref: item.label
+            for item in self.label_store.current_labels(document)
+        }
+        spans: list[SpeakerPresentationSpan] = []
+        for segment in projection.segments:
+            if segment.words:
+                spans.extend(
+                    self._word_spans(
+                        document,
+                        canonical_sha256,
+                        segment,
+                        projection.speaker_turns,
+                        labels,
+                    )
+                )
+            else:
+                spans.append(
+                    self._segment_span(
+                        document,
+                        canonical_sha256,
+                        segment,
+                        projection.speaker_turns,
+                        labels,
+                    )
+                )
+        return tuple(spans)
+
+    def _word_spans(
+        self,
+        document: IndexedDocument,
+        canonical_sha256: str,
+        segment: _Segment,
+        turns: list[_Turn],
+        labels: dict[str, str],
+    ) -> tuple[SpeakerPresentationSpan, ...]:
+        evidence = tuple(self._word_evidence(word, turns) for word in segment.words)
+        grouped: list[list[_WordEvidence]] = []
+        for word in evidence:
+            if (
+                grouped
+                and grouped[-1][-1].speaker_refs == word.speaker_refs
+                and grouped[-1][-1].kind is word.kind
+            ):
+                grouped[-1].append(word)
+            else:
+                grouped.append([word])
+        return tuple(
+            self._build_span(
+                document=document,
+                canonical_sha256=canonical_sha256,
+                segment_id=segment.segment_id,
+                start_seconds=group[0].start_seconds,
+                end_seconds=group[-1].end_seconds,
+                text="".join(item.text for item in group).strip(),
+                speaker_refs=group[0].speaker_refs,
+                kind=group[0].kind,
+                labels=labels,
+            )
+            for group in grouped
+        )
+
+    def _word_evidence(self, word: _Word, turns: list[_Turn]) -> _WordEvidence:
+        active = self._active_refs(word.start_seconds, word.end_seconds, turns)
+        if len(active) > 1:
+            return _WordEvidence(
+                word.start_seconds,
+                word.end_seconds,
+                word.text,
+                active,
+                SpeakerPresentationKind.OVERLAP,
+            )
+        if word.speaker_ref is not None and word.speaker_ref.strip():
+            return _WordEvidence(
+                word.start_seconds,
+                word.end_seconds,
+                word.text,
+                (word.speaker_ref,),
+                SpeakerPresentationKind.SINGLE,
+            )
+        return _WordEvidence(
+            word.start_seconds,
+            word.end_seconds,
+            word.text,
+            (),
+            SpeakerPresentationKind.UNATTRIBUTED,
+        )
+
+    def _segment_span(
+        self,
+        document: IndexedDocument,
+        canonical_sha256: str,
+        segment: _Segment,
+        turns: list[_Turn],
+        labels: dict[str, str],
+    ) -> SpeakerPresentationSpan:
+        if segment.speaker_ref is not None and segment.speaker_ref.strip():
+            refs = (segment.speaker_ref,)
+            kind = SpeakerPresentationKind.SINGLE
+        else:
+            refs = self._active_refs(segment.start_seconds, segment.end_seconds, turns)
+            if not refs:
+                kind = SpeakerPresentationKind.UNATTRIBUTED
+            elif len(refs) == 1:
+                # Canonical segment attribution deliberately declined this assignment.
+                # Preserve that uncertainty rather than deriving a stronger claim here.
+                refs = ()
+                kind = SpeakerPresentationKind.UNATTRIBUTED
+            elif self._has_simultaneous_overlap(
+                segment.start_seconds, segment.end_seconds, turns
+            ):
+                kind = SpeakerPresentationKind.OVERLAP
+            else:
+                kind = SpeakerPresentationKind.MIXED_UNRESOLVED
+        return self._build_span(
+            document=document,
+            canonical_sha256=canonical_sha256,
+            segment_id=segment.segment_id,
+            start_seconds=segment.start_seconds,
+            end_seconds=segment.end_seconds,
+            text=segment.text.strip(),
+            speaker_refs=refs,
+            kind=kind,
+            labels=labels,
+        )
+
+    @staticmethod
+    def _active_refs(
+        start_seconds: float,
+        end_seconds: float,
+        turns: list[_Turn],
+    ) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                {
+                    turn.speaker_ref
+                    for turn in turns
+                    if min(end_seconds, turn.end_seconds)
+                    > max(start_seconds, turn.start_seconds)
+                }
+            )
+        )
+
+    @staticmethod
+    def _has_simultaneous_overlap(
+        start_seconds: float,
+        end_seconds: float,
+        turns: list[_Turn],
+    ) -> bool:
+        relevant = [
+            turn
+            for turn in turns
+            if min(end_seconds, turn.end_seconds)
+            > max(start_seconds, turn.start_seconds)
+        ]
+        for index, first in enumerate(relevant):
+            for second in relevant[index + 1 :]:
+                if first.speaker_ref == second.speaker_ref:
+                    continue
+                if (
+                    min(end_seconds, first.end_seconds, second.end_seconds)
+                    > max(start_seconds, first.start_seconds, second.start_seconds)
+                ):
+                    return True
+        return False
+
+    @staticmethod
+    def _build_span(
+        *,
+        document: IndexedDocument,
+        canonical_sha256: str,
+        segment_id: str,
+        start_seconds: float,
+        end_seconds: float,
+        text: str,
+        speaker_refs: tuple[str, ...],
+        kind: SpeakerPresentationKind,
+        labels: dict[str, str],
+    ) -> SpeakerPresentationSpan:
+        speakers = tuple(
+            PresentedSpeaker(speaker_ref=ref, display_label=labels.get(ref))
+            for ref in speaker_refs
+        )
+        return SpeakerPresentationSpan(
+            document_id=document.document_id,
+            canonical_sha256=canonical_sha256,
+            segment_id=segment_id,
+            start_seconds=start_seconds,
+            end_seconds=end_seconds,
+            text=text,
+            speakers=speakers,
+            kind=kind,
+        )
+
+    def _load_projection(
+        self,
+        document: IndexedDocument,
+        canonical_sha256: str,
+    ) -> _CanonicalPresentationProjection:
+        try:
+            payload = self.file_manager.read_file(Path(document.canonical_path))
+            if hashlib.sha256(payload).hexdigest() != canonical_sha256:
+                raise SpeakerLabelStateError(
+                    "Canonical transcript changed; rebuild the library before reading speaker presentation"
+                )
+            return _CanonicalPresentationProjection.model_validate(json.loads(payload))
+        except SpeakerLabelStateError:
+            raise
+        except (
+            OSError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValidationError,
+            ValueError,
+        ) as exc:
+            raise SpeakerLabelStateError(
+                "Canonical speaker presentation evidence could not be validated safely",
+                cause=exc,
+            ) from exc
+
+    def _document(self, document_id: str) -> IndexedDocument:
+        document = next(
+            (
+                item
+                for item in self.index.documents()
+                if item.document_id == document_id
+            ),
+            None,
+        )
+        if document is None:
+            raise SpeakerLabelStateError(
+                "Transcript is not present in the local library; rebuild the library first"
+            )
+        return document
+
+    @staticmethod
+    def _require_canonical_hash(document: IndexedDocument) -> str:
+        if document.canonical_sha256 is None:
+            raise SpeakerLabelStateError(
+                "Transcript index predates canonical hashing; rebuild the library first"
+            )
+        return document.canonical_sha256

--- a/src/echoflow/library/speaker_presentation.py
+++ b/src/echoflow/library/speaker_presentation.py
@@ -70,8 +70,7 @@ class SpeakerPresentationSpan:
         if not self.document_id.strip() or not self.segment_id.strip():
             raise ValueError("presentation identity cannot be empty")
         if len(self.canonical_sha256) != 64 or any(
-            character not in "0123456789abcdef"
-            for character in self.canonical_sha256
+            character not in "0123456789abcdef" for character in self.canonical_sha256
         ):
             raise ValueError("canonical_sha256 must be a lowercase 64-character digest")
         if (
@@ -331,9 +330,8 @@ class SpeakerPresentationService:
             for second in relevant[index + 1 :]:
                 if first.speaker_ref == second.speaker_ref:
                     continue
-                if (
-                    min(end_seconds, first.end_seconds, second.end_seconds)
-                    > max(start_seconds, first.start_seconds, second.start_seconds)
+                if min(end_seconds, first.end_seconds, second.end_seconds) > max(
+                    start_seconds, first.start_seconds, second.start_seconds
                 ):
                     return True
         return False

--- a/src/echoflow/library/tests/test_speaker_presentation.py
+++ b/src/echoflow/library/tests/test_speaker_presentation.py
@@ -7,11 +7,11 @@ import pytest
 from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.library.errors import SpeakerLabelStateError
 from echoflow.library.index import IndexedDocument
+from echoflow.library.speaker_labels import SpeakerLabelStore
 from echoflow.library.speaker_presentation import (
     SpeakerPresentationKind,
     SpeakerPresentationService,
 )
-from echoflow.library.speaker_labels import SpeakerLabelStore
 
 
 class DocumentIndex:

--- a/src/echoflow/library/tests/test_speaker_presentation.py
+++ b/src/echoflow/library/tests/test_speaker_presentation.py
@@ -181,7 +181,9 @@ def test_simultaneous_turns_are_exposed_as_overlap_without_assigning_one_voice(
     assert span.text == "sorry"
 
 
-def test_unattributed_word_is_not_upgraded_from_single_active_turn(tmp_path: Path) -> None:
+def test_unattributed_word_is_not_upgraded_from_single_active_turn(
+    tmp_path: Path,
+) -> None:
     canonical = tmp_path / "transcript.json"
     digest = _write_canonical(
         canonical,
@@ -197,9 +199,7 @@ def test_unattributed_word_is_not_upgraded_from_single_active_turn(tmp_path: Pat
                 ]
             )
         ],
-        turns=[
-            {"start_seconds": 0.0, "end_seconds": 1.0, "speaker_ref": "speaker-01"}
-        ],
+        turns=[{"start_seconds": 0.0, "end_seconds": 1.0, "speaker_ref": "speaker-01"}],
     )
     service, _ = _service(tmp_path, _document(canonical, digest))
 
@@ -209,7 +209,9 @@ def test_unattributed_word_is_not_upgraded_from_single_active_turn(tmp_path: Pat
     assert span.speakers == ()
 
 
-def test_unaligned_sequential_speakers_are_mixed_not_false_overlap(tmp_path: Path) -> None:
+def test_unaligned_sequential_speakers_are_mixed_not_false_overlap(
+    tmp_path: Path,
+) -> None:
     canonical = tmp_path / "transcript.json"
     digest = _write_canonical(
         canonical,
@@ -278,9 +280,7 @@ def test_changed_canonical_generation_fails_closed(tmp_path: Path) -> None:
                 "speaker_ref": "speaker-01",
             }
         ],
-        turns=[
-            {"start_seconds": 0.0, "end_seconds": 1.0, "speaker_ref": "speaker-01"}
-        ],
+        turns=[{"start_seconds": 0.0, "end_seconds": 1.0, "speaker_ref": "speaker-01"}],
     )
     service, _ = _service(tmp_path, _document(canonical, digest))
     canonical.write_text('{"segments": []}')

--- a/src/echoflow/library/tests/test_speaker_presentation.py
+++ b/src/echoflow/library/tests/test_speaker_presentation.py
@@ -1,0 +1,289 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.library.errors import SpeakerLabelStateError
+from echoflow.library.index import IndexedDocument
+from echoflow.library.speaker_presentation import (
+    SpeakerPresentationKind,
+    SpeakerPresentationService,
+)
+from echoflow.library.speaker_labels import SpeakerLabelStore
+
+
+class DocumentIndex:
+    def __init__(self, document: IndexedDocument) -> None:
+        self.document = document
+
+    def documents(self) -> tuple[IndexedDocument, ...]:
+        return (self.document,)
+
+
+def _write_canonical(
+    path: Path,
+    *,
+    segments: list[dict[str, object]],
+    turns: list[dict[str, object]],
+) -> str:
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "job_id": "job-1",
+            "source": {
+                "sha256": "a" * 64,
+                "size_bytes": 100,
+                "modified_ns": 1,
+            },
+            "segments": segments,
+            "speaker_turns": turns,
+        },
+        sort_keys=True,
+    ).encode()
+    path.write_bytes(payload)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _document(path: Path, digest: str) -> IndexedDocument:
+    return IndexedDocument(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        detected_language="en",
+        canonical_path=str(path.resolve()),
+        source_path=None,
+        segment_count=1,
+        canonical_sha256=digest,
+    )
+
+
+def _service(
+    tmp_path: Path,
+    document: IndexedDocument,
+) -> tuple[SpeakerPresentationService, SpeakerLabelStore]:
+    file_manager = LocalFileManager()
+    store = SpeakerLabelStore(
+        tmp_path / "state" / "library" / "user-state" / "speaker-labels.json",
+        file_manager,  # type: ignore[arg-type]
+    )
+    service = SpeakerPresentationService(
+        index=DocumentIndex(document),  # type: ignore[arg-type]
+        label_store=store,
+        file_manager=file_manager,  # type: ignore[arg-type]
+    )
+    return service, store
+
+
+def _aligned_segment(words: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "segment_id": "segment-000000",
+        "start_seconds": 0.0,
+        "end_seconds": 3.0,
+        "text": "Hello yes absolutely",
+        "speaker_ref": None,
+        "words": words,
+    }
+
+
+def test_word_handoff_becomes_readable_spans_with_durable_display_labels(
+    tmp_path: Path,
+) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _write_canonical(
+        canonical,
+        segments=[
+            _aligned_segment(
+                [
+                    {
+                        "start_seconds": 0.0,
+                        "end_seconds": 0.8,
+                        "text": "Hello",
+                        "speaker_ref": "speaker-01",
+                    },
+                    {
+                        "start_seconds": 0.8,
+                        "end_seconds": 1.2,
+                        "text": " yes",
+                        "speaker_ref": "speaker-02",
+                    },
+                    {
+                        "start_seconds": 1.2,
+                        "end_seconds": 1.8,
+                        "text": " absolutely",
+                        "speaker_ref": "speaker-02",
+                    },
+                ]
+            )
+        ],
+        turns=[
+            {"start_seconds": 0.0, "end_seconds": 0.8, "speaker_ref": "speaker-01"},
+            {"start_seconds": 0.8, "end_seconds": 2.0, "speaker_ref": "speaker-02"},
+        ],
+    )
+    document = _document(canonical, digest)
+    service, labels = _service(tmp_path, document)
+    labels.set_label(document, speaker_ref="speaker-01", label="Interviewer")
+    labels.set_label(document, speaker_ref="speaker-02", label="Dr. Chen")
+
+    spans = service.spans("job-1")
+
+    assert len(spans) == 2
+    assert spans[0].text == "Hello"
+    assert spans[0].kind is SpeakerPresentationKind.SINGLE
+    assert spans[0].speakers[0].display_name == "Interviewer (speaker-01)"
+    assert spans[1].text == "yes absolutely"
+    assert spans[1].kind is SpeakerPresentationKind.SINGLE
+    assert spans[1].speakers[0].display_name == "Dr. Chen (speaker-02)"
+    assert spans[1].start_seconds == 0.8
+    assert spans[1].end_seconds == 1.8
+
+
+def test_simultaneous_turns_are_exposed_as_overlap_without_assigning_one_voice(
+    tmp_path: Path,
+) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _write_canonical(
+        canonical,
+        segments=[
+            _aligned_segment(
+                [
+                    {
+                        "start_seconds": 0.9,
+                        "end_seconds": 1.1,
+                        "text": "sorry",
+                        "speaker_ref": None,
+                    }
+                ]
+            )
+        ],
+        turns=[
+            {"start_seconds": 0.0, "end_seconds": 1.2, "speaker_ref": "speaker-01"},
+            {"start_seconds": 0.8, "end_seconds": 1.5, "speaker_ref": "speaker-02"},
+        ],
+    )
+    document = _document(canonical, digest)
+    service, labels = _service(tmp_path, document)
+    labels.set_label(document, speaker_ref="speaker-02", label="Dr. Chen")
+
+    span = service.spans("job-1")[0]
+
+    assert span.kind is SpeakerPresentationKind.OVERLAP
+    assert span.overlap
+    assert [speaker.speaker_ref for speaker in span.speakers] == [
+        "speaker-01",
+        "speaker-02",
+    ]
+    assert [speaker.display_name for speaker in span.speakers] == [
+        "speaker-01",
+        "Dr. Chen (speaker-02)",
+    ]
+    assert span.text == "sorry"
+
+
+def test_unattributed_word_is_not_upgraded_from_single_active_turn(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _write_canonical(
+        canonical,
+        segments=[
+            _aligned_segment(
+                [
+                    {
+                        "start_seconds": 0.2,
+                        "end_seconds": 0.5,
+                        "text": "uncertain",
+                        "speaker_ref": None,
+                    }
+                ]
+            )
+        ],
+        turns=[
+            {"start_seconds": 0.0, "end_seconds": 1.0, "speaker_ref": "speaker-01"}
+        ],
+    )
+    service, _ = _service(tmp_path, _document(canonical, digest))
+
+    span = service.spans("job-1")[0]
+
+    assert span.kind is SpeakerPresentationKind.UNATTRIBUTED
+    assert span.speakers == ()
+
+
+def test_unaligned_sequential_speakers_are_mixed_not_false_overlap(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _write_canonical(
+        canonical,
+        segments=[
+            {
+                "segment_id": "segment-000000",
+                "start_seconds": 0.0,
+                "end_seconds": 2.0,
+                "text": "A coarse segment with a handoff",
+                "speaker_ref": None,
+            }
+        ],
+        turns=[
+            {"start_seconds": 0.0, "end_seconds": 1.0, "speaker_ref": "speaker-01"},
+            {"start_seconds": 1.0, "end_seconds": 2.0, "speaker_ref": "speaker-02"},
+        ],
+    )
+    service, _ = _service(tmp_path, _document(canonical, digest))
+
+    span = service.spans("job-1")[0]
+
+    assert span.kind is SpeakerPresentationKind.MIXED_UNRESOLVED
+    assert not span.overlap
+    assert [speaker.speaker_ref for speaker in span.speakers] == [
+        "speaker-01",
+        "speaker-02",
+    ]
+
+
+def test_unaligned_simultaneous_speakers_are_marked_overlap(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _write_canonical(
+        canonical,
+        segments=[
+            {
+                "segment_id": "segment-000000",
+                "start_seconds": 0.0,
+                "end_seconds": 2.0,
+                "text": "A coarse overlapping segment",
+                "speaker_ref": None,
+            }
+        ],
+        turns=[
+            {"start_seconds": 0.0, "end_seconds": 1.5, "speaker_ref": "speaker-01"},
+            {"start_seconds": 1.0, "end_seconds": 2.0, "speaker_ref": "speaker-02"},
+        ],
+    )
+    service, _ = _service(tmp_path, _document(canonical, digest))
+
+    span = service.spans("job-1")[0]
+
+    assert span.kind is SpeakerPresentationKind.OVERLAP
+    assert span.overlap
+
+
+def test_changed_canonical_generation_fails_closed(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _write_canonical(
+        canonical,
+        segments=[
+            {
+                "segment_id": "segment-000000",
+                "start_seconds": 0.0,
+                "end_seconds": 1.0,
+                "text": "Hello",
+                "speaker_ref": "speaker-01",
+            }
+        ],
+        turns=[
+            {"start_seconds": 0.0, "end_seconds": 1.0, "speaker_ref": "speaker-01"}
+        ],
+    )
+    service, _ = _service(tmp_path, _document(canonical, digest))
+    canonical.write_text('{"segments": []}')
+
+    with pytest.raises(SpeakerLabelStateError, match="rebuild the library"):
+        service.spans("job-1")

--- a/src/echoflow/tests/test_cli_speaker_presentation.py
+++ b/src/echoflow/tests/test_cli_speaker_presentation.py
@@ -1,0 +1,138 @@
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import typer
+from typer.testing import CliRunner
+
+from echoflow.cli_library import register_library_commands
+from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.library.index import IndexedDocument
+from echoflow.library.speaker_labels import SpeakerLabelStore
+
+
+class DocumentIndex:
+    def __init__(self, document: IndexedDocument) -> None:
+        self.document = document
+
+    def documents(self) -> tuple[IndexedDocument, ...]:
+        return (self.document,)
+
+
+def _app(tmp_path: Path) -> typer.Typer:
+    canonical = tmp_path / "transcript.json"
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "job_id": "job-1",
+            "source": {
+                "sha256": "a" * 64,
+                "size_bytes": 100,
+                "modified_ns": 1,
+            },
+            "segments": [
+                {
+                    "segment_id": "segment-000000",
+                    "start_seconds": 0.0,
+                    "end_seconds": 2.0,
+                    "text": "Excuse me",
+                    "speaker_ref": None,
+                    "words": [
+                        {
+                            "start_seconds": 0.9,
+                            "end_seconds": 1.1,
+                            "text": "Excuse me",
+                            "speaker_ref": None,
+                        }
+                    ],
+                }
+            ],
+            "speaker_turns": [
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.2,
+                    "speaker_ref": "speaker-01",
+                },
+                {
+                    "start_seconds": 0.8,
+                    "end_seconds": 1.5,
+                    "speaker_ref": "speaker-02",
+                },
+            ],
+        },
+        sort_keys=True,
+    ).encode()
+    canonical.write_bytes(payload)
+    digest = hashlib.sha256(payload).hexdigest()
+    document = IndexedDocument(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        detected_language="en",
+        canonical_path=str(canonical.resolve()),
+        source_path=None,
+        segment_count=1,
+        canonical_sha256=digest,
+    )
+    file_manager = LocalFileManager()
+    labels = SpeakerLabelStore(
+        tmp_path / "state" / "library" / "user-state" / "speaker-labels.json",
+        file_manager,  # type: ignore[arg-type]
+    )
+    labels.set_label(document, speaker_ref="speaker-02", label="Dr. Chen")
+
+    container = Mock()
+    container.transcript_index.return_value = DocumentIndex(document)
+    container.speaker_label_store.return_value = labels
+    container.file_manager.return_value = file_manager
+    app = typer.Typer()
+    register_library_commands(app, lambda context: container)
+    return app
+
+
+def test_speaker_transcript_human_view_shows_overlap_and_display_label(
+    tmp_path: Path,
+) -> None:
+    result = CliRunner().invoke(
+        _app(tmp_path), ["library", "speakers", "transcript", "job-1"]
+    )
+
+    assert result.exit_code == 0
+    assert "00:00:00.900" in result.stdout
+    assert "00:00:01.100" in result.stdout
+    assert "speaker-01" in result.stdout
+    assert "Dr. Chen (speaker-02)" in result.stdout
+    assert "overlap" in result.stdout
+    assert "Excuse me" in result.stdout
+
+
+def test_speaker_transcript_json_keeps_raw_refs_labels_and_canonical_binding(
+    tmp_path: Path,
+) -> None:
+    result = CliRunner().invoke(
+        _app(tmp_path),
+        ["library", "speakers", "transcript", "job-1", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert len(payload) == 1
+    span = payload[0]
+    assert span["kind"] == "overlap"
+    assert span["overlap"] is True
+    assert span["start_seconds"] == 0.9
+    assert span["start_timestamp"] == "00:00:00.900"
+    assert span["end_timestamp"] == "00:00:01.100"
+    assert len(span["canonical_sha256"]) == 64
+    assert span["speakers"] == [
+        {
+            "display_label": None,
+            "display_name": "speaker-01",
+            "speaker_ref": "speaker-01",
+        },
+        {
+            "display_label": "Dr. Chen",
+            "display_name": "Dr. Chen (speaker-02)",
+            "speaker_ref": "speaker-02",
+        },
+    ]


### PR DESCRIPTION
## What changed

This tranche turns EchoFlow's existing word timing and anonymous diarization timeline into a conservative human-readable speaker transcript without changing canonical evidence.

### Derived speaker presentation

- add `SpeakerPresentationService` and typed presentation spans
- preserve exact source-relative time coordinates and canonical transcript SHA-256
- group adjacent aligned words only when their presentation speaker state is identical
- retain raw anonymous speaker refs while decorating them with current user-authored display labels
- expose four explicit presentation states: `single-speaker`, `overlap`, `mixed-unresolved`, and `unattributed`

### Overlap semantics

- detect genuine simultaneous speaker activity from the preserved diarization turn timeline
- expose all active anonymous refs when multiple speakers overlap the same aligned word interval
- never choose one speaker for an overlap merely to make the transcript look tidy
- do not promote an unattributed canonical word into a single-speaker claim just because one turn overlaps it
- distinguish sequential multi-speaker activity inside a coarse unaligned segment (`mixed-unresolved`) from actual simultaneous speech (`overlap`)

### CLI

Add:

```bash
echoflow library speakers transcript TRANSCRIPT_ID
```

The human view shows elapsed time, friendly display names plus evidence refs, presentation state, and transcript text. `--json` preserves numeric seconds, derived timestamps, canonical hash binding, raw refs, optional display labels, and explicit overlap state.

### Qualification

Tests cover word-level clean handoffs, grouping, display-label decoration, true simultaneous overlap, conservative unattributed words, sequential unaligned speakers versus genuine overlap, stale canonical refusal, and human/JSON CLI contracts.

### Documentation

`docs/speaker-names.md` explains how the derived speaker transcript reads handoffs and overlap while keeping canonical evidence and user-authored names separate.

## Why

EchoFlow already preserves the two evidence streams needed for better speaker UX: aligned transcript words and the full source-relative diarization turn timeline. This tranche makes that evidence legible without adding another ML model or pretending that source separation has occurred.

The presentation layer may reveal that several speakers were simultaneously active. It may not manufacture a stronger single-speaker attribution than canonical evidence supports.

## Deliberately not included

- source/speech separation
- biometric speaker identity
- cross-recording person linking
- rewriting canonical transcript JSON
- notes or annotation storage
- automatic correction of diarization errors

Those require different evidence and custody contracts.