### PR TITLE
feat(library): add aligned evidence navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ transcription service.
 
 The application does more than run a speech model. It inspects the machine it is running
 on, chooses a safe execution strategy, manages local model custody, survives interrupted
-work, preserves source provenance, publishes portable transcripts, keeps engine-produced
-word timing evidence, and builds a private searchable library over completed recordings.
+work, preserves source provenance, publishes portable transcripts, keeps word-level
+timing evidence, handles anonymous speaker evidence conservatively, and builds a private
+searchable library that can navigate results back to the canonical transcript.
 
 The original recording remains read-only input. Canonical transcript JSON is the
-authoritative transcript artifact. Working audio and search databases are derived state
-that can be regenerated.
+authoritative transcript artifact. User-authored knowledge stays separate from both.
+Working audio and search databases are derived state that can be regenerated.
 
 > **EchoFlow's product rule:** do complicated work locally, keep the evidence
 > understandable, portable, and owned by the user.
@@ -27,8 +28,8 @@ For the shortest path from clone to transcript, use
 
 ## What can it do right now?
 
-EchoFlow is pre-production, but the current backend already covers a surprisingly large
-part of the local recording lifecycle.
+EchoFlow is pre-production, but the backend already covers a surprisingly large part of
+the local recording-to-research lifecycle.
 
 | Area | Current foundation |
 |---|---|
@@ -36,18 +37,20 @@ part of the local recording lifecycle.
 | Hardware awareness | process-visible CPU/RAM, affinity/cgroup limits, accelerator topology, engine capability negotiation, and resource admission |
 | Media handling | FFprobe inspection, deterministic audio-stream selection, FFmpeg canonicalization, exact source-relative frame windows |
 | Word timing | native faster-whisper per-word timestamps validated, rebased to source-relative time, and preserved through resume |
+| Time provenance | human `HH:MM:SS.mmm` elapsed coordinates plus source-declared `timecode` / `creation_time` provenance when available |
 | Reliability | durable private checkpoints, validated resume, contiguous checkpoint ordering, bounded accelerated prefetch |
 | Languages | multilingual decoding plus conservative local text-language attribution |
-| Speakers | optional anonymous recording-scoped diarization, with word-level projection when timing evidence exists; currently blocked when its locked dependency security gate is unsafe |
+| Speakers | optional anonymous recording-scoped diarization, word-level handoffs, durable user display labels, and honest overlap/mixed presentation; diarization execution is currently security-held when its locked dependency gate is unsafe |
 | Difficult audio | optional deterministic local FFmpeg noise suppression with provenance and timeline-preservation checks |
 | Model custody | explicit inventory, recommendation, install, local revalidation, immutable revision pinning, and exact-revision removal |
 | Transcript output | canonical JSON plus deterministic TXT, SRT, and WebVTT derived views |
 | Search | private local BM25 lexical retrieval, optional semantic retrieval, and inspectable hybrid RRF ranking |
+| Evidence navigation | canonical-hash verification, aligned lexical highlights, bounded context expansion, speaker display integration, and deterministic source seek coordinates |
 | Evidence | source/canonical SHA-256, segment/word timestamps, speaker/language context, provenance, stale-index detection, and integrity receipts |
 | Portability | Linux, macOS, and Windows CI plus clean-wheel/package verification |
 
-The point of this list is not that users should learn every subsystem. It is that most
-of the annoying decisions around local transcription are becoming application behavior
+The point of this list is not that users should learn every subsystem. It is that most of
+the annoying decisions around local transcription are becoming application behavior
 instead of homework.
 
 ## The journey from recording to something useful
@@ -59,10 +62,9 @@ flowchart LR
     C --> D[Transcribe + word timing + checkpoint]
     D --> E[Canonical transcript]
     E --> F[TXT / SRT / WebVTT]
-    E --> G[Lexical search]
-    E --> H[Optional semantic search]
-    G --> I[Evidence-bearing results]
-    H --> I
+    E --> G[Lexical / semantic / hybrid search]
+    G --> H[Verify canonical evidence]
+    H --> I[Highlight + context + seek]
 
     classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
@@ -77,9 +79,9 @@ flowchart LR
     class G,H,I result
 ```
 
-That flow is intentionally evidence-first. Search results still point back to passages,
-timestamps, speakers/languages, and canonical transcript coordinates instead of
-replacing the corpus with an uncited generated answer.
+Search ranking is intentionally not treated as source truth. A ranked result points back
+to canonical transcript coordinates, and the navigation layer verifies that canonical
+generation before presenting precise word evidence.
 
 ## Install the current source build
 
@@ -104,11 +106,6 @@ uv run echoflow runner
 
 ```bash
 uv run echoflow models recommend
-```
-
-Install the model you intend to use:
-
-```bash
 uv run echoflow models install small
 ```
 
@@ -119,7 +116,7 @@ EchoFlow records and locally revalidates the immutable model revision it manages
 cached model does not become trusted application state merely because some bytes happen
 to exist in a Hugging Face cache.
 
-## Plan before you run
+## Plan, transcribe, and resume
 
 A dry run inspects the source and machine and shows the intended execution plan without
 starting recognition:
@@ -144,11 +141,6 @@ Add derived publication formats when useful:
 uv run echoflow transcribe interview.m4a --export txt --export srt --export vtt
 ```
 
-The recording is not overwritten. Canonical JSON remains authoritative; TXT/SRT/VTT can
-be deleted and regenerated.
-
-## Resume interrupted work
-
 If an in-progress job is interrupted, EchoFlow can restore its validated checkpoint
 contract:
 
@@ -157,11 +149,8 @@ uv run echoflow transcribe interview.m4a --resume JOB_ID
 ```
 
 Resume rechecks source identity and current resource admission. It does not silently
-change model revision, selected audio stream, enhancement contract, alignment contract,
-or execution target just to get moving again.
-
-Aligned word evidence already checkpointed for completed work is restored rather than
-recomputed under a potentially different execution contract.
+change model revision, selected audio stream, preprocessing, alignment, or execution
+target just to get moving again.
 
 ## Optional noise suppression
 
@@ -190,19 +179,28 @@ uv run echoflow transcribe interview.wav --diarize
 Diarization produces anonymous recording-scoped labels such as `speaker-01`; it does not
 perform biometric identity or cross-recording speaker linking.
 
-When word timing evidence exists, EchoFlow can reconcile speaker turns at the word level.
-A word receives a speaker only when exactly one diarized speaker overlaps that word. A
-segment that crosses a speaker handoff therefore stays unlabeled at the segment level
-rather than being assigned to the wrong person.
+When word timing exists, EchoFlow can preserve speaker handoffs without forcing one
+speaker onto the enclosing segment. The derived speaker transcript also distinguishes
+true simultaneous overlap from sequential mixed/unresolved text.
+
+After a transcript is in the library, you can assign your own durable display name:
+
+```bash
+uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
+uv run echoflow library speakers transcript JOB_ID
+```
+
+`Dr. Chen` is user-authored presentation state. `speaker-02` remains the anonymous
+evidence ref underneath it.
 
 The current pyannote dependency path is **security-held** while its locked Lightning
 version is affected by a compensated advisory. EchoFlow fails closed before pyannote
 execution/model acquisition while that condition remains true. See
-**[Anonymous speaker diarization](docs/architecture/diarization.md)**,
-**[Word-level timestamp alignment](docs/architecture/word-alignment.md)**, and
+**[Give the anonymous speakers names](docs/speaker-names.md)**,
+**[Anonymous speaker diarization](docs/architecture/diarization.md)**, and
 **[SECURITY.md](SECURITY.md)**.
 
-## Search your transcript library
+## Search and navigate your transcript library
 
 Build the private lexical library:
 
@@ -216,7 +214,13 @@ Search for exact or related words:
 uv run echoflow library search "housing insecurity"
 ```
 
-Filter by transcript evidence when needed:
+Ask for neighboring canonical context without changing the ranking:
+
+```bash
+uv run echoflow library search "housing insecurity" --context-segments 1
+```
+
+Filter by transcript evidence when useful:
 
 ```bash
 uv run echoflow library search \
@@ -225,15 +229,24 @@ uv run echoflow library search \
   --language en
 ```
 
+If `speaker-02` has a current user label, human search presentation can show
+`Dr. Chen (speaker-02)` while machine-readable output keeps the raw ref.
+
+Lexical results can now resolve matching aligned words back to canonical evidence and use
+the first exact match as a source seek coordinate. Semantic-only results deliberately
+stay passage-level because an embedding does not identify one magical matching word.
+Hybrid results preserve both retrieval provenance and exact lexical highlights when
+lexical evidence contributed.
+
 Inspect one transcript's custody and source-integrity evidence:
 
 ```bash
 uv run echoflow library show JOB_ID
 ```
 
-Word timing does not change ranking semantics. The current library still indexes
-canonical segment text once; the finer coordinates are available for later precise
-highlighting, jump-to-audio, and annotation UX.
+Read **[From search result to the exact evidence](docs/evidence-navigation.md)** for the
+human version and **[Evidence-first corpus search](docs/architecture/corpus-search.md)**
+for the implementation contract.
 
 ### ✨ Optional semantic and hybrid search
 
@@ -261,8 +274,8 @@ requirements.
 Hybrid retrieval combines BM25 and dense ranks using reciprocal rank fusion instead of
 pretending their raw scores share one scale.
 
-Read **[Semantic search, without the mystery box](docs/semantic-search.md)** before
-opening the deeper **[corpus-search architecture](docs/architecture/corpus-search.md)**.
+Read **[Semantic search, without the mystery box](docs/semantic-search.md)** for the
+plain-language explanation.
 
 ## What belongs to you? 🦝
 
@@ -272,11 +285,13 @@ The custody boundary is intentionally simple:
 |---|---|---|
 | Original recording | source evidence | **No** |
 | Canonical transcript JSON, including word timing evidence | authoritative transcript artifact | **No** |
-| Future notes/tags/annotations | user-authored knowledge | **No** |
+| Speaker display labels | user-authored knowledge | **No** |
+| Future notes/tags/annotations/collections | user-authored knowledge | **No** |
 | TXT/SRT/WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
 | Lexical search database | private search projection | Yes |
 | Semantic chunks/vectors | private search projection | Yes |
+| Evidence-navigation context/highlight views | derived presentation over canonical evidence | Yes |
 
 A database is allowed to make evidence useful. It is not allowed to become the only
 place the evidence exists.
@@ -286,7 +301,7 @@ place the evidence exists.
 The architecture is organized around narrow capabilities rather than one universal
 pipeline manager. Start with **[docs/architecture/README.md](docs/architecture/README.md)**.
 
-The most important references are:
+The most useful references are:
 
 - **[Processing capabilities](docs/architecture/processing-capabilities.md)** for the
   end-to-end execution map.
@@ -298,14 +313,12 @@ The most important references are:
   word timing, source-relative rebasing, checkpoint identity, and speaker handoffs.
 - **[Model management](docs/architecture/model-management.md)** for explicit acquisition,
   immutable revisions, and local custody.
-- **[Speech enhancement](docs/architecture/speech-enhancement.md)** for optional
-  preprocessing and provenance.
 - **[Diarization](docs/architecture/diarization.md)** for anonymous speaker evidence and
   the current security hold.
 - **[Corpus search](docs/architecture/corpus-search.md)** for lexical/semantic/hybrid
-  retrieval and data ownership.
+  retrieval, canonical navigation, and data ownership.
 
-Documentation itself has a contract now too. See
+Documentation itself has a contract too. See
 **[docs/documentation-style.md](docs/documentation-style.md)**.
 
 ## Quality and development
@@ -324,23 +337,23 @@ than a routine per-commit gate. See
 
 ## Where the project goes next
 
-The backend is broad enough that the next high-value work is increasingly about finer
-evidence navigation and ordinary-user delivery rather than inventing another ASR
-pipeline.
+The evidence plumbing is now much further along than the user-authored research
+workspace.
 
-Word timing is now part of the current faster-whisper evidence path. The next sequence is
-**original-media timecode/capture-time provenance**, then **better speaker
-overlap/display-label UX**, then richer research-workspace behavior over those aligned
-coordinates. Source separation for overlapping speakers remains a later, heavier
-capability once the simpler temporal evidence model is strong enough to support it.
+The next major product layer is **durable notes, tags, saved searches, collections, and
+annotation state anchored to verified canonical evidence locations**. After that, the
+highest-value work is qualifying semantic installation/model custody for ordinary source
+installs, dogfooding on representative consumer hardware, and building an installer plus
+thin graphical shell over the same application services.
 
-Installers and a thin graphical interface remain important for non-developer adoption.
-They should sit on top of the same application services, not fork the product into a
-second implementation.
+Source separation for genuinely overlapping speech remains later. EchoFlow can now
+represent overlap honestly, so separation should earn its model/compute/provenance cost
+by improving real recordings rather than appearing as an impressive checkbox.
 
 See **[ROADMAP.md](ROADMAP.md)** for the current sequencing and deliberate limits.
 
 ---
 
 **EchoFlow is trying to make sensitive local transcription boringly dependable, then
-make the resulting evidence easy to find without giving the corpus away.** 💃
+make the resulting evidence easy to find, navigate, and eventually annotate without
+giving the corpus away.** 💃

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,179 +3,149 @@
 EchoFlow is becoming a **private local workspace for recorded evidence**.
 
 Its job is not to out-engine speech-recognition runtimes. Its job is to make local
-transcription dependable, resumable, inspectable, searchable, and usable on ordinary
-computers while keeping source evidence and user-owned artifacts under clear custody.
+transcription dependable, resumable, inspectable, searchable, and useful on ordinary
+computers while keeping source evidence and user-authored knowledge under clear custody.
 
-Modern EchoFlow restarted on August 2, 2026. Since then, the project has moved very
-quickly from “can we transcribe a file?” to “can we preserve and navigate a local corpus
-of recorded evidence without giving the corpus away?”
+Modern EchoFlow restarted on August 2, 2026. The project has already moved from “can we
+transcribe a file?” to “can we preserve, search, and navigate a local corpus of recorded
+evidence without giving the corpus away?”
 
-That is a substantially different product.
-
-## Where we are now
-
-The backend foundation is broad enough that the next work is increasingly about
-**evidence navigation, qualification, packaging, and interface quality**, not inventing
-another transcription pipeline.
+That is now the useful product boundary.
 
 ```mermaid
 flowchart LR
     A[Local media] --> B[Reliable local transcription]
-    B --> C[Evidence-preserving canonical corpus]
+    B --> C[Evidence-preserving corpus]
     C --> D[Lexical + semantic retrieval]
-    D --> E[Finer evidence navigation]
-    E --> F[Beginner-friendly product shell]
+    D --> E[Aligned evidence navigation]
+    E --> F[Durable research workspace]
+    F --> G[Beginner-friendly product shell]
 
     classDef done fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
     classDef now fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
     classDef next fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
 
-    class A,B,C,D done
-    class E now
-    class F next
+    class A,B,C,D,E done
+    class F now
+    class G next
 ```
 
-## The current foundation: yes, we have been busy 💃
+# Current foundation: yes, we have been busy 💃
 
-### Local execution and hardware awareness
+The backend is broad enough that the next work is increasingly about **research workflow,
+qualification, packaging, and interface quality**, not inventing another transcription
+pipeline.
 
-EchoFlow currently has:
+## Local execution and media processing
+
+EchoFlow currently provides:
 
 - process-visible CPU and memory inspection, including relevant affinity/cgroup limits;
-- physical accelerator topology kept separate from engine/runtime capability;
+- physical accelerator topology kept separate from actual engine/runtime capability;
 - resource-admitted faster-whisper CPU/int8 and CUDA-capable strategies;
 - explicit refusal instead of silent substitution for infeasible user-selected
   strategies;
-- dedicated/shared/unified accelerator-memory accounting; and
+- dedicated/shared/unified accelerator-memory accounting;
+- FFprobe inspection with file-only protocol access and complete source SHA-256;
+- deterministic audio-stream selection;
+- FFmpeg canonicalization to mono 16 kHz PCM16 WAV when required;
+- exact integer-frame work windows;
+- optional deterministic FFmpeg noise suppression with provenance and timeline checks;
+  and
 - bounded one-segment CPU preparation overlap during accelerated inference while
   preserving ordered checkpoints.
 
 Performance ranks and memory estimates remain conservative heuristics pending
 representative-device qualification.
 
-### Media, timeline, alignment, and local preprocessing
+## Reliability, model custody, and timeline evidence
 
-The current media foundation includes:
+The current execution contract includes:
 
-- FFprobe inspection with file-only protocol access and complete source SHA-256;
-- deterministic audio-stream selection;
-- FFmpeg canonicalization to mono 16 kHz PCM16 WAV when required;
-- exact integer-frame work windows and source-relative segment timestamps;
-- faster-whisper native per-word timestamp evidence rebased onto that same source
-  timeline;
-- deterministic human elapsed presentation as unwrapped `HH:MM:SS.mmm` while numeric
-  source-relative seconds remain authoritative;
-- preservation of source-declared `timecode` and `creation_time` metadata at format and
-  stream scope when FFprobe reports it;
-- explicit provenance for conflicting source time declarations instead of silently
-  choosing one;
-- optional deterministic FFmpeg noise suppression;
-- timeline-preservation checks around enhanced audio; and
-- provenance recording for preprocessing that affected ASR input.
-
-Word alignment is part of the current faster-whisper execution/checkpoint contract. It
-preserves engine-produced timing rather than claiming an independent forced-alignment
-pass.
-
-Human elapsed strings are derived views, not durable evidence anchors. Source-declared
-timecode/capture metadata is parallel provenance, not a replacement for canonical
-elapsed time and not part of checkpoint source identity.
-
-The current time-provenance implementation deliberately does **not** perform SMPTE frame
-arithmetic, resolve drop-frame semantics, preserve every PTS/DTS origin, or infer
-cross-device synchronization. Those require qualified source semantics rather than
-optimistic string arithmetic.
-
-The original recording remains read-only evidence. Normalized/enhanced WAV files remain
-private derived processing material.
-
-### Model custody
-
-Faster-whisper model management currently provides:
-
-- offline inventory and recommendation;
-- explicit disk-admitted installation;
-- provider/repository provenance;
-- immutable resolved revisions;
-- local structural revalidation;
-- exact-revision removal; and
-- mandatory managed-model identity for ASR planning/execution.
-
-Transcription itself does not silently download ASR weights.
-
-### Reliability and recovery
-
-EchoFlow has:
-
-- durable private per-work-unit checkpoints;
-- validated resume;
+- explicit faster-whisper model inventory/recommendation/installation;
+- immutable resolved model revisions and local revalidation;
+- no silent ASR model download during transcription;
+- private per-work-unit checkpoints and validated resume;
 - source/model/stream/preprocessing/execution/alignment contract binding;
-- aligned word evidence persisted through checkpoint/resume;
 - contiguous-prefix checkpoint semantics;
-- cleanup of speculative/derived work without masking primary failures; and
-- durable lifecycle evidence around long-running work.
+- native faster-whisper word timestamps rebased onto one source-relative canonical
+  timeline;
+- aligned word evidence persisted through checkpoint/resume;
+- deterministic `HH:MM:SS.mmm` human elapsed presentation without 24-hour wrapping; and
+- preservation of source-declared `timecode` and `creation_time` metadata at format and
+  stream scope when FFprobe reports it.
 
-The goal is that an interrupted long recording is an inconvenience, not a fresh start.
+Numeric source-relative seconds remain authoritative navigation coordinates. Human clock
+strings are presentation. Source-declared camera/container metadata is parallel
+provenance, not a replacement timeline and not automatically trusted.
 
-### Language and speaker evidence
+## Language and speaker evidence
 
-The system currently supports:
+EchoFlow supports:
 
 - multilingual faster-whisper decoding;
 - conservative local text-language attribution that may leave ambiguous text unlabeled;
 - optional recording-scoped anonymous speaker diarization;
-- deterministic speaker-label normalization;
-- word-level projection when native word timing exists; and
-- conservative segment labeling that remains null across mixed speaker handoffs or
-  ambiguous overlap.
+- deterministic anonymous speaker refs;
+- word-level speaker projection when timing evidence supports it;
+- conservative null/mixed behavior instead of forcing one speaker across a handoff;
+- durable user-authored display labels such as `speaker-02 → Dr. Chen`, stored separately
+  from canonical evidence and rebuildable indexes; and
+- a derived overlap-aware speaker transcript that distinguishes `single-speaker`,
+  `overlap`, `mixed-unresolved`, and `unattributed` presentation states.
 
-The diarization path is **integrated but security-held** while its locked Lightning
+Speaker display names are bound to the exact canonical transcript generation. EchoFlow
+does not perform biometric identity inference or silently link anonymous speakers across
+recordings.
+
+The pyannote execution path remains **security-held** while its locked Lightning
 dependency is affected by the compensated CVE-2026-58659/PYSEC-2026-3624 advisory.
-EchoFlow fails closed before pyannote execution/acquisition while that gate is active.
+EchoFlow fails closed before that provider executes or acquires model state while the
+security gate is active.
 
-### Canonical transcript and exports
+## Canonical transcript and publications
 
 Canonical JSON is authoritative transcript evidence.
 
-It carries source and execution provenance, source-relative segment and word timestamps,
+It carries source/execution provenance, source-relative segment and word timestamps,
 source-declared temporal tags when present, language evidence, optional enhancement
 provenance, and optional speaker-turn/word speaker evidence.
 
-TXT, SRT, and WebVTT remain deterministic segment-oriented publication views that can be
-regenerated without rerunning recognition. More expressive intra-segment speaker
-presentation belongs to the speaker-UX tranche rather than being smuggled into timing
-work.
+TXT, SRT, and WebVTT remain deterministic derived publication views. They can be deleted
+and regenerated without rerunning recognition.
 
-### Transcript library and retrieval
+## Transcript library, search, and aligned navigation
 
 The local library now includes:
 
-- a database-neutral lexical search application port;
+- a database-neutral lexical search contract;
 - private DuckDB document/segment/term projections;
 - deterministic offline BM25-style ranking;
-- phrase, ANY/ALL, speaker, language, document, and timeline constraints;
-- canonical transcript SHA-256 in addition to source-media SHA-256;
-- deterministic `search-chunk-v1` retrieval windows anchored to exact canonical segment
-  IDs/timestamps;
-- an `EmbeddingProvider` + immutable `EmbeddingProfile` contract;
-- a strict-local Multilingual E5 Small provider;
-- private numeric semantic vectors;
-- exact local dense similarity with hard filters before top-K;
+- phrase, ANY/ALL, speaker, language, transcript, and timeline constraints;
+- canonical transcript SHA-256 plus source-media SHA-256;
+- deterministic segment-anchored semantic search chunks;
+- a provider-neutral embedding contract and strict-local Multilingual E5 Small profile;
+- private numeric semantic vectors and exact local dense similarity;
 - reciprocal-rank hybrid BM25 + dense retrieval;
-- one evidence-bearing `SearchResponse` with lexical/semantic/fused ranks;
-- human search-result time ranges such as `01:19:48.370–01:19:51.125` while JSON keeps
-  numeric seconds and exposes derived timestamp conveniences; and
-- corpus-fingerprint stale-vector refusal when canonical transcript bytes change.
+- stale-vector refusal when canonical transcript bytes change;
+- human elapsed result coordinates while JSON retains numeric seconds;
+- verified canonical evidence lookup after ranking;
+- exact aligned-word highlighting when lexical evidence justifies it;
+- semantic-only passage navigation without fabricated exact-word matches;
+- bounded neighboring canonical context expansion;
+- deterministic seek coordinates for future local media playback; and
+- current speaker display labels layered onto search presentation while raw anonymous
+  refs remain visible evidence.
 
-Nested word timing is additional canonical evidence. Current lexical/semantic projection
-continues indexing segment text once; later highlighting and jump-to-audio UX can use the
-finer coordinates without changing retrieval ranking semantics.
+Search ranking and evidence navigation are separate operations. A rebuildable index ranks
+a passage; the navigation layer verifies the canonical transcript before presenting a
+precise location.
 
-Semantic search is currently an advanced optional capability because the locked project
+Semantic search remains an advanced optional capability because the locked base project
 dependency graph does not yet include Sentence Transformers. Lexical search remains the
 normal dependency-light default.
 
-### Security, privacy, and quality foundation
+## Security, privacy, and quality foundation
 
 The project currently has:
 
@@ -190,77 +160,64 @@ The project currently has:
 - targeted Poodle mutation qualification for decision-heavy code.
 
 See [SECURITY.md](SECURITY.md) for the exact threat boundary. “Local-first” is not a
-claim that the entire host operating system or every native dependency is trusted.
+claim that the host operating system or every native dependency is trusted.
 
-## The product principle that should survive every feature
+# The custody rule that should survive every feature
 
-EchoFlow now has several kinds of data with deliberately different deletion semantics.
+EchoFlow has several classes of data with deliberately different deletion semantics.
 
 | Class | Examples | Rule |
 |---|---|---|
 | Authoritative evidence | original recording, canonical transcript | never treat as cache |
-| User-authored knowledge | future notes, speaker display labels, tags, annotations, collections | must survive index rebuilds |
+| User-authored knowledge | speaker labels, future notes/tags/annotations/collections | must survive index rebuilds |
 | Rebuildable projection | lexical index, semantic chunks/vectors, derived exports | may be regenerated from durable evidence |
 | Private execution state | normalization, enhancement, checkpoints, temporary segments | lifecycle-managed, not source truth |
-
-This distinction becomes more important as EchoFlow evolves from a transcription tool
-into a research library.
 
 🦝 The raccoon may rebuild an index. The raccoon may not eat your annotations.
 
 # Near-term product sequence
 
-Word timing and human/source time provenance now give EchoFlow a finer canonical evidence
-coordinate and a sane way to present it. The next work should make speaker evidence
-legible to humans, then exploit the same coordinates in the research workspace before
-heavier source-separation machinery arrives.
+Word timing, source time provenance, speaker naming, overlap presentation, and aligned
+search navigation are now foundation. The next work should build on those contracts
+rather than repeatedly reopening them.
 
-## 1. Better speaker UX: overlap + user-assigned display labels
+## 1. Durable research workspace state
 
-Anonymous diarization evidence should remain anonymous-by-default and recording-scoped.
+The next major product layer is user-authored research state over verified evidence
+locations.
 
-But users should eventually be able to map stable anonymous refs to meaningful display
-labels such as:
+Target direction:
 
-```text
-speaker-01 → Dr. Chen
-speaker-02 → Interviewer
-```
+- notes anchored to source/canonical identity plus durable segment/word/time coordinates;
+- tags;
+- saved searches;
+- collections;
+- annotation update/history semantics where useful;
+- exportable selected result sets; and
+- a transactional private user-state store appropriate for mutable/queryable knowledge.
 
-Those labels are **user-authored state**. They must not be disposable search/index
-metadata and should not rewrite the underlying anonymous speaker-turn evidence.
+Speaker labels proved the custody model in miniature. Notes and collections are higher
+volume and more queryable, so they should not simply accumulate forever in one giant JSON
+file. A small transactional store such as SQLite is a likely application adapter, behind
+ports that keep user knowledge separate from search implementation details.
 
-Word alignment already lets EchoFlow preserve an intra-segment handoff without forcing
-one segment-level speaker. The next presentation layer should make that evidence useful
-to a human:
+A note must never be anchored only to a formatted timestamp or disposable semantic chunk
+ID. If canonical evidence changes, EchoFlow should retain the note and report that its
+old anchor needs review rather than silently teleporting the annotation.
 
-- render word/fine-grained handoffs legibly;
-- preserve multiple active speaker refs where evidence supports overlap;
-- avoid forcing one speaker label onto genuinely ambiguous text;
-- let users assign display labels over stable anonymous refs; and
-- keep those labels durable and separate from rebuildable indexes.
+## 2. Search/research workspace ergonomics
 
-## 2. Search/research workspace UX over aligned coordinates
+Use real corpora to decide which navigation conveniences earn permanence:
 
-The retrieval engine supports lexical, semantic, and hybrid ranking, while canonical
-transcripts now have word timing and human elapsed coordinates. Real corpus use should
-drive the next interface layer:
+- result-context expansion beyond simple neighboring segments;
+- facets and typed constraints;
+- exportable/citable result sets;
+- saved-search and collection workflows;
+- local media playback over the existing seek contract; and
+- cross-feature presentation of speaker names, tags, and annotation state.
 
-- exact phrase/word highlighting inside a retrieved passage;
-- result-context expansion;
-- facets;
-- exportable result sets;
-- precise jump-to-audio/video using numeric source-relative seconds;
-- saved searches/collections; and
-- durable tags, notes, and annotations anchored to source identity plus durable canonical
-  evidence coordinates.
-
-The ownership rule is non-negotiable: user-authored state does not share deletion
-semantics with rebuildable indexes.
-
-A display string such as `01:19:48.370` is a convenience, not the annotation anchor.
-Likewise, a semantic chunk ID is rebuildable and must not become the only location of a
-user note.
+The GUI should eventually consume these same services. It should not invent a second
+search engine or a second definition of where transcript evidence lives.
 
 ## 3. Qualify semantic dependency and managed embedding custody
 
@@ -278,11 +235,11 @@ Target direction:
 - offline execution after installation; and
 - clean-wheel/platform qualification.
 
-Do not bypass `uv.lock` coherence to make the feature look more finished.
+Do not bypass `uv.lock` coherence merely to make the feature look more finished.
 
-## 4. Representative-device and enhancement qualification
+## 4. Representative-device qualification and dogfooding
 
-Collect repeated benchmark evidence from at least:
+Exercise real multi-recording corpora and collect repeated evidence from at least:
 
 - 8 GB Windows consumer hardware;
 - 16 GB commodity hardware;
@@ -292,148 +249,113 @@ Collect repeated benchmark evidence from at least:
 
 Measure cold/warm model behavior, real-time factor, thermal effects, CPU/RAM pressure,
 device memory/utilization where reliable, private disk cost, enhancement benefit/cost,
-embedding build cost, and semantic-query latency.
+embedding build cost, and semantic-query/navigation latency.
+
+Dogfood interruption/resume, noisy media, stale-process reconciliation, model
+remove/reinstall, source-integrity receipts, speaker naming/overlap, lexical/semantic/
+hybrid search, and aligned navigation using real interviews, lectures, meetings, and oral
+histories.
 
 Calibrate from measurements, not hardware marketing names.
 
-## 5. Deeper original-media clock qualification only when needed
+## 5. Beginner delivery surface
+
+EchoFlow's backend increasingly makes beginner-friendly decisions automatically. Its
+current source-install/terminal delivery still assumes a developer.
+
+A reasonable pre-1.0 usability milestone includes:
+
+1. durable notes/tags/collections over aligned evidence;
+2. semantic setup that no longer requires advanced manual environment preparation;
+3. representative qualification on ordinary hardware;
+4. polished error/recovery language;
+5. an installer/package path that does not require a developer environment; and
+6. a thin graphical shell over the existing application services.
+
+The GUI should be a presentation adapter, not a second implementation of transcription,
+search, time mapping, speaker policy, or model custody.
+
+## 6. Deeper original-media clock qualification only when real media requires it
 
 The current implementation preserves source-declared format/stream `timecode` and
-`creation_time` tags and keeps them distinct from canonical elapsed seconds.
+`creation_time` tags while keeping them distinct from canonical elapsed seconds.
 
-If real recordings require deterministic mapping to production/media clocks, extend that
-foundation with qualified evidence rather than guessing. Candidate work includes:
-
-- non-zero stream/container start-time or PTS/DTS origins;
-- exact rational frame rates and nominal timecode rates;
-- drop-frame/non-drop-frame semantics;
-- deterministic SMPTE-to-elapsed mappings;
-- timezone/offset normalization only when actually encoded; and
-- explicit synchronization relationships between independently recorded sources.
+If real recordings require deterministic production/media-clock mapping, qualify the
+necessary semantics rather than guessing. Candidate work includes non-zero stream
+origins, rational frame/timecode rates, drop-frame/non-drop-frame semantics, PTS/DTS
+mapping, timezone normalization only when actually encoded, and explicit synchronization
+relationships across independent sources.
 
 “Metadata exists” and “metadata is trustworthy enough to map onto transcript evidence”
 remain different states.
 
-# Beginner-ready milestone
-
-The backend is already beginner-oriented in many internal decisions: resource discovery,
-model custody, recovery, provenance, alignment, time navigation, and search are designed
-so the user does **not** need to manually operate those systems.
-
-But a beginner-friendly product also needs a beginner-friendly delivery surface.
-
-A reasonable pre-1.0 usability milestone is:
-
-1. clearer speaker labels/overlap behavior over aligned evidence;
-2. precise transcript navigation and durable note/annotation anchors;
-3. semantic dependency/model setup that no longer requires advanced manual environment
-   preparation;
-4. representative qualification on ordinary hardware;
-5. polished error/recovery language;
-6. an installer/package path that does not require a developer environment; and
-7. a thin graphical shell over the existing application services.
-
-The GUI should be a presentation adapter, not a second implementation of transcription,
-search, time mapping, or model policy.
-
 # Later capability: speech/source separation for overlapping speakers
 
-Source separation is valuable, but it is intentionally **later** than alignment and
-honest overlap representation.
+Source separation is valuable, but it remains intentionally later than honest overlap
+representation.
 
-Separating mixed speech into estimated source signals adds:
+Separating mixed speech into estimated source signals adds substantial compute/model
+cost, new dependency/model custody, uncertainty about source-to-human identity, derived
+audio provenance, and new failure modes. It should also demonstrate an actual end-to-end
+recognition benefit on representative overlap cases.
 
-- substantial compute/model cost;
-- new model custody/dependency concerns;
-- uncertainty about which separated signal corresponds to which human speaker;
-- timeline/provenance requirements for derived sources;
-- new failure modes; and
-- a need to prove end-to-end recognition benefit on representative overlap cases.
-
-EchoFlow should first become excellent at representing overlap honestly.
-
-Then, if real recordings demonstrate that overlap remains a major recognition failure,
-source separation can be evaluated as a targeted capability rather than an impressive
-but unqualified checkbox.
+EchoFlow can now represent simultaneous speaker evidence without choosing a fake winner.
+That is enough foundation to **measure** whether separation is worth the additional
+complexity.
 
 🧜‍♀️ We enter the deep water after learning to swim.
 
-# Other near-term engineering work
-
-## Dogfood the complete workflow
-
-Use real multi-recording corpora to exercise:
-
-- interruption/resume with aligned word evidence;
-- long-duration human time rendering across hour and 24-hour boundaries;
-- conflicting or absent source temporal metadata;
-- stale-process reconciliation;
-- progress rendering;
-- accelerator re-admission;
-- managed model removal/reinstall;
-- enhancement on noisy/long recordings;
-- transcript-library rebuilds;
-- source-integrity receipts; and
-- lexical/semantic/hybrid search.
-
-Retrieval questions worth measuring include whether current 220/300-word chunks behave
-well across interviews, lectures, meetings, and oral histories; whether exact vector scan
-remains interactive at realistic corpus sizes; and whether RRF improves conceptual
-recall without burying exact names/acronyms.
+# Other engineering work, when evidence asks for it
 
 ## Typed query evolution
 
 `SearchQuery` already owns text, phrase, ANY/ALL semantics, speaker, language,
 document/transcript, sorting, and bounded limits.
 
-Add date/tag/duration/facet/collection constraints only when real product use requires
-them.
-
+Add date/tag/duration/facet/collection constraints when real product use requires them.
 CLI syntax, future query chips, and any local natural-language convenience layer should
 compile to the same typed contract instead of growing separate search semantics.
 
 ## Bounded failure recovery
 
 Audio bisection/retry should be added only if representative long-recording failures show
-it is needed.
+it is needed. Do not front-load a recovery labyrinth for hypothetical failures.
 
-Do not front-load a recovery labyrinth for hypothetical failures.
+## Pre-production contract policy
 
-# Pre-production contract policy
+EchoFlow has not yet had a released/dogfooded durable compatibility boundary. Internal
+durable contracts therefore use one current canonical shape rather than accumulating
+migration branches for every unreleased intermediate state.
 
-EchoFlow has not had a released/dogfooded durable compatibility boundary yet.
-
-Internal durable contracts therefore use one current canonical shape rather than
-accumulating migration branches for every unreleased intermediate state.
-
-Unsupported schema versions still fail closed.
-
-When a real compatibility obligation exists, migrations should be introduced against
-actual persisted fixtures from that boundary.
+Unsupported schema versions still fail closed. When a real compatibility obligation
+exists, migrations should be introduced against actual persisted fixtures from that
+boundary.
 
 # Research candidates, not promises
 
 Interesting later investigations include:
 
 - independent forced alignment or phoneme-level timing if native word timing proves
-  insufficient for a real use case;
+  insufficient;
 - finer intra-clause/romanized language attribution;
-- improved overlap rendering and source separation;
+- source separation when measured overlap failures justify it;
 - richer PTS/SMPTE synchronization only when real media requires it;
 - alternative qualified multilingual embedding models;
 - character n-gram/fuzzy retrieval for ASR names/acronyms/misspellings;
 - a small local cross-encoder reranker if measured benefit justifies it;
-- resource-admitted HNSW only when exact-search latency justifies it;
+- resource-admitted HNSW only when exact-search latency justifies approximation;
 - constrained deterministic natural-language query grammar;
-- optional local query translation that shows the interpreted typed query to the user;
+- optional local query translation that shows the interpreted typed query;
 - optional summarization only over an explicitly selected/citable evidence set;
+- explicit user-authored cross-recording person relationships, without biometric
+  identity inference;
 - additional ASR engines when they provide a concrete advantage; and
 - additional accelerator backends when a real engine can consume them.
 
 The order can change when security review, dogfooding, hardware evidence, or complexity
 contradicts an assumption.
 
-The stable direction is much narrower:
+The stable direction is narrower:
 
 > **Make sensitive local transcription boringly dependable. Make its evidence easy to
-> navigate. Do not give the corpus away.** 💃
+> navigate and annotate. Do not give the corpus away.** 💃

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ EchoFlow is a **local-first workspace for recorded evidence**.
 
 It can inspect a recording, choose a safe way to run on the computer you actually have,
 transcribe locally, survive interruptions, preserve provenance, enrich the transcript,
-and help you find the important bit again later.
+search a private corpus, and navigate a result back to verified canonical evidence.
 
 You do **not** need to understand CUDA, DuckDB, BM25, vector spaces, immutable model
 revisions, or why a raccoon has been granted library privileges to use the product.
@@ -12,36 +12,38 @@ Those details exist because somebody has to care about them. EchoFlow would like
 somebody to be EchoFlow.
 
 > **The short version:** your recording stays yours, the canonical transcript remains
-> inspectable evidence, and most of the machinery EchoFlow builds around it can be
-> thrown away and rebuilt.
+> inspectable evidence, your own labels remain your knowledge, and most machinery built
+> around those things can be thrown away and rebuilt.
 
 🧜‍♀️
 
 ## What can EchoFlow do today?
 
 EchoFlow is still pre-production, but the backend is no longer a toy transcription
-script. The current foundation already covers the full local journey from media to a
-searchable evidence corpus.
+script. The current foundation covers the local journey from media to a searchable,
+navigable evidence corpus.
 
 | You want to… | EchoFlow currently… |
 |---|---|
 | Transcribe a recording privately | runs faster-whisper locally from a verified managed model |
 | Avoid melting a smaller laptop | inspects process-visible CPU, RAM, and compatible acceleration before choosing a strategy |
-| Use a GPU when it is *actually* usable | separates physical hardware discovery from engine/runtime capability instead of assuming “GPU visible = GPU works” |
+| Use a GPU when it is actually usable | separates physical hardware discovery from engine/runtime capability |
 | Survive an interruption | checkpoints completed work and validates the original contract on resume |
 | Keep the original recording intact | treats source media as read-only evidence and writes processing artifacts separately |
 | Handle video files | deterministically selects an audio stream and transcribes the audio-bearing source |
 | Clean up a noisy recording | optionally applies deterministic local noise suppression with provenance and timeline checks |
 | Work with multiple languages | supports multilingual decoding plus conservative local language attribution |
-| Distinguish speakers | has optional anonymous recording-scoped diarization, currently held behind a dependency security gate |
+| Distinguish speakers | preserves optional anonymous recording-scoped speaker evidence without claiming identity |
 | Give anonymous speakers useful names | stores user-assigned display labels separately from canonical diarization evidence and rebuildable search state |
+| Read awkward handoffs honestly | distinguishes clean speaker spans, true overlap, mixed/unresolved text, and unattributed text |
 | Publish useful transcript formats | produces canonical JSON plus rebuildable TXT, SRT, and WebVTT views |
 | Find an exact phrase later | builds a private local lexical/BM25 transcript library |
-| Find an idea even when the wording changed | supports optional local semantic retrieval |
-| Get the best of both search styles | combines lexical and semantic results with inspectable reciprocal-rank fusion |
+| Find an idea when the wording changed | supports optional local semantic retrieval |
+| Combine both search styles | uses inspectable reciprocal-rank fusion |
 | Stop calculating giant second counts | renders source-relative evidence as human `HH:MM:SS.mmm` coordinates while keeping numeric seconds authoritative |
 | Preserve camera/container time clues | records source-declared `timecode` and `creation_time` tags with format/stream provenance when present |
-| Verify where a result came from | carries timestamps, speakers/languages, hashes, canonical coordinates, and retrieval provenance |
+| Follow a search result back to evidence | verifies the canonical transcript, resolves exact lexical word matches when justified, expands context, and exposes a source seek coordinate |
+| See your speaker names in search | decorates current search presentation with names such as `Dr. Chen (speaker-02)` without replacing the anonymous evidence ref |
 
 That is a lot of machinery. The point is not to make you operate the machinery. The
 point is to make sensitive local transcription feel boringly dependable.
@@ -60,18 +62,26 @@ without requiring an architecture degree.
 Read **[Transcript time without calculator gymnastics](time-navigation.md)**.
 
 It explains what word timestamps buy you, why `4788.37` seconds becomes
-`01:19:48.370`, how future click-to-seek and notes should anchor to evidence, and why a
-camera's embedded timecode is a different clock.
+`01:19:48.370`, why source-declared camera time is a different clock, and how canonical
+numeric coordinates support source seeking.
 
 ### 👥 I want `speaker-02` to have a human name
 
 Read **[Give the anonymous speakers names](speaker-names.md)**.
 
 It explains why `speaker-02` remains evidence while `Dr. Chen` is your durable display
-label, how to name or un-name a speaker, and why labels do not silently jump across a
+label, how overlap/handoffs are presented, and why names do not silently jump across a
 changed transcript generation.
 
-### 🔎 I want to search my transcripts
+### 🔎 I found something. Show me the actual evidence.
+
+Read **[From search result to the exact evidence](evidence-navigation.md)**.
+
+It explains canonical hash verification, exact lexical word highlighting, semantic
+restraint, neighboring context, speaker display names, source seek coordinates, and the
+anchor a future note can reuse.
+
+### ✨ I want to understand semantic search
 
 Read **[Semantic search, without the mystery box](semantic-search.md)** for the
 plain-language explanation of lexical, semantic, and hybrid search, including what an
@@ -87,7 +97,8 @@ Security claims should be boring enough to audit.
 Open the **[architecture maintenance hatch](architecture/README.md)**.
 
 Those documents contain the exact contracts for media handling, execution strategy,
-model custody, checkpoints, diarization, enhancement, and transcript retrieval.
+model custody, checkpoints, diarization, enhancement, transcript retrieval, and evidence
+navigation.
 
 ### 🧪 I am here to break things professionally
 
@@ -107,7 +118,8 @@ flowchart LR
     H --> T[Transcription engine room\nASR + checkpoints + enrichment]
     T --> A[Archivist\ncanonical transcript + exports]
     A --> L[Librarian\nlexical + semantic + hybrid search]
-    L --> E[Evidence you can inspect again]
+    L --> N[Navigator\nverify + highlight + context + seek]
+    N --> E[Evidence you can inspect again]
 
     classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
@@ -119,7 +131,7 @@ flowchart LR
     class H compute
     class T process
     class A evidence
-    class L,E result
+    class L,N,E result
 ```
 
 The shared rule across the whole family is simple:
@@ -136,12 +148,13 @@ EchoFlow uses different custody rules for different kinds of data.
 | Original recording | source evidence | **No** |
 | Canonical transcript JSON | authoritative transcript artifact | **No** |
 | Speaker display labels | user-authored knowledge | **No** |
-| Future notes, tags, annotations | user-authored knowledge | **No** |
+| Future notes, tags, annotations, saved searches, collections | user-authored knowledge | **No** |
 | TXT / SRT / WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
 | Checkpoint machinery after successful publication | execution/recovery state | Usually disposable after completion |
 | Lexical search database | derived search projection | Yes |
 | Semantic chunks and vectors | derived search projection | Yes |
+| Search context/highlight views | derived presentation over canonical evidence | Yes |
 
 If deleting a search index destroys unique user-authored information, something has gone
 very wrong.
@@ -163,26 +176,24 @@ The detailed editorial rules live in **[documentation-style.md](documentation-st
 
 ## What is next?
 
-The backend is now broad enough that the next work is less about inventing a
-transcription engine and more about making evidence easier to navigate and the product
-easier to enter.
+The evidence-navigation sequence that used to live here as future work is now mostly
+foundation:
 
-The evidence-navigation sequence has advanced:
+1. word/timestamp alignment is implemented;
+2. human elapsed time and source-declared temporal provenance are implemented;
+3. durable recording-scoped speaker display labels are implemented;
+4. handoff/overlap-aware speaker presentation is implemented; and
+5. search results can now resolve back to verified canonical segments/words, add bounded
+   context, show current speaker names, and expose a seek coordinate.
 
-1. **word/timestamp alignment** is in the foundation, so canonical evidence has finer
-   word coordinates;
-2. **human elapsed time + original-media temporal provenance** makes those coordinates
-   readable and preserves source-declared time clues without conflating clocks;
-3. **user-assigned speaker display labels** now keep human naming separate from anonymous
-   diarization evidence and rebuildable indexes;
-4. **better overlap presentation and aligned research-navigation UX** can exploit the
-   same coordinates for highlighting, click-to-audio, durable notes, and annotations;
-5. **later, source separation for overlapping speech** remains a measured capability,
-   not a premature checkbox.
+The next big product layer is therefore **durable research state**: notes, tags, saved
+searches, collections, and annotations anchored to those verified evidence locations.
+Semantic dependency/model setup, representative-device qualification, installers, and a
+thin graphical shell follow as major usability/qualification work.
 
-Packaging, installers, and a thin graphical interface remain important for ordinary
-non-developer use. The architecture is already intentionally arranged so those can sit
-on top of the same services rather than creating a second pipeline.
+Speech/source separation remains later. EchoFlow can now represent overlap honestly, so
+a separation model should earn its compute/model/provenance cost with measured benefit
+on real recordings.
 
 For the fuller sequencing and research boundary, see **[ROADMAP.md](../ROADMAP.md)**.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -26,6 +26,10 @@ flowchart LR
     X --> C[Canonical transcript]
     C --> E[Derived exports]
     C --> L[Rebuildable search projections]
+    L --> S[Ranked search passages]
+    C --> N[Verified evidence navigation]
+    S --> N
+    U[User-authored state] --> N
 
     classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
@@ -36,26 +40,26 @@ flowchart LR
     class A,C evidence
     class M,R,P compute
     class X process
-    class E publish
-    class L result
+    class E,U publish
+    class L,S,N result
 ```
 
 The architectural through-line is custody: source evidence and canonical transcript
-truth remain distinguishable from temporary execution state, model dependencies, and
-rebuildable search infrastructure.
+truth remain distinguishable from temporary execution state, model dependencies,
+rebuildable search infrastructure, and durable user-authored knowledge.
 
 ## Where to look
 
 | Page | What question it answers |
 |---|---|
-| [Processing capabilities](processing-capabilities.md) | How does the whole local transcription system fit together? |
+| [Processing capabilities](processing-capabilities.md) | How does the whole local transcription/research system fit together? |
 | [Adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) | How does EchoFlow decide what this machine can safely run? |
 | [Media and timeline](media-and-timeline.md) | What source did we inspect, which audio stream did we use, and what do timestamps mean? |
 | [Word-level timestamp alignment](word-alignment.md) | How do engine-produced word timings become source-relative evidence and improve speaker handoffs? |
 | [Local model management](model-management.md) | Which model revision is allowed to execute, and how did it get here? |
 | [Speech enhancement](speech-enhancement.md) | How can preprocessing affect ASR without becoming source truth? |
 | [Anonymous speaker diarization](diarization.md) | How are speaker turns represented without pretending anonymous labels are identities? |
-| [Corpus search](corpus-search.md) | How does canonical evidence become lexical/semantic/hybrid retrieval without becoming database-owned? |
+| [Corpus search](corpus-search.md) | How do lexical/semantic/hybrid ranking and verified canonical navigation stay separate? |
 | [ROADMAP](../../ROADMAP.md) | What is implemented, what is next, and what remains research? |
 | [SECURITY](../../SECURITY.md) | What does the security boundary actually claim? |
 
@@ -74,7 +78,7 @@ rebuildable search infrastructure.
 | `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language attribution, word alignment, diarization, assembly, exports |
 | `workspace` | Private job paths and public artifact allocation |
 | `benchmarking` | Privacy-minimized local execution measurement |
-| `library` | Evidence-first lexical/semantic retrieval over rebuildable transcript projections |
+| `library` | Lexical/semantic retrieval, canonical evidence navigation, speaker presentation, and durable library-side user state |
 
 A couple of names are easy to misread. `runner` means the local compute environment
 available to the process; it is not a distributed task runner. `media.probe` performs
@@ -90,6 +94,15 @@ serialization are valuable. Small internal immutable values generally use frozen
 dataclasses. Services use narrow `Protocol` capabilities when substitution is real and
 useful for testing or multiple implementations.
 
+The search/research area now has three deliberately separate authorities:
+
+1. retrieval services rank rebuildable passages;
+2. canonical evidence navigation verifies and locates those passages; and
+3. user-state services provide durable human-authored labels without rewriting evidence.
+
+That split should survive the GUI. Presentation convenience is not permission to merge
+custody boundaries.
+
 Structlog remains behind `core.observability.ILogger`; application services should not
 need to import Structlog directly.
 
@@ -101,12 +114,13 @@ These rules are load-bearing:
 2. **Canonical transcript/checkpoint artifacts carry execution truth.**
 3. **Managed model manifests describe verified local execution dependencies.**
 4. **Lexical and semantic databases are derived, private, and rebuildable.**
-5. **Future user-authored notes, labels, tags, collections, and annotations must not
+5. **User-authored speaker labels, and future notes/tags/collections/annotations, do not
    share deletion semantics with rebuildable indexes.**
-6. **A convenience layer may not quietly become the only place unique evidence lives.**
+6. **Precise navigation must resolve back to verified canonical evidence rather than
+   trusting a stale search projection.**
+7. **A convenience layer may not quietly become the only place unique evidence lives.**
 
-That fifth rule matters more as the product becomes a research library. Search
-infrastructure is allowed to disappear. User-authored knowledge is not.
+Search infrastructure is allowed to disappear. User-authored knowledge is not.
 
 ## New abstraction test
 

--- a/docs/architecture/corpus-search.md
+++ b/docs/architecture/corpus-search.md
@@ -1,60 +1,63 @@
 # Evidence-first corpus search 🔎🦝
 
-Status: lexical retrieval implemented; semantic/hybrid foundation implemented with a strict-local optional E5 adapter  
-Last updated: August 17, 2026
+Status: lexical, semantic/hybrid, and canonical evidence-navigation foundations implemented  
+Last updated: August 18, 2026
 
 ## The human version
 
 A transcript library should help you find **what was said** without quietly replacing
 your evidence with a database, vector store, or generated answer.
 
-EchoFlow therefore supports three ways to retrieve transcript passages:
+EchoFlow supports three retrieval modes:
 
 | Mode | Best when… | Example |
 |---|---|---|
-| Lexical | you remember the actual words, names, acronyms, or identifiers | `rent increase` |
+| Lexical | you remember actual words, names, acronyms, or identifiers | `rent increase` |
 | Semantic | you remember the idea but not the wording | `people struggling to afford housing` |
 | Hybrid | you want exact terminology and conceptual similarity to support each other | research across a mixed corpus |
 
-The result is still a passage from the transcript with timestamps and evidence context.
+Retrieval ranks a passage. A separate navigation layer can then verify the exact canonical
+transcript generation and resolve that passage back to canonical segments and aligned
+words.
 
-The load-bearing ownership rule is:
+The load-bearing rule remains:
 
-> **Canonical transcript JSON is evidence. Search databases are projections.**
-
-That one sentence explains a large amount of the implementation below.
+> **Canonical transcript JSON is evidence. Search databases and navigation views are projections.**
 
 ```mermaid
 flowchart LR
     A[Original recording] -->|read only| B[Canonical transcript JSON]
     B --> C[Lexical projection]
-    B --> D[Deterministic semantic chunks]
+    B --> D[Semantic chunks]
     C --> E[BM25 ranking]
     D --> F[Local embeddings]
     F --> G[Exact semantic ranking]
     E --> H[Optional hybrid fusion]
     G --> H
-    E --> I[Evidence-bearing results]
+    E --> I[Ranked SearchResponse]
     G --> I
     H --> I
+    I --> V[Verify canonical SHA]
+    V --> N[EvidenceLocation\nsegments + words + seek + context]
 
     classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
     classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
     classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
 
-    class A,B evidence
+    class A,B,V evidence
     class C,D derived
     class E,F,G,H process
-    class I result
+    class I,N result
 ```
 
-For a non-architecture explanation of embeddings and the local privacy boundary, read
-**[Semantic search, without the mystery box](../semantic-search.md)** first.
+For a non-architecture explanation, read **[Semantic search, without the mystery
+box](../semantic-search.md)** and **[From search result to the exact
+evidence](../evidence-navigation.md)** first.
 
-## 🦝 What lives under the floorboards? Three durability classes
+## 🦝 Three durability classes
 
-Search becomes much easier to reason about when data is classified by whether it can be
+Search becomes easier to reason about when data is classified by whether it can be
 reconstructed.
 
 ### Authoritative evidence
@@ -64,59 +67,60 @@ reconstructed.
 
 ### User-authored knowledge
 
-Future notes, tags, collections, speaker display labels, annotations, and saved searches
-belong here.
+Speaker display labels are implemented here. Future notes, tags, collections,
+annotations, and saved searches belong in the same durability class.
 
 They are **not retrieval cache**. An index rebuild must never delete them. Durable
 annotations should anchor to canonical evidence coordinates, not only to disposable
-semantic chunk IDs.
+semantic chunk IDs or formatted timestamps.
 
-### Rebuildable projections
+### Rebuildable projections and views
 
-- document projection;
-- segment projection;
+- document/segment projection;
 - lexical term statistics;
 - deterministic search chunks;
-- dense embeddings; and
-- retrieval statistics.
+- dense embeddings;
+- retrieval statistics; and
+- derived context/highlight/navigation presentation.
 
-If every search database disappeared, EchoFlow should be able to reconstruct search
-from canonical transcripts without losing unique user-authored information.
+If every search database disappeared, EchoFlow should be able to reconstruct search from
+canonical transcripts without losing unique user-authored information.
 
 ## Canonical hashing and stale-state refusal
 
 EchoFlow records two different SHA-256 digests in the lexical document projection:
 
-- `source_sha256`: the recording digest captured when transcription was planned;
-- `canonical_sha256`: the digest of the exact canonical transcript JSON bytes indexed
-  by the library.
-
-They answer different questions.
+- `source_sha256`: recording digest captured during transcription;
+- `canonical_sha256`: digest of the exact canonical transcript JSON bytes indexed by the
+  library.
 
 The original recording may remain byte-identical while the canonical transcript changes
 because it was regenerated, enriched, corrected, or replaced.
 
 Every semantic generation records a `corpus_fingerprint` derived from sorted
-`(document_id, canonical_sha256)` pairs.
+`(document_id, canonical_sha256)` pairs. Semantic/hybrid retrieval refuses stale vectors.
+
+Evidence navigation has an additional boundary: before exposing precise canonical
+segments/words, `EvidenceLocator` re-reads the canonical JSON and verifies its SHA-256,
+job ID, and source SHA against the ranked passage. A result whose indexed evidence no
+longer matches the canonical file fails closed rather than presenting stale precision.
 
 ```mermaid
-flowchart LR
-    A[Canonical JSON changes] --> B[Lexical rebuild sees new canonical SHA]
-    B --> C{Semantic fingerprint still matches?}
-    C -->|yes| D[Search normally]
-    C -->|no| E[Refuse semantic / hybrid search]
-    E --> F[Rebuild embeddings]
+flowchart TD
+    A[Ranked passage] --> B{Canonical SHA still matches?}
+    B -->|no| X[Refuse precise navigation]
+    B -->|yes| C{Result segment IDs still exist?}
+    C -->|no| X
+    C -->|yes| D[Resolve canonical words + context]
 
-    classDef changed fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef ok fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+    classDef result fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
     classDef stop fill:#FFD6D6,stroke:#9E3434,stroke-width:2px,color:#351616
 
-    class A,B changed
-    class C,D ok
-    class E,F stop
+    class A result
+    class B,C,D evidence
+    class X stop
 ```
-
-EchoFlow does not quietly search stale vectors.
 
 ## Lexical retrieval
 
@@ -140,28 +144,19 @@ SearchQuery
 
 User values remain parameterized. The storage adapter owns SQL. The user does not.
 
+Lexical tokenization is now a shared library text rule rather than a DuckDB-private
+helper. Ranking and exact canonical-word highlighting therefore use the same
+Unicode-aware token semantics instead of drifting independently.
+
 Lexical search remains the base/default mode and does not require a semantic runtime.
 
 ## Why semantic search needs chunks
 
-ASR segments are evidence coordinates, not automatically good retrieval units.
+ASR segments are evidence coordinates, not automatically good retrieval units. A
+canonical segment might contain only `Yeah.` or `And then we moved.`
 
-A canonical segment might contain only:
-
-```text
-Yeah.
-```
-
-or:
-
-```text
-And then we moved.
-```
-
-Embedding tiny fragments like that can lose useful surrounding meaning. EchoFlow
-therefore combines adjacent canonical segments into deterministic retrieval windows.
-
-`search-chunk-v1` currently uses:
+EchoFlow therefore combines adjacent canonical segments into deterministic retrieval
+windows. `search-chunk-v1` currently uses:
 
 - target size: 220 whitespace-delimited words;
 - maximum target size: 300 words;
@@ -174,11 +169,8 @@ therefore combines adjacent canonical segments into deterministic retrieval wind
 - sorted language and anonymous speaker references observed in the window.
 
 If one canonical segment is already larger than the target/max window, it remains one
-chunk. EchoFlow does not invent fake evidence coordinates merely to satisfy a retrieval
-heuristic.
-
-A search chunk is **never canonical evidence**. It is a disposable window pointing back
-to canonical segments.
+chunk. A search chunk is **never canonical evidence**. It is a disposable window
+pointing back to canonical segments.
 
 ## Embedding profile: the model is not the whole contract
 
@@ -199,70 +191,34 @@ resolved_revision    immutable snapshot revision
 embedding_schema     1
 ```
 
-That profile matters because two models can disagree about dimensions, pooling,
-normalization, query instructions, passage instructions, and distance semantics even if
-both advertise themselves as “embeddings.”
+The profile matters because dimensions, pooling, normalization, query instructions,
+passage instructions, and distance semantics are all load-bearing parts of one vector
+space.
 
-The model is replaceable. **The retrieval contract must remain explicit.**
-
-`EmbeddingProvider` therefore exposes separate methods:
-
-```python
-embed_queries(texts)
-embed_passages(texts)
-```
-
-E5 uses distinct query-side and passage-side transforms, so EchoFlow does not flatten
-the interface into a misleading generic `embed(text)` call.
+`EmbeddingProvider` exposes separate `embed_queries()` and `embed_passages()` operations.
+E5 uses distinct query-side and passage-side transforms, so EchoFlow does not flatten the
+interface into a misleading generic `embed(text)` call.
 
 ## Strict-local model boundary 🔐
 
-`SentenceTransformersE5Provider` accepts a local snapshot directory. The directory name
-must agree with the recorded immutable revision.
+`SentenceTransformersE5Provider` accepts a local snapshot directory whose name must
+agree with the recorded immutable revision. It uses local-only model resolution and
+disables remote model code.
 
-The provider loads `SentenceTransformer` from that local path with:
-
-- local-only model resolution; and
-- remote model code disabled.
-
-It never hands a repository ID to the runtime during indexing/search.
-
-Provider output is checked before it can replace valid semantic state. Validation covers:
-
-- non-empty text inputs;
-- one output vector per input;
-- exactly 384 dimensions for this profile;
-- finite numeric values; and
-- expected L2 normalization.
-
-A failed rebuild must not destroy the previous valid semantic generation.
-
-### Dependency boundary
+Provider output is validated for one vector per input, expected dimensions, finite
+numeric values, and L2 normalization before it may replace valid semantic state. A
+failed rebuild must not destroy the previous generation.
 
 The locked project dependency graph does **not yet** declare Sentence Transformers as a
-semantic extra. That is deliberate.
-
-Semantic search is currently an implemented optional capability for environments that
-already provide a compatible runtime and local immutable Multilingual E5 Small snapshot.
-A later qualification tranche can add an audited/locked semantic extra and managed model
-acquisition without changing the application retrieval contract.
-
-Lexical search remains fully available without it.
+semantic extra. Semantic search is therefore currently an advanced optional capability
+for environments that already provide a compatible runtime and immutable local model
+snapshot. Lexical search remains fully available without it.
 
 ## Numeric vector storage, now that we have earned the jargon
 
-EchoFlow keeps semantic vectors as numeric data that the current search backend can
-inspect directly.
-
-In `DuckDbSemanticIndex`, vectors are stored as DuckDB `FLOAT[]` rather than opaque
-BLOBs.
-
-There. We have reached the sentence that used to be thrown at readers without a
-staircase. 💃
-
-The application boundary remains `tuple[float, ...]`, so a later adapter can choose a
-fixed-length vector type, compressed representation, or different backend without
-changing the domain contract.
+`DuckDbSemanticIndex` stores vectors as numeric DuckDB `FLOAT[]`, not opaque BLOBs. The
+application boundary remains `tuple[float, ...]`, so a later backend can choose a
+different physical representation without changing the domain contract.
 
 The semantic database is private rebuildable state under:
 
@@ -270,147 +226,157 @@ The semantic database is private rebuildable state under:
 STATE_DIR/library/semantic.duckdb
 ```
 
-It is intentionally separate from the lexical database in this tranche so semantic
-storage/rebuild evolution does not destabilize the already-working BM25 path.
+It is intentionally separate from the lexical database so semantic evolution does not
+destabilize the dependency-light BM25 path.
 
 ## Exact local similarity first
 
 The first semantic implementation performs an **exact scan** over eligible local chunks.
+Hard filters are applied before top-K ranking for transcript IDs, language, speaker,
+phrase constraints, and `ALL` lexical terms where applicable.
 
-Hard filters are applied before top-K ranking:
-
-- transcript/document IDs;
-- language;
-- speaker;
-- exact phrase when requested; and
-- `ALL` lexical terms when requested.
-
-Filtering first avoids starvation. A search constrained to one speaker must not inspect
-the global top 100 vectors and only afterward discover that none belonged to that
-speaker.
-
-No ANN/HNSW index exists yet. Approximate nearest-neighbor indexing is an optimization,
-not a product requirement. It should appear only when measured corpus size shows that an
-exact local scan misses an interactive latency target.
+No ANN/HNSW index exists yet. Approximate nearest-neighbor indexing is an optimization
+that should appear only when measured corpus size shows exact local scan no longer meets
+an interactive latency target.
 
 An 8 GB laptop should not pay an ANN tax because ANN is fashionable.
 
-## 💃 Bringing the ranks together: hybrid retrieval
+## 💃 Hybrid retrieval
 
 Lexical BM25 scores and dense semantic similarity scores do not share one trustworthy
-scale.
-
-EchoFlow therefore does not normalize them into a fake universal relevance probability.
-It combines **ranks** using reciprocal rank fusion (RRF) with `k=60`.
-
-```mermaid
-flowchart TD
-    Q[SearchQuery] --> L[Lexical retrieval / BM25]
-    Q --> S[Semantic retrieval / exact dense search]
-    L --> LR[Lexical chunk ranks]
-    S --> SR[Semantic chunk ranks]
-    LR --> R[RRF k=60]
-    SR --> R
-    R --> E[Evidence-bearing SearchResponse]
-
-    classDef query fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef rank fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef fuse fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class Q query
-    class L,S,LR,SR rank
-    class R fuse
-    class E result
-```
-
-The core formula is:
+scale. EchoFlow combines **ranks** using reciprocal rank fusion (RRF) with `k=60`:
 
 ```text
 RRF(d) = Σ 1 / (60 + rank_i(d))
 ```
 
-Hybrid retrieval overfetches candidate ranks before fusion so one retrieval mode has
-room to contribute candidates that the other missed. Current implementation bounds the
-candidate pool rather than allowing unbounded work.
+Hybrid retrieval overfetches bounded candidate ranks before fusion so one mode can
+contribute passages the other missed. `SearchResponse` preserves lexical, semantic, and
+fused ranks. Timeline presentation may reorder results chronologically without rewriting
+those stored relevance ranks.
 
-`SearchResponse` preserves lexical, semantic, and fused rank provenance. Timeline
-presentation may reorder results chronologically without falsely rewriting that stored
-relevance rank.
+## SearchResponse is ranking provenance, not the final research view
 
-## Evidence-bearing results
-
-The retrieval response is not just `text + score`.
-
-A `SearchPassage` can carry:
+`SearchPassage` carries enough evidence to identify the ranked window:
 
 - document/source identity;
 - canonical transcript identity/hash;
-- deterministic chunk ID;
+- optional deterministic chunk ID;
 - constituent canonical segment IDs;
-- start/end timestamps;
-- speaker and language evidence;
-- lexical rank;
-- semantic rank;
-- fused rank; and
-- the actual transcript passage.
+- lexical matched-segment IDs when available;
+- source-relative start/end timestamps;
+- anonymous speaker/language evidence;
+- lexical/semantic/fused ranks; and
+- transcript passage text.
 
-That means a presentation layer can show a useful result while retaining the route back
-to source evidence.
+It deliberately does **not** pretend to be a fully resolved canonical annotation target.
+That is the job of the next layer.
+
+## Canonical evidence navigation
+
+`EvidenceLocator` takes a `SearchResponse` and resolves each ranked passage back to the
+verified canonical transcript.
+
+The derived `EvidenceLocation` includes:
+
+- exact canonical/source identity;
+- result segment IDs;
+- numeric result start/end;
+- a deterministic `seek_seconds` coordinate;
+- result speaker refs observed in canonical segment/word evidence;
+- exact matched aligned words when justified; and
+- bounded canonical context segments.
+
+Context expansion is controlled after ranking, currently by `--context-segments 0..10`.
+It does not feed neighboring text back into BM25/dense ranking.
+
+### Exact highlighting is intentionally asymmetric
+
+A lexical result identifies matched canonical segment evidence. When aligned words exist,
+EchoFlow can apply the same lexical token semantics to those canonical words and expose
+exact highlighted word coordinates.
+
+Phrase queries require contiguous query tokens before words are marked as the phrase.
+
+A semantic-only result has no equivalent exact-word claim. It receives canonical passage
+navigation and a seek coordinate, but **no fabricated word highlight**.
+
+Hybrid results may contain exact lexical highlights when lexical evidence contributed to
+the fused result.
+
+This asymmetry is intentional. Embedding similarity answers “which passage is related?”
+It does not answer “which exact word caused the similarity?”
+
+## Speaker display integration
+
+`ResearchNavigationService` composes three authorities without merging them:
+
+1. `TranscriptLibraryService` ranks passages;
+2. `EvidenceLocator` verifies/resolves canonical coordinates;
+3. `SpeakerLabelService` adds current user-authored display names for the exact canonical
+   generation.
+
+A human may see `Dr. Chen (speaker-02)`, while JSON retains raw `speaker_refs` and exposes
+friendly labels separately. Ranking/filtering continues to use anonymous evidence refs.
+
+Label resolution is batched per canonical generation so a large result set does not
+reread private speaker-label state once per row.
+
+```mermaid
+flowchart LR
+    R[SearchResponse] --> N[ResearchNavigationService]
+    C[Verified canonical evidence] --> N
+    U[User speaker labels] --> N
+    N --> V[LocatedSearchPassage]
+
+    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class R derived
+    class C evidence
+    class U user
+    class N,V view
+```
+
+That service is intended for CLI, future GUI, Python, and other presentation adapters.
+The terminal does not own the navigation semantics.
+
+## Future notes can reuse the same coordinate system
+
+Notes and annotations are not implemented yet, but this navigation layer establishes the
+anchor they should reuse: canonical/source identity, segment IDs, word indices where
+available, and numeric source-relative seconds.
+
+A note should never depend only on a formatted timestamp or disposable semantic chunk
+ID. If canonical evidence changes, EchoFlow should retain user knowledge and report the
+stale anchor instead of silently moving it.
 
 ## Provider interoperability without model roulette
 
 The search core depends on `EmbeddingProvider` + `EmbeddingProfile`, not an E5-specific
-domain type.
-
-Tests include a fake non-E5 provider to prove that the application/service contract is
-provider-agnostic.
-
-The ordinary CLI nevertheless qualifies one concrete profile today. It does **not**
-accept arbitrary Hugging Face repository IDs as if all embedding models were
-interchangeable.
+domain type. The ordinary CLI nevertheless qualifies one concrete profile today rather
+than accepting arbitrary model IDs as interchangeable.
 
 A future provider registry can expose additional qualified local profiles once EchoFlow
 can validate their full retrieval contract.
 
-## What happens when a better model arrives?
-
-Canonical transcripts do not need to migrate.
-
-```mermaid
-flowchart LR
-    T[Canonical transcripts] --> P1[Embedding profile v1]
-    T --> P2[Embedding profile v2]
-    P1 --> V1[Old rebuildable vectors]
-    P2 --> V2[New rebuildable vectors]
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef profile fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-
-    class T evidence
-    class P1,P2 profile
-    class V1,V2 derived
-```
-
-Vectors are derived state. Replace the qualified profile, rebuild the semantic
-projection, keep the evidence.
-
 ## Current deliberate limits
 
-The current search system does not provide:
+The current search/navigation system does not provide:
 
-- generated corpus answers or “chat with your transcripts” as the primary interface;
+- generated corpus answers as the primary interface;
 - arbitrary-model CLI selection;
 - bundled embedding weights;
-- ANN/HNSW;
-- learned reranking;
-- saved searches, collections, tags, notes, or annotations; or
-- word-level alignment for sub-segment highlighting/anchoring.
+- ANN/HNSW or learned reranking;
+- saved searches, collections, tags, notes, or annotations;
+- a graphical local media player;
+- cross-recording biometric/person identity; or
+- source separation for overlapping speech.
 
-The next retrieval UX work should be driven by real corpora: snippets/highlighting,
-context expansion, facets, exportable result sets, precise jump-to-audio, saved/user
-state, and finer alignment coordinates.
+Those are separate product layers. The current frontier is durable user-authored research
+state over the verified evidence coordinates that search navigation now exposes.
 
 The product rule stays evidence-first:
 

--- a/docs/architecture/processing-capabilities.md
+++ b/docs/architecture/processing-capabilities.md
@@ -1,12 +1,12 @@
 # Processing capabilities 🎛️
 
 EchoFlow is not one giant transcription function. It composes small local capabilities
-into a reproducible job whose source, execution choices, recovery state, transcript, and
-search projections remain explainable afterward.
+into a reproducible workflow whose source, execution choices, recovery state, transcript,
+search projections, and research-navigation views remain explainable afterward.
 
 This page is the **family portrait** for maintainers.
 
-For the narrower contracts, see:
+For narrower contracts, see:
 
 - [adaptive heterogeneous execution](adaptive-heterogeneous-execution.md);
 - [media and timeline](media-and-timeline.md);
@@ -18,17 +18,18 @@ For the narrower contracts, see:
 
 ## What the user experiences
 
-The intended experience is much simpler than the machinery:
+The intended experience is simpler than the machinery:
 
 1. give EchoFlow a recording;
 2. let it inspect the source and current machine;
 3. install a recommended model explicitly if needed;
 4. transcribe locally;
 5. resume if interrupted;
-6. export useful views; and
-7. search completed transcripts later.
+6. export useful views;
+7. search completed transcripts; and
+8. follow a result back to verified canonical evidence.
 
-Underneath that, EchoFlow is preserving enough evidence to explain how each result was
+Underneath that, EchoFlow preserves enough evidence to explain how each result was
 produced.
 
 ```mermaid
@@ -38,11 +39,13 @@ flowchart LR
     C --> D[Build immutable plan]
     D --> E[Normalize / enhance if needed]
     E --> F[Segment + local ASR]
-    F --> G[Word timing + ordered checkpoints]
+    F --> G[Word timing + checkpoints]
     G --> H[Language + optional speaker evidence]
     H --> I[Canonical transcript]
     I --> J[Derived exports]
     I --> K[Lexical / semantic search]
+    K --> N[Verify + highlight + context + seek]
+    U[User speaker labels] --> N
 
     classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef inspect fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
@@ -53,24 +56,21 @@ flowchart LR
     class A,I evidence
     class B,C,D inspect
     class E,F,G,H process
-    class J publish
-    class K result
+    class J,U publish
+    class K,N result
 ```
-
-That diagram is the product shape in one picture.
 
 ## 1. Media inspection: what is this file?
 
-`FfprobeMediaProbe` owns source facts, not transcoding.
+`FfprobeMediaProbe` owns source facts, not transcoding. It reads bounded FFprobe metadata
+with file-only protocol access, fingerprints the complete source, and refuses a file
+whose observed identity changes during inspection.
 
-It reads bounded FFprobe metadata with file-only protocol access, fingerprints the
-complete source, and refuses a file whose observed identity changes during inspection.
+`AudioStreamSelector` chooses one deterministic audio stream. The choice becomes
+provenance and resume restores it instead of silently choosing another track.
 
-`AudioStreamSelector` then chooses one deterministic audio stream, using the first audio
-stream by default or an explicit `--audio-stream INDEX`.
-
-The stream choice becomes provenance. Resume restores it rather than silently selecting
-a different track.
+Source-declared `timecode` and `creation_time` tags are preserved with format/stream
+scope when available. They remain provenance, not canonical elapsed-time authority.
 
 ## 2. Resource/runtime inspection: what can this computer really do?
 
@@ -78,12 +78,9 @@ a different track.
 including relevant affinity/cgroup limits.
 
 `HardwareTopologyInspector` adds physical accelerator evidence.
-
 `EngineCapabilityRegistry` separately asks the installed engine/runtime which concrete
-device/compute targets are actually executable.
-
-`StrategyEvaluator` admits and ranks safe strategies against system RAM, device memory,
-runtime capability, and profile intent.
+device/compute targets are executable. `StrategyEvaluator` admits/ranks safe strategies
+against RAM, device memory, runtime capability, and profile intent.
 
 A visible GPU is not assumed usable. Shared/unified accelerator memory is not counted as
 bonus physical RAM. Explicit impossible strategies fail instead of being silently
@@ -92,18 +89,14 @@ replaced.
 See [adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) for the
 whole hardware cabaret. 💃
 
-## 3. Model custody: which exact dependency is allowed to execute?
+## 3. Model custody: which exact dependency may execute?
 
-A safe strategy is not executable until its selected faster-whisper model has a verified
+A strategy is not executable until its selected faster-whisper model has a verified
 managed immutable revision.
 
-`ModelManager` owns explicit ASR acquisition/custody. Planning asks it for the locally
-revalidated resolved revision.
-
-If the model is not managed, planning fails with an install-first message.
-
-At execution time, faster-whisper runs with `local_files_only=True` and the exact
-revision already recorded in the plan.
+`ModelManager` owns explicit acquisition/custody. Planning asks it for the locally
+revalidated revision. At execution, faster-whisper uses local-only model resolution and
+the exact revision already recorded in the plan.
 
 No transcription-time ASR download fallback exists.
 
@@ -121,126 +114,141 @@ mono
 Already-canonical WAV may use `DIRECT`; other supported audio-bearing media uses
 `FFMPEG_NORMALIZE`.
 
-Normalization changes representation, not the public transcript timeline.
-
-Exact PCM frame intervals define durable work windows.
+Normalization changes representation, not the public transcript timeline. Exact PCM
+frame intervals define durable work windows.
 
 ## 5. Optional enhancement: help ASR without rewriting the source
 
-When `--enhance` is enabled, the current `FfmpegAfftdnEnhancer` creates a private
-`enhanced.wav` from canonical audio using the fixed current filter contract.
+When `--enhance` is enabled, `FfmpegAfftdnEnhancer` creates private enhanced audio from
+canonical audio using the fixed current filter contract.
 
-ASR may consume the enhanced derivative. The original recording remains authoritative.
-
-EchoFlow checks channel count, sample width, sample rate, and frame count before
-accepting the derivative so preprocessing cannot quietly shift the transcript timeline.
+ASR may consume the derivative. The original recording remains authoritative. EchoFlow
+checks channel count, sample width, sample rate, and frame count before accepting the
+derivative so preprocessing cannot quietly shift transcript time.
 
 Anonymous diarization deliberately continues to read the unmodified canonical decode in
 enhancement v1.
 
-## 6. Segmentation, word timing, and checkpointing: make interruption survivable
+## 6. Segmentation, word timing, and checkpointing
 
 EchoFlow owns deterministic segmentation:
 
 - exact integer PCM frame boundaries;
-- stable zero-based `audio-XXXXXX` work IDs;
+- stable zero-based work IDs;
 - 600-second maximum work windows;
 - no work-window overlap;
 - one job-scoped ASR session; and
 - strictly ordered checkpoint commits.
 
-The faster-whisper session requests native word timestamps. Each engine-produced word is
-validated inside its ASR segment and later rebased from work-window time onto the same
-source-relative timeline as the canonical segment.
+The faster-whisper session requests native word timestamps. Engine-produced words are
+validated and rebased from work-window time onto the same source-relative timeline as
+canonical segments.
 
-Per-window checkpoints persist that word evidence. The checkpoint manifest records an
-explicit alignment identity so a pre-alignment checkpoint cannot silently resume into a
-partially aligned transcript.
+Per-window checkpoints persist aligned word evidence. The manifest records alignment
+identity so incompatible pre-alignment state cannot silently resume into a mixed job.
 
 Accelerated execution may materialize at most one future segment while the current one
-is being inferred.
+is inferred. Completed checkpoints must remain a contiguous prefix of the deterministic
+work plan.
 
-A completed checkpoint set must remain a contiguous prefix of the deterministic work
-plan.
+Resume restores the source/model/device/decode/enhancement/segmentation/alignment
+contract and re-admits current resources.
 
-Resume restores the original source/model/device/decode/enhancement/segmentation and
-alignment contract and re-admits current resources.
+## 7. Recognition and multilingual attribution
 
-## 7. Recognition, word alignment, and multilingual attribution
+The faster-whisper backend performs managed local ASR plus native word timing. EchoFlow
+does not currently run a separate forced-alignment model.
 
-The faster-whisper backend performs managed local ASR and preserves its native per-word
-timing evidence. EchoFlow does not run a separate forced-alignment model in this tranche.
+With no explicit language, multilingual behavior can reconsider language within durable
+work units rather than latching one job-wide prompt forever.
 
-With no explicit language, the current multilingual behavior can reconsider language
-within durable work units rather than latching one job-wide acoustic prompt forever.
-
-Published text-language labels come from local deterministic language attribution,
-which can leave ambiguous short text unlabeled rather than fabricating certainty.
-
-This is better support for changing languages, not a claim of perfect arbitrary
-word-level code-switch attribution.
+Published text-language labels come from local deterministic attribution, which may leave
+ambiguous short text unlabeled rather than fabricating certainty.
 
 ## 8. Optional anonymous speaker evidence
 
 Diarization is recording-scoped enrichment, not identity.
 
-The current pyannote capability is security-gated because the locked Lightning
-dependency is affected by a compensated advisory. EchoFlow refuses the vulnerable path
-before pyannote import/model acquisition.
+The pyannote capability remains security-gated because the locked Lightning dependency
+is affected by a compensated advisory. EchoFlow refuses the vulnerable path before
+provider execution/model acquisition.
 
-When operationally qualified, diarization contributes an exact speaker-turn timeline.
-Word timing now gives projection a finer evidence coordinate than an entire ASR segment:
-a word receives a speaker only when exactly one diarized speaker overlaps its interval.
+When speaker evidence exists, word timing provides a finer projection coordinate than a
+whole ASR segment. A word receives a speaker only when exactly one diarized speaker
+overlaps that word interval.
 
-The enclosing segment keeps a convenience `speaker_ref` only when every aligned word is
-attributed to the same speaker. Mixed handoffs and ambiguous overlap therefore remain
-explicit instead of being flattened into one guessed label.
+The enclosing segment keeps a convenience `speaker_ref` only when aligned words support
+one uniform speaker. Mixed handoffs and ambiguous overlap stay explicit.
+
+The library adds two human-facing layers without rewriting that evidence:
+
+- durable user-authored names such as `speaker-02 → Dr. Chen`, bound to the exact canonical
+  transcript generation; and
+- an overlap-aware derived transcript that distinguishes `single-speaker`, `overlap`,
+  `mixed-unresolved`, and `unattributed` states.
+
+No biometric identity or cross-recording person inference occurs.
 
 ## 9. Canonical transcript and derived exports
 
 Canonical JSON is authoritative transcript evidence.
 
-The current contract records source/stream provenance, execution plan identity,
-managed model revision, source-relative segment timestamps, nested source-relative word
-timing evidence, language evidence, optional enhancement provenance, and optional
-diarization evidence.
+It records source/stream provenance, execution-plan identity, managed model revision,
+source-relative segment and word timing, language evidence, optional enhancement
+provenance, source-declared temporal tags, and optional diarization evidence.
 
-TXT, SRT, and WebVTT remain deterministic segment-oriented publication views.
+TXT, SRT, and WebVTT remain deterministic segment-oriented publication views. They are
+useful. They are not recognition truth.
 
-They are useful. They are not recognition truth. More expressive word/speaker rendering
-belongs to later presentation work rather than quietly changing caption semantics in the
-alignment tranche.
-
-## 10. Transcript library and search 🦝
+## 10. Transcript library and retrieval 🦝
 
 Canonical transcript JSON can be projected into private rebuildable search state.
 
-Lexical retrieval uses the database-neutral `TranscriptIndex` application port and a
-current DuckDB BM25 implementation.
-
-Semantic retrieval adds deterministic segment-anchored chunks, an
-`EmbeddingProvider`/`EmbeddingProfile` contract, strict-local Multilingual E5 Small,
-private numeric vectors, exact dense similarity, and corpus-fingerprint stale-state
-refusal.
+Lexical retrieval uses the database-neutral `TranscriptIndex` application port and
+DuckDB BM25 adapter. Semantic retrieval adds deterministic segment-anchored chunks,
+`EmbeddingProvider`/`EmbeddingProfile`, strict-local Multilingual E5 Small, private
+numeric vectors, exact dense similarity, and stale-corpus refusal.
 
 `TranscriptSearch` can combine lexical and semantic ranks with RRF while preserving
-lexical, semantic, and fused provenance in one evidence-bearing `SearchResponse`.
+lexical, semantic, and fused provenance in one `SearchResponse`.
 
-The current search projection deliberately ignores nested word evidence and indexes
-canonical segment text once. Future highlighting/jump-to-audio UX may consume word
-coordinates without changing the ranking contract.
+Nested word evidence remains outside ranking storage. Search indexes canonical segment
+text once.
 
-Search infrastructure must never become the only home of future user-authored notes,
-labels, tags, collections, or annotations.
+## 11. Canonical evidence navigation
 
-## 11. Private storage and observability
+Retrieval and navigation are separate capabilities.
 
-Structured logging uses Structlog behind `ILogger`.
+`EvidenceLocator` takes ranked passages and re-verifies the exact canonical transcript
+SHA/source identity before exposing precise coordinates. It can then:
 
-Routine logs redact local paths by default.
+- resolve result segment IDs;
+- expose exact aligned words for lexical matches;
+- preserve phrase contiguity for exact phrase highlighting;
+- avoid exact-word claims for semantic-only results;
+- add bounded neighboring canonical context; and
+- choose a deterministic source-relative seek coordinate.
 
-Private job/checkpoint state, model caches, normalized/enhanced audio, and segment
-materializations remain distinct from user-visible transcript artifacts.
+`ResearchNavigationService` composes that canonical location with current user-assigned
+speaker display labels. Ranking/filtering still uses anonymous refs; presentation may
+show `Dr. Chen (speaker-02)`.
+
+This service is deliberately reusable by CLI, future GUI, Python, and other adapters.
+The terminal is not the owner of research-navigation semantics.
+
+## 12. Private storage, user state, and observability
+
+Structured logging uses Structlog behind `ILogger`. Routine logs redact local paths by
+default.
+
+Private job/checkpoint state, model caches, normalized/enhanced audio, segment
+materializations, search databases, and user-authored state remain distinct from
+user-visible transcript artifacts.
+
+Speaker display labels are the first implemented durable library-side user state. Future
+notes/tags/collections/annotations must share the **durability class**, not necessarily
+the same physical JSON adapter. Higher-volume mutable/queryable research state will
+likely justify a transactional user-state store behind application ports.
 
 POSIX private state uses owner-only mode policy; Windows uses current-user DACL policy.
 These are filesystem access controls, not application-level encryption or secure
@@ -268,11 +276,14 @@ erasure.
 | `SpeakerDiarizer` | anonymous speaker-turn evidence | biometric identity |
 | `TranscriptExporter` | derived TXT/SRT/VTT | recognition truth |
 | `TranscriptIndex` | database-neutral lexical search contract | semantic execution |
-| `DuckDbTranscriptIndex` | private BM25 projection | canonical transcript truth |
+| `DuckDbTranscriptIndex` | private BM25 projection | canonical truth |
 | `EmbeddingProvider` | query/passage embedding semantics | corpus custody |
-| `DuckDbSemanticIndex` | rebuildable vector state + exact similarity | canonical evidence |
+| `DuckDbSemanticIndex` | rebuildable vectors + exact similarity | canonical evidence |
 | `TranscriptSearch` | retrieval composition + RRF | storage implementation |
-| `TranscriptLibraryService` | discovery/rebuild/stale-state/retrieval/integrity receipts | SQL ownership |
+| `TranscriptLibraryService` | discovery/rebuild/stale-state/retrieval/integrity receipts | user annotations |
+| `SpeakerLabelService` | durable human names over anonymous refs | diarization evidence |
+| `EvidenceLocator` | verified canonical result coordinates | ranking |
+| `ResearchNavigationService` | retrieval + location + display composition | canonical mutation |
 | `WorkspaceService` | private/public path allocation | audio semantics |
 
 Protocols exist around real substitutable behavior, not because every class deserves a
@@ -282,40 +293,39 @@ ceremonial interface.
 
 EchoFlow does not currently claim:
 
-- calibrated performance across representative hardware;
+- calibrated performance across representative consumer hardware;
 - every visible accelerator is useful/faster;
 - alternate ASR engines;
 - arbitrary word-level code-switch attribution;
 - independent forced alignment or phoneme-level timing;
-- biometric speaker identity;
-- user-assigned speaker display labels;
-- polished overlap handling;
-- simultaneous-speaker/source separation;
+- biometric or cross-recording speaker identity;
+- speech/source separation;
 - generative restoration;
 - automatic enhancement selection;
-- original SMPTE/container/capture-time provenance beyond source-relative elapsed time;
+- trusted deterministic SMPTE/PTS mapping beyond preserved source declarations;
 - storage durability across sudden power loss;
 - malicious same-user TOCTOU resistance;
 - secure erasure;
 - a qualified locked semantic dependency extra;
-- ANN/HNSW, learned reranking, generated corpus answers, or durable user annotations;
-  or
+- ANN/HNSW, learned reranking, or generated corpus answers;
+- durable notes/tags/collections/annotations/saved searches; or
 - a polished installer/desktop GUI.
 
-## What is becoming the next product layer?
+## What is the next product layer?
 
-Word timing establishes the first finer-grained evidence coordinate below an ASR segment.
-The next high-value work is increasingly about using and extending that evidence:
+Word timing, time provenance, speaker naming, overlap presentation, and aligned search
+navigation are now foundation.
 
-1. original-media timecode and capture-time provenance;
-2. better speaker overlap presentation and user-assigned display labels;
-3. search highlighting, precise jump-to-audio, and durable annotation UX over aligned
-   coordinates; and
-4. later, source separation for genuinely overlapping speech when evidence and measured
-   benefit justify the additional model/compute complexity.
+The next major product layer is **durable user-authored research state over verified
+evidence locations**: notes, tags, saved searches, collections, annotations, and
+exportable/citable selected result sets.
 
-Those capabilities strengthen the user experience without changing the architecture's
-central rule:
+After that come semantic-install qualification, representative-device dogfooding, and a
+beginner-friendly installer/thin graphical shell over these same application services.
+
+Source separation remains later and evidence-driven. EchoFlow can now represent overlap
+honestly; another model should earn its compute/custody/provenance burden with measured
+benefit.
 
 > **Source evidence stays authoritative. Derived machinery stays explainable. User
 > knowledge does not get mistaken for cache.**

--- a/docs/architecture/word-alignment.md
+++ b/docs/architecture/word-alignment.md
@@ -2,25 +2,25 @@
 
 A transcript that says *what* somebody said is useful. A transcript that can also point
 to **when each word occurred** is much more useful for speaker handoffs, search
-highlighting, jump-to-audio, precise annotations, and later editing interfaces.
+highlighting, source seeking, precise annotations, and later editing interfaces.
 
-EchoFlow now preserves word timing evidence already produced by faster-whisper. It does
-not invent timestamps from character positions, and it does not run a separate forced
-alignment model in this tranche.
+EchoFlow preserves word timing evidence already produced by faster-whisper. It does not
+invent timestamps from character positions, and it does not currently run a separate
+forced-alignment model.
 
 > **The rule:** preserve the engine's word evidence, put it on the same source-relative
 > timeline as the canonical transcript, and stay conservative when that evidence is
 > ambiguous.
 
-🦝 The scholarly raccoon would like the record to show that “more precise coordinates”
-does not mean “permission to become more confident than the evidence.”
+🦝 “More precise coordinates” does not mean “permission to become more confident than
+the evidence.”
 
 ## What changes for a user?
 
-Usually, nothing about the command.
+Usually, nothing about the transcription command.
 
-Word timing is part of the current faster-whisper transcription contract. A normal local
-transcription can now produce canonical segment evidence shaped conceptually like:
+Word timing is part of the current faster-whisper execution/checkpoint contract. A normal
+local transcription can produce canonical evidence shaped conceptually like:
 
 ```text
 segment  12.40s ─ 15.10s   "we moved the meeting to Friday"
@@ -33,23 +33,20 @@ word     14.20s ─ 14.45s   " to"
 word     14.45s ─ 15.10s   " Friday"
 ```
 
-The exact word token text is retained from the engine, including meaningful leading
-whitespace. Presentation code may trim or style that text later; canonical evidence does
-not quietly rewrite it for aesthetics.
+Exact engine token text is retained, including meaningful leading whitespace.
+Presentation may trim/style later; canonical evidence does not rewrite it for aesthetics.
 
 ## The timeline stays the same
 
-EchoFlow already owns deterministic work windows over canonical decoded audio. The ASR
-engine sees one materialized window at a time and returns timestamps relative to that
-window.
-
-Alignment extends the existing assembly rule to words:
+EchoFlow owns deterministic work windows over canonical decoded audio. Faster-whisper
+returns timestamps relative to one work window. Assembly rebases both segment and word
+intervals onto one source-relative timeline.
 
 ```mermaid
 flowchart LR
     A[Source audio timeline] --> B[Deterministic work window]
     B --> C[Faster-whisper]
-    C --> D[Segment-relative words]
+    C --> D[Window-relative words]
     D --> E[Source-relative word evidence]
     E --> F[Canonical transcript JSON]
 
@@ -62,11 +59,11 @@ flowchart LR
     class E,F result
 ```
 
-If work window 7 begins at source second `4200` and the engine reports a word at
-`21.70s`, the canonical word starts at source second `4221.70`.
+If work window 7 begins at source second `4200` and the engine reports a word at `21.70`,
+the canonical word starts at `4221.70`.
 
-Segmentation is therefore still an execution detail. It does not reset public word
-coordinates to zero every ten minutes.
+Segmentation is an execution detail. It does not reset published word time every ten
+minutes.
 
 ## Evidence model
 
@@ -78,61 +75,52 @@ coordinates to zero every ten minutes.
 - optional engine word probability; and
 - optional anonymous `speaker_ref` after diarization projection.
 
-`AlignedRecognizedSegment` retains the existing segment contract and adds an ordered
-`words` tuple.
+`AlignedRecognizedSegment` retains the segment contract and adds an ordered `words`
+tuple.
 
-Word evidence is validated before it can become canonical state:
+Validation requires finite/non-negative ordered time, segment containment within a small
+boundary tolerance, ordered non-overlapping word intervals beyond that tolerance,
+probability within zero-to-one when present, and non-blank word evidence.
 
-- timestamps must be finite and non-negative;
-- end may equal start because EchoFlow does not fabricate duration for a zero-duration
-  engine observation;
-- words must remain in timeline order;
-- overlapping word intervals are rejected beyond a small boundary tolerance;
-- words must remain within their containing segment beyond that same tolerance;
-- probability, when present, must be finite and between zero and one; and
-- blank word tokens are not accepted as evidence.
-
-The boundary tolerance exists for small floating-point/engine rounding differences. It
-changes **validation**, not stored timestamps. EchoFlow does not nudge every timestamp
-onto a prettier grid.
+The tolerance handles small floating-point/engine boundary differences. It changes
+**validation**, not stored timestamps. EchoFlow does not nudge timestamps onto a prettier
+grid.
 
 ## Is this forced alignment?
 
 No.
 
-A forced aligner usually takes known text plus audio and performs a separate alignment
-step intended to reconcile that text to acoustic time. This tranche does not do that.
+A forced aligner usually takes known text plus audio and performs a separate acoustic
+alignment pass. EchoFlow asks faster-whisper for its native word timing and preserves it.
 
-EchoFlow asks faster-whisper to return its native word timestamps and preserves them.
-That has three useful properties:
+That avoids another model/download and another heavy inference pass, while keeping timing
+attributable to the same managed ASR execution that produced the text.
 
-1. no additional alignment model or model download;
-2. no second heavy inference pass merely to obtain word coordinates; and
-3. timing evidence remains attributable to the same managed ASR execution that produced
-   the recognized text.
-
-It also means EchoFlow should not advertise these timestamps as independently corrected
+It also means EchoFlow should not advertise native word timing as independently corrected
 forced-alignment truth.
 
 ## Speaker handoffs get much better 💃
 
-Before word timing, ASR segments and diarization turns had different boundaries. If one
-ASR segment crossed from `speaker-01` to `speaker-02`, EchoFlow correctly left the whole
-segment unlabeled rather than guessing.
+ASR segments and diarization turns have different boundaries. Word intervals let EchoFlow
+project anonymous turns onto smaller evidence coordinates.
 
-With word intervals, diarization can project onto the finer evidence:
+A word receives a speaker only when exactly one diarized speaker overlaps that word
+interval. The enclosing segment keeps a convenience speaker only when the aligned words
+support one uniform speaker.
+
+Mixed handoffs and ambiguous overlap therefore remain explicit.
 
 ```mermaid
 flowchart TD
-    A[ASR segment spans two speakers] --> B[Aligned words]
+    A[ASR segment spans speakers] --> B[Aligned words]
     B --> C[Compare each word with speaker turns]
     C --> D{Exactly one speaker overlaps?}
-    D -->|yes| E[Attach anonymous speaker ref to word]
+    D -->|yes| E[Attach anonymous ref to word]
     D -->|no| F[Leave word unattributed]
-    E --> G{Every word has the same speaker?}
+    E --> G{Every word same speaker?}
     F --> G
-    G -->|yes| H[Also keep segment-level convenience label]
-    G -->|no| I[Segment speaker stays null]
+    G -->|yes| H[Keep segment convenience label]
+    G -->|no| I[Segment speaker remains null]
 
     classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
@@ -145,84 +133,86 @@ flowchart TD
     class F,I ambiguous
 ```
 
-So this:
+EchoFlow now also has a derived speaker transcript that presents clean handoffs, true
+simultaneous overlap, sequential mixed/unresolved text, and unattributed text separately.
+User-assigned names such as `Dr. Chen (speaker-02)` remain durable presentation state over
+anonymous evidence, not replacements for it.
 
-```text
-speaker-01: "I think we should"
-speaker-02: "move it to Friday"
-```
-
-can live inside one ASR segment without EchoFlow claiming the entire sentence belonged
-to either person.
-
-If two diarized speakers overlap the same word interval, that word remains unattributed.
-Later source separation may provide additional evidence, but alignment alone does not
-solve simultaneous speech.
+Alignment alone still does not separate simultaneous speech into independent audio
+sources.
 
 ## Checkpoint and resume semantics
 
-Alignment changes recognized evidence, so it is part of the private checkpoint contract
-rather than a hidden backend switch.
+Alignment changes recognized evidence, so it belongs in the private checkpoint contract.
 
-New manifests record an alignment identity containing:
+New manifests record:
 
 ```text
-schema_version = 1
-provider       = faster-whisper
-word_timestamps = true
+schema_version   = 1
+provider         = faster-whisper
+word_timestamps  = true
 ```
 
-Per-window checkpoint payloads persist the aligned words themselves. Resume restores
-that evidence before source-relative assembly.
-
-A pre-alignment checkpoint that lacks the alignment contract is refused rather than
-being combined with newly aligned segments. EchoFlow is pre-production, so preserving a
-single current contract is preferable to inventing migration support for unreleased
-checkpoint shapes.
+Per-window checkpoint payloads persist aligned words. Resume restores that evidence before
+source-relative assembly. A checkpoint lacking the current alignment contract is refused
+rather than being mixed with newly aligned work.
 
 ## What happens to search?
 
-Nothing surprising.
+Ranking still indexes canonical **segment text once**. Nested words do not become one
+search document per token.
 
-Lexical and semantic retrieval continue to index the canonical **segment text once**.
-The transcript-library projection deliberately ignores additional nested word evidence
-for now.
+What changed later is the presentation/navigation consumer.
 
-That means alignment does not suddenly turn one sentence into six search documents or
-change BM25 statistics merely because the canonical transcript has finer coordinates.
-Future retrieval UX may use word evidence for highlighting and precise jump-to-audio,
-but the current ranking contract remains segment/chunk based.
+After lexical/semantic/hybrid retrieval ranks a passage, `EvidenceLocator` can verify the
+exact canonical transcript and resolve the result back onto segment and word evidence:
 
-## What this unlocks
+- lexical results may highlight matching aligned words;
+- exact phrase highlights require contiguous canonical word tokens;
+- semantic-only results receive passage navigation but no invented exact-word match;
+- neighboring canonical context may be added after ranking; and
+- the first justified aligned match can become a source seek coordinate.
 
-Word coordinates create a useful seam for several later capabilities:
+So alignment enriches navigation **without changing ranking semantics**.
 
-- highlight the exact returned phrase while preserving segment-level search ranking;
-- jump playback closer to the relevant word rather than only the containing segment;
-- anchor durable annotations more precisely;
-- render speaker handoffs inside a long ASR segment;
-- improve subtitle/caption editing interfaces; and
-- compare future forced-alignment providers without changing the canonical source
-  timeline.
+See **[Evidence-first corpus search](corpus-search.md)** and
+**[From search result to the exact evidence](../evidence-navigation.md)**.
 
-Those consumers should use the timing evidence that actually exists rather than derive
-fake word positions from character counts.
+## What else word coordinates now support
+
+The implemented consumers include:
+
+- finer anonymous speaker handoffs;
+- overlap-aware speaker presentation;
+- human source-relative time display;
+- exact lexical result highlighting; and
+- deterministic search-result seek coordinates.
+
+The same coordinates are ready to support later:
+
+- durable note/tag/annotation anchors;
+- graphical click-to-media playback;
+- subtitle/caption editing; and
+- comparison with a future independently qualified forced-alignment provider.
+
+Those consumers should use actual canonical timing evidence rather than derive fake word
+positions from character counts.
 
 ## What this does **not** claim
 
-This tranche does not provide:
+Word alignment does not provide:
 
 - independent forced alignment;
 - phoneme-level timestamps;
 - fabricated character offsets;
-- calibrated probability as a universal confidence score;
-- automatic correction of recognized text from timing evidence;
-- original-media SMPTE/container/capture-time provenance;
-- user-assigned speaker names/display labels; or
-- speech/source separation for simultaneous speakers.
+- calibrated word probability as a universal confidence score;
+- automatic text correction from timing evidence;
+- speech/source separation for simultaneous speakers; or
+- biometric/cross-recording speaker identity.
 
-The next provenance tranche is original-media timecode/capture-time representation.
-Better speaker display/overlap UX follows, with source separation intentionally later.
+Original-media temporal provenance, user display labels, overlap presentation, and
+aligned search navigation are now separate implemented layers above the word-coordinate
+foundation.
 
 🧜‍♀️ One timeline at a time. The mermaid has seen what happens when clocks are allowed
 to breed unsupervised.

--- a/docs/evidence-navigation.md
+++ b/docs/evidence-navigation.md
@@ -1,0 +1,231 @@
+# 🔎 From search result to the exact evidence
+
+Search is useful when it finds something. Research gets easier when the result can also
+answer **“where, exactly, did this come from?”**
+
+EchoFlow now has a navigation layer between retrieval and presentation. BM25, semantic
+search, and hybrid retrieval still decide *which passage ranks*. Then EchoFlow goes back
+to the authoritative canonical transcript, verifies that it is still the exact transcript
+that was indexed, and resolves the result onto canonical segments and word timing.
+
+That distinction is important. A search database may point at evidence. It does not get
+to become the evidence.
+
+```mermaid
+flowchart LR
+    Q[Your query] --> R[Lexical / semantic / hybrid ranking]
+    R --> P[Ranked passage]
+    P --> V[Verify canonical transcript SHA]
+    V --> E[Canonical segment + word coordinates]
+    E --> H[Human context + highlights]
+    E --> S[Seek coordinate]
+    E --> N[Future note / tag anchor]
+
+    classDef query fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class Q query
+    class R,P derived
+    class V,E evidence
+    class H,S,N view
+```
+
+🦝 Search may know the neighborhood. The canonical transcript still owns the street
+address.
+
+## What changes when I search?
+
+The command is still the ordinary library search:
+
+```bash
+echoflow library search "housing affordability"
+```
+
+EchoFlow still returns the same retrieval provenance: source and canonical hashes,
+segment/chunk identities, numeric source-relative time, languages, anonymous speaker
+refs, and lexical/semantic/fused ranks.
+
+The result can now also carry a verified **evidence location**:
+
+- the exact canonical transcript generation;
+- the result segment IDs;
+- the source-relative result interval;
+- a deterministic seek coordinate;
+- canonical word matches when lexical evidence justifies them;
+- current user-assigned speaker display names without replacing anonymous refs; and
+- optional neighboring canonical context.
+
+Machine-readable JSON keeps those layers separate rather than flattening them into one
+mystery object.
+
+## Exact highlighting is allowed to say “I don't know”
+
+Lexical search knows which canonical segment matched the terms you asked for. When that
+segment has aligned word timing, EchoFlow can resolve the same lexical token semantics
+onto canonical words and highlight the words that actually matched.
+
+For an exact phrase:
+
+```bash
+echoflow library search "housing affordability" --phrase
+```
+
+EchoFlow requires the phrase tokens to be contiguous before marking the canonical words
+as the exact match.
+
+Semantic retrieval is different. An embedding may decide this passage:
+
+```text
+I was spending almost seventy percent of my pay on the apartment.
+```
+
+is relevant to:
+
+```text
+people struggling to afford housing
+```
+
+There may be **no single word** in the passage that means “this is the semantic match.”
+So a semantic-only result gets a verified passage and seek coordinate, but EchoFlow does
+not underline a random noun and pretend the vector model pointed at it.
+
+Hybrid retrieval may have both kinds of evidence. When lexical evidence contributed to
+a result, exact lexical highlights can be shown alongside the fused ranking provenance.
+
+💃 Precision is useful. Decorative certainty is not.
+
+## Give me a little more context
+
+A ranked passage is often easier to understand with the sentence before and after it.
+You can request neighboring canonical segments without changing retrieval ranking:
+
+```bash
+echoflow library search \
+  "housing affordability" \
+  --context-segments 1
+```
+
+`--context-segments` accepts `0` through `10`. The default is `0`, so ordinary searches
+stay compact.
+
+Context expansion happens **after ranking**. EchoFlow does not secretly feed the extra
+context back into BM25 or semantic scoring and then pretend the ranks mean the same
+thing.
+
+The returned context marks which segments are actual result evidence and which are only
+neighbors provided for reading.
+
+## What about speaker names?
+
+If you previously assigned:
+
+```text
+speaker-02 → Dr. Chen
+```
+
+ordinary search presentation can now show:
+
+```text
+Dr. Chen (speaker-02)
+```
+
+The anonymous `speaker-02` remains in the machine-readable evidence. The friendly label
+comes from separate private user-authored state and is resolved only when it matches the
+exact canonical transcript generation behind the result.
+
+So rebuilding a search index does not eat the name, and changing the transcript does not
+silently attach Dr. Chen to tomorrow's unrelated `speaker-02`.
+
+See **[Give the anonymous speakers names](speaker-names.md)** for the full custody model.
+
+## Can this jump to the original audio or video?
+
+The application contract now exposes the coordinate a player needs.
+
+If an exact aligned lexical match begins at:
+
+```text
+4788.370 seconds
+```
+
+that becomes the preferred seek point:
+
+```text
+01:19:48.370
+```
+
+If a result has no justified exact word match, the passage start remains the safe seek
+coordinate.
+
+EchoFlow still does not ship the graphical local media player itself. A future GUI can
+consume this service directly rather than reverse-engineering positions from rendered
+text or internal work chunks.
+
+## And Susan's notes? 📝
+
+Notes are still future user-authored state. This feature intentionally stops one layer
+before building the notebook.
+
+What changed is that the notebook no longer needs to invent its own evidence coordinates.
+A future note can point at the same verified location used by search navigation:
+
+```text
+canonical transcript SHA-256
+source SHA-256
+segment ID(s)
+word index/indices when available
+numeric start/end seconds
+```
+
+The note body remains separate durable user knowledge.
+
+That means:
+
+- changing clock display formatting does not detach the note;
+- rebuilding BM25 does not delete the note;
+- rebuilding semantic vectors does not delete the note;
+- changing the canonical transcript can be detected instead of silently teleporting the
+  note; and
+- a GUI, CLI, export adapter, or future citation workflow can all consume one anchoring
+  contract.
+
+```mermaid
+flowchart TD
+    A[📜 Canonical transcript evidence] --> L[Verified evidence location]
+    L --> R[Search result view]
+    L --> P[Future local player]
+    L --> N[Future user note]
+    I[🦝 Rebuildable indexes] --> R
+    U[User speaker labels] --> R
+
+    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
+    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
+    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+
+    class A,L evidence
+    class I derived
+    class U,N user
+    class R,P view
+```
+
+## What this deliberately does not do
+
+Evidence navigation does not:
+
+- change BM25, semantic similarity, or RRF ranking;
+- claim an exact word match for semantic-only relevance;
+- rewrite canonical JSON;
+- bake speaker display names into diarization evidence;
+- create notes, tags, collections, or saved searches yet; or
+- ship a graphical media player.
+
+Those are separate product layers. The useful thing about this tranche is that they can
+now share one verified coordinate system instead of each inventing a slightly different
+idea of “where this quote came from.”
+
+For the retrieval internals, open **[Evidence-first corpus search](architecture/corpus-search.md)**.
+For how the underlying timeline works, see **[Transcript time without calculator
+gymnastics](time-navigation.md)**.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,7 @@ flowchart LR
     D --> E[Canonical transcript]
     E --> F[Exports]
     E --> G[Private local search]
+    G --> H[Verified evidence navigation]
 
     classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
@@ -35,11 +36,11 @@ flowchart LR
     class B,C compute
     class D process
     class E,F publish
-    class G result
+    class G,H result
 ```
 
 The original recording is treated as read-only input. EchoFlow writes working files,
-checkpoints, transcripts, exports, and search state separately.
+checkpoints, transcripts, exports, user-authored state, and search state separately.
 
 ## 1. Install the source build
 
@@ -70,7 +71,7 @@ CUDA device zero, and model X.” That is application work.
 
 ## 2. Install a transcription model
 
-Ask EchoFlow which managed model currently fits the machine and processing policy:
+Ask EchoFlow which managed model fits the machine and processing policy:
 
 ```bash
 uv run echoflow models recommend
@@ -82,16 +83,12 @@ Then install the model you intend to use. For example:
 uv run echoflow models install small
 ```
 
-### Why is installation a separate step?
-
-Because downloading model weights is a network-bearing action.
-
-EchoFlow makes that boundary explicit instead of quietly reaching out to the internet
-when you start transcription. Once a verified managed model is present locally,
-transcription uses that local immutable revision.
+Downloading model weights is a network-bearing action, so EchoFlow makes installation
+explicit. Once a verified managed model is local, transcription uses that immutable
+revision instead of silently reaching out to the network.
 
 🦝 **Raccoon translation:** downloading the toolbox and using the toolbox are different
-things. EchoFlow does not pretend otherwise.
+things.
 
 ## 3. Inspect a recording before doing the work
 
@@ -101,9 +98,6 @@ starting recognition:
 ```bash
 uv run echoflow transcribe interview.m4a --dry-run
 ```
-
-This is useful when you want to see which strategy, model, stream, storage estimate, and
-resource budget would be used before committing to a long run.
 
 For machine-readable output:
 
@@ -121,6 +115,10 @@ EchoFlow may need to decode or normalize the selected audio stream into a determ
 working format. That working audio is private derived state. Your original recording is
 not overwritten.
 
+The current faster-whisper path also asks for native word timing. Those word intervals
+are validated and rebased onto one source-relative timeline so internal work chunks do
+not reset the published clock.
+
 The durable transcript is canonical JSON. If you also want ordinary reading/subtitle
 formats:
 
@@ -135,7 +133,7 @@ without running speech recognition again.
 
 Long recordings and laptops occasionally have opinions.
 
-When a job has durable checkpoints, resume it with the original input and the job ID:
+When a job has durable checkpoints, resume it with the original input and job ID:
 
 ```bash
 uv run echoflow transcribe interview.m4a --resume JOB_ID
@@ -143,22 +141,17 @@ uv run echoflow transcribe interview.m4a --resume JOB_ID
 
 Resume is deliberately conservative. EchoFlow rechecks source identity and current
 resources and restores the original execution contract rather than silently switching
-models, streams, or preprocessing halfway through the evidence trail.
+models, streams, preprocessing, or alignment halfway through the evidence trail.
 
 ## 6. Optional: clean up a noisy recording
-
-You can explicitly ask EchoFlow to apply its current deterministic local FFmpeg noise
-suppression before ASR:
 
 ```bash
 uv run echoflow transcribe noisy-interview.wav --enhance
 ```
 
 Enhancement is off by default. The processed audio remains private working material and
-does not replace the source recording.
-
-EchoFlow also verifies that preprocessing did not alter the frame count/sample rate or
-otherwise shift the timeline it uses for transcript timestamps.
+does not replace the source recording. EchoFlow verifies that preprocessing did not
+shift the timeline used for transcript evidence.
 
 For the engineering contract, see
 **[Local speech enhancement](architecture/speech-enhancement.md)**.
@@ -179,10 +172,28 @@ recordings.
 gate while the locked Lightning version is affected by a compensated advisory. While
 that gate is active, EchoFlow refuses diarization before model execution/acquisition.
 
-See **[Anonymous speaker diarization](architecture/diarization.md)** and
-**[SECURITY.md](../SECURITY.md)** for the exact boundary.
+Once speaker evidence exists in a canonical transcript and the library has been rebuilt,
+you can give one anonymous ref a durable human-facing name:
 
-## 8. Build your local transcript library 🔎
+```bash
+uv run echoflow library speakers list JOB_ID
+uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
+```
+
+You name `speaker-02` once for that canonical transcript generation. You do not edit each
+occurrence by hand.
+
+For a handoff/overlap-aware transcript view:
+
+```bash
+uv run echoflow library speakers transcript JOB_ID
+```
+
+See **[Give the anonymous speakers names](speaker-names.md)**,
+**[Anonymous speaker diarization](architecture/diarization.md)**, and
+**[SECURITY.md](../SECURITY.md)** for the exact boundaries.
+
+## 8. Build and search your local transcript library 🔎
 
 Once you have completed canonical transcripts, build the private lexical library:
 
@@ -196,7 +207,13 @@ Search it:
 uv run echoflow library search "housing insecurity"
 ```
 
-Filter by evidence when you know more about what you want:
+Ask for one neighboring canonical segment on each side:
+
+```bash
+uv run echoflow library search "housing insecurity" --context-segments 1
+```
+
+Filter by anonymous evidence refs or language when useful:
 
 ```bash
 uv run echoflow library search \
@@ -205,14 +222,25 @@ uv run echoflow library search \
   --language en
 ```
 
+If `speaker-02` has a current user label, the human result can show
+`Dr. Chen (speaker-02)` while JSON keeps the raw anonymous ref and exposes the friendly
+label separately.
+
+Lexical results with aligned word evidence can highlight the exact canonical words that
+matched and expose the first match as a source seek coordinate. Semantic-only results
+stay passage-level rather than inventing an exact word.
+
 Inspect one transcript's evidence receipt:
 
 ```bash
 uv run echoflow library show JOB_ID
 ```
 
-The search database is a rebuildable projection. The canonical transcript remains the
-authoritative artifact.
+The search databases are rebuildable projections. The navigation layer re-verifies the
+canonical transcript before presenting precise evidence coordinates.
+
+Read **[From search result to the exact evidence](evidence-navigation.md)** for the
+human explanation.
 
 ## 9. Optional: search by meaning, not only matching words ✨
 
@@ -234,15 +262,14 @@ I was spending almost seventy percent of my pay on the apartment.
 Those sentences share little vocabulary, but they express a related idea.
 
 EchoFlow's current semantic foundation uses a local sentence-embedding model and private
-rebuildable vectors. Search results still return original transcript passages with their
-evidence coordinates.
+rebuildable vectors. Search results still point back to original canonical transcript
+evidence.
 
 ### Is this sent to a hosted AI service?
 
-Not during semantic indexing or search in the current implementation.
-
-The embedding provider loads from a local immutable model snapshot. Acquiring model
-weights is a separate network-bearing action.
+Not during semantic indexing or search in the current implementation. The embedding
+provider loads from a local immutable model snapshot. Acquiring model weights is a
+separate network-bearing action.
 
 ### Is semantic search part of the normal install yet?
 
@@ -252,8 +279,8 @@ The locked project dependency graph does not yet include Sentence Transformers, 
 semantic path currently expects an environment that already supplies a compatible local
 runtime and Multilingual E5 Small snapshot. Lexical search works without any of this.
 
-If you want the full explanation without being thrown into vector-storage internals,
-read **[Semantic search, without the mystery box](semantic-search.md)**.
+Read **[Semantic search, without the mystery box](semantic-search.md)** for the full
+plain-language explanation.
 
 ## What EchoFlow stores 🦝
 
@@ -263,15 +290,19 @@ flowchart LR
     B --> C[TXT / SRT / VTT]
     B --> D[Lexical search state]
     B --> E[Optional semantic search state]
+    B --> N[Verified navigation views]
     A --> F[Private working audio + checkpoints]
+    U[User speaker labels] --> N
 
     classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
     classDef work fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
+    classDef user fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
 
     class A,B evidence
-    class C,D,E derived
+    class C,D,E,N derived
     class F work
+    class U user
 ```
 
 The useful distinction is not “database versus file.” It is **can this be reconstructed
@@ -279,13 +310,14 @@ without losing something the user authored or relied on as evidence?**
 
 - The original recording is source evidence.
 - Canonical transcript JSON is the authoritative transcript artifact.
-- Future notes/tags/annotations are user-authored state and must not be treated as cache.
-- TXT/SRT/VTT and search indexes are derived and rebuildable.
+- Speaker display labels are durable user-authored state.
+- Future notes/tags/annotations/collections belong to that same durable class.
+- TXT/SRT/VTT, search indexes, and navigation views are derived and rebuildable.
 - Working audio and most execution material are private processing state.
 
 Delete a search index? Rebuild her.
 
-Delete the only canonical transcript or a future annotation? That is data loss.
+Delete the only canonical transcript or somebody's annotation? That is data loss.
 
 ## Where do I go when I want more detail?
 
@@ -293,8 +325,8 @@ Delete the only canonical transcript or a future annotation? That is data loss.
 
 The **[architecture index](architecture/README.md)** is the maintenance hatch for
 contributors and technically curious readers. It covers resource admission, media and
-timeline semantics, model custody, diarization, enhancement, checkpoints, and search in
-exact terms.
+timeline semantics, model custody, diarization, enhancement, checkpoints, search, and
+canonical evidence navigation in exact terms.
 
 The **[security policy](../SECURITY.md)** defines what “local-first” protects and what it
 does not claim.

--- a/docs/speaker-names.md
+++ b/docs/speaker-names.md
@@ -172,6 +172,28 @@ This view is **derived presentation**, not a new canonical transcript. Numeric s
 
 One conservative rule matters: if a canonical aligned word is unattributed, the presentation layer will not promote it to a single named speaker merely because one diarization turn happens to overlap. Presentation may expose additional **multi-speaker overlap**, but it does not manufacture a stronger single-speaker claim than canonical evidence already made.
 
+## Do the names show up when I search too?
+
+Yes. Ordinary transcript-library search now consumes the same current display-label state.
+
+If you assigned:
+
+```text
+speaker-02 → Dr. Chen
+```
+
+then a human search result involving that speaker can show:
+
+```text
+Dr. Chen (speaker-02)
+```
+
+Machine-readable output keeps `speaker-02` in `speaker_refs` and exposes the friendly label separately. Ranking and speaker filters still operate on anonymous evidence refs. A human name is presentation, not a new search identity.
+
+The search navigation layer resolves names only for the exact canonical generation behind the result. It also batches the lookup per transcript generation rather than repeatedly rereading private label state for every result row.
+
+See **[From search result to the exact evidence](evidence-navigation.md)** for highlighting, context, and source seek behavior.
+
 ## Where are these labels stored?
 
 Speaker names are **private user-authored state**, not rebuildable search state.

--- a/docs/time-navigation.md
+++ b/docs/time-navigation.md
@@ -3,13 +3,11 @@
 A transcript is much more useful when “where did they say that?” has an answer that a
 human can actually use.
 
-EchoFlow therefore keeps **one durable numeric timeline** and can present it as a familiar
-clock-style coordinate.
+EchoFlow keeps **one durable numeric source-relative timeline** and derives familiar
+clock-style coordinates from it.
 
 If a passage begins `4788.37` seconds into a recording, you should not have to divide by
-60 twice in your head.
-
-EchoFlow can present that as:
+60 twice in your head. EchoFlow can present that as:
 
 ```text
 01:19:48.370
@@ -52,90 +50,94 @@ The numbers are the anchor. The clock-style strings are the label on the drawer.
 
 ```mermaid
 flowchart LR
-    W[📜 Canonical word evidence<br/>4788.370 seconds] --> H[✨ Human display<br/>01:19:48.370]
-    W --> P[▶️ Future player seek<br/>seek to 4788.370]
-    W --> N[📝 Future note anchor<br/>source + evidence span]
-    W --> S[🔎 Search result<br/>show the useful time]
+    W[Canonical word evidence\n4788.370 seconds] --> H[Human display\n01:19:48.370]
+    W --> S[Search evidence locator\nseek to 4788.370]
+    W --> P[Future local player]
+    W --> N[Future note anchor]
 
     classDef truth fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
     classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
     class W truth
-    class H,P,N,S view
+    class H,S,P,N view
 ```
 
-## Can I click a word and jump to that exact place in the recording?
+## Can search find the exact place now?
 
-**The evidence coordinate needed for that now exists.**
+Yes, when the retrieval evidence justifies that precision.
 
-A future local player can take a word's `start_seconds` and seek the original recording
-to that point. Search results already carry source-relative start/end seconds, and the
-human CLI view now renders them as `HH:MM:SS.mmm` instead of asking you to interpret a
-large decimal number.
+The transcript-library navigation layer now reopens the exact canonical transcript,
+verifies its SHA-256, and resolves a ranked search result back to canonical segments and
+aligned words.
 
-EchoFlow does **not yet ship the graphical media-player click handler**. The important
-part is that the UI will not need to guess where a phrase lives when that layer arrives.
-It can consume canonical evidence that already has the coordinate.
+For lexical search, matching aligned words can become the exact highlighted evidence and
+the first matched word becomes the preferred source seek coordinate.
+
+For example:
+
+```text
+query: "housing cost"
+matched canonical words: housing → cost
+seek_seconds: 4788.370
+seek_timestamp: 01:19:48.370
+```
+
+Semantic-only retrieval is intentionally less precise. An embedding can say “this
+passage is related to your query” without identifying one exact matching word. EchoFlow
+therefore exposes the verified passage and its start time rather than fabricating a word
+highlight.
+
+Read **[From search result to the exact evidence](evidence-navigation.md)** for context
+expansion, speaker names, and the full search-to-canonical contract.
+
+## Can I click a word and jump to the recording?
+
+**The application coordinate needed for that now exists.**
+
+A local player can seek the original recording using numeric `seek_seconds`. Search
+navigation now exposes that coordinate directly, so a future GUI does not need to guess
+from rendered text or reconstruct internal work chunks.
+
+EchoFlow does **not yet ship the graphical media-player click handler**. The missing
+piece is presentation, not timeline plumbing.
 
 ## What about notes and annotations? 📝
 
 Notes are planned as **durable user-authored knowledge**, not search-index metadata.
 There is not yet a finished notes editor or annotation store.
 
-When that feature arrives, a note should anchor to durable evidence, conceptually:
+The evidence-navigation layer now gives that future feature a concrete anchor to reuse:
 
 ```text
-source SHA-256:   <recording fingerprint>
-start:            4788.370 s
-end:              4791.125 s
-canonical span:   the relevant segment/word evidence
-note:             "Participant connects housing cost to the decision to leave."
+source SHA-256
+canonical transcript SHA-256
+canonical segment ID(s)
+word index/indices when available
+numeric start/end seconds
 ```
 
-It should **not** anchor only to:
+A note should **not** anchor only to:
 
 ```text
 "01:19:48.370"
 ```
 
-Why? Because `01:19:48.370` is presentation. We may later offer a different visual
-format, but a researcher's sticky note should not fall off the transcript because
-someone changed the clock typography.
+because that is presentation. It also should not anchor only to a semantic-search chunk
+ID because chunks and indexes are rebuildable.
 
-It also should not anchor only to a semantic-search chunk ID. Search chunks and indexes
-are rebuildable. Notes are not.
-
-```mermaid
-flowchart TD
-    A[🎙️ Original recording<br/>read-only evidence] --> C[📜 Canonical transcript]
-    C --> W[Word / segment coordinates]
-    W --> N[📝 Future user note]
-    C --> I[🔎 Rebuildable search index]
-    I --> R[Search result]
-    R -. points back to .-> W
-
-    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef durable fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef rebuild fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    class A source
-    class C,W,N durable
-    class I,R rebuild
-```
-
-If the librarian rebuilds the index, the note remains attached to the evidence. This is
-one of EchoFlow's custody rules, not a decorative preference.
+If the librarian rebuilds the index, the note must remain attached to durable evidence.
+If the canonical transcript changes, EchoFlow should retain the note and report that its
+old anchor needs review rather than silently moving it.
 
 ## Do internal work chunks reset the clock?
 
 No.
 
 EchoFlow currently uses application-owned work windows that are **10 minutes by default**
-(`600` seconds), not hour-long user-visible transcript sections. Those windows exist so
-long recordings can be processed and checkpointed safely.
-
-They are an implementation detail.
+(`600` seconds). Those windows exist so long recordings can be processed and
+checkpointed safely. They are an implementation detail.
 
 When a work window starts at `4200` seconds and faster-whisper reports a word at `588.37`
-seconds inside that work window, assembly rebases it onto the source timeline:
+seconds inside that window, assembly rebases it onto the source timeline:
 
 ```text
 4200.000 + 588.370 = 4788.370 seconds
@@ -159,7 +161,7 @@ timecode:      10:00:00:00
 creation_time: 2026-04-05T12:34:56Z
 ```
 
-EchoFlow now asks FFprobe for `timecode` and `creation_time` at both container and stream
+EchoFlow asks FFprobe for `timecode` and `creation_time` at both container and stream
 scope. When present, those declarations are preserved in canonical source provenance,
 including where they came from.
 
@@ -171,11 +173,11 @@ So the model stays parallel:
 
 ```mermaid
 flowchart LR
-    M[🎥 Original media] --> E[Canonical elapsed time<br/>0.000 s → ...]
-    M --> T[Declared timecode<br/>if source provides it]
-    M --> C[Declared creation time<br/>if source provides it]
+    M[Original media] --> E[Canonical elapsed time\n0.000 s → ...]
+    M --> T[Declared timecode\nif source provides it]
+    M --> C[Declared creation time\nif source provides it]
 
-    E --> X[📜 Transcript evidence]
+    E --> X[Canonical transcript evidence]
     T --> X
     C --> X
 
@@ -200,24 +202,27 @@ called `timestamp`.
 Because SMPTE-style timecode is not just wall-clock `HH:MM:SS` with two extra digits.
 Frame rate and drop-frame/non-drop-frame semantics can change the arithmetic.
 
-This tranche deliberately preserves source declarations **without inventing a mapping it
-cannot yet qualify**.
+EchoFlow preserves source declarations **without inventing a mapping it cannot yet
+qualify**.
 
 For ordinary transcript navigation, no such mapping is necessary. Canonical elapsed time
-already gives a local player an exact seek coordinate.
+already gives a local player a deterministic seek coordinate.
 
 ## What you get now
 
 | Need | Current behavior |
 |---|---|
 | “Where is 4788 seconds?” | rendered as `01:19:48.000` |
-| Search result navigation | human elapsed start/end plus numeric seconds in JSON |
+| Search result navigation | verified canonical location plus numeric/human seek coordinate |
+| Exact lexical word match | highlighted aligned words when canonical timing evidence supports it |
+| Semantic-only result | verified passage coordinate without fabricated word precision |
+| Neighboring reading context | bounded canonical segment expansion after ranking |
 | Word-level position | native faster-whisper word start/end retained in canonical evidence |
 | Speaker handoff inside one ASR segment | word evidence can carry the handoff without inventing one segment speaker |
 | Original `timecode` metadata | preserved when FFprobe reports it, with source scope |
 | Original `creation_time` metadata | preserved when FFprobe reports it, with source scope |
-| Click word to play source | coordinate is ready; graphical player interaction is still future UI work |
-| Durable notes/annotations | architecture is ready for canonical anchors; editor/storage is still future work |
+| Click word to play source | seek contract is ready; graphical player interaction is still future UI work |
+| Durable notes/annotations | evidence anchor is ready; editor/storage is still future work |
 | SMPTE frame arithmetic | intentionally not inferred without qualified frame semantics |
 
 ## The small rule underneath all of this
@@ -226,5 +231,6 @@ already gives a local player an exact seek coordinate.
 confuse the three.** ✨
 
 For the exact implementation contract, see
-**[Media normalization and transcript timeline](architecture/media-and-timeline.md)** and
-**[Word-level timestamp alignment](architecture/word-alignment.md)**.
+**[Media normalization and transcript timeline](architecture/media-and-timeline.md)**,
+**[Word-level timestamp alignment](architecture/word-alignment.md)**, and
+**[Evidence-first corpus search](architecture/corpus-search.md)**.

--- a/src/echoflow/app/app_container.py
+++ b/src/echoflow/app/app_container.py
@@ -18,6 +18,8 @@ from echoflow.core.performance_tracker import PerformanceTracker
 from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.library.duckdb_index import DuckDbTranscriptIndex
 from echoflow.library.duckdb_semantic import DuckDbSemanticIndex
+from echoflow.library.evidence import EvidenceLocator
+from echoflow.library.research import ResearchNavigationService
 from echoflow.library.semantic import EmbeddingProfile, SentenceTransformersE5Provider
 from echoflow.library.service import TranscriptLibraryService
 from echoflow.library.speaker_label_service import SpeakerLabelService
@@ -259,6 +261,13 @@ class AppContainer(containers.DeclarativeContainer):
         file_manager=file_manager,
         semantic_index=semantic_index,
         embedding_provider_factory=embedding_provider_factory,
+    )
+    evidence_locator = providers.Singleton(EvidenceLocator, file_manager=file_manager)
+    research_navigation = providers.Singleton(
+        ResearchNavigationService,
+        transcript_library=transcript_library,
+        evidence_locator=evidence_locator,
+        speaker_labels=speaker_labels,
     )
     checkpoint_store = providers.Factory(
         LocalCheckpointStore, file_manager=file_manager

--- a/src/echoflow/cli_library.py
+++ b/src/echoflow/cli_library.py
@@ -8,17 +8,24 @@ from typing import Annotated, cast
 import typer
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from echoflow.app.app_container import AppContainer
 from echoflow.cli_speakers import register_speaker_commands
 from echoflow.core.errors import EchoFlowError
+from echoflow.library.evidence import (
+    EvidenceContextSegment,
+    EvidenceLocation,
+    EvidenceWord,
+)
 from echoflow.library.index import (
     IndexedDocument,
     SearchOperator,
     SearchQuery,
     SearchSort,
 )
-from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
+from echoflow.library.research import LocatedSearchPassage, ResearchSearchResponse
+from echoflow.library.retrieval import RetrievalMode
 from echoflow.library.semantic import EmbeddingProfile, SemanticState
 from echoflow.library.service import (
     LibraryEvidenceReceipt,
@@ -72,7 +79,57 @@ def _state_dict(state: SemanticState) -> dict[str, object]:
     }
 
 
-def _passage_dict(passage: SearchPassage) -> dict[str, object]:
+def _word_dict(word: EvidenceWord) -> dict[str, object]:
+    return {
+        "segment_id": word.segment_id,
+        "word_index": word.word_index,
+        "start_seconds": word.start_seconds,
+        "end_seconds": word.end_seconds,
+        "start_timestamp": format_elapsed_timestamp(word.start_seconds),
+        "end_timestamp": format_elapsed_timestamp(word.end_seconds),
+        "text": word.text,
+        "speaker_ref": word.speaker_ref,
+        "highlighted": word.highlighted,
+    }
+
+
+def _context_segment_dict(segment: EvidenceContextSegment) -> dict[str, object]:
+    return {
+        "segment_id": segment.segment_id,
+        "start_seconds": segment.start_seconds,
+        "end_seconds": segment.end_seconds,
+        "start_timestamp": format_elapsed_timestamp(segment.start_seconds),
+        "end_timestamp": format_elapsed_timestamp(segment.end_seconds),
+        "text": segment.text,
+        "speaker_refs": list(segment.speaker_refs),
+        "is_result_segment": segment.is_result_segment,
+        "lexical_match": segment.lexical_match,
+        "words": [_word_dict(word) for word in segment.words],
+    }
+
+
+def _evidence_dict(location: EvidenceLocation) -> dict[str, object]:
+    return {
+        "document_id": location.document_id,
+        "source_sha256": location.source_sha256,
+        "canonical_sha256": location.canonical_sha256,
+        "result_segment_ids": list(location.result_segment_ids),
+        "start_seconds": location.start_seconds,
+        "end_seconds": location.end_seconds,
+        "start_timestamp": format_elapsed_timestamp(location.start_seconds),
+        "end_timestamp": format_elapsed_timestamp(location.end_seconds),
+        "seek_seconds": location.seek_seconds,
+        "seek_timestamp": format_elapsed_timestamp(location.seek_seconds),
+        "result_speaker_refs": list(location.result_speaker_refs),
+        "matched_words": [_word_dict(word) for word in location.matched_words],
+        "context_segments": [
+            _context_segment_dict(segment) for segment in location.context_segments
+        ],
+    }
+
+
+def _located_dict(result: LocatedSearchPassage) -> dict[str, object]:
+    passage = result.passage
     return {
         "document_id": passage.document_id,
         "source_sha256": passage.source_sha256,
@@ -89,14 +146,21 @@ def _passage_dict(passage: SearchPassage) -> dict[str, object]:
         "text": passage.text,
         "languages": list(passage.languages),
         "speaker_refs": list(passage.speaker_refs),
+        "speaker_display_labels": {
+            item.speaker_ref: item.display_label
+            for item in result.speakers
+            if item.display_label is not None
+        },
         "lexical_rank": passage.lexical_rank,
         "semantic_rank": passage.semantic_rank,
         "fused_rank": passage.fused_rank,
+        "evidence_location": _evidence_dict(result.evidence),
     }
 
 
-def _response_dict(response: SearchResponse) -> dict[str, object]:
-    query = response.query
+def _response_dict(response: ResearchSearchResponse) -> dict[str, object]:
+    retrieval = response.retrieval
+    query = retrieval.query
     return {
         "query": {
             "text": query.text,
@@ -109,18 +173,18 @@ def _response_dict(response: SearchResponse) -> dict[str, object]:
             "limit": query.limit,
         },
         "retrieval": {
-            "mode": response.mode.value,
-            "lexical_backend_id": response.lexical_backend_id,
-            "semantic_backend_id": response.semantic_backend_id,
+            "mode": retrieval.mode.value,
+            "lexical_backend_id": retrieval.lexical_backend_id,
+            "semantic_backend_id": retrieval.semantic_backend_id,
             "semantic_profile": (
                 None
-                if response.semantic_profile is None
-                else _profile_dict(response.semantic_profile)
+                if retrieval.semantic_profile is None
+                else _profile_dict(retrieval.semantic_profile)
             ),
-            "fusion_profile": response.fusion_profile,
+            "fusion_profile": retrieval.fusion_profile,
         },
         "result_count": len(response.results),
-        "results": [_passage_dict(item) for item in response.results],
+        "results": [_located_dict(item) for item in response.results],
     }
 
 
@@ -178,41 +242,69 @@ def _render_receipt(receipt: LibraryEvidenceReceipt, console: Console) -> None:
     console.print(table)
 
 
-def _render_response(response: SearchResponse, console: Console) -> None:
+def _render_context(result: LocatedSearchPassage) -> Text:
+    rendered = Text()
+    for index, segment in enumerate(result.evidence.context_segments):
+        if index:
+            rendered.append("\n")
+        rendered.append("› " if segment.is_result_segment else "  ", style="bold")
+        if segment.words:
+            for word in segment.words:
+                style = "bold underline" if word.highlighted else None
+                if not segment.is_result_segment and style is None:
+                    style = "dim"
+                rendered.append(word.text, style=style)
+        else:
+            rendered.append(
+                segment.text,
+                style=None if segment.is_result_segment else "dim",
+            )
+    return rendered
+
+
+def _render_response(response: ResearchSearchResponse, console: Console) -> None:
+    retrieval = response.retrieval
     table = Table(
         title=(
-            f"EchoFlow {response.mode.value} evidence search: "
+            f"EchoFlow {retrieval.mode.value} evidence search: "
             f"{len(response.results)} result(s)"
         )
     )
     table.add_column("Recording")
-    table.add_column("Time", min_width=12, no_wrap=True)
+    table.add_column("Evidence time", min_width=12, no_wrap=True)
     table.add_column("Speaker")
     table.add_column("Language")
     table.add_column("Ranks")
-    table.add_column("Passage")
+    table.add_column("Passage + context")
     for result in response.results:
+        passage = result.passage
         recording = (
-            result.document_id
-            if result.source_path is None
-            else Path(result.source_path).name
+            passage.document_id
+            if passage.source_path is None
+            else Path(passage.source_path).name
         )
         ranks = (
-            f"L:{result.lexical_rank or '-'} "
-            f"S:{result.semantic_rank or '-'} "
-            f"F:{result.fused_rank}"
+            f"L:{passage.lexical_rank or '-'} "
+            f"S:{passage.semantic_rank or '-'} "
+            f"F:{passage.fused_rank or '-'}"
         )
+        if result.evidence.matched_words:
+            start = result.evidence.matched_words[0].start_seconds
+            end = result.evidence.matched_words[-1].end_seconds
+        else:
+            start = passage.start_seconds
+            end = passage.end_seconds
         time_range = (
-            f"{format_elapsed_timestamp(result.start_seconds)}\n"
-            f"{format_elapsed_timestamp(result.end_seconds)}"
+            f"{format_elapsed_timestamp(start)}\n"
+            f"{format_elapsed_timestamp(end)}"
         )
         table.add_row(
             recording,
             time_range,
-            ", ".join(result.speaker_refs) or "unknown",
-            ", ".join(result.languages) or "unknown",
+            ", ".join(item.display_name for item in result.speakers) or "unknown",
+            ", ".join(passage.languages) or "unknown",
             ranks,
-            result.text,
+            _render_context(result),
         )
     console.print(table)
 
@@ -332,6 +424,7 @@ def _search_library(
     sort: SearchSort,
     mode: RetrievalMode,
     limit: int,
+    context_segments: int,
     json_output: bool,
     container_factory: ContainerFactory,
 ) -> None:
@@ -348,8 +441,8 @@ def _search_library(
         )
         response = (
             container_factory(_root_context(context))
-            .transcript_library()
-            .retrieve(query, mode=mode)
+            .research_navigation()
+            .search(query, mode=mode, context_segments=context_segments)
         )
     except Exception as exc:
         _handle_error(exc)
@@ -505,6 +598,13 @@ def register_library_commands(
             ),
         ] = RetrievalMode.LEXICAL,
         limit: int = typer.Option(100, "--limit", min=1, max=1_000),
+        context_segments: int = typer.Option(
+            0,
+            "--context-segments",
+            min=0,
+            max=10,
+            help="Include this many canonical segments before and after each result.",
+        ),
         json_output: bool = typer.Option(False, "--json"),
     ) -> None:
         _search_library(
@@ -518,6 +618,7 @@ def register_library_commands(
             sort=sort,
             mode=mode,
             limit=limit,
+            context_segments=context_segments,
             json_output=json_output,
             container_factory=container_factory,
         )

--- a/src/echoflow/cli_library.py
+++ b/src/echoflow/cli_library.py
@@ -295,8 +295,7 @@ def _render_response(response: ResearchSearchResponse, console: Console) -> None
             start = passage.start_seconds
             end = passage.end_seconds
         time_range = (
-            f"{format_elapsed_timestamp(start)}\n"
-            f"{format_elapsed_timestamp(end)}"
+            f"{format_elapsed_timestamp(start)}\n{format_elapsed_timestamp(end)}"
         )
         table.add_row(
             recording,

--- a/src/echoflow/library/__init__.py
+++ b/src/echoflow/library/__init__.py
@@ -2,6 +2,12 @@
 
 from echoflow.library.duckdb_index import DuckDbTranscriptIndex
 from echoflow.library.duckdb_semantic import DuckDbSemanticIndex
+from echoflow.library.evidence import (
+    EvidenceContextSegment,
+    EvidenceLocation,
+    EvidenceLocator,
+    EvidenceWord,
+)
 from echoflow.library.index import (
     IndexedDocument,
     IndexedSegment,
@@ -11,6 +17,12 @@ from echoflow.library.index import (
     SearchSort,
     TranscriptIndex,
     TranscriptMatch,
+)
+from echoflow.library.research import (
+    LocatedSearchPassage,
+    ResearchNavigationService,
+    ResearchSearchResponse,
+    SpeakerDisplay,
 )
 from echoflow.library.retrieval import (
     LexicalRetriever,
@@ -47,12 +59,19 @@ __all__ = [
     "EmbeddingProfile",
     "EmbeddingProvider",
     "EmbeddingVector",
+    "EvidenceContextSegment",
+    "EvidenceLocation",
+    "EvidenceLocator",
+    "EvidenceWord",
     "IndexedDocument",
     "IndexedSegment",
     "IndexedTranscript",
     "LexicalRetriever",
     "LibraryEvidenceReceipt",
     "LibraryRebuildReport",
+    "LocatedSearchPassage",
+    "ResearchNavigationService",
+    "ResearchSearchResponse",
     "RetrievalMode",
     "SearchChunk",
     "SearchOperator",
@@ -66,6 +85,7 @@ __all__ = [
     "SemanticState",
     "SentenceTransformersE5Provider",
     "SourceIntegrity",
+    "SpeakerDisplay",
     "TranscriptIndex",
     "TranscriptLibraryService",
     "TranscriptMatch",

--- a/src/echoflow/library/duckdb_index.py
+++ b/src/echoflow/library/duckdb_index.py
@@ -1,4 +1,3 @@
-import re
 from collections import Counter
 from pathlib import Path
 
@@ -13,8 +12,7 @@ from echoflow.library.index import (
     SearchSort,
     TranscriptMatch,
 )
-
-_TOKEN_PATTERN = re.compile(r"\w+(?:['’]\w+)*", re.UNICODE)
+from echoflow.library.text import lexical_tokens
 
 _SEARCH_SQL_PREFIX = """
     WITH query_terms AS (
@@ -72,11 +70,6 @@ _RELEVANCE_SEARCH_SQL = (
 _TIMELINE_SEARCH_SQL = (
     _SEARCH_SQL_PREFIX + "ORDER BY s.document_id, s.start_seconds, s.segment_id LIMIT ?"
 )
-
-
-def lexical_tokens(text: str) -> tuple[str, ...]:
-    """Return deterministic, Unicode-aware lexical tokens for local ranking."""
-    return tuple(match.group(0).casefold() for match in _TOKEN_PATTERN.finditer(text))
 
 
 def _numeric_cell(value: object, field: str) -> float:

--- a/src/echoflow/library/duckdb_semantic.py
+++ b/src/echoflow/library/duckdb_semantic.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import duckdb
 
 from echoflow.core.file_manager_facade import FileManagerFacade
-from echoflow.library.duckdb_index import lexical_tokens
 from echoflow.library.index import SearchOperator, SearchQuery
 from echoflow.library.semantic import (
     EmbeddingProfile,
@@ -15,6 +14,7 @@ from echoflow.library.semantic import (
     SemanticCandidate,
     SemanticState,
 )
+from echoflow.library.text import lexical_tokens
 
 
 class DuckDbSemanticIndex:

--- a/src/echoflow/library/errors.py
+++ b/src/echoflow/library/errors.py
@@ -23,3 +23,9 @@ class SpeakerLabelStateError(TranscriptLibraryError):
     """User-authored speaker label state is invalid, stale, or unavailable."""
 
     exit_code = 2
+
+
+class EvidenceNavigationError(TranscriptLibraryError):
+    """A ranked result cannot be reconciled safely with canonical evidence."""
+
+    exit_code = 2

--- a/src/echoflow/library/evidence.py
+++ b/src/echoflow/library/evidence.py
@@ -1,0 +1,348 @@
+"""Resolve ranked transcript passages back to verified canonical evidence coordinates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.errors import EvidenceNavigationError
+from echoflow.library.retrieval import SearchPassage, SearchResponse
+from echoflow.library.text import lexical_tokens
+
+_MAX_CANONICAL_BYTES = 256 * 1024 * 1024
+_MAX_CONTEXT_SEGMENTS = 10
+
+
+class _CanonicalSource(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    sha256: str
+
+
+class _CanonicalWord(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    start_seconds: float
+    end_seconds: float
+    text: str
+    speaker_ref: str | None = None
+
+
+class _CanonicalSegment(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    segment_id: str
+    start_seconds: float
+    end_seconds: float
+    text: str
+    speaker_ref: str | None = None
+    words: list[_CanonicalWord] = Field(default_factory=list)
+
+
+class _CanonicalTranscript(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    schema_version: int
+    job_id: str
+    source: _CanonicalSource
+    segments: list[_CanonicalSegment]
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceWord:
+    """One canonical word coordinate used by a derived research view."""
+
+    segment_id: str
+    word_index: int
+    start_seconds: float
+    end_seconds: float
+    text: str
+    speaker_ref: str | None
+    highlighted: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.segment_id.strip():
+            raise ValueError("segment_id cannot be empty")
+        if self.word_index < 0:
+            raise ValueError("word_index cannot be negative")
+        if self.start_seconds < 0 or self.end_seconds < self.start_seconds:
+            raise ValueError("word timestamps must be ordered and non-negative")
+        if not self.text.strip():
+            raise ValueError("word text cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceContextSegment:
+    """One canonical segment included in a result or its requested context."""
+
+    segment_id: str
+    start_seconds: float
+    end_seconds: float
+    text: str
+    speaker_refs: tuple[str, ...]
+    words: tuple[EvidenceWord, ...]
+    is_result_segment: bool
+    lexical_match: bool
+
+    def __post_init__(self) -> None:
+        if not self.segment_id.strip():
+            raise ValueError("segment_id cannot be empty")
+        if self.start_seconds < 0 or self.end_seconds < self.start_seconds:
+            raise ValueError("segment timestamps must be ordered and non-negative")
+        if not self.text.strip():
+            raise ValueError("segment text cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceLocation:
+    """Verified canonical coordinates for one ranked search passage."""
+
+    document_id: str
+    source_sha256: str
+    canonical_sha256: str
+    canonical_path: str
+    source_path: str | None
+    result_segment_ids: tuple[str, ...]
+    start_seconds: float
+    end_seconds: float
+    seek_seconds: float
+    result_speaker_refs: tuple[str, ...]
+    matched_words: tuple[EvidenceWord, ...]
+    context_segments: tuple[EvidenceContextSegment, ...]
+
+    def __post_init__(self) -> None:
+        if not self.document_id.strip():
+            raise ValueError("document_id cannot be empty")
+        if not self.result_segment_ids:
+            raise ValueError("evidence location requires at least one result segment")
+        if self.start_seconds < 0 or self.end_seconds < self.start_seconds:
+            raise ValueError("evidence timestamps must be ordered and non-negative")
+        if not self.start_seconds <= self.seek_seconds <= self.end_seconds:
+            raise ValueError("seek coordinate must remain inside result evidence")
+
+
+class EvidenceLocator:
+    """Verify canonical custody, expand context, and resolve justified word highlights."""
+
+    def __init__(self, file_manager: FileManagerFacade) -> None:
+        self.file_manager = file_manager
+
+    def locate_response(
+        self,
+        response: SearchResponse,
+        *,
+        context_segments: int = 0,
+    ) -> tuple[EvidenceLocation, ...]:
+        if context_segments < 0 or context_segments > _MAX_CONTEXT_SEGMENTS:
+            raise ValueError(
+                f"context_segments must be between 0 and {_MAX_CONTEXT_SEGMENTS}"
+            )
+        cache: dict[tuple[str, str], _CanonicalTranscript] = {}
+        return tuple(
+            self._locate(
+                passage,
+                response=response,
+                context_segments=context_segments,
+                cache=cache,
+            )
+            for passage in response.results
+        )
+
+    def _locate(
+        self,
+        passage: SearchPassage,
+        *,
+        response: SearchResponse,
+        context_segments: int,
+        cache: dict[tuple[str, str], _CanonicalTranscript],
+    ) -> EvidenceLocation:
+        canonical_sha256 = passage.canonical_sha256
+        if canonical_sha256 is None:
+            raise EvidenceNavigationError(
+                "Transcript index predates canonical hashing; rebuild the library before navigating evidence"
+            )
+        cache_key = (passage.canonical_path, canonical_sha256)
+        canonical = cache.get(cache_key)
+        if canonical is None:
+            canonical = self._load_canonical(passage, canonical_sha256)
+            cache[cache_key] = canonical
+
+        by_id = {segment.segment_id: index for index, segment in enumerate(canonical.segments)}
+        try:
+            result_indices = tuple(by_id[item] for item in passage.segment_ids)
+        except KeyError as exc:
+            raise EvidenceNavigationError(
+                "Search result references canonical evidence that no longer exists"
+            ) from exc
+        if not result_indices:
+            raise EvidenceNavigationError("Search result has no canonical evidence segments")
+
+        first_result = min(result_indices)
+        last_result = max(result_indices)
+        context_start = max(0, first_result - context_segments)
+        context_end = min(len(canonical.segments), last_result + context_segments + 1)
+        result_ids = set(passage.segment_ids)
+        lexical_ids = set(passage.matched_segment_ids)
+        query_tokens = lexical_tokens(response.query.text)
+        context: list[EvidenceContextSegment] = []
+        matched_words: list[EvidenceWord] = []
+
+        for segment in canonical.segments[context_start:context_end]:
+            should_highlight = segment.segment_id in lexical_ids
+            highlighted_indices = (
+                self._highlighted_word_indices(
+                    segment.words,
+                    query_tokens=query_tokens,
+                    phrase=response.query.phrase,
+                )
+                if should_highlight
+                else set()
+            )
+            words = tuple(
+                EvidenceWord(
+                    segment_id=segment.segment_id,
+                    word_index=index,
+                    start_seconds=word.start_seconds,
+                    end_seconds=word.end_seconds,
+                    text=word.text,
+                    speaker_ref=word.speaker_ref,
+                    highlighted=index in highlighted_indices,
+                )
+                for index, word in enumerate(segment.words)
+            )
+            matched_words.extend(word for word in words if word.highlighted)
+            context.append(
+                EvidenceContextSegment(
+                    segment_id=segment.segment_id,
+                    start_seconds=segment.start_seconds,
+                    end_seconds=segment.end_seconds,
+                    text=segment.text,
+                    speaker_refs=self._segment_speakers(segment),
+                    words=words,
+                    is_result_segment=segment.segment_id in result_ids,
+                    lexical_match=should_highlight,
+                )
+            )
+
+        result_segments = tuple(canonical.segments[index] for index in result_indices)
+        result_start = min(segment.start_seconds for segment in result_segments)
+        result_end = max(segment.end_seconds for segment in result_segments)
+        if passage.start_seconds < result_start - 1e-6 or passage.end_seconds > result_end + 1e-6:
+            raise EvidenceNavigationError(
+                "Search result timing does not fit its canonical evidence segments"
+            )
+        result_speakers = tuple(
+            sorted(
+                {
+                    ref
+                    for segment in result_segments
+                    for ref in self._segment_speakers(segment)
+                }
+            )
+        )
+        if not result_speakers:
+            result_speakers = passage.speaker_refs
+        seek_seconds = matched_words[0].start_seconds if matched_words else passage.start_seconds
+
+        return EvidenceLocation(
+            document_id=passage.document_id,
+            source_sha256=passage.source_sha256,
+            canonical_sha256=canonical_sha256,
+            canonical_path=passage.canonical_path,
+            source_path=passage.source_path,
+            result_segment_ids=passage.segment_ids,
+            start_seconds=passage.start_seconds,
+            end_seconds=passage.end_seconds,
+            seek_seconds=seek_seconds,
+            result_speaker_refs=result_speakers,
+            matched_words=tuple(matched_words),
+            context_segments=tuple(context),
+        )
+
+    def _load_canonical(
+        self,
+        passage: SearchPassage,
+        canonical_sha256: str,
+    ) -> _CanonicalTranscript:
+        try:
+            payload = self.file_manager.read_file(Path(passage.canonical_path))
+            if len(payload) > _MAX_CANONICAL_BYTES:
+                raise EvidenceNavigationError(
+                    "Canonical transcript is too large to navigate safely"
+                )
+            if hashlib.sha256(payload).hexdigest() != canonical_sha256:
+                raise EvidenceNavigationError(
+                    "Canonical transcript changed; rebuild the library before navigating evidence"
+                )
+            canonical = _CanonicalTranscript.model_validate(json.loads(payload))
+            if canonical.schema_version != 1:
+                raise EvidenceNavigationError(
+                    "Canonical transcript schema is unsupported by this EchoFlow build"
+                )
+            if canonical.job_id != passage.document_id:
+                raise EvidenceNavigationError(
+                    "Canonical transcript identity does not match the search result"
+                )
+            if canonical.source.sha256 != passage.source_sha256:
+                raise EvidenceNavigationError(
+                    "Canonical source identity does not match the search result"
+                )
+            return canonical
+        except EvidenceNavigationError:
+            raise
+        except (
+            OSError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValidationError,
+            ValueError,
+        ) as exc:
+            raise EvidenceNavigationError(
+                "Canonical evidence could not be validated for navigation",
+                cause=exc,
+            ) from exc
+
+    @staticmethod
+    def _segment_speakers(segment: _CanonicalSegment) -> tuple[str, ...]:
+        refs = {
+            word.speaker_ref
+            for word in segment.words
+            if word.speaker_ref is not None and word.speaker_ref.strip()
+        }
+        if segment.speaker_ref is not None and segment.speaker_ref.strip():
+            refs.add(segment.speaker_ref)
+        return tuple(sorted(refs))
+
+    @staticmethod
+    def _highlighted_word_indices(
+        words: list[_CanonicalWord],
+        *,
+        query_tokens: tuple[str, ...],
+        phrase: bool,
+    ) -> set[int]:
+        if not words or not query_tokens:
+            return set()
+        flattened: list[tuple[str, int]] = []
+        for index, word in enumerate(words):
+            flattened.extend((token, index) for token in lexical_tokens(word.text))
+        if not flattened:
+            return set()
+        if not phrase:
+            requested = set(query_tokens)
+            return {word_index for token, word_index in flattened if token in requested}
+
+        tokens = tuple(token for token, _ in flattened)
+        width = len(query_tokens)
+        highlighted: set[int] = set()
+        for offset in range(0, len(tokens) - width + 1):
+            if tokens[offset : offset + width] != query_tokens:
+                continue
+            highlighted.update(
+                word_index for _, word_index in flattened[offset : offset + width]
+            )
+        return highlighted

--- a/src/echoflow/library/evidence.py
+++ b/src/echoflow/library/evidence.py
@@ -161,93 +161,21 @@ class EvidenceLocator:
         context_segments: int,
         cache: dict[tuple[str, str], _CanonicalTranscript],
     ) -> EvidenceLocation:
-        canonical_sha256 = passage.canonical_sha256
-        if canonical_sha256 is None:
-            raise EvidenceNavigationError(
-                "Transcript index predates canonical hashing; rebuild the library before navigating evidence"
-            )
-        cache_key = (passage.canonical_path, canonical_sha256)
-        canonical = cache.get(cache_key)
-        if canonical is None:
-            canonical = self._load_canonical(passage, canonical_sha256)
-            cache[cache_key] = canonical
-
-        by_id = {segment.segment_id: index for index, segment in enumerate(canonical.segments)}
-        try:
-            result_indices = tuple(by_id[item] for item in passage.segment_ids)
-        except KeyError as exc:
-            raise EvidenceNavigationError(
-                "Search result references canonical evidence that no longer exists"
-            ) from exc
-        if not result_indices:
-            raise EvidenceNavigationError("Search result has no canonical evidence segments")
-
-        first_result = min(result_indices)
-        last_result = max(result_indices)
-        context_start = max(0, first_result - context_segments)
-        context_end = min(len(canonical.segments), last_result + context_segments + 1)
-        result_ids = set(passage.segment_ids)
-        lexical_ids = set(passage.matched_segment_ids)
-        query_tokens = lexical_tokens(response.query.text)
-        context: list[EvidenceContextSegment] = []
-        matched_words: list[EvidenceWord] = []
-
-        for segment in canonical.segments[context_start:context_end]:
-            should_highlight = segment.segment_id in lexical_ids
-            highlighted_indices = (
-                self._highlighted_word_indices(
-                    segment.words,
-                    query_tokens=query_tokens,
-                    phrase=response.query.phrase,
-                )
-                if should_highlight
-                else set()
-            )
-            words = tuple(
-                EvidenceWord(
-                    segment_id=segment.segment_id,
-                    word_index=index,
-                    start_seconds=word.start_seconds,
-                    end_seconds=word.end_seconds,
-                    text=word.text,
-                    speaker_ref=word.speaker_ref,
-                    highlighted=index in highlighted_indices,
-                )
-                for index, word in enumerate(segment.words)
-            )
-            matched_words.extend(word for word in words if word.highlighted)
-            context.append(
-                EvidenceContextSegment(
-                    segment_id=segment.segment_id,
-                    start_seconds=segment.start_seconds,
-                    end_seconds=segment.end_seconds,
-                    text=segment.text,
-                    speaker_refs=self._segment_speakers(segment),
-                    words=words,
-                    is_result_segment=segment.segment_id in result_ids,
-                    lexical_match=should_highlight,
-                )
-            )
-
-        result_segments = tuple(canonical.segments[index] for index in result_indices)
-        result_start = min(segment.start_seconds for segment in result_segments)
-        result_end = max(segment.end_seconds for segment in result_segments)
-        if passage.start_seconds < result_start - 1e-6 or passage.end_seconds > result_end + 1e-6:
-            raise EvidenceNavigationError(
-                "Search result timing does not fit its canonical evidence segments"
-            )
-        result_speakers = tuple(
-            sorted(
-                {
-                    ref
-                    for segment in result_segments
-                    for ref in self._segment_speakers(segment)
-                }
-            )
+        canonical_sha256, canonical = self._canonical_for_passage(passage, cache)
+        result_indices = self._result_indices(passage, canonical)
+        context, matched_words = self._context_for_passage(
+            passage,
+            canonical=canonical,
+            result_indices=result_indices,
+            response=response,
+            context_segments=context_segments,
         )
-        if not result_speakers:
-            result_speakers = passage.speaker_refs
-        seek_seconds = matched_words[0].start_seconds if matched_words else passage.start_seconds
+        result_segments = tuple(canonical.segments[index] for index in result_indices)
+        self._validate_result_timing(passage, result_segments)
+        result_speakers = self._result_speakers(passage, result_segments)
+        seek_seconds = (
+            matched_words[0].start_seconds if matched_words else passage.start_seconds
+        )
 
         return EvidenceLocation(
             document_id=passage.document_id,
@@ -260,9 +188,149 @@ class EvidenceLocator:
             end_seconds=passage.end_seconds,
             seek_seconds=seek_seconds,
             result_speaker_refs=result_speakers,
-            matched_words=tuple(matched_words),
-            context_segments=tuple(context),
+            matched_words=matched_words,
+            context_segments=context,
         )
+
+    def _canonical_for_passage(
+        self,
+        passage: SearchPassage,
+        cache: dict[tuple[str, str], _CanonicalTranscript],
+    ) -> tuple[str, _CanonicalTranscript]:
+        canonical_sha256 = passage.canonical_sha256
+        if canonical_sha256 is None:
+            raise EvidenceNavigationError(
+                "Transcript index predates canonical hashing; rebuild the library before navigating evidence"
+            )
+        cache_key = (passage.canonical_path, canonical_sha256)
+        canonical = cache.get(cache_key)
+        if canonical is None:
+            canonical = self._load_canonical(passage, canonical_sha256)
+            cache[cache_key] = canonical
+        return canonical_sha256, canonical
+
+    @staticmethod
+    def _result_indices(
+        passage: SearchPassage,
+        canonical: _CanonicalTranscript,
+    ) -> tuple[int, ...]:
+        by_id = {
+            segment.segment_id: index
+            for index, segment in enumerate(canonical.segments)
+        }
+        try:
+            result_indices = tuple(by_id[item] for item in passage.segment_ids)
+        except KeyError as exc:
+            raise EvidenceNavigationError(
+                "Search result references canonical evidence that no longer exists"
+            ) from exc
+        if not result_indices:
+            raise EvidenceNavigationError("Search result has no canonical evidence segments")
+        return result_indices
+
+    def _context_for_passage(
+        self,
+        passage: SearchPassage,
+        *,
+        canonical: _CanonicalTranscript,
+        result_indices: tuple[int, ...],
+        response: SearchResponse,
+        context_segments: int,
+    ) -> tuple[tuple[EvidenceContextSegment, ...], tuple[EvidenceWord, ...]]:
+        first_result = min(result_indices)
+        last_result = max(result_indices)
+        context_start = max(0, first_result - context_segments)
+        context_end = min(len(canonical.segments), last_result + context_segments + 1)
+        result_ids = set(passage.segment_ids)
+        lexical_ids = set(passage.matched_segment_ids)
+        query_tokens = lexical_tokens(response.query.text)
+        context: list[EvidenceContextSegment] = []
+        matched_words: list[EvidenceWord] = []
+
+        for segment in canonical.segments[context_start:context_end]:
+            rendered, highlighted = self._context_segment(
+                segment,
+                result_ids=result_ids,
+                lexical_ids=lexical_ids,
+                query_tokens=query_tokens,
+                phrase=response.query.phrase,
+            )
+            context.append(rendered)
+            matched_words.extend(highlighted)
+        return tuple(context), tuple(matched_words)
+
+    def _context_segment(
+        self,
+        segment: _CanonicalSegment,
+        *,
+        result_ids: set[str],
+        lexical_ids: set[str],
+        query_tokens: tuple[str, ...],
+        phrase: bool,
+    ) -> tuple[EvidenceContextSegment, tuple[EvidenceWord, ...]]:
+        should_highlight = segment.segment_id in lexical_ids
+        highlighted_indices = self._highlighted_word_indices(
+            segment.words,
+            query_tokens=query_tokens,
+            phrase=phrase,
+        ) if should_highlight else set()
+        words = tuple(
+            EvidenceWord(
+                segment_id=segment.segment_id,
+                word_index=index,
+                start_seconds=word.start_seconds,
+                end_seconds=word.end_seconds,
+                text=word.text,
+                speaker_ref=word.speaker_ref,
+                highlighted=index in highlighted_indices,
+            )
+            for index, word in enumerate(segment.words)
+        )
+        highlighted = tuple(word for word in words if word.highlighted)
+        return (
+            EvidenceContextSegment(
+                segment_id=segment.segment_id,
+                start_seconds=segment.start_seconds,
+                end_seconds=segment.end_seconds,
+                text=segment.text,
+                speaker_refs=self._segment_speakers(segment),
+                words=words,
+                is_result_segment=segment.segment_id in result_ids,
+                lexical_match=should_highlight,
+            ),
+            highlighted,
+        )
+
+    @staticmethod
+    def _validate_result_timing(
+        passage: SearchPassage,
+        result_segments: tuple[_CanonicalSegment, ...],
+    ) -> None:
+        result_start = min(segment.start_seconds for segment in result_segments)
+        result_end = max(segment.end_seconds for segment in result_segments)
+        if (
+            passage.start_seconds < result_start - 1e-6
+            or passage.end_seconds > result_end + 1e-6
+        ):
+            raise EvidenceNavigationError(
+                "Search result timing does not fit its canonical evidence segments"
+            )
+
+    def _result_speakers(
+        self,
+        passage: SearchPassage,
+        result_segments: tuple[_CanonicalSegment, ...],
+    ) -> tuple[str, ...]:
+        result_speakers = tuple(
+            sorted(
+                {
+                    ref
+                    for segment in result_segments
+                    for ref in self._segment_speakers(segment)
+                }
+            )
+        )
+        return result_speakers or passage.speaker_refs
 
     def _load_canonical(
         self,

--- a/src/echoflow/library/evidence.py
+++ b/src/echoflow/library/evidence.py
@@ -225,7 +225,9 @@ class EvidenceLocator:
                 "Search result references canonical evidence that no longer exists"
             ) from exc
         if not result_indices:
-            raise EvidenceNavigationError("Search result has no canonical evidence segments")
+            raise EvidenceNavigationError(
+                "Search result has no canonical evidence segments"
+            )
         return result_indices
 
     def _context_for_passage(
@@ -269,11 +271,15 @@ class EvidenceLocator:
         phrase: bool,
     ) -> tuple[EvidenceContextSegment, tuple[EvidenceWord, ...]]:
         should_highlight = segment.segment_id in lexical_ids
-        highlighted_indices = self._highlighted_word_indices(
-            segment.words,
-            query_tokens=query_tokens,
-            phrase=phrase,
-        ) if should_highlight else set()
+        highlighted_indices = (
+            self._highlighted_word_indices(
+                segment.words,
+                query_tokens=query_tokens,
+                phrase=phrase,
+            )
+            if should_highlight
+            else set()
+        )
         words = tuple(
             EvidenceWord(
                 segment_id=segment.segment_id,

--- a/src/echoflow/library/research.py
+++ b/src/echoflow/library/research.py
@@ -22,7 +22,7 @@ class SpeakerDisplay:
     def display_name(self) -> str:
         if self.display_label is None:
             return self.speaker_ref
-        return f"{self.display_label} ({self.speaker_ref})"
+        return f"{self.display_label}\n{self.speaker_ref}"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/echoflow/library/research.py
+++ b/src/echoflow/library/research.py
@@ -49,7 +49,9 @@ class ResearchSearchResponse:
 
     def __post_init__(self) -> None:
         if len(self.retrieval.results) != len(self.results):
-            raise ValueError("research results must preserve retrieval result cardinality")
+            raise ValueError(
+                "research results must preserve retrieval result cardinality"
+            )
         if tuple(item.passage for item in self.results) != self.retrieval.results:
             raise ValueError("research results must preserve retrieval result order")
 

--- a/src/echoflow/library/research.py
+++ b/src/echoflow/library/research.py
@@ -1,0 +1,119 @@
+"""Compose ranked retrieval with verified canonical navigation and user display state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from echoflow.library.evidence import EvidenceLocation, EvidenceLocator
+from echoflow.library.index import SearchQuery
+from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
+from echoflow.library.service import TranscriptLibraryService
+from echoflow.library.speaker_label_service import SpeakerLabelService
+
+
+@dataclass(frozen=True, slots=True)
+class SpeakerDisplay:
+    """Anonymous evidence reference plus optional user-authored presentation label."""
+
+    speaker_ref: str
+    display_label: str | None = None
+
+    @property
+    def display_name(self) -> str:
+        if self.display_label is None:
+            return self.speaker_ref
+        return f"{self.display_label} ({self.speaker_ref})"
+
+
+@dataclass(frozen=True, slots=True)
+class LocatedSearchPassage:
+    """One ranked passage enriched with verified canonical navigation coordinates."""
+
+    passage: SearchPassage
+    evidence: EvidenceLocation
+    speakers: tuple[SpeakerDisplay, ...]
+
+    def __post_init__(self) -> None:
+        if self.passage.document_id != self.evidence.document_id:
+            raise ValueError("passage and evidence document identities must match")
+        if self.passage.canonical_sha256 != self.evidence.canonical_sha256:
+            raise ValueError("passage and evidence canonical identities must match")
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchSearchResponse:
+    """Retrieval provenance plus canonical navigation for every result."""
+
+    retrieval: SearchResponse
+    results: tuple[LocatedSearchPassage, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.retrieval.results) != len(self.results):
+            raise ValueError("research results must preserve retrieval result cardinality")
+        if tuple(item.passage for item in self.results) != self.retrieval.results:
+            raise ValueError("research results must preserve retrieval result order")
+
+
+class ResearchNavigationService:
+    """Make search results usable without changing ranking or canonical evidence."""
+
+    def __init__(
+        self,
+        transcript_library: TranscriptLibraryService,
+        evidence_locator: EvidenceLocator,
+        speaker_labels: SpeakerLabelService,
+    ) -> None:
+        self.transcript_library = transcript_library
+        self.evidence_locator = evidence_locator
+        self.speaker_labels = speaker_labels
+
+    def search(
+        self,
+        query: SearchQuery,
+        *,
+        mode: RetrievalMode = RetrievalMode.LEXICAL,
+        context_segments: int = 0,
+    ) -> ResearchSearchResponse:
+        retrieval = self.transcript_library.retrieve(query, mode=mode)
+        locations = self.evidence_locator.locate_response(
+            retrieval,
+            context_segments=context_segments,
+        )
+
+        requested: dict[tuple[str, str], set[str]] = {}
+        for location in locations:
+            key = (location.document_id, location.canonical_sha256)
+            requested.setdefault(key, set()).update(location.result_speaker_refs)
+        labels_by_generation: dict[tuple[str, str], dict[str, str]] = {}
+        for key, refs in requested.items():
+            document_id, canonical_sha256 = key
+            labels_by_generation[key] = self.speaker_labels.display_labels(
+                document_id=document_id,
+                canonical_sha256=canonical_sha256,
+                speaker_refs=tuple(sorted(refs)),
+            )
+
+        results = tuple(
+            self._located(passage, location, labels_by_generation)
+            for passage, location in zip(retrieval.results, locations, strict=True)
+        )
+        return ResearchSearchResponse(retrieval=retrieval, results=results)
+
+    @staticmethod
+    def _located(
+        passage: SearchPassage,
+        location: EvidenceLocation,
+        labels_by_generation: dict[tuple[str, str], dict[str, str]],
+    ) -> LocatedSearchPassage:
+        labels = labels_by_generation.get(
+            (location.document_id, location.canonical_sha256), {}
+        )
+        speakers = tuple(
+            SpeakerDisplay(speaker_ref=ref, display_label=labels.get(ref))
+            for ref in location.result_speaker_refs
+        )
+        return LocatedSearchPassage(
+            passage=passage,
+            evidence=location,
+            speakers=speakers,
+        )

--- a/src/echoflow/library/speaker_label_service.py
+++ b/src/echoflow/library/speaker_label_service.py
@@ -83,17 +83,18 @@ class SpeakerLabelService:
         canonical_sha256: str | None,
         speaker_refs: tuple[str, ...],
     ) -> dict[str, str]:
-        """Resolve only labels bound to the exact evidence generation in a result."""
-        resolved: dict[str, str] = {}
-        for speaker_ref in speaker_refs:
-            label = self.store.resolve(
-                document_id=document_id,
-                canonical_sha256=canonical_sha256,
-                speaker_ref=speaker_ref,
-            )
-            if label is not None:
-                resolved[speaker_ref] = label
-        return resolved
+        """Resolve labels for one exact canonical generation with one state read."""
+        if canonical_sha256 is None or not speaker_refs:
+            return {}
+        document = self._document(document_id)
+        if document.canonical_sha256 != canonical_sha256:
+            return {}
+        requested = set(speaker_refs)
+        return {
+            item.speaker_ref: item.label
+            for item in self.store.current_labels(document)
+            if item.speaker_ref in requested
+        }
 
     def _document(self, document_id: str) -> IndexedDocument:
         document = next(

--- a/src/echoflow/library/tests/test_evidence.py
+++ b/src/echoflow/library/tests/test_evidence.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import pytest
 
 from echoflow.interfaces.local_file_manager import LocalFileManager
-from echoflow.library.evidence import EvidenceLocator
 from echoflow.library.errors import EvidenceNavigationError
+from echoflow.library.evidence import EvidenceLocator
 from echoflow.library.index import SearchQuery
 from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
 from echoflow.library.semantic import EmbeddingProfile

--- a/src/echoflow/library/tests/test_evidence.py
+++ b/src/echoflow/library/tests/test_evidence.py
@@ -8,7 +8,12 @@ from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.library.evidence import EvidenceLocator
 from echoflow.library.errors import EvidenceNavigationError
 from echoflow.library.index import SearchQuery
-from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
+from echoflow.library.retrieval import (
+    RetrievalMode,
+    SearchPassage,
+    SearchResponse,
+)
+from echoflow.library.semantic import EmbeddingProfile
 
 
 def _canonical(path: Path) -> str:
@@ -181,9 +186,7 @@ def test_semantic_only_result_does_not_invent_exact_word_highlight(tmp_path: Pat
         mode=RetrievalMode.SEMANTIC,
         lexical_backend_id=None,
         semantic_backend_id="duckdb-exact-vector-v1",
-        semantic_profile=pytest.importorskip(
-            "echoflow.library.semantic"
-        ).EmbeddingProfile(
+        semantic_profile=EmbeddingProfile(
             profile_id="profile",
             provider="fake",
             model_id="fake/model",

--- a/src/echoflow/library/tests/test_evidence.py
+++ b/src/echoflow/library/tests/test_evidence.py
@@ -1,0 +1,252 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.library.evidence import EvidenceLocator
+from echoflow.library.errors import EvidenceNavigationError
+from echoflow.library.index import SearchQuery
+from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
+
+
+def _canonical(path: Path) -> str:
+    document = {
+        "schema_version": 1,
+        "job_id": "job-1",
+        "source": {"sha256": "a" * 64},
+        "segments": [
+            {
+                "segment_id": "segment-000000",
+                "start_seconds": 0.0,
+                "end_seconds": 1.0,
+                "text": "Before the answer.",
+                "speaker_ref": "speaker-01",
+                "words": [
+                    {
+                        "start_seconds": 0.0,
+                        "end_seconds": 0.4,
+                        "text": "Before",
+                        "speaker_ref": "speaker-01",
+                    },
+                    {
+                        "start_seconds": 0.5,
+                        "end_seconds": 0.8,
+                        "text": " the",
+                        "speaker_ref": "speaker-01",
+                    },
+                    {
+                        "start_seconds": 0.8,
+                        "end_seconds": 1.0,
+                        "text": " answer.",
+                        "speaker_ref": "speaker-01",
+                    },
+                ],
+            },
+            {
+                "segment_id": "segment-000001",
+                "start_seconds": 1.0,
+                "end_seconds": 3.0,
+                "text": "Housing affordability matters here.",
+                "speaker_ref": "speaker-02",
+                "words": [
+                    {
+                        "start_seconds": 1.1,
+                        "end_seconds": 1.5,
+                        "text": "Housing",
+                        "speaker_ref": "speaker-02",
+                    },
+                    {
+                        "start_seconds": 1.6,
+                        "end_seconds": 2.2,
+                        "text": " affordability",
+                        "speaker_ref": "speaker-02",
+                    },
+                    {
+                        "start_seconds": 2.3,
+                        "end_seconds": 2.6,
+                        "text": " matters",
+                        "speaker_ref": "speaker-02",
+                    },
+                    {
+                        "start_seconds": 2.7,
+                        "end_seconds": 3.0,
+                        "text": " here.",
+                        "speaker_ref": "speaker-02",
+                    },
+                ],
+            },
+            {
+                "segment_id": "segment-000002",
+                "start_seconds": 3.0,
+                "end_seconds": 4.0,
+                "text": "After the answer.",
+                "speaker_ref": None,
+            },
+        ],
+    }
+    payload = json.dumps(document, sort_keys=True).encode()
+    path.write_bytes(payload)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _passage(path: Path, digest: str, *, matched: bool = True) -> SearchPassage:
+    return SearchPassage(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256=digest,
+        canonical_path=str(path),
+        source_path="/recording.wav",
+        chunk_id=None,
+        segment_ids=("segment-000001",),
+        matched_segment_ids=("segment-000001",) if matched else (),
+        start_seconds=1.0,
+        end_seconds=3.0,
+        text="Housing affordability matters here.",
+        languages=("en",),
+        speaker_refs=("speaker-02",),
+        lexical_rank=1 if matched else None,
+        semantic_rank=None if matched else 1,
+        fused_rank=None,
+    )
+
+
+def _response(
+    passage: SearchPassage,
+    *,
+    query: SearchQuery,
+    mode: RetrievalMode = RetrievalMode.LEXICAL,
+) -> SearchResponse:
+    return SearchResponse(
+        query=query,
+        mode=mode,
+        lexical_backend_id="duckdb-bm25-v1" if mode is RetrievalMode.LEXICAL else None,
+        semantic_backend_id=(
+            None if mode is RetrievalMode.LEXICAL else "duckdb-exact-vector-v1"
+        ),
+        semantic_profile=None,
+        fusion_profile=None,
+        results=(passage,),
+    )
+
+
+def _locator() -> EvidenceLocator:
+    return EvidenceLocator(LocalFileManager())  # type: ignore[arg-type]
+
+
+def test_lexical_result_highlights_aligned_words_and_seeks_to_first_match(
+    tmp_path: Path,
+) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _canonical(canonical)
+    passage = _passage(canonical, digest)
+    response = _response(passage, query=SearchQuery("housing matters"))
+
+    location = _locator().locate_response(response)[0]
+
+    assert [word.text.strip() for word in location.matched_words] == [
+        "Housing",
+        "matters",
+    ]
+    assert location.seek_seconds == 1.1
+    assert location.result_speaker_refs == ("speaker-02",)
+    assert location.context_segments[0].segment_id == "segment-000001"
+
+
+def test_phrase_highlight_requires_contiguous_canonical_word_tokens(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _canonical(canonical)
+    passage = _passage(canonical, digest)
+    response = _response(
+        passage,
+        query=SearchQuery("housing affordability", phrase=True),
+    )
+
+    location = _locator().locate_response(response)[0]
+
+    assert [word.word_index for word in location.matched_words] == [0, 1]
+    assert [word.text.strip() for word in location.matched_words] == [
+        "Housing",
+        "affordability",
+    ]
+
+
+def test_semantic_only_result_does_not_invent_exact_word_highlight(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _canonical(canonical)
+    passage = _passage(canonical, digest, matched=False)
+    response = SearchResponse(
+        query=SearchQuery("people struggling to pay rent"),
+        mode=RetrievalMode.SEMANTIC,
+        lexical_backend_id=None,
+        semantic_backend_id="duckdb-exact-vector-v1",
+        semantic_profile=pytest.importorskip(
+            "echoflow.library.semantic"
+        ).EmbeddingProfile(
+            profile_id="profile",
+            provider="fake",
+            model_id="fake/model",
+            resolved_revision="revision",
+            dimensions=2,
+            normalization="l2",
+            pooling="mean",
+            distance_metric="dot",
+            query_prefix="query: ",
+            passage_prefix="passage: ",
+            chunking_profile_id="search-chunk-v1",
+            snapshot_path="/private/revision",
+        ),
+        fusion_profile=None,
+        results=(passage,),
+    )
+
+    location = _locator().locate_response(response)[0]
+
+    assert location.matched_words == ()
+    assert location.seek_seconds == 1.0
+    assert not any(
+        word.highlighted
+        for segment in location.context_segments
+        for word in segment.words
+    )
+
+
+def test_context_expansion_keeps_neighbors_distinct_from_result(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _canonical(canonical)
+    response = _response(_passage(canonical, digest), query=SearchQuery("housing"))
+
+    location = _locator().locate_response(response, context_segments=1)[0]
+
+    assert [segment.segment_id for segment in location.context_segments] == [
+        "segment-000000",
+        "segment-000001",
+        "segment-000002",
+    ]
+    assert [segment.is_result_segment for segment in location.context_segments] == [
+        False,
+        True,
+        False,
+    ]
+    assert location.context_segments[2].words == ()
+
+
+def test_stale_canonical_bytes_fail_closed(tmp_path: Path) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _canonical(canonical)
+    response = _response(_passage(canonical, digest), query=SearchQuery("housing"))
+    canonical.write_text('{"schema_version": 1}')
+
+    with pytest.raises(EvidenceNavigationError, match="changed"):
+        _locator().locate_response(response)
+
+
+@pytest.mark.parametrize("context_segments", [-1, 11])
+def test_context_expansion_is_bounded(tmp_path: Path, context_segments: int) -> None:
+    canonical = tmp_path / "transcript.json"
+    digest = _canonical(canonical)
+    response = _response(_passage(canonical, digest), query=SearchQuery("housing"))
+
+    with pytest.raises(ValueError, match="between 0 and 10"):
+        _locator().locate_response(response, context_segments=context_segments)

--- a/src/echoflow/library/tests/test_evidence.py
+++ b/src/echoflow/library/tests/test_evidence.py
@@ -155,7 +155,9 @@ def test_lexical_result_highlights_aligned_words_and_seeks_to_first_match(
     assert location.context_segments[0].segment_id == "segment-000001"
 
 
-def test_phrase_highlight_requires_contiguous_canonical_word_tokens(tmp_path: Path) -> None:
+def test_phrase_highlight_requires_contiguous_canonical_word_tokens(
+    tmp_path: Path,
+) -> None:
     canonical = tmp_path / "transcript.json"
     digest = _canonical(canonical)
     passage = _passage(canonical, digest)
@@ -173,7 +175,9 @@ def test_phrase_highlight_requires_contiguous_canonical_word_tokens(tmp_path: Pa
     ]
 
 
-def test_semantic_only_result_does_not_invent_exact_word_highlight(tmp_path: Path) -> None:
+def test_semantic_only_result_does_not_invent_exact_word_highlight(
+    tmp_path: Path,
+) -> None:
     canonical = tmp_path / "transcript.json"
     digest = _canonical(canonical)
     passage = _passage(canonical, digest, matched=False)

--- a/src/echoflow/library/tests/test_evidence.py
+++ b/src/echoflow/library/tests/test_evidence.py
@@ -8,11 +8,7 @@ from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.library.evidence import EvidenceLocator
 from echoflow.library.errors import EvidenceNavigationError
 from echoflow.library.index import SearchQuery
-from echoflow.library.retrieval import (
-    RetrievalMode,
-    SearchPassage,
-    SearchResponse,
-)
+from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
 from echoflow.library.semantic import EmbeddingProfile
 
 

--- a/src/echoflow/library/tests/test_research.py
+++ b/src/echoflow/library/tests/test_research.py
@@ -1,0 +1,143 @@
+from unittest.mock import Mock
+
+from echoflow.library.evidence import EvidenceLocation
+from echoflow.library.index import SearchQuery
+from echoflow.library.research import ResearchNavigationService
+from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
+
+
+def _passage() -> SearchPassage:
+    return SearchPassage(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256="b" * 64,
+        canonical_path="/canonical.json",
+        source_path="/recording.wav",
+        chunk_id=None,
+        segment_ids=("segment-000001",),
+        matched_segment_ids=("segment-000001",),
+        start_seconds=1.0,
+        end_seconds=2.0,
+        text="Housing matters",
+        languages=("en",),
+        speaker_refs=("speaker-02",),
+        lexical_rank=1,
+        semantic_rank=None,
+        fused_rank=None,
+    )
+
+
+def _location(*, refs: tuple[str, ...] = ("speaker-02",)) -> EvidenceLocation:
+    return EvidenceLocation(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256="b" * 64,
+        canonical_path="/canonical.json",
+        source_path="/recording.wav",
+        result_segment_ids=("segment-000001",),
+        start_seconds=1.0,
+        end_seconds=2.0,
+        seek_seconds=1.0,
+        result_speaker_refs=refs,
+        matched_words=(),
+        context_segments=(),
+    )
+
+
+def _retrieval(*passages: SearchPassage) -> SearchResponse:
+    return SearchResponse(
+        query=SearchQuery("housing"),
+        mode=RetrievalMode.LEXICAL,
+        lexical_backend_id="duckdb-bm25-v1",
+        semantic_backend_id=None,
+        semantic_profile=None,
+        fusion_profile=None,
+        results=tuple(passages),
+    )
+
+
+def test_research_navigation_adds_display_names_without_mutating_retrieval() -> None:
+    passage = _passage()
+    retrieval = _retrieval(passage)
+    library = Mock()
+    library.retrieve.return_value = retrieval
+    locator = Mock()
+    locator.locate_response.return_value = (_location(),)
+    labels = Mock()
+    labels.display_labels.return_value = {"speaker-02": "Dr. Chen"}
+    service = ResearchNavigationService(library, locator, labels)
+
+    response = service.search(SearchQuery("housing"), context_segments=1)
+
+    assert response.retrieval is retrieval
+    assert response.results[0].passage is passage
+    assert response.results[0].passage.speaker_refs == ("speaker-02",)
+    assert response.results[0].speakers[0].display_name == "Dr. Chen (speaker-02)"
+    locator.locate_response.assert_called_once_with(retrieval, context_segments=1)
+    labels.display_labels.assert_called_once_with(
+        document_id="job-1",
+        canonical_sha256="b" * 64,
+        speaker_refs=("speaker-02",),
+    )
+
+
+def test_label_lookup_is_batched_per_canonical_generation() -> None:
+    first = _passage()
+    second = SearchPassage(
+        document_id=first.document_id,
+        source_sha256=first.source_sha256,
+        canonical_sha256=first.canonical_sha256,
+        canonical_path=first.canonical_path,
+        source_path=first.source_path,
+        chunk_id=None,
+        segment_ids=("segment-000002",),
+        matched_segment_ids=("segment-000002",),
+        start_seconds=3.0,
+        end_seconds=4.0,
+        text="Another speaker",
+        languages=("en",),
+        speaker_refs=("speaker-03",),
+        lexical_rank=2,
+        semantic_rank=None,
+        fused_rank=None,
+    )
+    retrieval = _retrieval(first, second)
+    library = Mock()
+    library.retrieve.return_value = retrieval
+    locator = Mock()
+    locator.locate_response.return_value = (
+        _location(refs=("speaker-02",)),
+        EvidenceLocation(
+            document_id="job-1",
+            source_sha256="a" * 64,
+            canonical_sha256="b" * 64,
+            canonical_path="/canonical.json",
+            source_path="/recording.wav",
+            result_segment_ids=("segment-000002",),
+            start_seconds=3.0,
+            end_seconds=4.0,
+            seek_seconds=3.0,
+            result_speaker_refs=("speaker-03",),
+            matched_words=(),
+            context_segments=(),
+        ),
+    )
+    labels = Mock()
+    labels.display_labels.return_value = {
+        "speaker-02": "Dr. Chen",
+        "speaker-03": "Interviewer",
+    }
+    service = ResearchNavigationService(library, locator, labels)
+
+    response = service.search(SearchQuery("housing"))
+
+    assert labels.display_labels.call_count == 1
+    labels.display_labels.assert_called_once_with(
+        document_id="job-1",
+        canonical_sha256="b" * 64,
+        speaker_refs=("speaker-02", "speaker-03"),
+    )
+    assert [result.speakers[0].display_name for result in response.results] == [
+        "Dr. Chen (speaker-02)",
+        "Interviewer (speaker-03)",
+    ]

--- a/src/echoflow/library/tests/test_research.py
+++ b/src/echoflow/library/tests/test_research.py
@@ -72,7 +72,7 @@ def test_research_navigation_adds_display_names_without_mutating_retrieval() -> 
     assert response.retrieval is retrieval
     assert response.results[0].passage is passage
     assert response.results[0].passage.speaker_refs == ("speaker-02",)
-    assert response.results[0].speakers[0].display_name == "Dr. Chen (speaker-02)"
+    assert response.results[0].speakers[0].display_name == "Dr. Chen\nspeaker-02"
     locator.locate_response.assert_called_once_with(retrieval, context_segments=1)
     labels.display_labels.assert_called_once_with(
         document_id="job-1",
@@ -138,6 +138,6 @@ def test_label_lookup_is_batched_per_canonical_generation() -> None:
         speaker_refs=("speaker-02", "speaker-03"),
     )
     assert [result.speakers[0].display_name for result in response.results] == [
-        "Dr. Chen (speaker-02)",
-        "Interviewer (speaker-03)",
+        "Dr. Chen\nspeaker-02",
+        "Interviewer\nspeaker-03",
     ]

--- a/src/echoflow/library/text.py
+++ b/src/echoflow/library/text.py
@@ -1,0 +1,12 @@
+"""Shared deterministic text semantics for transcript retrieval and navigation."""
+
+from __future__ import annotations
+
+import re
+
+_TOKEN_PATTERN = re.compile(r"\w+(?:['’]\w+)*", re.UNICODE)
+
+
+def lexical_tokens(text: str) -> tuple[str, ...]:
+    """Return the Unicode-aware tokens used by lexical ranking and highlighting."""
+    return tuple(match.group(0).casefold() for match in _TOKEN_PATTERN.finditer(text))

--- a/src/echoflow/tests/test_cli_library.py
+++ b/src/echoflow/tests/test_cli_library.py
@@ -23,11 +23,7 @@ from echoflow.library.research import (
     ResearchSearchResponse,
     SpeakerDisplay,
 )
-from echoflow.library.retrieval import (
-    RetrievalMode,
-    SearchPassage,
-    SearchResponse,
-)
+from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
 from echoflow.library.semantic import EmbeddingProfile, SemanticState
 from echoflow.library.service import (
     LibraryEvidenceReceipt,

--- a/src/echoflow/tests/test_cli_library.py
+++ b/src/echoflow/tests/test_cli_library.py
@@ -6,12 +6,12 @@ import typer
 from typer.testing import CliRunner
 
 from echoflow.cli_library import register_library_commands
+from echoflow.library.errors import TranscriptLibraryError
 from echoflow.library.evidence import (
     EvidenceContextSegment,
     EvidenceLocation,
     EvidenceWord,
 )
-from echoflow.library.errors import TranscriptLibraryError
 from echoflow.library.index import (
     IndexedDocument,
     SearchOperator,

--- a/src/echoflow/tests/test_cli_library.py
+++ b/src/echoflow/tests/test_cli_library.py
@@ -23,7 +23,11 @@ from echoflow.library.research import (
     ResearchSearchResponse,
     SpeakerDisplay,
 )
-from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
+from echoflow.library.retrieval import (
+    RetrievalMode,
+    SearchPassage,
+    SearchResponse,
+)
 from echoflow.library.semantic import EmbeddingProfile, SemanticState
 from echoflow.library.service import (
     LibraryEvidenceReceipt,

--- a/src/echoflow/tests/test_cli_library.py
+++ b/src/echoflow/tests/test_cli_library.py
@@ -6,12 +6,22 @@ import typer
 from typer.testing import CliRunner
 
 from echoflow.cli_library import register_library_commands
+from echoflow.library.evidence import (
+    EvidenceContextSegment,
+    EvidenceLocation,
+    EvidenceWord,
+)
 from echoflow.library.errors import TranscriptLibraryError
 from echoflow.library.index import (
     IndexedDocument,
     SearchOperator,
     SearchQuery,
     SearchSort,
+)
+from echoflow.library.research import (
+    LocatedSearchPassage,
+    ResearchSearchResponse,
+    SpeakerDisplay,
 )
 from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
 from echoflow.library.semantic import EmbeddingProfile, SemanticState
@@ -87,10 +97,77 @@ def _response(query: SearchQuery | None = None) -> SearchResponse:
     )
 
 
-def _app_with_library(library: Mock) -> tuple[typer.Typer, Mock]:
+def _located(
+    retrieval: SearchResponse | None = None,
+    *,
+    passage: SearchPassage | None = None,
+) -> ResearchSearchResponse:
+    retrieval = retrieval or _response()
+    passage = passage or retrieval.results[0]
+    word = EvidenceWord(
+        segment_id=passage.segment_ids[0],
+        word_index=0,
+        start_seconds=1.5,
+        end_seconds=1.9,
+        text="housing",
+        speaker_ref="speaker-02",
+        highlighted=True,
+    )
+    context = EvidenceContextSegment(
+        segment_id=passage.segment_ids[0],
+        start_seconds=passage.start_seconds,
+        end_seconds=passage.end_seconds,
+        text=passage.text,
+        speaker_refs=("speaker-02",),
+        words=(
+            word,
+            EvidenceWord(
+                segment_id=passage.segment_ids[0],
+                word_index=1,
+                start_seconds=2.0,
+                end_seconds=2.5,
+                text=" affordability matters",
+                speaker_ref="speaker-02",
+            ),
+        ),
+        is_result_segment=True,
+        lexical_match=True,
+    )
+    evidence = EvidenceLocation(
+        document_id=passage.document_id,
+        source_sha256=passage.source_sha256,
+        canonical_sha256=passage.canonical_sha256 or "1" * 64,
+        canonical_path=passage.canonical_path,
+        source_path=passage.source_path,
+        result_segment_ids=passage.segment_ids,
+        start_seconds=passage.start_seconds,
+        end_seconds=passage.end_seconds,
+        seek_seconds=1.5,
+        result_speaker_refs=("speaker-02",),
+        matched_words=(word,),
+        context_segments=(context,),
+    )
+    return ResearchSearchResponse(
+        retrieval=retrieval,
+        results=(
+            LocatedSearchPassage(
+                passage=passage,
+                evidence=evidence,
+                speakers=(SpeakerDisplay("speaker-02", "Dr. Chen"),),
+            ),
+        ),
+    )
+
+
+def _app_with_library(
+    library: Mock,
+    *,
+    research: Mock | None = None,
+) -> tuple[typer.Typer, Mock]:
     app = typer.Typer()
     container = Mock()
     container.transcript_library.return_value = library
+    container.research_navigation.return_value = research or Mock()
     container.semantic_embedding_provider.return_value = Mock()
     register_library_commands(app, lambda context: container)
     return app, container
@@ -174,12 +251,18 @@ def test_library_show_explains_source_integrity_and_storage_custody() -> None:
     assert payload["canonical_sha256"] == "1" * 64
 
 
-def test_library_search_compiles_cli_options_to_unified_retrieval_contract() -> None:
+def test_library_search_compiles_cli_options_to_research_navigation_contract() -> None:
     library = Mock()
-    captured: list[tuple[SearchQuery, RetrievalMode]] = []
+    research = Mock()
+    captured: list[tuple[SearchQuery, RetrievalMode, int]] = []
 
-    def capture(query: SearchQuery, *, mode: RetrievalMode) -> SearchResponse:
-        captured.append((query, mode))
+    def capture(
+        query: SearchQuery,
+        *,
+        mode: RetrievalMode,
+        context_segments: int,
+    ) -> ResearchSearchResponse:
+        captured.append((query, mode, context_segments))
         passage = SearchPassage(
             document_id="job-1",
             source_sha256="0" * 64,
@@ -198,7 +281,7 @@ def test_library_search_compiles_cli_options_to_unified_retrieval_contract() -> 
             semantic_rank=1,
             fused_rank=1,
         )
-        return SearchResponse(
+        retrieval = SearchResponse(
             query=query,
             mode=mode,
             lexical_backend_id="duckdb-bm25-v1",
@@ -207,9 +290,10 @@ def test_library_search_compiles_cli_options_to_unified_retrieval_contract() -> 
             fusion_profile="rrf-k60-v1",
             results=(passage,),
         )
+        return _located(retrieval, passage=passage)
 
-    library.retrieve.side_effect = capture
-    app, _ = _app_with_library(library)
+    research.search.side_effect = capture
+    app, _ = _app_with_library(library, research=research)
     runner = CliRunner()
 
     result = runner.invoke(
@@ -232,6 +316,8 @@ def test_library_search_compiles_cli_options_to_unified_retrieval_contract() -> 
             "hybrid",
             "--limit",
             "25",
+            "--context-segments",
+            "2",
             "--json",
         ],
     )
@@ -246,9 +332,17 @@ def test_library_search_compiles_cli_options_to_unified_retrieval_contract() -> 
     assert payload["results"][0]["fused_rank"] == 1
     assert payload["results"][0]["start_seconds"] == 1.5
     assert payload["results"][0]["start_timestamp"] == "00:00:01.500"
-    assert payload["results"][0]["end_timestamp"] == "00:00:04.000"
-    query, mode = captured[0]
+    assert payload["results"][0]["speaker_refs"] == ["speaker-02"]
+    assert payload["results"][0]["speaker_display_labels"] == {
+        "speaker-02": "Dr. Chen"
+    }
+    assert payload["results"][0]["evidence_location"]["seek_seconds"] == 1.5
+    assert payload["results"][0]["evidence_location"]["matched_words"][0][
+        "highlighted"
+    ] is True
+    query, mode, context_segments = captured[0]
     assert mode is RetrievalMode.HYBRID
+    assert context_segments == 2
     assert query.text == "housing affordability"
     assert query.phrase is True
     assert query.operator is SearchOperator.ALL
@@ -259,16 +353,17 @@ def test_library_search_compiles_cli_options_to_unified_retrieval_contract() -> 
     assert query.limit == 25
 
 
-def test_library_search_human_view_keeps_evidence_and_ranks_visible() -> None:
+def test_library_search_human_view_shows_display_name_and_highlighted_evidence() -> None:
     library = Mock()
-    library.retrieve.return_value = _response()
-    app, _ = _app_with_library(library)
+    research = Mock()
+    research.search.return_value = _located()
+    app, _ = _app_with_library(library, research=research)
     result = CliRunner().invoke(app, ["library", "search", "housing"])
 
     assert result.exit_code == 0
     assert "interview" in result.stdout
     assert "00:00:01.500" in result.stdout
-    assert "00:00:02.500" in result.stdout
+    assert "Dr. Chen" in result.stdout
     assert "speaker-02" in result.stdout
     assert "L:1" in result.stdout
     assert "housing" in result.stdout

--- a/src/echoflow/tests/test_cli_library.py
+++ b/src/echoflow/tests/test_cli_library.py
@@ -333,13 +333,12 @@ def test_library_search_compiles_cli_options_to_research_navigation_contract() -
     assert payload["results"][0]["start_seconds"] == 1.5
     assert payload["results"][0]["start_timestamp"] == "00:00:01.500"
     assert payload["results"][0]["speaker_refs"] == ["speaker-02"]
-    assert payload["results"][0]["speaker_display_labels"] == {
-        "speaker-02": "Dr. Chen"
-    }
+    assert payload["results"][0]["speaker_display_labels"] == {"speaker-02": "Dr. Chen"}
     assert payload["results"][0]["evidence_location"]["seek_seconds"] == 1.5
-    assert payload["results"][0]["evidence_location"]["matched_words"][0][
-        "highlighted"
-    ] is True
+    assert (
+        payload["results"][0]["evidence_location"]["matched_words"][0]["highlighted"]
+        is True
+    )
     query, mode, context_segments = captured[0]
     assert mode is RetrievalMode.HYBRID
     assert context_segments == 2
@@ -353,7 +352,9 @@ def test_library_search_compiles_cli_options_to_research_navigation_contract() -
     assert query.limit == 25
 
 
-def test_library_search_human_view_shows_display_name_and_highlighted_evidence() -> None:
+def test_library_search_human_view_shows_display_name_and_highlighted_evidence() -> (
+    None
+):
     library = Mock()
     research = Mock()
     research.search.return_value = _located()


### PR DESCRIPTION
## What changed

This tranche turns ranked transcript search into a verified research-navigation surface without changing ranking semantics or canonical evidence.

### Canonical evidence locator

- re-read and SHA-256 verify canonical transcript JSON before deriving navigation state
- resolve ranked passages back to exact canonical segment IDs and aligned word coordinates
- expose a deterministic seek coordinate for every result
- allow bounded neighboring canonical context with `--context-segments 0..10`
- fail closed when indexed canonical identity is stale or result segments no longer exist

### Exact highlighting without invented precision

- reuse EchoFlow's lexical token semantics for both ranking and word-level highlighting
- highlight aligned words only when the retrieval result carries lexical matched-segment evidence
- preserve exact phrase behavior across contiguous canonical word tokens
- semantic-only results remain passage-level and do not receive fabricated exact-word matches
- hybrid results may expose exact lexical highlights when lexical evidence contributed

### Speaker display integration

- decorate ordinary search results with current user-authored display names while preserving raw anonymous refs
- resolve labels only against the exact canonical generation
- batch label resolution per canonical transcript generation rather than repeatedly reading private state per speaker

### Application and CLI

- add `EvidenceLocator` and `ResearchNavigationService` as reusable application services
- keep retrieval/ranking, canonical evidence navigation, and user-authored display state as separate authorities
- extend existing `echoflow library search` rather than creating a parallel search command
- keep existing JSON fields additive and add speaker display labels plus a structured `evidence_location`

### Qualification in progress

Focused tests cover lexical word highlights, exact phrase highlights, semantic restraint, bounded context expansion, stale canonical refusal, speaker-label decoration, batched label lookup, and CLI human/JSON contracts. Normal Linux Quality plus macOS/Windows platform qualification remains the merge gate.

### Documentation pass still in progress

This draft will also refresh README, docs lobby, speaker/time/search documentation, architecture, and ROADMAP so completed word timing, time provenance, speaker naming, and overlap UX are represented as current foundation rather than future work.

## Why

Search already finds evidence. Word timing already gives that evidence fine-grained coordinates. Speaker labels already let a human name anonymous voice clusters. This tranche composes those capabilities into one inspectable navigation layer so future highlighting, click-to-media, notes, tags, and a GUI can consume the same application contract instead of each inventing its own coordinate system.

The core rule remains: retrieval may rank derived views, but navigation must resolve back to exact canonical evidence before presenting a precise location.