### PR TITLE
docs: align product map with current research workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,20 @@
 **Private local transcription that remembers where everything came from.**
 
 EchoFlow is a local-first Python application for turning recordings into durable,
-searchable evidence. It is designed for interviews, research recordings, meetings,
-lectures, oral histories, and other audio you may not want wandering off to a hosted
-transcription service.
+searchable evidence and keeping research work attached to that evidence without handing
+the corpus to a hosted transcription service.
 
-The application does more than run a speech model. It inspects the machine it is running
-on, chooses a safe execution strategy, manages local model custody, survives interrupted
+It does more than run a speech model. EchoFlow inspects the machine it is running on,
+chooses a safe execution strategy, manages local model custody, survives interrupted
 work, preserves source provenance, publishes portable transcripts, keeps word-level
-timing evidence, handles anonymous speaker evidence conservatively, and builds a private
-searchable library that can navigate results back to the canonical transcript.
+timing evidence, handles anonymous speaker evidence conservatively, searches a private
+local corpus, navigates results back to verified canonical evidence, and stores durable
+notes/tags/collections separately from rebuildable search machinery.
 
-The original recording remains read-only input. Canonical transcript JSON is the
-authoritative transcript artifact. User-authored knowledge stays separate from both.
-Working audio and search databases are derived state that can be regenerated.
+The original recording remains read-only source evidence. Canonical transcript JSON is
+the authoritative transcript artifact. Human-authored research state is authoritative
+user knowledge. DuckDB search and research projections are acceleration structures that
+may be deleted and rebuilt.
 
 > **EchoFlow's product rule:** do complicated work locally, keep the evidence
 > understandable, portable, and owned by the user.
@@ -24,116 +25,79 @@ For the human-friendly documentation lobby, start at **[docs/README.md](docs/REA
 For the shortest path from clone to transcript, use
 **[Getting started](docs/getting-started.md)**.
 
-🧜‍♀️
-
 ## What can it do right now?
 
-EchoFlow is pre-production, but the backend already covers a surprisingly large part of
-the local recording-to-research lifecycle.
+EchoFlow is pre-production, but the backend now covers most of the local
+recording-to-research lifecycle.
 
 | Area | Current foundation |
 |---|---|
 | Local transcription | faster-whisper CPU/int8 and CUDA-capable strategies with explicit managed model revisions |
 | Hardware awareness | process-visible CPU/RAM, affinity/cgroup limits, accelerator topology, engine capability negotiation, and resource admission |
 | Media handling | FFprobe inspection, deterministic audio-stream selection, FFmpeg canonicalization, exact source-relative frame windows |
-| Word timing | native faster-whisper per-word timestamps validated, rebased to source-relative time, and preserved through resume |
+| Word timing | native faster-whisper word timestamps validated, rebased to source-relative time, and preserved through resume |
 | Time provenance | human `HH:MM:SS.mmm` elapsed coordinates plus source-declared `timecode` / `creation_time` provenance when available |
 | Reliability | durable private checkpoints, validated resume, contiguous checkpoint ordering, bounded accelerated prefetch |
 | Languages | multilingual decoding plus conservative local text-language attribution |
-| Speakers | optional anonymous recording-scoped diarization, word-level handoffs, durable user display labels, and honest overlap/mixed presentation; diarization execution is currently security-held when its locked dependency gate is unsafe |
+| Speakers | optional anonymous recording-scoped diarization, word-level handoffs, durable display labels, and honest overlap/mixed presentation; diarization remains security-held when its locked dependency gate is unsafe |
 | Difficult audio | optional deterministic local FFmpeg noise suppression with provenance and timeline-preservation checks |
 | Model custody | explicit inventory, recommendation, install, local revalidation, immutable revision pinning, and exact-revision removal |
 | Transcript output | canonical JSON plus deterministic TXT, SRT, and WebVTT derived views |
 | Search | private local BM25 lexical retrieval, optional semantic retrieval, and inspectable hybrid RRF ranking |
 | Evidence navigation | canonical-hash verification, aligned lexical highlights, bounded context expansion, speaker display integration, and deterministic source seek coordinates |
-| Evidence | source/canonical SHA-256, segment/word timestamps, speaker/language context, provenance, stale-index detection, and integrity receipts |
-| Portability | Linux, macOS, and Windows CI plus clean-wheel/package verification |
+| Research workspace | authoritative SQLite notes/tags/collections anchored to exact canonical evidence, plus a rebuildable DuckDB research projection |
+| Research-aware search | tag, collection, note-text, and with-notes constraints applied before lexical ranking or semantic scoring |
+| Quality | Linux/macOS/Windows CI, strict typing, lint/format/security rules, complexity/dead-code checks, branch coverage, dependency audit, package build, and clean-wheel verification |
 
-The point of this list is not that users should learn every subsystem. It is that most of
-the annoying decisions around local transcription are becoming application behavior
-instead of homework.
+The point is not that users should learn every subsystem. It is that most of the annoying
+choices around local transcription, provenance, search, and research-state custody are
+becoming application behavior instead of homework.
 
 ## The journey from recording to something useful
 
 ```mermaid
 flowchart LR
-    A[Original recording] --> B[Inspect source + machine]
+    A[Original recording] --> B[Inspect source and machine]
     B --> C[Choose safe local strategy]
-    C --> D[Transcribe + word timing + checkpoint]
-    D --> E[Canonical transcript]
-    E --> F[TXT / SRT / WebVTT]
-    E --> G[Lexical / semantic / hybrid search]
+    C --> D[Transcribe and checkpoint]
+    D --> E[Canonical transcript JSON]
+    E --> F[TXT SRT WebVTT]
+    E --> G[Lexical semantic hybrid search]
     G --> H[Verify canonical evidence]
-    H --> I[Highlight + context + seek]
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef publish fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A evidence
-    class B,C compute
-    class D process
-    class E,F publish
-    class G,H,I result
+    H --> I[Context highlights and seek]
+    I --> J[Durable notes tags collections]
+    J --> G
 ```
 
-Search ranking is intentionally not treated as source truth. A ranked result points back
-to canonical transcript coordinates, and the navigation layer verifies that canonical
-generation before presenting precise word evidence.
+Text fallback: the original recording produces a canonical transcript; rebuildable search
+ranks passages; canonical navigation verifies those passages; durable research state is
+attached to exact evidence and can constrain later searches.
+
+Search ranking is intentionally not source truth. A ranked result points back to canonical
+transcript coordinates, and the navigation layer verifies that canonical generation
+before presenting precise word evidence or accepting a durable note anchor.
 
 ## Install the current source build
 
-EchoFlow does not publish end-user installers or Releases yet. The current supported
-path is a source/developer install with Python 3.12 and `uv`:
+EchoFlow does not publish end-user installers or Releases yet. The supported path is a
+source/developer install with Python 3.12 and `uv`:
 
 ```bash
 git clone https://github.com/SSD1805/EchoFlow.git
 cd EchoFlow
 uv sync --locked --extra transcription
-```
-
-Initialize private application state and inspect the machine:
-
-```bash
 uv run echoflow init
 uv run echoflow doctor
-uv run echoflow runner
 ```
 
-## Let EchoFlow recommend a transcription model
+## Plan, transcribe, and resume
 
 ```bash
 uv run echoflow models recommend
 uv run echoflow models install small
-```
-
-Model installation is an explicit network-bearing action. Transcription itself does not
-silently download faster-whisper weights.
-
-EchoFlow records and locally revalidates the immutable model revision it manages. A
-cached model does not become trusted application state merely because some bytes happen
-to exist in a Hugging Face cache.
-
-## Plan, transcribe, and resume
-
-A dry run inspects the source and machine and shows the intended execution plan without
-starting recognition:
-
-```bash
 uv run echoflow transcribe interview.m4a --dry-run
-```
-
-Then transcribe locally:
-
-```bash
 uv run echoflow transcribe interview.m4a
 ```
-
-The current faster-whisper execution path requests native word timestamps. EchoFlow
-validates and rebases those word intervals onto the same source-relative timeline as the
-canonical segment instead of running a second forced-alignment model.
 
 Add derived publication formats when useful:
 
@@ -141,66 +105,36 @@ Add derived publication formats when useful:
 uv run echoflow transcribe interview.m4a --export txt --export srt --export vtt
 ```
 
-If an in-progress job is interrupted, EchoFlow can restore its validated checkpoint
-contract:
+Resume a validated interrupted job with the original input and job ID:
 
 ```bash
 uv run echoflow transcribe interview.m4a --resume JOB_ID
 ```
 
-Resume rechecks source identity and current resource admission. It does not silently
-change model revision, selected audio stream, preprocessing, alignment, or execution
-target just to get moving again.
+Model acquisition is explicit and network-bearing. Transcription itself does not silently
+download faster-whisper weights. Resume rechecks source identity and current resource
+admission rather than silently changing the original execution contract.
 
-## Optional noise suppression
-
-For a difficult recording, deterministic local FFmpeg noise suppression can be enabled
-explicitly:
-
-```bash
-uv run echoflow transcribe noisy-interview.wav --enhance
-```
-
-The enhanced audio is private derived processing material, not a replacement for the
-source. EchoFlow verifies that preprocessing did not change the frame/timeline shape
-before allowing ASR to consume it.
-
-See **[Local speech enhancement](docs/architecture/speech-enhancement.md)** for the exact
-provider and failure contract.
-
-## Optional anonymous speaker diarization
-
-The user surface is:
+## Optional anonymous speakers
 
 ```bash
 uv run echoflow transcribe interview.wav --diarize
 ```
 
-Diarization produces anonymous recording-scoped labels such as `speaker-01`; it does not
-perform biometric identity or cross-recording speaker linking.
-
-When word timing exists, EchoFlow can preserve speaker handoffs without forcing one
-speaker onto the enclosing segment. The derived speaker transcript also distinguishes
-true simultaneous overlap from sequential mixed/unresolved text.
-
-After a transcript is in the library, you can assign your own durable display name:
+Diarization produces anonymous recording-scoped refs such as `speaker-01`; it does not
+perform biometric identity or cross-recording speaker linking. After a transcript is in
+the library, a user can assign a durable display label:
 
 ```bash
 uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
 uv run echoflow library speakers transcript JOB_ID
 ```
 
-`Dr. Chen` is user-authored presentation state. `speaker-02` remains the anonymous
-evidence ref underneath it.
+`Dr. Chen` is user-authored presentation state. `speaker-02` remains the evidence ref.
+The current pyannote dependency path remains security-held while its locked Lightning
+version is affected by the compensated advisory described in **[SECURITY.md](SECURITY.md)**.
 
-The current pyannote dependency path is **security-held** while its locked Lightning
-version is affected by a compensated advisory. EchoFlow fails closed before pyannote
-execution/model acquisition while that condition remains true. See
-**[Give the anonymous speakers names](docs/speaker-names.md)**,
-**[Anonymous speaker diarization](docs/architecture/diarization.md)**, and
-**[SECURITY.md](SECURITY.md)**.
-
-## Search and navigate your transcript library
+## Search, navigate, and annotate the local library
 
 Build the private lexical library:
 
@@ -208,152 +142,123 @@ Build the private lexical library:
 uv run echoflow library rebuild
 ```
 
-Search for exact or related words:
+Search it:
 
 ```bash
 uv run echoflow library search "housing insecurity"
 ```
 
-Ask for neighboring canonical context without changing the ranking:
+Add neighboring canonical context without changing ranking:
 
 ```bash
 uv run echoflow library search "housing insecurity" --context-segments 1
 ```
 
-Filter by transcript evidence when useful:
+Research metadata can constrain transcript retrieval before scoring:
 
 ```bash
 uv run echoflow library search \
-  "rent increase" \
-  --speaker speaker-02 \
-  --language en
+  "housing affordability" \
+  --tag methodology \
+  --collection "Chapter 3" \
+  --with-notes
 ```
 
-If `speaker-02` has a current user label, human search presentation can show
-`Dr. Chen (speaker-02)` while machine-readable output keeps the raw ref.
-
-Lexical results can now resolve matching aligned words back to canonical evidence and use
-the first exact match as a source seek coordinate. Semantic-only results deliberately
-stay passage-level because an embedding does not identify one magical matching word.
-Hybrid results preserve both retrieval provenance and exact lexical highlights when
-lexical evidence contributed.
-
-Inspect one transcript's custody and source-integrity evidence:
+The notebook itself is durable user state:
 
 ```bash
-uv run echoflow library show JOB_ID
+uv run echoflow library notes
+
+uv run echoflow library notes add JOB_ID segment-000042 \
+  --body "Compare this with the 2024 survey." \
+  --tag methodology \
+  --collection "Chapter 3"
 ```
 
-Read **[From search result to the exact evidence](docs/evidence-navigation.md)** for the
-human version and **[Evidence-first corpus search](docs/architecture/corpus-search.md)**
-for the implementation contract.
+The CLI currently exposes canonical segment IDs because it needs a real evidence address.
+A future graphical shell can turn transcript selection into the same verified
+`EvidenceAnchor` without asking a normal person to type IDs.
 
-### ✨ Optional semantic and hybrid search
+Read **[Your notes should survive the machinery](docs/research-notes.md)** and
+**[From search result to the exact evidence](docs/evidence-navigation.md)** for the human
+versions of those contracts.
 
-Lexical search is good at finding the words you typed. Semantic search can also find a
-passage whose wording differs but whose meaning is related.
+### Optional semantic and hybrid search
 
-For example, the query:
-
-```text
-people struggling to afford housing
-```
-
-may help retrieve:
-
-```text
-I was spending almost seventy percent of my pay on the apartment.
-```
+Semantic search can find related wording while lexical search remains the dependency-light
+default. Hybrid retrieval combines BM25 and dense ranks using reciprocal rank fusion
+instead of pretending their raw scores share one scale.
 
 The current semantic foundation uses a strict-local Multilingual E5 Small profile and
-private rebuildable vectors. It is deliberately optional: the locked project dependency
-graph does not yet include Sentence Transformers, so a compatible local runtime and
-immutable local model snapshot are currently advanced setup rather than base-install
-requirements.
+private rebuildable vectors. The locked base project still does not declare Sentence
+Transformers as a normal semantic extra, so semantic setup remains advanced rather than
+part of the ordinary source install.
 
-Hybrid retrieval combines BM25 and dense ranks using reciprocal rank fusion instead of
-pretending their raw scores share one scale.
-
-Read **[Semantic search, without the mystery box](docs/semantic-search.md)** for the
-plain-language explanation.
+Read **[Semantic search, without the mystery box](docs/semantic-search.md)**.
 
 ## What belongs to you? 🦝
-
-The custody boundary is intentionally simple:
 
 | Artifact | Role | Rebuildable? |
 |---|---|---|
 | Original recording | source evidence | **No** |
-| Canonical transcript JSON, including word timing evidence | authoritative transcript artifact | **No** |
+| Canonical transcript JSON | authoritative transcript evidence | **No** |
 | Speaker display labels | user-authored knowledge | **No** |
-| Future notes/tags/annotations/collections | user-authored knowledge | **No** |
+| Research notes, tags, collections, evidence anchors | user-authored knowledge | **No** |
+| Future saved searches / curated result sets | user-authored knowledge | **No** |
 | TXT/SRT/WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
 | Lexical search database | private search projection | Yes |
 | Semantic chunks/vectors | private search projection | Yes |
-| Evidence-navigation context/highlight views | derived presentation over canonical evidence | Yes |
+| Research query projection | derived relationships/terms over durable research state | Yes |
+| Evidence-navigation views | derived presentation over canonical evidence | Yes |
 
-A database is allowed to make evidence useful. It is not allowed to become the only
-place the evidence exists.
+A database is allowed to make evidence useful. It is not allowed to become the only place
+unique evidence or human research exists.
 
 ## For maintainers
 
-The architecture is organized around narrow capabilities rather than one universal
-pipeline manager. Start with **[docs/architecture/README.md](docs/architecture/README.md)**.
-
-The most useful references are:
+Start with **[docs/architecture/README.md](docs/architecture/README.md)**. Particularly
+useful references are:
 
 - **[Processing capabilities](docs/architecture/processing-capabilities.md)** for the
-  end-to-end execution map.
-- **[Adaptive heterogeneous execution](docs/architecture/adaptive-heterogeneous-execution.md)**
-  for machine discovery, engine capability, strategy admission, and bounded overlap.
-- **[Media and timeline](docs/architecture/media-and-timeline.md)** for stream selection,
-  canonical audio, and timestamp semantics.
-- **[Word-level timestamp alignment](docs/architecture/word-alignment.md)** for native
-  word timing, source-relative rebasing, checkpoint identity, and speaker handoffs.
-- **[Model management](docs/architecture/model-management.md)** for explicit acquisition,
-  immutable revisions, and local custody.
-- **[Diarization](docs/architecture/diarization.md)** for anonymous speaker evidence and
-  the current security hold.
+  end-to-end capability map;
 - **[Corpus search](docs/architecture/corpus-search.md)** for lexical/semantic/hybrid
-  retrieval, canonical navigation, and data ownership.
+  retrieval and canonical navigation;
+- **[Durable research state](docs/architecture/research-state.md)** for SQLite authority,
+  the monotonic change journal, DuckDB projection, watermark, and research filtering;
+- **[Model management](docs/architecture/model-management.md)** for explicit model
+  acquisition and immutable revision custody; and
+- **[SECURITY.md](SECURITY.md)** for the actual local-first threat boundary.
 
-Documentation itself has a contract too. See
-**[docs/documentation-style.md](docs/documentation-style.md)**.
-
-## Quality and development
-
-Production code uses a `src/` layout. Tests are colocated beneath the package whose
-contract they protect.
-
-Normal repository qualification includes Ruff lint/format/security rules, strict mypy,
-Vulture, Radon complexity/maintainability checks, branch coverage, locked dependency
-verification/auditing, package builds, clean-wheel verification, and Linux/macOS/Windows
-CI.
-
-Mutation testing with Poodle is targeted qualification for load-bearing decisions rather
-than a routine per-commit gate. See
-**[docs/development/testing-and-bisect.md](docs/development/testing-and-bisect.md)**.
+Normal qualification includes Ruff lint/format/security rules, strict mypy, Vulture,
+Radon, branch coverage, locked dependency verification/auditing, package builds,
+clean-wheel verification, and Linux/macOS/Windows CI. Targeted mutation testing with
+Poodle is reserved for load-bearing decision logic rather than routine per-commit work.
 
 ## Where the project goes next
 
-The evidence plumbing is now much further along than the user-authored research
-workspace.
+The backend research-state foundation is built. The highest-value next work is no longer
+another database.
 
-The next major product layer is **durable notes, tags, saved searches, collections, and
-annotation state anchored to verified canonical evidence locations**. After that, the
-highest-value work is qualifying semantic installation/model custody for ordinary source
-installs, dogfooding on representative consumer hardware, and building an installer plus
-thin graphical shell over the same application services.
+The sequence is now:
 
-Source separation for genuinely overlapping speech remains later. EchoFlow can now
-represent overlap honestly, so separation should earn its model/compute/provenance cost
-by improving real recordings rather than appearing as an impressive checkbox.
+1. **Unified library discovery**: one human-facing doorway across transcript evidence,
+   notes, tags, collections, and later saved searches without exposing storage topology.
+2. **Saved searches and useful derived navigation**: durable saved query intent plus
+   derived frequent/recent tags, facets, and citable/selected result sets where they help.
+3. **First thin GUI**: browse/search transcripts, select evidence, add/edit notes and tags,
+   and jump to source media by reusing existing application services and evidence anchors.
+4. **Research portability and corpus-scale ergonomics**: durable research export,
+   incremental library refresh, and measured performance on realistic corpora.
+5. **Productization**: qualify semantic installation/model custody, representative
+   consumer hardware, installers, and polished recovery language.
 
-See **[ROADMAP.md](ROADMAP.md)** for the current sequencing and deliberate limits.
+Source separation for genuinely overlapping speech remains later. It should earn its
+model/compute/provenance cost with measured benefit on real recordings.
+
+See **[ROADMAP.md](ROADMAP.md)** for the detailed sequence and deliberate limits.
 
 ---
 
-**EchoFlow is trying to make sensitive local transcription boringly dependable, then
-make the resulting evidence easy to find, navigate, and eventually annotate without
-giving the corpus away.** 💃
+**Make sensitive local transcription boringly dependable. Make its evidence easy to
+navigate and annotate. Do not give the corpus away.** 💃

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,37 +2,37 @@
 
 EchoFlow is becoming a **private local workspace for recorded evidence**.
 
-Its job is not to out-engine speech-recognition runtimes. Its job is to make local
-transcription dependable, resumable, inspectable, searchable, and useful on ordinary
-computers while keeping source evidence and user-authored knowledge under clear custody.
+Its job is not to out-engine every speech-recognition runtime. Its job is to make local
+transcription dependable, resumable, inspectable, searchable, navigable, annotatable, and
+portable on ordinary computers while keeping source evidence and user-authored knowledge
+under clear custody.
 
 Modern EchoFlow restarted on August 2, 2026. The project has already moved from “can we
-transcribe a file?” to “can we preserve, search, and navigate a local corpus of recorded
-evidence without giving the corpus away?”
+transcribe a file?” to “can a person build and use a private local evidence library without
+giving the corpus away?”
 
 That is now the useful product boundary.
 
 ```mermaid
 flowchart LR
     A[Local media] --> B[Reliable local transcription]
-    B --> C[Evidence-preserving corpus]
-    C --> D[Lexical + semantic retrieval]
-    D --> E[Aligned evidence navigation]
+    B --> C[Canonical evidence]
+    C --> D[Lexical semantic hybrid retrieval]
+    D --> E[Verified evidence navigation]
     E --> F[Durable research workspace]
-    F --> G[Beginner-friendly product shell]
-
-    classDef done fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-    classDef now fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef next fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-
-    class A,B,C,D,E done
-    class F now
-    class G next
+    F --> G[Unified library discovery]
+    G --> H[Saved views and derived navigation]
+    H --> I[Thin graphical shell]
 ```
 
-# Current foundation: yes, we have been busy 💃
+Text fallback: transcription, evidence preservation, retrieval, navigation, and durable
+research state are foundation. Unified discovery is next; saved views/derived navigation
+follow; the first GUI should sit on those same services rather than inventing another
+application.
 
-The backend is broad enough that the next work is increasingly about **research workflow,
+# Current foundation
+
+The backend is broad enough that the next work is increasingly about **human workflow,
 qualification, packaging, and interface quality**, not inventing another transcription
 pipeline.
 
@@ -43,24 +43,22 @@ EchoFlow currently provides:
 - process-visible CPU and memory inspection, including relevant affinity/cgroup limits;
 - physical accelerator topology kept separate from actual engine/runtime capability;
 - resource-admitted faster-whisper CPU/int8 and CUDA-capable strategies;
-- explicit refusal instead of silent substitution for infeasible user-selected
-  strategies;
+- explicit refusal instead of silent substitution for infeasible user-selected strategies;
 - dedicated/shared/unified accelerator-memory accounting;
 - FFprobe inspection with file-only protocol access and complete source SHA-256;
 - deterministic audio-stream selection;
 - FFmpeg canonicalization to mono 16 kHz PCM16 WAV when required;
 - exact integer-frame work windows;
-- optional deterministic FFmpeg noise suppression with provenance and timeline checks;
-  and
-- bounded one-segment CPU preparation overlap during accelerated inference while
-  preserving ordered checkpoints.
+- optional deterministic FFmpeg noise suppression with provenance and timeline checks; and
+- bounded one-segment CPU preparation overlap during accelerated inference while preserving
+  ordered checkpoints.
 
 Performance ranks and memory estimates remain conservative heuristics pending
 representative-device qualification.
 
 ## Reliability, model custody, and timeline evidence
 
-The current execution contract includes:
+The execution contract includes:
 
 - explicit faster-whisper model inventory/recommendation/installation;
 - immutable resolved model revisions and local revalidation;
@@ -72,12 +70,12 @@ The current execution contract includes:
   timeline;
 - aligned word evidence persisted through checkpoint/resume;
 - deterministic `HH:MM:SS.mmm` human elapsed presentation without 24-hour wrapping; and
-- preservation of source-declared `timecode` and `creation_time` metadata at format and
-  stream scope when FFprobe reports it.
+- preservation of source-declared `timecode` and `creation_time` metadata when FFprobe
+  reports it.
 
 Numeric source-relative seconds remain authoritative navigation coordinates. Human clock
-strings are presentation. Source-declared camera/container metadata is parallel
-provenance, not a replacement timeline and not automatically trusted.
+strings are presentation. Source-declared media clocks are parallel provenance unless a
+future media qualification proves a trustworthy mapping.
 
 ## Language and speaker evidence
 
@@ -89,30 +87,26 @@ EchoFlow supports:
 - deterministic anonymous speaker refs;
 - word-level speaker projection when timing evidence supports it;
 - conservative null/mixed behavior instead of forcing one speaker across a handoff;
-- durable user-authored display labels such as `speaker-02 → Dr. Chen`, stored separately
-  from canonical evidence and rebuildable indexes; and
-- a derived overlap-aware speaker transcript that distinguishes `single-speaker`,
-  `overlap`, `mixed-unresolved`, and `unattributed` presentation states.
+- durable user-authored display labels such as `speaker-02 → Dr. Chen`; and
+- derived overlap-aware presentation distinguishing `single-speaker`, `overlap`,
+  `mixed-unresolved`, and `unattributed` states.
 
 Speaker display names are bound to the exact canonical transcript generation. EchoFlow
 does not perform biometric identity inference or silently link anonymous speakers across
 recordings.
 
 The pyannote execution path remains **security-held** while its locked Lightning
-dependency is affected by the compensated CVE-2026-58659/PYSEC-2026-3624 advisory.
-EchoFlow fails closed before that provider executes or acquires model state while the
-security gate is active.
+dependency is affected by the compensated advisory described in `SECURITY.md`.
 
 ## Canonical transcript and publications
 
-Canonical JSON is authoritative transcript evidence.
+Canonical JSON is authoritative transcript evidence. It carries source/execution
+provenance, source-relative segment and word timestamps, source-declared temporal tags
+when present, language evidence, optional enhancement provenance, and optional speaker
+turn/word speaker evidence.
 
-It carries source/execution provenance, source-relative segment and word timestamps,
-source-declared temporal tags when present, language evidence, optional enhancement
-provenance, and optional speaker-turn/word speaker evidence.
-
-TXT, SRT, and WebVTT remain deterministic derived publication views. They can be deleted
-and regenerated without rerunning recognition.
+TXT, SRT, and WebVTT are deterministic derived publication views. They can be deleted and
+regenerated without rerunning recognition.
 
 ## Transcript library, search, and aligned navigation
 
@@ -128,103 +122,161 @@ The local library now includes:
 - private numeric semantic vectors and exact local dense similarity;
 - reciprocal-rank hybrid BM25 + dense retrieval;
 - stale-vector refusal when canonical transcript bytes change;
-- human elapsed result coordinates while JSON retains numeric seconds;
 - verified canonical evidence lookup after ranking;
 - exact aligned-word highlighting when lexical evidence justifies it;
 - semantic-only passage navigation without fabricated exact-word matches;
 - bounded neighboring canonical context expansion;
 - deterministic seek coordinates for future local media playback; and
-- current speaker display labels layered onto search presentation while raw anonymous
-  refs remain visible evidence.
+- current speaker display labels layered onto presentation while raw anonymous refs remain
+  visible evidence.
 
-Search ranking and evidence navigation are separate operations. A rebuildable index ranks
-a passage; the navigation layer verifies the canonical transcript before presenting a
-precise location.
+Search ranking and evidence navigation remain separate operations. A rebuildable index
+ranks a passage; navigation verifies canonical evidence before presenting precision.
 
-Semantic search remains an advanced optional capability because the locked base project
-dependency graph does not yet include Sentence Transformers. Lexical search remains the
-normal dependency-light default.
+## Durable research workspace
 
-## Security, privacy, and quality foundation
+This is now **foundation**, not future work.
 
-The project currently has:
+EchoFlow provides:
 
-- path-redacted routine logs;
-- platform-specific private storage enforcement;
-- explicit network-bearing model acquisition boundaries;
-- no hosted transcription integration or application telemetry;
-- Linux/macOS/Windows CI;
-- strict mypy, Ruff lint/format/security rules, Vulture, Radon, and branch coverage;
-- locked dependency auditing and clean-wheel/package checks;
-- Hypothesis property tests around load-bearing invariants; and
-- targeted Poodle mutation qualification for decision-heavy code.
+- authoritative private SQLite state for notes, tags, collections, and evidence anchors;
+- exact source/canonical generation identity in durable note anchors;
+- contiguous canonical segment-span validation before a note is accepted;
+- optional sub-segment source-relative start/end coordinates;
+- durable stale-generation retention rather than silent note teleportation;
+- a monotonic transactional SQLite change journal;
+- bounded idempotent projection replay;
+- a rebuildable DuckDB research projection with an atomic convergence watermark;
+- fail-closed handling when a projection claims to be ahead of authority;
+- deterministic full rebuild when retained journal history cannot bridge a gap;
+- note/tag/collection notebook filtering;
+- tag/collection/note-text/with-notes constraints applied before transcript ranking or
+  semantic scoring; and
+- one `ResearchWorkspaceService` application boundary for CLI and future GUI adapters.
 
-See [SECURITY.md](SECURITY.md) for the exact threat boundary. “Local-first” is not a
-claim that the host operating system or every native dependency is trusted.
-
-# The custody rule that should survive every feature
-
-EchoFlow has several classes of data with deliberately different deletion semantics.
+The custody hierarchy is now:
 
 | Class | Examples | Rule |
 |---|---|---|
-| Authoritative evidence | original recording, canonical transcript | never treat as cache |
-| User-authored knowledge | speaker labels, future notes/tags/annotations/collections | must survive index rebuilds |
-| Rebuildable projection | lexical index, semantic chunks/vectors, derived exports | may be regenerated from durable evidence |
+| Authoritative evidence | original recording, canonical transcript JSON | never treat as cache |
+| Authoritative user knowledge | speaker labels, notes, tags, collections, future saved searches/result sets | must survive index rebuilds |
+| Rebuildable projection | lexical index, semantic chunks/vectors, research query projection, derived exports | may be regenerated |
 | Private execution state | normalization, enhancement, checkpoints, temporary segments | lifecycle-managed, not source truth |
 
 🦝 The raccoon may rebuild an index. The raccoon may not eat your annotations.
 
 # Near-term product sequence
 
-Word timing, source time provenance, speaker naming, overlap presentation, and aligned
-search navigation are now foundation. The next work should build on those contracts
-rather than repeatedly reopening them.
+The next work should make the existing backend **easy to use** rather than reopening
+solved custody/search contracts.
 
-## 1. Durable research workspace state
+## 1. Unified library discovery
 
-The next major product layer is user-authored research state over verified evidence
-locations.
+This is the next feature tranche.
+
+Today users can search transcript evidence and query notes, but the surfaces still expose
+the history of how the backend was built. The product should provide one human-facing
+library doorway.
 
 Target direction:
 
-- notes anchored to source/canonical identity plus durable segment/word/time coordinates;
-- tags;
-- saved searches;
-- collections;
-- annotation update/history semantics where useful;
-- exportable selected result sets; and
-- a transactional private user-state store appropriate for mutable/queryable knowledge.
+- one typed application query that can surface grouped transcript evidence, notes, tags,
+  collections, and eventually saved searches;
+- preserve type-specific semantics rather than inventing one fake score across unlike
+  result kinds;
+- reuse `ResearchWorkspaceService`, `EvidenceLocator`, and existing transcript retrieval;
+- keep storage topology invisible to presentation code;
+- show stable human evidence coordinates while retaining exact canonical IDs in
+  machine-readable output; and
+- leave room for the GUI to consume the exact same discovery service.
 
-Speaker labels proved the custody model in miniature. Notes and collections are higher
-volume and more queryable, so they should not simply accumulate forever in one giant JSON
-file. A small transactional store such as SQLite is a likely application adapter, behind
-ports that keep user knowledge separate from search implementation details.
+A likely CLI shape is `echoflow library find QUERY`, but the application service contract
+matters more than the command spelling.
 
-A note must never be anchored only to a formatted timestamp or disposable semantic chunk
-ID. If canonical evidence changes, EchoFlow should retain the note and report that its
-old anchor needs review rather than silently teleporting the annotation.
+## 2. Saved searches and useful derived navigation
 
-## 2. Search/research workspace ergonomics
+Saved searches are **durable user-authored workspace state** and belong in authoritative
+SQLite. They should preserve typed query intent, not a blob of rendered CLI text.
 
-Use real corpora to decide which navigation conveniences earn permanence:
+Useful derived navigation should remain disposable. Candidate conveniences include:
 
-- result-context expansion beyond simple neighboring segments;
-- facets and typed constraints;
-- exportable/citable result sets;
-- saved-search and collection workflows;
-- local media playback over the existing seek contract; and
-- cross-feature presentation of speaker names, tags, and annotation state.
+- most-used tags, derived from current relationships rather than stored counters;
+- recently used tags/collections;
+- facets and counts where they reduce hunting;
+- recent searches if they prove useful;
+- saved search names/descriptions;
+- selected/citable result sets; and
+- stale-anchor review surfaces.
 
-The GUI should eventually consume these same services. It should not invent a second
-search engine or a second definition of where transcript evidence lives.
+Do not make every convenience statistic another authoritative table. The durable object
+is the user's tag/search/collection; popularity and recency rankings are views.
 
-## 3. Qualify semantic dependency and managed embedding custody
+## 3. First thin GUI
+
+The GUI has now earned its place because the backend is ahead of the human interface.
+
+The first graphical vertical slice should remain deliberately small and beautiful rather
+than becoming a second application implementation.
+
+It should support:
+
+- browse/open local transcripts;
+- unified library search/discovery;
+- readable transcript evidence with speaker/time context;
+- click or select evidence and create/edit/delete a note;
+- apply/create tags and collections, with frequent/recent suggestions;
+- browse notes and saved searches; and
+- jump to the existing source-relative seek coordinate in local media playback.
+
+The GUI must consume existing application services and `EvidenceAnchor`. It must not own a
+second search engine, second note schema, second speaker policy, or second definition of
+where evidence lives.
+
+Visual direction can be refined later, but the intended shell is light, calm, legible,
+and evidence-first rather than dashboard-heavy.
+
+## 4. Research portability and selected-result export
+
+Portability is part of EchoFlow's ownership thesis, not decorative export polish.
+
+Target first formats:
+
+- CSV for ordinary tabular interoperability;
+- JSON/JSONL for machine-readable structure;
+- Markdown for human-readable research bundles; and
+- a whole-workspace/user-state export manifest when the schema is ready.
+
+Exports should retain evidence coordinates such as document ID, source/canonical SHA-256,
+segment IDs, and numeric start/end seconds where applicable.
+
+Native XLSX is optional later. CSV already opens in Excel, Numbers, LibreOffice, R,
+pandas, and many research tools without adding a workbook dependency.
+
+## 5. Incremental library refresh and corpus-scale qualification
+
+`library rebuild` remains the correct repair path, but normal growth should not require
+re-reading an entire large corpus because one transcript changed.
+
+Add an incremental refresh path keyed by stable transcript generation identity, likely
+`document_id + canonical_sha256`, using the existing lexical index `upsert/remove`
+capabilities:
+
+- new transcript → upsert;
+- changed canonical generation → replace/upsert;
+- removed transcript → remove;
+- unchanged transcript → skip.
+
+Keep full rebuild as explicit recovery.
+
+Then measure realistic corpora rather than optimizing by instinct. Representative
+qualification should include startup, warm/cold search, filtered lexical/semantic queries,
+notebook queries, one-edit projection catch-up, large-batch projection catch-up, and full
+rebuild behavior.
+
+## 6. Qualify semantic dependency and managed embedding custody
 
 Before semantic search is advertised as a normal source install, qualify a locked
-optional semantic dependency set.
-
-Target direction:
+optional semantic dependency set with:
 
 - one explicit semantic extra;
 - managed acquisition of the exact qualified E5 snapshot;
@@ -235,11 +287,11 @@ Target direction:
 - offline execution after installation; and
 - clean-wheel/platform qualification.
 
-Do not bypass `uv.lock` coherence merely to make the feature look more finished.
+Do not bypass `uv.lock` coherence merely to make the feature look finished.
 
-## 4. Representative-device qualification and dogfooding
+## 7. Representative-device dogfooding and delivery
 
-Exercise real multi-recording corpora and collect repeated evidence from at least:
+Exercise real multi-recording corpora on at least:
 
 - 8 GB Windows consumer hardware;
 - 16 GB commodity hardware;
@@ -247,81 +299,50 @@ Exercise real multi-recording corpora and collect repeated evidence from at leas
 - a discrete-GPU laptop; and
 - larger 32/64 GB workstations.
 
-Measure cold/warm model behavior, real-time factor, thermal effects, CPU/RAM pressure,
-device memory/utilization where reliable, private disk cost, enhancement benefit/cost,
-embedding build cost, and semantic-query/navigation latency.
+Measure real-time factor, cold/warm model behavior, thermal effects, memory pressure,
+private disk cost, enhancement cost/benefit, embedding build cost, library refresh cost,
+and interactive query latency.
 
-Dogfood interruption/resume, noisy media, stale-process reconciliation, model
-remove/reinstall, source-integrity receipts, speaker naming/overlap, lexical/semantic/
-hybrid search, and aligned navigation using real interviews, lectures, meetings, and oral
-histories.
+Use those measurements to calibrate strategy recommendations and installer defaults.
 
-Calibrate from measurements, not hardware marketing names.
+A pre-1.0 delivery milestone should include polished recovery/error language and an
+installer/package path that does not require a developer environment.
 
-## 5. Beginner delivery surface
+# Conditional later capabilities
 
-EchoFlow's backend increasingly makes beginner-friendly decisions automatically. Its
-current source-install/terminal delivery still assumes a developer.
+## Deeper original-media clock qualification
 
-A reasonable pre-1.0 usability milestone includes:
-
-1. durable notes/tags/collections over aligned evidence;
-2. semantic setup that no longer requires advanced manual environment preparation;
-3. representative qualification on ordinary hardware;
-4. polished error/recovery language;
-5. an installer/package path that does not require a developer environment; and
-6. a thin graphical shell over the existing application services.
-
-The GUI should be a presentation adapter, not a second implementation of transcription,
-search, time mapping, speaker policy, or model custody.
-
-## 6. Deeper original-media clock qualification only when real media requires it
-
-The current implementation preserves source-declared format/stream `timecode` and
-`creation_time` tags while keeping them distinct from canonical elapsed seconds.
-
-If real recordings require deterministic production/media-clock mapping, qualify the
-necessary semantics rather than guessing. Candidate work includes non-zero stream
-origins, rational frame/timecode rates, drop-frame/non-drop-frame semantics, PTS/DTS
-mapping, timezone normalization only when actually encoded, and explicit synchronization
-relationships across independent sources.
+Only add production/media-clock mapping when real recordings require it. Candidate work
+includes non-zero stream origins, rational frame/timecode rates, drop-frame semantics,
+PTS/DTS mapping, and explicit synchronization relationships across independent sources.
 
 “Metadata exists” and “metadata is trustworthy enough to map onto transcript evidence”
 remain different states.
 
-# Later capability: speech/source separation for overlapping speakers
+## Speech/source separation for overlapping speakers
 
-Source separation is valuable, but it remains intentionally later than honest overlap
-representation.
+Source separation remains later than honest overlap representation. It adds substantial
+compute/model custody, uncertainty, derived-audio provenance, and failure modes.
 
-Separating mixed speech into estimated source signals adds substantial compute/model
-cost, new dependency/model custody, uncertainty about source-to-human identity, derived
-audio provenance, and new failure modes. It should also demonstrate an actual end-to-end
-recognition benefit on representative overlap cases.
-
-EchoFlow can now represent simultaneous speaker evidence without choosing a fake winner.
-That is enough foundation to **measure** whether separation is worth the additional
-complexity.
-
-🧜‍♀️ We enter the deep water after learning to swim.
+It should demonstrate measurable end-to-end recognition benefit on representative overlap
+cases before entering the normal product path.
 
 # Other engineering work, when evidence asks for it
 
 ## Typed query evolution
 
-`SearchQuery` already owns text, phrase, ANY/ALL semantics, speaker, language,
-document/transcript, sorting, and bounded limits.
+The unified discovery/search surface should compile into typed query contracts. Do not let
+CLI flags, GUI chips, saved searches, and a future natural-language convenience layer grow
+separate semantics.
 
-Add date/tag/duration/facet/collection constraints when real product use requires them.
-CLI syntax, future query chips, and any local natural-language convenience layer should
-compile to the same typed contract instead of growing separate search semantics.
+Add date/duration/fuzzy/facet constraints only when real use needs them.
 
 ## Bounded failure recovery
 
 Audio bisection/retry should be added only if representative long-recording failures show
 it is needed. Do not front-load a recovery labyrinth for hypothetical failures.
 
-## Pre-production contract policy
+## Pre-production durable-contract policy
 
 EchoFlow has not yet had a released/dogfooded durable compatibility boundary. Internal
 durable contracts therefore use one current canonical shape rather than accumulating
@@ -338,17 +359,14 @@ Interesting later investigations include:
 - independent forced alignment or phoneme-level timing if native word timing proves
   insufficient;
 - finer intra-clause/romanized language attribution;
-- source separation when measured overlap failures justify it;
-- richer PTS/SMPTE synchronization only when real media requires it;
-- alternative qualified multilingual embedding models;
 - character n-gram/fuzzy retrieval for ASR names/acronyms/misspellings;
 - a small local cross-encoder reranker if measured benefit justifies it;
 - resource-admitted HNSW only when exact-search latency justifies approximation;
 - constrained deterministic natural-language query grammar;
 - optional local query translation that shows the interpreted typed query;
 - optional summarization only over an explicitly selected/citable evidence set;
-- explicit user-authored cross-recording person relationships, without biometric
-  identity inference;
+- explicit user-authored cross-recording person relationships, without biometric identity
+  inference;
 - additional ASR engines when they provide a concrete advantage; and
 - additional accelerator backends when a real engine can consume them.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,21 +12,23 @@ Local-first describes where EchoFlow performs work. It is not a claim that the h
 operating system, selected storage, third-party libraries, model files, native media
 parsers, or external executables are trusted.
 
-Recording names and local paths are potentially sensitive. Routine logs redact paths by
-default. Full path logging requires explicit `ECHOFLOW_LOG_PATHS=full`.
+Recording names, transcript content, research notes, tags/collections, and local paths
+may all be sensitive. Routine logs redact paths by default. Full path logging requires
+explicit `ECHOFLOW_LOG_PATHS=full`.
 
-Public failure messages omit input/artifact paths. Human and JSON command results may
-include paths when paths are an intentional command result; callers control where those
-results are stored or forwarded.
+Public failure messages omit input/artifact paths and should not expose note bodies or
+other unexpected internal research content. Human and JSON command results may include
+paths, transcript evidence, or note content when those values are an intentional command
+result; callers control where those results are stored or forwarded.
 
 ## Private local storage
 
-Private state, cache, model, and per-job directories use platform-specific access
-controls. POSIX private directories/files are tightened and verified as `0700`/`0600`.
-On Windows, EchoFlow uses built-in identity/ACL utilities to resolve the current user,
-remove inherited access, grant the current SID access, and verify the resulting DACL.
-A private operation fails rather than silently continuing when the required identity or
-ACL enforcement cannot be established.
+Private state, cache, model, per-job, and research-state directories use platform-specific
+access controls. POSIX private directories/files are tightened and verified as
+`0700`/`0600`. On Windows, EchoFlow uses built-in identity/ACL utilities to resolve the
+current user, remove inherited access, grant the current SID access, and verify the
+resulting DACL. A private operation fails rather than silently continuing when the
+required identity or ACL enforcement cannot be established.
 
 These controls protect the normal current-user filesystem boundary. They are not
 application-level encryption. Local administrators, equivalent privileged processes,
@@ -35,6 +37,43 @@ private state. EchoFlow does not claim secure erasure.
 
 Public transcript artifacts remain ordinary user files. At-rest encryption is an OS,
 volume, or storage responsibility today.
+
+## Research-state privacy boundary
+
+Research notes, tags, collections, and evidence anchors are durable private user-authored
+state. They may reveal participant identities, research hypotheses, interpretations,
+case themes, or other information that is at least as sensitive as transcript text.
+
+EchoFlow stores this state in an authoritative private SQLite database. The database may
+contain:
+
+- note prose;
+- tag and collection names;
+- note-to-tag and note-to-collection relationships;
+- exact source/canonical evidence anchors; and
+- the monotonic change journal used to drive projection convergence.
+
+The separate DuckDB research database is a **rebuildable private projection**, not public
+or disposable in the privacy sense. It may contain note IDs, canonical evidence keys,
+tag/collection IDs, projected relationships, and deterministic lexical terms derived from
+note text. Those values can still disclose research semantics even though authoritative
+note prose remains in SQLite.
+
+SQLite and DuckDB are not attached and do not share a cross-database transaction. User
+mutations commit only to authoritative SQLite with their journal event; a deterministic
+projector later updates DuckDB. Deleting or rebuilding the DuckDB research projection must
+never delete SQLite user state.
+
+Neither database is encrypted by EchoFlow today. They rely on the private filesystem
+boundary described above and any OS/volume encryption the user configures.
+
+Research indexing/search does not upload notes, tags, collections, evidence anchors, or
+projection contents. EchoFlow has no hosted note synchronization or research telemetry.
+
+If a canonical transcript generation changes, existing notes remain durable historical
+state and are not silently re-anchored onto new evidence. Future saved searches and
+curated result sets should inherit the same durable-user-state privacy class unless their
+contract explicitly says otherwise.
 
 ## Supported versions
 
@@ -48,9 +87,9 @@ dogfooded compatibility boundary exists.
 
 ## Reporting a vulnerability
 
-Use GitHub private vulnerability reporting/security advisories. Do not include
-sensitive recordings, transcripts, participant identifiers, tokens, or private
-filesystem layouts in a public issue.
+Use GitHub private vulnerability reporting/security advisories. Do not include sensitive
+recordings, transcripts, participant identifiers, research notes, tags, collection names,
+tokens, or private filesystem layouts in a public issue.
 
 Include the affected commit/version, operating system, minimal reproduction, impact,
 and whether exploitation requires a malicious local file, another local process, or
@@ -149,8 +188,8 @@ checkpoints do not use OS temporary directories because they must survive proces
 restarts/reboots. Disposable segment and derived audio files remain transient
 implementation state.
 
-The current checkpoint manifest omits source path, source filename, and model-cache
-path while binding:
+The current checkpoint manifest omits source path, source filename, and model-cache path
+while binding:
 
 - source fingerprint/media identity and selected audio stream;
 - profile/provisional state;
@@ -160,8 +199,8 @@ path while binding:
 - segmentation settings and exact PCM frame windows; and
 - resource requirements.
 
-Completed checkpoint payloads contain exact recognized text required for recovery.
-That text is not masked because masking would change the recovered transcript.
+Completed checkpoint payloads contain exact recognized text required for recovery. That
+text is not masked because masking would change the recovered transcript.
 
 Resume accepts only a contiguous prefix whose manifest, windows, payload integrity,
 source identity, engine version, and current resource admission all agree. It never
@@ -219,9 +258,9 @@ guarantees.
 
 ## Risks outside the implemented boundary
 
-FFmpeg, FFprobe, ASR, and optional model/native dependencies execute in the current
-process/user security context rather than an OS sandbox. EchoFlow does not currently
-provide:
+FFmpeg, FFprobe, ASR, optional model/native dependencies, SQLite, and DuckDB execute in
+the current process/user security context rather than an OS sandbox. EchoFlow does not
+currently provide:
 
 - independent upstream model signatures/allowlists;
 - process-wide network egress enforcement;
@@ -232,5 +271,6 @@ provide:
 - malicious same-user TOCTOU protection; or
 - protection from a compromised account or local administrator.
 
-Resource admission and private-storage controls are meaningful safety boundaries, but
-none of the stronger properties above should be inferred from “local-first.”
+Resource admission, private-storage controls, and the authority/projection custody split
+are meaningful safety boundaries, but none of the stronger properties above should be
+inferred from “local-first.”

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,41 +16,35 @@ somebody to be EchoFlow.
 > inspectable evidence, your notes and labels remain your knowledge, and most machinery
 > built around those things can be thrown away and rebuilt.
 
-🧜‍♀️
-
 ## What can EchoFlow do today?
 
-EchoFlow is still pre-production, but the backend is no longer a toy transcription
-script. The current foundation covers the local journey from media to a searchable,
-navigable evidence corpus with durable user-authored research state.
+EchoFlow is still pre-production, but the backend is no longer a toy transcription script.
+The current foundation covers the local journey from media to a searchable, navigable
+evidence corpus with durable user-authored research state.
 
 | You want to… | EchoFlow currently… |
 |---|---|
 | Transcribe a recording privately | runs faster-whisper locally from a verified managed model |
 | Avoid melting a smaller laptop | inspects process-visible CPU, RAM, and compatible acceleration before choosing a strategy |
-| Use a GPU when it is actually usable | separates physical hardware discovery from engine/runtime capability |
 | Survive an interruption | checkpoints completed work and validates the original contract on resume |
 | Keep the original recording intact | treats source media as read-only evidence and writes processing artifacts separately |
 | Handle video files | deterministically selects an audio stream and transcribes the audio-bearing source |
 | Clean up a noisy recording | optionally applies deterministic local noise suppression with provenance and timeline checks |
 | Work with multiple languages | supports multilingual decoding plus conservative local language attribution |
 | Distinguish speakers | preserves optional anonymous recording-scoped speaker evidence without claiming identity |
-| Give anonymous speakers useful names | stores user-assigned display labels separately from canonical diarization evidence and rebuildable search state |
-| Read awkward handoffs honestly | distinguishes clean speaker spans, true overlap, mixed/unresolved text, and unattributed text |
+| Give speakers useful display names | stores user-assigned labels separately from canonical diarization evidence |
+| Read awkward handoffs honestly | distinguishes clean speaker spans, overlap, mixed/unresolved text, and unattributed text |
 | Publish useful transcript formats | produces canonical JSON plus rebuildable TXT, SRT, and WebVTT views |
 | Find an exact phrase later | builds a private local lexical/BM25 transcript library |
-| Find an idea when the wording changed | supports optional local semantic retrieval |
+| Find an idea when wording changed | supports optional local semantic retrieval |
 | Combine both search styles | uses inspectable reciprocal-rank fusion |
-| Stop calculating giant second counts | renders source-relative evidence as human `HH:MM:SS.mmm` coordinates while keeping numeric seconds authoritative |
-| Preserve camera/container time clues | records source-declared `timecode` and `creation_time` tags with format/stream provenance when present |
-| Follow a search result back to evidence | verifies the canonical transcript, resolves exact lexical word matches when justified, expands context, and exposes a source seek coordinate |
-| See your speaker names in search | decorates current search presentation with names such as `Dr. Chen (speaker-02)` without replacing the anonymous evidence ref |
+| Follow a search result back to evidence | verifies the canonical transcript, resolves exact lexical words when justified, expands context, and exposes a source seek coordinate |
 | Keep durable research notes | stores notes, tags, and collections in authoritative private SQLite state anchored to exact canonical evidence |
-| Query your notebook quickly | projects only queryable research metadata into rebuildable DuckDB state |
-| Search transcript evidence through your notes | applies tag/collection/note-text constraints before lexical ranking or semantic vector scoring |
+| Query your notebook quickly | projects only query-relevant research relationships and lexical terms into rebuildable DuckDB state |
+| Search transcript evidence through your notes | applies tag/collection/note-text constraints before lexical ranking or semantic scoring |
 
-That is a lot of machinery. The point is not to make you operate the machinery. The
-point is to make sensitive local transcription and research feel boringly dependable.
+The point is not to make users operate the machinery. The point is to make sensitive local
+transcription and research feel boringly dependable.
 
 ## Pick your doorway
 
@@ -58,8 +52,8 @@ point is to make sensitive local transcription and research feel boringly depend
 
 Start with **[Getting started](getting-started.md)**.
 
-It walks through installation, model setup, transcription, resume, exports, and search
-without requiring an architecture degree.
+It walks through installation, model setup, transcription, resume, exports, search, and
+the current command-line research notebook.
 
 ### 📝 I want to keep notes beside the evidence
 
@@ -69,22 +63,6 @@ It explains durable evidence anchors, notes/tags/collections, notebook queries,
 research-aware transcript search, stale transcript generations, and why deleting a search
 index cannot delete your research work.
 
-### 🕰️ I want to understand transcript time and jumping around
-
-Read **[Transcript time without calculator gymnastics](time-navigation.md)**.
-
-It explains what word timestamps buy you, why `4788.37` seconds becomes
-`01:19:48.370`, why source-declared camera time is a different clock, and how canonical
-numeric coordinates support source seeking.
-
-### 👥 I want `speaker-02` to have a human name
-
-Read **[Give the anonymous speakers names](speaker-names.md)**.
-
-It explains why `speaker-02` remains evidence while `Dr. Chen` is your durable display
-label, how overlap/handoffs are presented, and why names do not silently jump across a
-changed transcript generation.
-
 ### 🔎 I found something. Show me the actual evidence.
 
 Read **[From search result to the exact evidence](evidence-navigation.md)**.
@@ -92,6 +70,20 @@ Read **[From search result to the exact evidence](evidence-navigation.md)**.
 It explains canonical hash verification, exact lexical word highlighting, semantic
 restraint, neighboring context, speaker display names, source seek coordinates, and the
 durable anchor research notes reuse.
+
+### 🕰️ I want to understand transcript time and jumping around
+
+Read **[Transcript time without calculator gymnastics](time-navigation.md)**.
+
+It explains source-relative timing, human elapsed display, source-declared media metadata,
+and why playback should seek by canonical numeric coordinates.
+
+### 👥 I want `speaker-02` to have a human name
+
+Read **[Give the anonymous speakers names](speaker-names.md)**.
+
+It explains why `speaker-02` remains evidence while `Dr. Chen` is durable user-authored
+presentation state.
 
 ### ✨ I want to understand semantic search
 
@@ -101,8 +93,7 @@ embedding is and what stays local.
 
 ### 🔐 I care about privacy and security boundaries
 
-Read **[SECURITY.md](../SECURITY.md)**. That document intentionally uses less glitter.
-Security claims should be boring enough to audit.
+Read **[SECURITY.md](../SECURITY.md)**. Security claims should be boring enough to audit.
 
 ### 🔧 I am maintaining or extending EchoFlow
 
@@ -115,55 +106,40 @@ navigation, and durable research-state projection.
 ### 🧪 I am here to break things professionally
 
 The [development docs](development/) cover benchmarking, test design, bisect strategy,
-and targeted mutation qualification.
-
----
+semantic retrieval qualification, and targeted mutation testing.
 
 ## The EchoFlow family portrait
 
-The product makes more sense when its capabilities are grouped by the job they perform.
-
 ```mermaid
 flowchart LR
-    U[Your recording] --> C[Custodian\nsource + provenance]
-    C --> H[Hardware sommelier\nfit work to this machine]
-    H --> T[Transcription engine room\nASR + checkpoints + enrichment]
-    T --> A[Archivist\ncanonical transcript + exports]
-    A --> L[Librarian\nlexical + semantic + hybrid search]
-    L --> N[Navigator\nverify + highlight + context + seek]
-    N --> R[Research notebook\ndurable notes + tags + collections]
-    R --> E[Evidence you can inspect again]
-
-    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class U,C source
-    class H compute
-    class T process
-    class A evidence
-    class L,N,E result
-    class R evidence
+    A[Your recording] --> B[Local transcription]
+    B --> C[Canonical transcript]
+    C --> D[Lexical semantic hybrid search]
+    D --> E[Verified evidence navigation]
+    E --> F[Research notebook]
+    F --> D
+    F --> G[Future unified discovery and GUI]
 ```
 
-The shared rule across the whole family is simple:
+Text fallback: canonical evidence feeds rebuildable search; search resolves back to
+verified evidence; durable notes/tags/collections attach to that evidence and can constrain
+later retrieval; the next user-facing layer unifies those capabilities rather than
+reimplementing them.
+
+The shared rule is simple:
 
 **Do complicated work locally. Keep the evidence understandable, portable, and owned by
 the user.**
 
 ## What belongs to you, and what can the raccoon rebuild? 🦝
 
-EchoFlow uses different custody rules for different kinds of data.
-
 | Data | What it is | Rebuildable? |
 |---|---|---|
 | Original recording | source evidence | **No** |
 | Canonical transcript JSON | authoritative transcript artifact | **No** |
 | Speaker display labels | user-authored knowledge | **No** |
-| Research notes, tags, collections, and evidence anchors | user-authored knowledge | **No** |
-| Future saved searches / curated result sets | user-authored knowledge | **No** |
+| Research notes, tags, collections, evidence anchors | user-authored knowledge | **No** |
+| Future saved searches / selected result sets | user-authored knowledge | **No** |
 | TXT / SRT / WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
 | Checkpoint machinery after successful publication | execution/recovery state | Usually disposable after completion |
@@ -175,44 +151,39 @@ EchoFlow uses different custody rules for different kinds of data.
 If deleting a search or research projection destroys unique user-authored information,
 something has gone very wrong.
 
+## Where the product is going next
+
+The research-navigation sequence that used to live here as future work is now foundation:
+word timing, human/source time semantics, speaker display labels, overlap-aware speaker
+presentation, verified search navigation, and durable notes/tags/collections are all
+implemented.
+
+The next layers are intentionally more human-facing:
+
+1. **Unified library discovery** across transcript evidence, notes, tags, collections, and
+   later saved searches.
+2. **Saved searches and useful derived navigation**, including frequent/recent tags and
+   facets where they reduce hunting without creating new authoritative counters.
+3. **A thin graphical shell** that can browse/search transcripts, select evidence, create
+   notes, apply tags/collections, and seek local media using existing application services.
+4. **Portable research export and incremental library refresh** so ownership and larger
+   corpora remain pleasant rather than merely correct.
+5. **Productization** through semantic-install qualification, representative-device
+   dogfooding, installers, and polished recovery/error language.
+
+The GUI should be a presentation adapter, not a second implementation of transcription,
+search, time mapping, speaker policy, evidence anchoring, or research-state custody.
+
+For the fuller sequencing and deliberate limits, see **[ROADMAP.md](../ROADMAP.md)**.
+
 ## Why the docs have different personalities
 
-Not every reader needs the same depth.
-
-- **Welcome/onboarding docs** explain the product in ordinary language and may contain
-  raccoons, mermaids, dancing women, and other signs of life.
+- **Welcome/onboarding docs** explain the product in ordinary language.
 - **Feature guides** explain *why* a capability exists before exposing implementation
   detail.
-- **Architecture docs** keep exact contracts, but each should still provide a
-  plain-English doorway and useful diagrams.
-- **Security, audit, schema, and command contracts** prioritize unambiguous language over
-  jokes.
+- **Architecture docs** keep exact contracts, but provide a plain-English doorway.
+- **Security, audit, schema, and command contracts** prioritize unambiguous language.
 
 The detailed editorial rules live in **[documentation-style.md](documentation-style.md)**.
-
-## What is next?
-
-The research-navigation sequence that used to live here as future work is now mostly
-foundation:
-
-1. word/timestamp alignment is implemented;
-2. human elapsed time and source-declared temporal provenance are implemented;
-3. durable recording-scoped speaker display labels are implemented;
-4. handoff/overlap-aware speaker presentation is implemented;
-5. search results resolve back to verified canonical segments/words with bounded context
-   and seek coordinates; and
-6. durable notes/tags/collections now live in authoritative SQLite state with a
-   rebuildable DuckDB research projection for fast notebook and transcript filtering.
-
-The next research-workspace layer is narrower: saved searches, citable/exportable result
-sets, richer annotation/playback ergonomics, and a thin graphical shell over the same
-application services. Semantic dependency/model setup, representative-device
-qualification, and installers remain major productization work.
-
-Speech/source separation remains later. EchoFlow can now represent overlap honestly, so
-a separation model should earn its compute/model/provenance cost with measured benefit
-on real recordings.
-
-For the fuller sequencing and research boundary, see **[ROADMAP.md](../ROADMAP.md)**.
 
 💃 **You are now allowed to leave the documentation lobby.**

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -6,9 +6,9 @@ The user-facing docs explain what EchoFlow does. These pages explain **why the b
 exist, what each capability owns, what it refuses to own, and which invariants must
 survive refactors**.
 
-If you are trying to transcribe a file rather than maintain the system, back out gently
-and use **[Getting started](../getting-started.md)**. There is no prize for learning
-cgroup accounting before lunch.
+If you are trying to transcribe a file rather than maintain the system, use
+**[Getting started](../getting-started.md)**. There is no prize for learning cgroup
+accounting before lunch.
 
 ## The shape of the system
 
@@ -19,36 +19,31 @@ Injector.
 
 ```mermaid
 flowchart LR
-    A[Source media] --> M[Media inspection]
-    M --> R[Resource + runtime inspection]
-    R --> P[Immutable plan]
-    P --> X[Local execution]
-    X --> C[Canonical transcript]
-    C --> E[Derived exports]
-    C --> L[Rebuildable search projections]
-    L --> S[Ranked search passages]
-    C --> N[Verified evidence navigation]
-    S --> N
-    N --> U[Authoritative user research state]
-    U --> RP[Rebuildable research projection]
-    RP --> S
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef publish fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A,C evidence
-    class M,R,P compute
-    class X process
-    class E,U publish
-    class L,S,N,RP result
+    A[Source media] --> B[Media and resource inspection]
+    B --> C[Immutable local plan]
+    C --> D[Transcription and checkpoints]
+    D --> E[Canonical transcript JSON]
+    E --> F[Derived exports]
+    E --> G[DuckDB lexical and semantic projections]
+    G --> H[Ranked passages]
+    E --> I[Verified evidence navigation]
+    H --> I
+    I --> J[SQLite research authority]
+    J --> K[Deterministic projector]
+    K --> L[DuckDB research projection]
+    L --> H
+    J --> M[ResearchWorkspaceService]
+    I --> M
 ```
 
-The architectural through-line is custody: source evidence and canonical transcript
-truth remain distinguishable from temporary execution state, model dependencies,
-rebuildable search infrastructure, and durable user-authored knowledge.
+Text fallback: source media produces canonical transcript evidence; DuckDB search
+projections rank passages; evidence navigation verifies those passages; SQLite owns
+human-authored research state; a deterministic projector builds disposable DuckDB query
+state; `ResearchWorkspaceService` is the application-facing seam across those boundaries.
+
+The architectural through-line is **custody**. Source evidence, canonical transcript
+truth, private execution state, managed model dependencies, rebuildable indexes, and
+durable human knowledge intentionally have different deletion and recovery semantics.
 
 ## Where to look
 
@@ -57,16 +52,14 @@ rebuildable search infrastructure, and durable user-authored knowledge.
 | [Processing capabilities](processing-capabilities.md) | How does the whole local transcription/research system fit together? |
 | [Adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) | How does EchoFlow decide what this machine can safely run? |
 | [Media and timeline](media-and-timeline.md) | What source did we inspect, which audio stream did we use, and what do timestamps mean? |
-| [Word-level timestamp alignment](word-alignment.md) | How do engine-produced word timings become source-relative evidence and improve speaker handoffs? |
+| [Word-level timestamp alignment](word-alignment.md) | How do engine-produced word timings become source-relative evidence? |
 | [Local model management](model-management.md) | Which model revision is allowed to execute, and how did it get here? |
 | [Speech enhancement](speech-enhancement.md) | How can preprocessing affect ASR without becoming source truth? |
 | [Anonymous speaker diarization](diarization.md) | How are speaker turns represented without pretending anonymous labels are identities? |
 | [Corpus search](corpus-search.md) | How do lexical/semantic/hybrid ranking and verified canonical navigation stay separate? |
-| [Durable research state](research-state.md) | How do authoritative SQLite notes and rebuildable DuckDB research projections stay consistent without sharing custody? |
+| [Durable research state](research-state.md) | Why does SQLite own human research while DuckDB owns rebuildable acceleration, and how do they converge? |
 | [ROADMAP](../../ROADMAP.md) | What is implemented, what is next, and what remains research? |
 | [SECURITY](../../SECURITY.md) | What does the security boundary actually claim? |
-
-🧜‍♀️ The mermaid has no architectural responsibility. She is observing.
 
 ## Package map
 
@@ -81,11 +74,10 @@ rebuildable search infrastructure, and durable user-authored knowledge.
 | `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language attribution, word alignment, diarization, assembly, exports |
 | `workspace` | Private job paths and public artifact allocation |
 | `benchmarking` | Privacy-minimized local execution measurement |
-| `library` | Lexical/semantic retrieval, canonical evidence navigation, speaker presentation, authoritative research state, and rebuildable research projection |
+| `library` | Retrieval, canonical evidence navigation, speaker presentation, authoritative research state, and rebuildable research projection |
 
-A couple of names are easy to misread. `runner` means the local compute environment
-available to the process; it is not a distributed task runner. `media.probe` performs
-inspection, not transcoding.
+`runner` means the local compute environment visible to the process; it is not a
+distributed task runner. `media.probe` performs inspection, not transcoding.
 
 ## Capability boundaries
 
@@ -95,57 +87,99 @@ everything vaguely adjacent to it.
 External/configuration/durable-data boundaries may use Pydantic where parsing and
 serialization are valuable. Small internal immutable values generally use frozen/slotted
 dataclasses. Services use narrow `Protocol` capabilities when substitution is real and
-useful for testing or multiple implementations.
+useful.
 
-The search/research area now has four deliberately separate authorities:
+The search/research area has deliberately separate responsibilities:
 
-1. retrieval services rank rebuildable passages;
-2. canonical evidence navigation verifies and locates those passages;
-3. authoritative research-state services own durable human-authored notes, tags, and
-   collections without rewriting evidence; and
-4. the research projector owns only the deterministic DuckDB acceleration layer and its
-   convergence watermark.
+1. `TranscriptLibraryService` and retrieval services discover/rank rebuildable transcript
+   passages.
+2. `EvidenceLocator` verifies and resolves those passages back to canonical evidence.
+3. `SpeakerLabelService` owns durable recording-scoped human display names without
+   rewriting diarization evidence.
+4. `ResearchStateStore` owns durable human-authored notes, tags, collections, and
+   evidence anchors.
+5. `ResearchStateProjector` owns convergence from authoritative SQLite state into the
+   rebuildable research projection.
+6. `ResearchProjectionIndex` owns fast derived research constraints and summaries.
+7. `ResearchWorkspaceService` composes those capabilities for presentation adapters.
 
-That split should survive the GUI. Presentation convenience is not permission to merge
-custody boundaries.
+That split should survive unified discovery and the GUI. Presentation convenience is not
+permission to merge custody boundaries.
 
-Structlog remains behind `core.observability.ILogger`; application services should not
-need to import Structlog directly.
+## Why SQLite and DuckDB both exist
+
+The two engines serve different workloads and different custody classes.
+
+SQLite is authoritative for irreplaceable, frequently mutated user research. DuckDB is
+used for rebuildable analytical/query projections over transcript and research data.
+There is **one authority**, not two masters.
+
+```text
+SQLite authority
+      |
+      | monotonic transactional change journal
+      v
+ResearchStateProjector
+      |
+      v
+DuckDB research projection
+```
+
+If the research projection disappears, rebuild it. If SQLite user state disappears,
+unique human work is lost. That asymmetry is intentional.
+
+See [Durable research state](research-state.md) for the full transaction, watermark,
+rebuild, and fail-closed contract.
 
 ## The custody rules 🦝
 
 These rules are load-bearing:
 
 1. **Original media is source evidence and treated as read-only input.**
-2. **Canonical transcript/checkpoint artifacts carry execution truth.**
+2. **Canonical transcript JSON is authoritative transcript evidence.**
 3. **Managed model manifests describe verified local execution dependencies.**
-4. **Lexical, semantic, and research DuckDB databases are derived, private, and
-   rebuildable.**
-5. **User-authored speaker labels, research notes, tags, collections, and future curated
-   result sets do not share deletion semantics with rebuildable indexes.**
-6. **Research-state joins include canonical generation identity, not a friendly segment
-   ID alone.**
-7. **Precise navigation must resolve back to verified canonical evidence rather than
-   trusting a stale search projection.**
-8. **A convenience layer may not quietly become the only place unique evidence or user
+4. **Lexical, semantic, and research DuckDB databases are private rebuildable
+   projections.**
+5. **User-authored speaker labels, notes, tags, collections, future saved searches, and
+   curated result sets do not share deletion semantics with indexes.**
+6. **Research-state joins include canonical generation identity, not a friendly segment ID
+   alone.**
+7. **Precise navigation resolves back to verified canonical evidence rather than trusting
+   a stale search projection.**
+8. **Research filters are applied before ranking/scoring when they define eligible
+   evidence.**
+9. **A convenience layer may not quietly become the only place unique evidence or user
    knowledge lives.**
 
 Search infrastructure is allowed to disappear. User-authored knowledge is not.
 
+## The next architectural seam
+
+The next user-facing feature is **unified library discovery**. It should compose existing
+services rather than create another database or search engine.
+
+A future discovery service may return grouped typed results such as transcript evidence,
+notes, tags, collections, and saved searches. It should preserve each result type's own
+semantics rather than inventing one universal relevance score across unlike objects.
+
+Saved searches belong to durable SQLite user state because they are authored workspace
+intent. Frequent/recent tag rankings are derived convenience views and should not become
+precious counters.
+
+The first GUI then becomes a thin presentation adapter over the same discovery,
+`ResearchWorkspaceService`, `EvidenceAnchor`, speaker, time, and playback-seek contracts.
+
 ## New abstraction test
 
-Before adding a manager, framework, registry, adapter hierarchy, or generalized plugin
-system, ask which concrete capability or invariant it protects.
+Before adding a manager, framework, registry, adapter hierarchy, generalized plugin
+system, or “database wrapper,” ask which concrete capability or invariant it protects.
 
 File count is not an architectural problem. Repeated policy, unclear ownership, and
 unprovable invariants are.
 
 ## Documentation contract
 
-Architecture docs may be technical. They should not require a reader to decode a wall of
-implementation nouns before learning the purpose.
-
-Each architecture page should aim to provide:
+Architecture pages should provide:
 
 - a plain-English doorway;
 - a visual model when structure matters;

--- a/docs/architecture/corpus-search.md
+++ b/docs/architecture/corpus-search.md
@@ -1,6 +1,7 @@
 # Evidence-first corpus search 🔎🦝
 
-Status: lexical, semantic/hybrid, and canonical evidence-navigation foundations implemented  
+Status: lexical, semantic/hybrid, canonical evidence navigation, and research-aware
+filtering implemented  
 Last updated: August 18, 2026
 
 ## The human version
@@ -8,7 +9,7 @@ Last updated: August 18, 2026
 A transcript library should help you find **what was said** without quietly replacing
 your evidence with a database, vector store, or generated answer.
 
-EchoFlow supports three retrieval modes:
+EchoFlow supports three transcript retrieval modes:
 
 | Mode | Best when… | Example |
 |---|---|---|
@@ -16,63 +17,56 @@ EchoFlow supports three retrieval modes:
 | Semantic | you remember the idea but not the wording | `people struggling to afford housing` |
 | Hybrid | you want exact terminology and conceptual similarity to support each other | research across a mixed corpus |
 
-Retrieval ranks a passage. A separate navigation layer can then verify the exact canonical
-transcript generation and resolve that passage back to canonical segments and aligned
-words.
+Retrieval ranks a passage. A separate navigation layer verifies the exact canonical
+transcript generation and resolves that passage back to canonical segments and aligned
+words. A research-workspace layer can then decorate or constrain those results using
+durable notes/tags/collections without teaching the search index that human-authored
+knowledge is transcript truth.
 
-The load-bearing rule remains:
-
-> **Canonical transcript JSON is evidence. Search databases and navigation views are projections.**
+> **Canonical transcript JSON is evidence. SQLite research state is human-authored truth.
+> DuckDB search/research databases are rebuildable projections.**
 
 ```mermaid
 flowchart LR
-    A[Original recording] -->|read only| B[Canonical transcript JSON]
-    B --> C[Lexical projection]
-    B --> D[Semantic chunks]
-    C --> E[BM25 ranking]
-    D --> F[Local embeddings]
-    F --> G[Exact semantic ranking]
-    E --> H[Optional hybrid fusion]
-    G --> H
-    E --> I[Ranked SearchResponse]
-    G --> I
-    H --> I
-    I --> V[Verify canonical SHA]
-    V --> N[EvidenceLocation\nsegments + words + seek + context]
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A,B,V evidence
-    class C,D derived
-    class E,F,G,H process
-    class I,N result
+    A[Canonical transcript JSON] --> B[Lexical projection]
+    A --> C[Semantic chunks and vectors]
+    B --> D[BM25 ranking]
+    C --> E[Dense ranking]
+    D --> F[Hybrid RRF when requested]
+    E --> F
+    D --> G[Ranked passages]
+    E --> G
+    F --> G
+    G --> H[Verify canonical evidence]
+    H --> I[Segments words context seek]
+    J[SQLite notes tags collections] --> K[DuckDB research projection]
+    K --> B
+    K --> C
+    I --> L[ResearchWorkspaceService]
+    J --> L
 ```
 
-For a non-architecture explanation, read **[Semantic search, without the mystery
-box](../semantic-search.md)** and **[From search result to the exact
-evidence](../evidence-navigation.md)** first.
+Text fallback: canonical transcript evidence produces rebuildable lexical/semantic search
+state; ranked passages are re-verified against canonical evidence; authoritative SQLite
+research state is projected into DuckDB only to accelerate research constraints and
+summaries.
 
-## 🦝 Three durability classes
-
-Search becomes easier to reason about when data is classified by whether it can be
-reconstructed.
+## Durability classes
 
 ### Authoritative evidence
 
 - original recording supplied by the user;
 - canonical transcript JSON.
 
-### User-authored knowledge
+### Authoritative user knowledge
 
-Speaker display labels are implemented here. Future notes, tags, collections,
-annotations, and saved searches belong in the same durability class.
+- speaker display labels;
+- research notes;
+- tags;
+- collections;
+- future saved searches and curated result sets.
 
-They are **not retrieval cache**. An index rebuild must never delete them. Durable
-annotations should anchor to canonical evidence coordinates, not only to disposable
-semantic chunk IDs or formatted timestamps.
+These are **not retrieval cache**. An index rebuild must never delete them.
 
 ### Rebuildable projections and views
 
@@ -80,11 +74,13 @@ semantic chunk IDs or formatted timestamps.
 - lexical term statistics;
 - deterministic search chunks;
 - dense embeddings;
+- normalized chunk-to-segment relationships;
+- derived research relationships/lexical note terms;
 - retrieval statistics; and
-- derived context/highlight/navigation presentation.
+- context/highlight/navigation presentation.
 
-If every search database disappeared, EchoFlow should be able to reconstruct search from
-canonical transcripts without losing unique user-authored information.
+If every DuckDB file disappeared, EchoFlow should reconstruct search/query acceleration
+without losing unique evidence or human-authored research.
 
 ## Canonical hashing and stale-state refusal
 
@@ -94,32 +90,20 @@ EchoFlow records two different SHA-256 digests in the lexical document projectio
 - `canonical_sha256`: digest of the exact canonical transcript JSON bytes indexed by the
   library.
 
-The original recording may remain byte-identical while the canonical transcript changes
-because it was regenerated, enriched, corrected, or replaced.
-
 Every semantic generation records a `corpus_fingerprint` derived from sorted
 `(document_id, canonical_sha256)` pairs. Semantic/hybrid retrieval refuses stale vectors.
 
-Evidence navigation has an additional boundary: before exposing precise canonical
-segments/words, `EvidenceLocator` re-reads the canonical JSON and verifies its SHA-256,
-job ID, and source SHA against the ranked passage. A result whose indexed evidence no
-longer matches the canonical file fails closed rather than presenting stale precision.
+Before exposing precise canonical segments/words, `EvidenceLocator` re-reads canonical
+JSON and verifies its SHA-256, document identity, and source SHA against the ranked
+passage. Stale indexed evidence fails closed instead of presenting fake precision.
 
 ```mermaid
 flowchart TD
-    A[Ranked passage] --> B{Canonical SHA still matches?}
-    B -->|no| X[Refuse precise navigation]
-    B -->|yes| C{Result segment IDs still exist?}
-    C -->|no| X
-    C -->|yes| D[Resolve canonical words + context]
-
-    classDef result fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef stop fill:#FFD6D6,stroke:#9E3434,stroke-width:2px,color:#351616
-
-    class A result
-    class B,C,D evidence
-    class X stop
+    A[Ranked passage] --> B{Canonical generation still matches}
+    B -->|No| C[Refuse precise navigation]
+    B -->|Yes| D{Segment IDs still exist}
+    D -->|No| C
+    D -->|Yes| E[Resolve canonical words context and seek]
 ```
 
 ## Lexical retrieval
@@ -128,35 +112,23 @@ flowchart TD
 segment, and term-statistic tables and computes deterministic BM25-style ranking without
 installing DuckDB's FTS extension.
 
-The public application query remains typed through `SearchQuery`:
-
-```text
-SearchQuery
-  text = "housing"
-  phrase = false
-  operator = any | all
-  speaker_refs = ["speaker-02"]
-  languages = ["en"]
-  document_ids = ["job-123"]
-  sort = relevance | timeline
-  limit = 100
-```
+The public query is typed through `SearchQuery`, including text, phrase/ANY/ALL semantics,
+speaker/language/document/timeline constraints, bounded limits, sorting, and optional
+`evidence_scope`.
 
 User values remain parameterized. The storage adapter owns SQL. The user does not.
 
-Lexical tokenization is now a shared library text rule rather than a DuckDB-private
-helper. Ranking and exact canonical-word highlighting therefore use the same
-Unicode-aware token semantics instead of drifting independently.
+Lexical tokenization is a shared library rule so ranking and exact canonical-word
+highlighting use the same Unicode-aware token semantics.
 
-Lexical search remains the base/default mode and does not require a semantic runtime.
+Lexical search remains the dependency-light default.
 
-## Why semantic search needs chunks
+## Semantic search chunks
 
-ASR segments are evidence coordinates, not automatically good retrieval units. A
-canonical segment might contain only `Yeah.` or `And then we moved.`
+ASR segments are evidence coordinates, not automatically ideal retrieval units. EchoFlow
+combines adjacent canonical segments into deterministic retrieval windows.
 
-EchoFlow therefore combines adjacent canonical segments into deterministic retrieval
-windows. `search-chunk-v1` currently uses:
+`search-chunk-v1` currently uses:
 
 - target size: 220 whitespace-delimited words;
 - maximum target size: 300 words;
@@ -166,17 +138,16 @@ windows. `search-chunk-v1` currently uses:
 - content SHA-256;
 - first/last segment IDs plus the complete ordered segment-ID tuple;
 - exact source-relative start/end timestamps; and
-- sorted language and anonymous speaker references observed in the window.
+- sorted language and anonymous speaker refs observed in the window.
 
-If one canonical segment is already larger than the target/max window, it remains one
-chunk. A search chunk is **never canonical evidence**. It is a disposable window
-pointing back to canonical segments.
+A search chunk is never canonical evidence. It is a disposable retrieval window pointing
+back to canonical segments.
 
-## Embedding profile: the model is not the whole contract
+## Embedding profile and strict-local boundary
 
 One semantic index generation has one coherent `EmbeddingProfile`.
 
-The first qualified real adapter targets:
+The current qualified profile targets:
 
 ```text
 model_id             intfloat/multilingual-e5-small
@@ -191,192 +162,149 @@ resolved_revision    immutable snapshot revision
 embedding_schema     1
 ```
 
-The profile matters because dimensions, pooling, normalization, query instructions,
-passage instructions, and distance semantics are all load-bearing parts of one vector
-space.
+`EmbeddingProvider` exposes separate query/passage operations because E5 uses different
+transforms on each side. Provider output is validated for cardinality, dimensions, finite
+values, and normalization before it may replace valid semantic state.
 
-`EmbeddingProvider` exposes separate `embed_queries()` and `embed_passages()` operations.
-E5 uses distinct query-side and passage-side transforms, so EchoFlow does not flatten the
-interface into a misleading generic `embed(text)` call.
+The base locked project still does **not** declare Sentence Transformers as a normal
+semantic extra. Semantic search therefore remains advanced optional setup while lexical
+search remains fully available.
 
-## Strict-local model boundary 🔐
+## Numeric storage and exact similarity first
 
-`SentenceTransformersE5Provider` accepts a local snapshot directory whose name must
-agree with the recorded immutable revision. It uses local-only model resolution and
-disables remote model code.
-
-Provider output is validated for one vector per input, expected dimensions, finite
-numeric values, and L2 normalization before it may replace valid semantic state. A
-failed rebuild must not destroy the previous generation.
-
-The locked project dependency graph does **not yet** declare Sentence Transformers as a
-semantic extra. Semantic search is therefore currently an advanced optional capability
-for environments that already provide a compatible runtime and immutable local model
-snapshot. Lexical search remains fully available without it.
-
-## Numeric vector storage, now that we have earned the jargon
-
-`DuckDbSemanticIndex` stores vectors as numeric DuckDB `FLOAT[]`, not opaque BLOBs. The
-application boundary remains `tuple[float, ...]`, so a later backend can choose a
-different physical representation without changing the domain contract.
-
-The semantic database is private rebuildable state under:
-
-```text
-STATE_DIR/library/semantic.duckdb
-```
-
-It is intentionally separate from the lexical database so semantic evolution does not
-destabilize the dependency-light BM25 path.
-
-## Exact local similarity first
+`DuckDbSemanticIndex` stores vectors as DuckDB `FLOAT[]`, not opaque BLOBs. The
+application boundary remains `tuple[float, ...]`.
 
 The first semantic implementation performs an **exact scan** over eligible local chunks.
-Hard filters are applied before top-K ranking for transcript IDs, language, speaker,
-phrase constraints, and `ALL` lexical terms where applicable.
+Hard filters are applied before top-K ranking. No ANN/HNSW index exists yet; approximation
+should appear only when measured corpus size shows exact local scan misses an interactive
+latency target.
 
-No ANN/HNSW index exists yet. Approximate nearest-neighbor indexing is an optimization
-that should appear only when measured corpus size shows exact local scan no longer meets
-an interactive latency target.
+## Hybrid retrieval
 
-An 8 GB laptop should not pay an ANN tax because ANN is fashionable.
-
-## 💃 Hybrid retrieval
-
-Lexical BM25 scores and dense semantic similarity scores do not share one trustworthy
-scale. EchoFlow combines **ranks** using reciprocal rank fusion (RRF) with `k=60`:
+Lexical BM25 and dense semantic scores do not share one trustworthy scale. EchoFlow
+combines **ranks** using reciprocal rank fusion (RRF) with `k=60`:
 
 ```text
 RRF(d) = Σ 1 / (60 + rank_i(d))
 ```
 
-Hybrid retrieval overfetches bounded candidate ranks before fusion so one mode can
-contribute passages the other missed. `SearchResponse` preserves lexical, semantic, and
-fused ranks. Timeline presentation may reorder results chronologically without rewriting
-those stored relevance ranks.
-
-## SearchResponse is ranking provenance, not the final research view
-
-`SearchPassage` carries enough evidence to identify the ranked window:
-
-- document/source identity;
-- canonical transcript identity/hash;
-- optional deterministic chunk ID;
-- constituent canonical segment IDs;
-- lexical matched-segment IDs when available;
-- source-relative start/end timestamps;
-- anonymous speaker/language evidence;
-- lexical/semantic/fused ranks; and
-- transcript passage text.
-
-It deliberately does **not** pretend to be a fully resolved canonical annotation target.
-That is the job of the next layer.
+Hybrid retrieval overfetches bounded candidate ranks before fusion. `SearchResponse`
+preserves lexical, semantic, and fused ranks.
 
 ## Canonical evidence navigation
 
-`EvidenceLocator` takes a `SearchResponse` and resolves each ranked passage back to the
-verified canonical transcript.
-
-The derived `EvidenceLocation` includes:
+`EvidenceLocator` resolves a ranked passage back to the verified canonical transcript and
+produces an `EvidenceLocation` with:
 
 - exact canonical/source identity;
 - result segment IDs;
 - numeric result start/end;
-- a deterministic `seek_seconds` coordinate;
-- result speaker refs observed in canonical segment/word evidence;
+- deterministic `seek_seconds`;
+- canonical speaker refs;
 - exact matched aligned words when justified; and
 - bounded canonical context segments.
 
-Context expansion is controlled after ranking, currently by `--context-segments 0..10`.
-It does not feed neighboring text back into BM25/dense ranking.
-
-### Exact highlighting is intentionally asymmetric
-
-A lexical result identifies matched canonical segment evidence. When aligned words exist,
-EchoFlow can apply the same lexical token semantics to those canonical words and expose
-exact highlighted word coordinates.
-
-Phrase queries require contiguous query tokens before words are marked as the phrase.
-
-A semantic-only result has no equivalent exact-word claim. It receives canonical passage
-navigation and a seek coordinate, but **no fabricated word highlight**.
-
-Hybrid results may contain exact lexical highlights when lexical evidence contributed to
-the fused result.
-
-This asymmetry is intentional. Embedding similarity answers “which passage is related?”
-It does not answer “which exact word caused the similarity?”
+Lexical results may expose exact aligned-word matches. Semantic-only results do not
+fabricate exact-word precision. Hybrid results may expose lexical highlights when lexical
+evidence contributed.
 
 ## Speaker display integration
 
-`ResearchNavigationService` composes three authorities without merging them:
+`ResearchNavigationService` composes transcript retrieval, canonical evidence location,
+and current user-assigned speaker display labels.
 
-1. `TranscriptLibraryService` ranks passages;
-2. `EvidenceLocator` verifies/resolves canonical coordinates;
-3. `SpeakerLabelService` adds current user-authored display names for the exact canonical
-   generation.
-
-A human may see `Dr. Chen (speaker-02)`, while JSON retains raw `speaker_refs` and exposes
+A human may see `Dr. Chen (speaker-02)`, while JSON retains raw anonymous refs and exposes
 friendly labels separately. Ranking/filtering continues to use anonymous evidence refs.
 
-Label resolution is batched per canonical generation so a large result set does not
-reread private speaker-label state once per row.
+## Durable research state now reuses the same evidence coordinates
 
-```mermaid
-flowchart LR
-    R[SearchResponse] --> N[ResearchNavigationService]
-    C[Verified canonical evidence] --> N
-    U[User speaker labels] --> N
-    N --> V[LocatedSearchPassage]
+Notes are implemented and anchored through `EvidenceLocator` rather than a parallel
+annotation coordinate system.
 
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
+A durable `EvidenceAnchor` includes:
 
-    class R derived
-    class C evidence
-    class U user
-    class N,V view
+```text
+document_id
+source_sha256
+canonical_sha256
+segment_ids
+start_seconds
+end_seconds
 ```
 
-That service is intended for CLI, future GUI, Python, and other presentation adapters.
-The terminal does not own the navigation semantics.
+Multi-segment anchors must be contiguous. If canonical evidence changes, the note remains
+durable historical user state but does not silently reattach to a new generation.
 
-## Future notes can reuse the same coordinate system
+## Research filters are pre-ranking constraints
 
-Notes and annotations are not implemented yet, but this navigation layer establishes the
-anchor they should reuse: canonical/source identity, segment IDs, word indices where
-available, and numeric source-relative seconds.
+`ResearchWorkspaceService` can constrain transcript search using:
 
-A note should never depend only on a formatted timestamp or disposable semantic chunk
-ID. If canonical evidence changes, EchoFlow should retain user knowledge and report the
-stale anchor instead of silently moving it.
+- tags;
+- collections;
+- note text; and
+- `with_notes`.
 
-## Provider interoperability without model roulette
+Human names resolve once to durable IDs. The rebuildable DuckDB research projection then
+returns canonical evidence scope. BM25 ranking or semantic vector scoring runs **inside
+that scope**.
 
-The search core depends on `EmbeddingProvider` + `EmbeddingProfile`, not an E5-specific
-domain type. The ordinary CLI nevertheless qualifies one concrete profile today rather
-than accepting arbitrary model IDs as interchangeable.
+The search contract distinguishes:
 
-A future provider registry can expose additional qualified local profiles once EchoFlow
-can validate their full retrieval contract.
+```text
+evidence_scope = None
+```
+
+from:
+
+```text
+evidence_scope = ()
+```
+
+`None` means no research restriction. An empty tuple means the research restriction
+matched nothing and search must return nothing. This prevents an empty filter from
+accidentally widening into a corpus-wide query.
+
+## Normalized semantic segment mapping
+
+Semantic chunks keep their JSON provenance, but `DuckDbSemanticIndex` also maintains a
+derived relational `chunk_segments` mapping.
+
+That relation lets EchoFlow:
+
+- constrain semantic candidates by research evidence before vector scoring; and
+- resolve lexical segment IDs back to semantic chunks for hybrid reconciliation without
+  scanning every chunk's JSON metadata.
+
+Existing semantic indexes can derive the relation locally without recomputing embeddings.
+
+## Search and research presentation remain separate from storage
+
+`ResearchWorkspaceService` is the product-facing seam. CLI and future GUI adapters should
+use it rather than deciding whether to query SQLite or DuckDB themselves.
+
+The next **unified library discovery** layer should compose existing transcript search,
+notes, tags, collections, and later saved searches into grouped typed results. It should
+not invent one universal relevance score across unlike objects or a second search engine.
+
+Saved searches will belong to durable SQLite user state. Frequent/recent tag rankings are
+derived convenience views.
 
 ## Current deliberate limits
 
-The current search/navigation system does not provide:
+The current search/navigation/workspace system does not provide:
 
 - generated corpus answers as the primary interface;
 - arbitrary-model CLI selection;
 - bundled embedding weights;
 - ANN/HNSW or learned reranking;
-- saved searches, collections, tags, notes, or annotations;
+- saved-search objects;
+- curated/exportable result-set objects;
+- automatic cross-generation note re-anchoring;
 - a graphical local media player;
+- a polished GUI;
 - cross-recording biometric/person identity; or
 - source separation for overlapping speech.
-
-Those are separate product layers. The current frontier is durable user-authored research
-state over the verified evidence coordinates that search navigation now exposes.
 
 The product rule stays evidence-first:
 

--- a/docs/architecture/media-and-timeline.md
+++ b/docs/architecture/media-and-timeline.md
@@ -7,7 +7,7 @@ useful:
 2. **Where is a transcript span inside that recording?**
 3. **What other clocks did the original media claim to have?**
 
-Those are different questions. The architecture now keeps their answers separate.
+Those are different questions. The architecture keeps their answers separate.
 
 The canonical transcript timeline is always **elapsed source-relative seconds from the
 selected audio origin**. Humans can view that coordinate as `HH:MM:SS.mmm`. Original
@@ -16,7 +16,7 @@ source-declared provenance when FFprobe reports them.
 
 Nothing rewrites the meaning of the canonical elapsed coordinate.
 
-For the plain-language navigation guide, see
+For the plain-language guide, see
 **[Transcript time without calculator gymnastics](../time-navigation.md)**.
 
 ## The human version
@@ -32,7 +32,7 @@ The human presentation is:
 ```
 
 That timeline survives normalization, segmentation, checkpoints, enhancement, word
-alignment, and assembly.
+alignment, assembly, search navigation, and durable note anchoring.
 
 A file may also declare something like:
 
@@ -47,37 +47,27 @@ was historically correct merely because a tag exists.
 
 ```mermaid
 flowchart LR
-    A[🎙️ Local media file] --> B[FFprobe + SHA-256]
-    B --> R[Canonical elapsed timeline<br/>0.000 s → ...]
-    B --> T[Declared timecode tags]
-    B --> C[Declared creation-time tags]
-    R --> W[Word + segment evidence]
-    W --> H[✨ Human display<br/>HH:MM:SS.mmm]
-    T --> P[Canonical source provenance]
-    C --> P
-    W --> X[📜 Canonical transcript]
-    P --> X
-
-    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef canonical fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef provenance fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A source
-    class R,W,X canonical
-    class B,T,C,P provenance
-    class H view
+    A[Local media] --> B[FFprobe and source SHA]
+    B --> C[Canonical elapsed seconds]
+    B --> D[Declared timecode]
+    B --> E[Declared creation time]
+    C --> F[Word and segment evidence]
+    F --> G[Canonical transcript JSON]
+    D --> G
+    E --> G
+    F --> H[Human elapsed display]
+    F --> I[Search seek and EvidenceAnchor]
 ```
 
 ## One input boundary for audio and video
 
 EchoFlow treats every supported input as **audio-bearing local media**.
 
-Video is not a second downstream pipeline. FFprobe discovers the streams, EchoFlow
-selects one audio stream, and transcription later discards unrelated video/subtitle/
-attachment/data streams from the working audio path.
+Video is not a second downstream pipeline. FFprobe discovers streams, EchoFlow selects
+one audio stream, and transcription discards unrelated video/subtitle/attachment/data
+streams from the working audio path.
 
-That means `interview.m4a`, `lecture.wav`, and `meeting.mp4` all converge on the same
+`interview.m4a`, `lecture.wav`, and `meeting.mp4` therefore converge on the same
 transcription contract once one audio stream has been selected.
 
 Temporal metadata discovery remains attached to the original media evidence, not to a
@@ -99,14 +89,12 @@ For one local source it:
 - snapshots filesystem identity again; and
 - refuses the input if the source changed during inspection.
 
-The result is immutable `MediaInfo` evidence.
-
-Routine logs omit local paths by default because recording names and directory layouts
-may themselves be sensitive.
+The result is immutable `MediaInfo` evidence. Routine logs omit local paths by default
+because recording names and directory layouts may themselves be sensitive.
 
 ## Source-declared temporal tags
 
-`MediaTemporalTag` records four things:
+`MediaTemporalTag` records:
 
 | Field | Meaning |
 |---|---|
@@ -117,26 +105,9 @@ may themselves be sensitive.
 
 A stream-scoped tag must reference a stream that FFprobe actually discovered.
 
-Conflicting values are intentionally preserved rather than silently resolved. For
-example, a format-level timecode and a video-stream timecode may disagree. EchoFlow's
-current job is to retain that evidence with enough provenance for a later qualified
-mapping decision.
-
-```mermaid
-flowchart TD
-    M[Original MOV file] --> F[Format tags]
-    M --> V[Video stream 0 tags]
-    M --> A[Audio stream 1 tags]
-    F --> E[Temporal provenance tuple]
-    V --> E
-    A --> E
-    E --> C[Canonical transcript source provenance]
-
-    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    class M source
-    class F,V,A,E,C evidence
-```
+Conflicting values are preserved rather than silently resolved. A format-level timecode
+and video-stream timecode may disagree. EchoFlow retains both with enough provenance for
+a later qualified mapping decision.
 
 The values are *declarations*, not trusted wall-clock facts.
 
@@ -150,15 +121,11 @@ Without an override, the first audio stream is selected. With:
 uv run echoflow transcribe meeting.mp4 --audio-stream 2
 ```
 
-EchoFlow validates that stream index `2` is actually audio and records that choice in
-the job/source contract.
+EchoFlow validates that stream index `2` is audio and records that choice in the job/source
+contract.
 
-Resume restores the same selected stream. It does not decide that a different track is
-close enough.
-
-Selection uses `dataclasses.replace`, so temporal provenance discovered from the original
-container survives a user-selected audio-stream change without being rediscovered or
-mutated.
+Resume restores the same selected stream. It does not decide another track is close
+enough.
 
 ## Canonical working audio
 
@@ -172,38 +139,24 @@ The current deterministic processing representation is:
 | channels | 1 (mono) |
 
 If a source WAV already satisfies the contract, planning can choose `DIRECT`.
-
 Other supported audio-bearing media uses `FFMPEG_NORMALIZE`, mapping exactly the selected
 audio stream and dropping unrelated streams.
 
-The resulting `normalized.wav` lives inside the private job workspace.
-
-It is **not a second source of truth**. It is a deterministic working representation that
-can be discarded after the job lifecycle no longer needs it.
+The resulting `normalized.wav` lives inside the private job workspace. It is **not a
+second source of truth**. It is deterministic working material that can be discarded after
+the job lifecycle no longer needs it.
 
 ## Optional enhanced derivative
 
 With `--enhance`, EchoFlow creates a private `enhanced.wav` after canonical decode and
 before ASR segmentation.
 
-The enhanced file may change sample values. It may not silently change the timeline
-shape.
+The enhanced file may change sample values. It may not silently change timeline shape.
+EchoFlow checks channel count, sample width, sample rate, and frame count. A mismatch fails
+closed and the derivative is removed where possible.
 
-EchoFlow checks:
-
-- channel count;
-- sample width;
-- sample rate; and
-- frame count.
-
-Any mismatch fails closed and the derived output is removed where possible.
-
-Why so fussy? Because if preprocessing trims, pads, resamples, or changes the channel
-structure without telling anyone, every downstream timestamp becomes suspicious.
-
-Anonymous diarization intentionally continues to consume the unmodified canonical
-decode in the first enhancement version. See
-**[speech-enhancement.md](speech-enhancement.md)** for that provider boundary.
+Anonymous diarization intentionally consumes the unmodified canonical decode in the first
+enhancement version. See **[speech-enhancement.md](speech-enhancement.md)**.
 
 ## Source-relative timestamps
 
@@ -216,7 +169,7 @@ Application-owned work units are represented by integer PCM frame intervals:
 [start_frame, end_frame)
 ```
 
-Seconds are derived from those exact frames and the canonical sample rate.
+Seconds are derived from exact frames and the canonical sample rate.
 
 Faster-whisper returns segment and native word timestamps relative to the materialized
 work interval. Assembly adds the interval's source-relative offset:
@@ -230,20 +183,12 @@ engine word at 588.37 s    → canonical word at 4788.37 s
                               → display 01:19:48.370
 ```
 
-The default work-window duration is currently 600 seconds (10 minutes). Those work
-windows are an execution/checkpoint detail, not a user-facing time coordinate. They
-never reset the published transcript timeline.
-
-SRT and WebVTT also render from canonical timestamps. Segment/checkpoint boundaries
-therefore do not reset subtitle time to zero.
-
-💃 The timeline survives the choreography.
+Work windows are an execution/checkpoint detail. They never reset the published transcript
+timeline. SRT and WebVTT also render from canonical timestamps.
 
 ## Human elapsed timestamps are derived views
 
 `format_elapsed_timestamp()` renders canonical seconds as unwrapped `HH:MM:SS.mmm`.
-
-Examples:
 
 | Numeric evidence | Human display |
 |---:|---|
@@ -253,40 +198,26 @@ Examples:
 | `4788.37` | `01:19:48.370` |
 | `86400.0` | `24:00:00.000` |
 
-Hours intentionally do not wrap at 24. A 30-hour oral-history corpus item is elapsed
-media, not a wall clock.
-
-The formatter rounds to milliseconds deterministically and handles rollover, so
-`59.9996` becomes `00:01:00.000` rather than producing an impossible `00:00:60.000`.
-
-Search JSON retains numeric `start_seconds`/`end_seconds` and adds derived
-`start_timestamp`/`end_timestamp` conveniences. The human table shows the formatted
-range.
+Hours intentionally do not wrap at 24. A 30-hour recording is elapsed media, not a wall
+clock.
 
 Formatted strings are not durable anchors.
 
 ## Canonical source provenance
 
-The original local media file remains authoritative.
-
-EchoFlow records enough execution context to explain how canonical text was produced,
-including:
+EchoFlow records enough context to explain how canonical text was produced, including:
 
 - source fingerprint/media identity;
 - selected audio stream;
 - source-declared temporal tags when present;
 - decode strategy;
 - managed ASR engine/model/revision and execution target;
-- enhancement provider/version/operation/parameters when used;
+- enhancement provider/version/parameters when used;
 - language and optional speaker evidence; and
 - source-relative segment and word timestamps.
 
-Temporal tags are included in canonical source provenance only when they exist, so files
-without them retain the previous wire shape.
-
-Temporal tags deliberately do **not** participate in checkpoint source equality. Source
-identity remains the cryptographic/file/media identity contract. A camera clock changing
-its story is provenance drift, not a new SHA-256 source.
+Temporal tags deliberately do **not** replace source identity. Source identity remains the
+cryptographic/file/media contract.
 
 ## Why EchoFlow does not add elapsed time to SMPTE yet
 
@@ -297,65 +228,46 @@ A source string such as:
 ```
 
 looks temptingly like a clock. It is not enough information for safe arithmetic.
-
 SMPTE-style timecode can depend on frame rate and drop-frame/non-drop-frame semantics.
 Container/device metadata may also be missing, stale, copied, or contradictory.
 
-This tranche therefore preserves source-declared values but **does not invent a mapping
-from canonical seconds to SMPTE frames** without qualified frame semantics.
+EchoFlow therefore preserves source declarations but **does not invent a mapping from
+canonical seconds to SMPTE frames** without qualified frame semantics.
 
-That limitation does not block ordinary click-to-audio navigation. A local player can
-seek directly to canonical `start_seconds`.
+That limitation does not block ordinary click-to-media navigation. A local player can seek
+directly to canonical `seek_seconds`.
 
-Future SMPTE mapping, if product use requires it, should qualify:
+Future SMPTE mapping, if real product use requires it, should qualify exact/rational frame
+rate, nominal frame-numbering rate, drop-frame semantics, source of the declaration,
+conflict policy, and rollover tests.
 
-- exact/rational frame rate;
-- nominal frame-numbering rate;
-- drop-frame semantics;
-- source of the timecode declaration;
-- conflict-resolution policy; and
-- deterministic mapping tests around minute/hour/day rollover.
+## Word timing, playback, and durable notes use the same elapsed axis
 
-## Relationship to word timing
+These features solve different jobs but share one coordinate system:
 
-Word timing and media temporal provenance solve different problems.
+**Word timing** answers: where does this word live in canonical elapsed time?
 
-**Word timing** answers:
+**Human formatting** answers: how should a person read that coordinate?
 
-> Where does this word live inside the canonical elapsed timeline?
+**Playback seek** answers: where should a local player jump?
 
-**Human elapsed formatting** answers:
+**EvidenceAnchor** answers: which exact canonical evidence does this user note refer to?
 
-> How do I show that coordinate without making a person calculate 4788 seconds?
+Durable notes are now implemented. An anchor contains exact document/source/canonical
+generation identity, canonical segment IDs, and numeric source-relative start/end seconds.
+A note does not depend on a pretty timestamp or rebuildable search chunk.
 
-**Original-media temporal metadata** answers:
-
-> What other clock information did the source itself declare?
-
-Together they support richer evidence receipts without pretending every clock is the
-same clock.
-
-```text
-word "budget"
-  canonical elapsed seconds: 4788.370
-  human elapsed display:     01:19:48.370
-  declared source timecode:  10:00:00:00   (if present; not yet mapped)
-  declared creation time:    2026-04-05T12:34:56Z   (if present)
+```mermaid
+flowchart TD
+    A[Canonical elapsed evidence] --> B[Human timestamp]
+    A --> C[Search seek_seconds]
+    A --> D[EvidenceAnchor]
+    D --> E[SQLite durable note]
+    C --> F[Future GUI player]
 ```
 
-## Relationship to future notes and click-to-seek
-
-A graphical player does not exist yet, and neither does the durable notes editor/store.
-The coordinate contract they need now does.
-
-A future player should seek by numeric canonical seconds.
-
-A future annotation should anchor to durable evidence such as source SHA-256 plus a
-canonical word/segment time span. It should not anchor only to a pretty timestamp string
-or rebuildable search-chunk ID.
-
-That keeps user-authored knowledge attached even when search indexes are rebuilt or time
-display formatting changes.
+The graphical player is still future presentation work; the timeline and note-storage
+contracts it needs already exist.
 
 ## Why the stages remain separate
 
@@ -369,12 +281,14 @@ Enhancement answers **did the user request a provenance-bearing acoustic transfo
 
 Word alignment answers **where do finer text units sit on the canonical timeline?**
 
-Human timestamp formatting answers **how should a person read that elapsed coordinate?**
+Human formatting answers **how should a person read that elapsed coordinate?**
 
 Temporal provenance answers **what other source clocks were declared alongside it?**
 
-Keeping these responsibilities separate makes metadata discovery side-effect free,
-keeps source authority explicit, and leaves room for richer evidence without rewriting
-the meaning of timestamps that already exist.
+Evidence anchoring answers **where does durable user-authored knowledge attach?**
+
+Keeping these responsibilities separate makes metadata discovery side-effect free, keeps
+source authority explicit, and lets search, notes, exports, and a future GUI reuse the same
+evidence instead of inventing parallel timelines.
 
 🧜‍♀️ Multiple clocks. One transcript. No temporal soup.

--- a/docs/architecture/processing-capabilities.md
+++ b/docs/architecture/processing-capabilities.md
@@ -2,7 +2,7 @@
 
 EchoFlow is not one giant transcription function. It composes small local capabilities
 into a reproducible workflow whose source, execution choices, recovery state, transcript,
-search projections, and research-navigation views remain explainable afterward.
+search projections, navigation views, and research state remain explainable afterward.
 
 This page is the **family portrait** for maintainers.
 
@@ -13,8 +13,9 @@ For narrower contracts, see:
 - [word-level timestamp alignment](word-alignment.md);
 - [model management](model-management.md);
 - [speech enhancement](speech-enhancement.md);
-- [diarization](diarization.md); and
-- [corpus search](corpus-search.md).
+- [diarization](diarization.md);
+- [corpus search](corpus-search.md); and
+- [durable research state](research-state.md).
 
 ## What the user experiences
 
@@ -25,57 +26,50 @@ The intended experience is simpler than the machinery:
 3. install a recommended model explicitly if needed;
 4. transcribe locally;
 5. resume if interrupted;
-6. export useful views;
-7. search completed transcripts; and
-8. follow a result back to verified canonical evidence.
+6. publish useful transcript views;
+7. search completed transcripts;
+8. follow a result back to verified canonical evidence; and
+9. keep durable notes/tags/collections attached to that evidence.
 
-Underneath that, EchoFlow preserves enough evidence to explain how each result was
-produced.
+The next product work is making those existing capabilities easier to discover and use
+through one library surface and eventually a thin GUI.
 
 ```mermaid
 flowchart LR
-    A[Local recording] --> B[Inspect source]
-    B --> C[Inspect machine + runtime]
-    C --> D[Build immutable plan]
-    D --> E[Normalize / enhance if needed]
-    E --> F[Segment + local ASR]
-    F --> G[Word timing + checkpoints]
-    G --> H[Language + optional speaker evidence]
-    H --> I[Canonical transcript]
-    I --> J[Derived exports]
-    I --> K[Lexical / semantic search]
-    K --> N[Verify + highlight + context + seek]
-    U[User speaker labels] --> N
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef inspect fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef publish fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A,I evidence
-    class B,C,D inspect
-    class E,F,G,H process
-    class J,U publish
-    class K,N result
+    A[Local recording] --> B[Inspect source and runtime]
+    B --> C[Immutable plan]
+    C --> D[Normalize enhance segment ASR]
+    D --> E[Word timing and checkpoints]
+    E --> F[Language and speaker evidence]
+    F --> G[Canonical transcript JSON]
+    G --> H[Derived exports]
+    G --> I[Lexical semantic hybrid search]
+    I --> J[Verified evidence navigation]
+    J --> K[SQLite notes tags collections]
+    K --> L[DuckDB research projection]
+    L --> I
 ```
+
+Text fallback: local execution produces canonical transcript evidence; rebuildable search
+ranks it; verified navigation resolves results; durable research state attaches to exact
+canonical evidence and can constrain later retrieval.
 
 ## 1. Media inspection: what is this file?
 
 `FfprobeMediaProbe` owns source facts, not transcoding. It reads bounded FFprobe metadata
-with file-only protocol access, fingerprints the complete source, and refuses a file
-whose observed identity changes during inspection.
+with file-only protocol access, fingerprints the complete source, and refuses a file whose
+observed identity changes during inspection.
 
 `AudioStreamSelector` chooses one deterministic audio stream. The choice becomes
 provenance and resume restores it instead of silently choosing another track.
 
-Source-declared `timecode` and `creation_time` tags are preserved with format/stream
-scope when available. They remain provenance, not canonical elapsed-time authority.
+Source-declared `timecode` and `creation_time` tags are preserved with format/stream scope
+when available. They remain provenance, not canonical elapsed-time authority.
 
 ## 2. Resource/runtime inspection: what can this computer really do?
 
-`RunnerInspector` observes CPU and system memory actually visible to the process,
-including relevant affinity/cgroup limits.
+`RunnerInspector` observes CPU and system memory actually visible to the process, including
+relevant affinity/cgroup limits.
 
 `HardwareTopologyInspector` adds physical accelerator evidence.
 `EngineCapabilityRegistry` separately asks the installed engine/runtime which concrete
@@ -85,9 +79,6 @@ against RAM, device memory, runtime capability, and profile intent.
 A visible GPU is not assumed usable. Shared/unified accelerator memory is not counted as
 bonus physical RAM. Explicit impossible strategies fail instead of being silently
 replaced.
-
-See [adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) for the
-whole hardware cabaret. 💃
 
 ## 3. Model custody: which exact dependency may execute?
 
@@ -100,7 +91,7 @@ the exact revision already recorded in the plan.
 
 No transcription-time ASR download fallback exists.
 
-## 4. Canonical audio: one deterministic working representation
+## 4. Canonical audio and optional enhancement
 
 The current canonical processing format is:
 
@@ -114,22 +105,17 @@ mono
 Already-canonical WAV may use `DIRECT`; other supported audio-bearing media uses
 `FFMPEG_NORMALIZE`.
 
-Normalization changes representation, not the public transcript timeline. Exact PCM
-frame intervals define durable work windows.
-
-## 5. Optional enhancement: help ASR without rewriting the source
+Normalization changes representation, not the public transcript timeline. Exact PCM frame
+intervals define durable work windows.
 
 When `--enhance` is enabled, `FfmpegAfftdnEnhancer` creates private enhanced audio from
-canonical audio using the fixed current filter contract.
-
-ASR may consume the derivative. The original recording remains authoritative. EchoFlow
-checks channel count, sample width, sample rate, and frame count before accepting the
-derivative so preprocessing cannot quietly shift transcript time.
+canonical audio using the fixed current filter contract. The original recording remains
+authoritative, and EchoFlow verifies the derivative did not change the timeline shape.
 
 Anonymous diarization deliberately continues to read the unmodified canonical decode in
 enhancement v1.
 
-## 6. Segmentation, word timing, and checkpointing
+## 5. Segmentation, word timing, and checkpointing
 
 EchoFlow owns deterministic segmentation:
 
@@ -144,52 +130,38 @@ The faster-whisper session requests native word timestamps. Engine-produced word
 validated and rebased from work-window time onto the same source-relative timeline as
 canonical segments.
 
-Per-window checkpoints persist aligned word evidence. The manifest records alignment
-identity so incompatible pre-alignment state cannot silently resume into a mixed job.
+Per-window checkpoints persist aligned word evidence. Resume restores the
+source/model/device/decode/enhancement/segmentation/alignment contract and re-admits current
+resources.
 
-Accelerated execution may materialize at most one future segment while the current one
-is inferred. Completed checkpoints must remain a contiguous prefix of the deterministic
-work plan.
+Accelerated execution may materialize at most one future segment while the current one is
+inferred. Completed checkpoints remain a contiguous prefix of the deterministic work plan.
 
-Resume restores the source/model/device/decode/enhancement/segmentation/alignment
-contract and re-admits current resources.
-
-## 7. Recognition and multilingual attribution
+## 6. Recognition, language, and speaker evidence
 
 The faster-whisper backend performs managed local ASR plus native word timing. EchoFlow
 does not currently run a separate forced-alignment model.
 
 With no explicit language, multilingual behavior can reconsider language within durable
-work units rather than latching one job-wide prompt forever.
+work units rather than latching one job-wide prompt forever. Published text-language
+labels come from local deterministic attribution, which may leave ambiguous text
+unlabeled.
 
-Published text-language labels come from local deterministic attribution, which may leave
-ambiguous short text unlabeled rather than fabricating certainty.
-
-## 8. Optional anonymous speaker evidence
-
-Diarization is recording-scoped enrichment, not identity.
-
-The pyannote capability remains security-gated because the locked Lightning dependency
-is affected by a compensated advisory. EchoFlow refuses the vulnerable path before
-provider execution/model acquisition.
-
-When speaker evidence exists, word timing provides a finer projection coordinate than a
-whole ASR segment. A word receives a speaker only when exactly one diarized speaker
-overlaps that word interval.
+Diarization is recording-scoped enrichment, not identity. When speaker evidence exists,
+word timing provides a finer projection coordinate than a whole ASR segment. A word
+receives a speaker only when exactly one diarized speaker overlaps that word interval.
 
 The enclosing segment keeps a convenience `speaker_ref` only when aligned words support
 one uniform speaker. Mixed handoffs and ambiguous overlap stay explicit.
 
-The library adds two human-facing layers without rewriting that evidence:
+The library adds human-facing display labels such as `speaker-02 → Dr. Chen` without
+rewriting anonymous canonical evidence. No biometric or cross-recording person inference
+occurs.
 
-- durable user-authored names such as `speaker-02 → Dr. Chen`, bound to the exact canonical
-  transcript generation; and
-- an overlap-aware derived transcript that distinguishes `single-speaker`, `overlap`,
-  `mixed-unresolved`, and `unattributed` states.
+The current pyannote path remains security-gated while the locked Lightning dependency is
+affected by the compensated advisory described in `SECURITY.md`.
 
-No biometric identity or cross-recording person inference occurs.
-
-## 9. Canonical transcript and derived exports
+## 7. Canonical transcript and derived exports
 
 Canonical JSON is authoritative transcript evidence.
 
@@ -200,12 +172,12 @@ provenance, source-declared temporal tags, and optional diarization evidence.
 TXT, SRT, and WebVTT remain deterministic segment-oriented publication views. They are
 useful. They are not recognition truth.
 
-## 10. Transcript library and retrieval 🦝
+## 8. Transcript library and retrieval 🦝
 
 Canonical transcript JSON can be projected into private rebuildable search state.
 
-Lexical retrieval uses the database-neutral `TranscriptIndex` application port and
-DuckDB BM25 adapter. Semantic retrieval adds deterministic segment-anchored chunks,
+Lexical retrieval uses the database-neutral `TranscriptIndex` application port and DuckDB
+BM25 adapter. Semantic retrieval adds deterministic segment-anchored chunks,
 `EmbeddingProvider`/`EmbeddingProfile`, strict-local Multilingual E5 Small, private
 numeric vectors, exact dense similarity, and stale-corpus refusal.
 
@@ -215,7 +187,7 @@ lexical, semantic, and fused provenance in one `SearchResponse`.
 Nested word evidence remains outside ranking storage. Search indexes canonical segment
 text once.
 
-## 11. Canonical evidence navigation
+## 9. Canonical evidence navigation
 
 Retrieval and navigation are separate capabilities.
 
@@ -233,26 +205,43 @@ SHA/source identity before exposing precise coordinates. It can then:
 speaker display labels. Ranking/filtering still uses anonymous refs; presentation may
 show `Dr. Chen (speaker-02)`.
 
-This service is deliberately reusable by CLI, future GUI, Python, and other adapters.
-The terminal is not the owner of research-navigation semantics.
+## 10. Durable research workspace
 
-## 12. Private storage, user state, and observability
+Notes, tags, and collections are now implemented durable library-side state.
+
+`ResearchWorkspaceService` is the application-facing facade over:
+
+- transcript retrieval;
+- verified `EvidenceAnchor` creation;
+- authoritative SQLite research state;
+- the monotonic change journal;
+- `ResearchStateProjector` convergence;
+- rebuildable DuckDB research relationships/terms; and
+- transcript search constrained by research metadata.
+
+A note anchor includes document identity, source SHA-256, canonical transcript SHA-256,
+canonical segment IDs, and numeric source-relative time. Multi-segment anchors must be
+contiguous.
+
+If the canonical transcript generation changes, the note survives as durable historical
+user state but does not silently attach to the new generation.
+
+Research tag/collection/note-text constraints are resolved to canonical evidence scope
+**before** BM25 ranking or semantic vector scoring.
+
+SQLite user state is not rebuildable. The DuckDB research projection is.
+
+## 11. Private storage and observability
 
 Structured logging uses Structlog behind `ILogger`. Routine logs redact local paths by
 default.
 
 Private job/checkpoint state, model caches, normalized/enhanced audio, segment
-materializations, search databases, and user-authored state remain distinct from
-user-visible transcript artifacts.
-
-Speaker display labels are the first implemented durable library-side user state. Future
-notes/tags/collections/annotations must share the **durability class**, not necessarily
-the same physical JSON adapter. Higher-volume mutable/queryable research state will
-likely justify a transactional user-state store behind application ports.
+materializations, search databases, SQLite research authority, and rebuildable research
+projection remain distinct from user-visible transcript artifacts.
 
 POSIX private state uses owner-only mode policy; Windows uses current-user DACL policy.
-These are filesystem access controls, not application-level encryption or secure
-erasure.
+These are filesystem access controls, not application-level encryption or secure erasure.
 
 ## Capability ownership map
 
@@ -280,10 +269,14 @@ erasure.
 | `EmbeddingProvider` | query/passage embedding semantics | corpus custody |
 | `DuckDbSemanticIndex` | rebuildable vectors + exact similarity | canonical evidence |
 | `TranscriptSearch` | retrieval composition + RRF | storage implementation |
-| `TranscriptLibraryService` | discovery/rebuild/stale-state/retrieval/integrity receipts | user annotations |
-| `SpeakerLabelService` | durable human names over anonymous refs | diarization evidence |
-| `EvidenceLocator` | verified canonical result coordinates | ranking |
-| `ResearchNavigationService` | retrieval + location + display composition | canonical mutation |
+| `TranscriptLibraryService` | discovery/rebuild/stale-state/retrieval/integrity receipts | durable research authority |
+| `SpeakerLabelService` | durable human display names | diarization evidence |
+| `EvidenceLocator` | verified canonical result/anchor coordinates | ranking |
+| `ResearchNavigationService` | retrieval + location + speaker-display composition | canonical mutation |
+| `ResearchStateStore` | durable notes/tags/collections + evidence anchors | search ranking |
+| `ResearchStateProjector` | deterministic projection convergence | user truth |
+| `ResearchProjectionIndex` | fast research filtering/summaries | authoritative note content |
+| `ResearchWorkspaceService` | one application seam over research + evidence + retrieval | database topology leakage |
 | `WorkspaceService` | private/public path allocation | audio semantics |
 
 Protocols exist around real substitutable behavior, not because every class deserves a
@@ -303,29 +296,31 @@ EchoFlow does not currently claim:
 - generative restoration;
 - automatic enhancement selection;
 - trusted deterministic SMPTE/PTS mapping beyond preserved source declarations;
-- storage durability across sudden power loss;
 - malicious same-user TOCTOU resistance;
 - secure erasure;
 - a qualified locked semantic dependency extra;
 - ANN/HNSW, learned reranking, or generated corpus answers;
-- durable notes/tags/collections/annotations/saved searches; or
+- saved-search objects or curated/citable result sets;
+- automatic cross-generation note re-anchoring; or
 - a polished installer/desktop GUI.
 
 ## What is the next product layer?
 
-Word timing, time provenance, speaker naming, overlap presentation, and aligned search
-navigation are now foundation.
+The backend research workspace is now foundation.
 
-The next major product layer is **durable user-authored research state over verified
-evidence locations**: notes, tags, saved searches, collections, annotations, and
-exportable/citable selected result sets.
+The next sequence is:
 
-After that come semantic-install qualification, representative-device dogfooding, and a
-beginner-friendly installer/thin graphical shell over these same application services.
+1. **unified library discovery** across transcript evidence, notes, tags, collections, and
+   later saved searches;
+2. **saved searches and useful derived navigation**, such as most-used/recent tags and
+   facets computed from authoritative relationships rather than stored counters;
+3. **a thin GUI** over the same application services, evidence anchors, and seek contract;
+4. **research export + incremental library refresh + realistic corpus benchmarks**; and
+5. **semantic-install, representative-device, and installer qualification**.
 
-Source separation remains later and evidence-driven. EchoFlow can now represent overlap
-honestly; another model should earn its compute/custody/provenance burden with measured
-benefit.
+Source separation remains later and evidence-driven. EchoFlow can already represent
+overlap honestly; another model should earn its compute/custody/provenance burden with
+measured benefit.
 
 > **Source evidence stays authoritative. Derived machinery stays explainable. User
 > knowledge does not get mistaken for cache.**

--- a/docs/architecture/research-state.md
+++ b/docs/architecture/research-state.md
@@ -16,39 +16,28 @@ coordinates them through stable evidence identities and a deterministic projecto
 
 ```mermaid
 flowchart LR
-    C[📜 Canonical transcript] --> A[Verified EvidenceAnchor]
-    A --> S[(SQLite\nauthoritative user state)]
-    S --> O[Monotonic change journal]
-    O --> P[Research projector]
-    P --> D[(DuckDB\nrebuildable research projection)]
-    D --> Q[Typed research constraints]
-    Q --> L[Lexical / semantic retrieval]
-    L --> C
-
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef durable fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-
-    class C,A evidence
-    class S durable
-    class O,P,Q process
-    class D,L derived
+    A[Canonical transcript] --> B[Verified EvidenceAnchor]
+    B --> C[SQLite authority]
+    C --> D[Monotonic change journal]
+    D --> E[ResearchStateProjector]
+    E --> F[DuckDB research projection]
+    F --> G[Typed research constraints]
+    G --> H[Lexical semantic retrieval]
+    H --> A
 ```
+
+Text fallback: canonical evidence creates a verified anchor; user research commits to
+SQLite with a monotonic journal; a deterministic projector builds disposable DuckDB query
+state; research constraints are then pushed into transcript retrieval.
 
 ## Why two stores?
 
 One database could technically hold everything. That would make the custody boundary
 worse.
 
-Transcript lexical indexes, semantic vectors, and research query projections are caches
-in the architectural sense: they may be deleted and rebuilt. Notes and other human-authored
+Transcript indexes, semantic vectors, and research query projections are caches in the
+architectural sense: they may be deleted and rebuilt. Notes and other human-authored
 knowledge are not caches.
-
-Putting both classes of state behind one deletion/rebuild lifecycle would create an easy
-failure mode where an index-maintenance operation can destroy unique user work.
-
-The dual-store design makes the rule physical:
 
 | Store | Authority | Contains | Rebuildable? |
 |---|---|---|---|
@@ -57,60 +46,48 @@ The dual-store design makes the rule physical:
 | DuckDB lexical index | derived | transcript terms and segment metadata | Yes |
 | DuckDB semantic index | derived | semantic chunks, segment map, numeric vectors | Yes |
 
-## Why SQLite for durable state and DuckDB for the projection?
+## Why SQLite for durable state and DuckDB for projection?
 
-This is a workload and custody decision, not a claim that one database is generally better
-than the other.
+This is a workload and custody decision, not a claim that one database is universally
+better.
 
-SQLite is a strong fit for the authoritative research workspace because that workload is
-transactional and mutation-heavy. A user repeatedly creates, edits, deletes, renames, and
-relates small durable records. EchoFlow needs those writes to commit atomically with
-constraints, foreign keys, and crash-safe local durability. SQLite is designed for that
-kind of embedded application state.
+SQLite fits the authoritative research workspace because the workload is transactional
+and mutation-heavy. A user repeatedly creates, edits, deletes, renames, and relates small
+durable records. EchoFlow needs those writes to commit atomically with constraints,
+foreign keys, and crash-safe local durability.
 
-DuckDB is a strong fit for the query side because EchoFlow also performs analytical work:
-scanning many transcript segments, joining projected relationships, filtering large local
-corpora, computing lexical statistics, restricting semantic candidates, and ranking
-results. That is the workload DuckDB is intended to make fast.
+DuckDB fits the query side because EchoFlow also performs analytical work: scanning many
+segments, joining projected relationships, filtering local corpora, computing lexical
+statistics, restricting semantic candidates, and ranking results.
 
-The split therefore follows the shape of the work:
-
-| Need | Better fit in EchoFlow | Reason |
+| Need | Better fit here | Reason |
 |---|---|---|
 | Small frequent user-authored writes | SQLite | transactional embedded application state |
-| Relational integrity for precious records | SQLite | foreign keys and straightforward durable mutations |
+| Relational integrity for precious records | SQLite | constraints and straightforward durable mutation |
 | Corpus scans and analytical joins | DuckDB | columnar analytical execution |
-| Search/ranking projections | DuckDB | optimized for large local query workloads |
+| Search/ranking projections | DuckDB | large local query workloads |
 | State that must survive index deletion | SQLite | authoritative user custody |
 | State that may be rebuilt for speed | DuckDB | disposable projection semantics |
 
 ### Why not DuckDB for both?
 
-DuckDB could technically store notes, tags, and collections. The problem is not that it
-would immediately lose them. The problem is that EchoFlow would then be choosing an
-analytical database as the system of record for frequently-mutated, irreplaceable user
-state when SQLite is purpose-built for that workload.
+DuckDB could technically store notes, tags, and collections. The issue is not that it
+would instantly lose them. The issue is that EchoFlow would then choose an analytical
+database as the system of record for frequently mutated, irreplaceable user state while
+also treating DuckDB files as rebuildable machinery.
 
-More importantly, it would blur the deletion boundary. EchoFlow intentionally treats its
-DuckDB files as rebuildable machinery. A future maintainer should be able to remove a
-corrupt lexical, semantic, or research projection and rebuild it without first asking
-whether unique human research is hiding inside the same lifecycle.
+That blurs the deletion boundary and makes future repair operations more dangerous.
 
 ### Why not SQLite for both?
 
-SQLite could also technically hold transcript search state, and SQLite FTS may be useful
-for some local note-text operations. But EchoFlow's transcript retrieval path increasingly
-looks like an analytical corpus workload rather than ordinary row lookup. DuckDB is the
-better home for large scans, joins, ranking support, vector candidate filtering, and other
-rebuildable search structures.
-
-Using SQLite for everything would simplify the number of database engines while giving up
-the engine that better matches EchoFlow's corpus-scale analytical work.
+SQLite could technically hold transcript search state, but EchoFlow's retrieval path is
+increasingly an analytical corpus workload. DuckDB is the better home for large scans,
+joins, ranking support, vector candidate filtering, and other rebuildable structures.
 
 ### Why not make both authoritative?
 
-Two authoritative stores would create a dual-master problem. A user mutation could succeed
-in one database and fail in the other, leaving EchoFlow to decide which copy is true.
+Two authoritative stores would create a dual-master problem. A mutation could succeed in
+one database and fail in the other, leaving EchoFlow to decide which copy is true.
 
 EchoFlow avoids that class of conflict entirely:
 
@@ -126,11 +103,7 @@ DuckDB projection
 ```
 
 All user-authored mutations commit to SQLite. DuckDB receives only a derived,
-reconstructable representation. If the stores disagree, SQLite wins. If DuckDB is missing,
-stale, or damaged, EchoFlow catches it up or rebuilds it.
-
-That single-authority rule is the main reason the two-database design remains manageable
-rather than becoming distributed-state synchronization inside a desktop application.
+reconstructable representation. If the stores disagree, SQLite wins.
 
 ## Evidence identity is the join contract
 
@@ -143,14 +116,10 @@ The load-bearing projected evidence key is:
 ```
 
 The full durable anchor also carries source identity and source-relative time coordinates.
+Including canonical SHA-256 prevents a stale annotation from silently attaching to a new
+transcript generation that reuses `segment-000042`.
 
-Including the canonical SHA-256 prevents a stale annotation from silently attaching to a
-new transcript generation that happens to reuse `segment-000042`.
-
-A current transcript may therefore have a segment named `segment-000042` while an older
-note anchored to an earlier canonical SHA remains intentionally unmatched.
-
-That is not data loss. It is stale-generation isolation.
+That is stale-generation isolation, not data loss.
 
 ## Verified anchors
 
@@ -159,22 +128,17 @@ That is not data loss. It is stale-generation isolation.
 Before creating a durable note, the application verifies that:
 
 1. the requested document is present in the current transcript library;
-2. the canonical transcript bytes still hash to the indexed canonical SHA-256;
-3. the requested segment IDs exist in canonical order;
+2. canonical transcript bytes still hash to the indexed canonical SHA-256;
+3. requested segment IDs exist in canonical order;
 4. a multi-segment selection is contiguous; and
-5. any optional sub-segment start/end coordinates remain inside the selected canonical
-   span.
+5. optional sub-segment start/end coordinates remain inside the selected canonical span.
 
-The storage adapter therefore receives an already-qualified evidence address rather than
-being asked to decide whether a transcript pointer is trustworthy.
+The storage adapter receives an already-qualified evidence address rather than being asked
+to decide whether a transcript pointer is trustworthy.
 
-The same anchor contract is intended for a future GUI. Text selection can produce an
-`EvidenceAnchor`; it does not need a GUI-only identity scheme.
+The planned GUI should reuse this exact anchor contract for transcript selection.
 
 ## SQLite authority and transaction boundary
-
-The research-state adapter uses SQLite because the workload is mutable, relational, local,
-and modest enough that an embedded transactional database is appropriate.
 
 The authoritative write path uses:
 
@@ -188,49 +152,49 @@ A note cannot commit successfully while its corresponding projection-change even
 missing.
 
 The authoritative monotonic sequence is stored as durable SQLite metadata. It is not
-inferred from the highest surviving outbox row, because outbox rows may later be compacted.
+inferred from the highest surviving outbox row because journal rows may later be
+compacted.
 
 ## Change journal and projector
 
 Every user-state mutation advances a monotonic sequence and records the affected note in
-the SQLite change journal.
+the SQLite journal.
 
-The projector consumes that journal in bounded batches.
+The projector consumes changes in bounded batches. For each touched note, the DuckDB
+projection is replaced from current authoritative state. Replay is therefore idempotent:
+processing the same change twice converges to the same projection.
 
-For each touched note, the DuckDB projection is replaced from current authoritative state.
-That makes replay idempotent: processing the same change twice converges to the same
-projection.
-
-The DuckDB watermark advances in the **same DuckDB transaction** as the corresponding
+The DuckDB watermark advances in the **same DuckDB transaction** as corresponding
 projection rows.
 
-The projector therefore has three normal recovery modes:
+That means DuckDB cannot truthfully say “projected through 128” if rows for 128 did not
+commit.
 
 ### Incremental catch-up
 
-If the DuckDB watermark is behind and retained journal history bridges the gap, replay
-bounded batches until an empty journal read and the authoritative sequence agree at the
-same observation point.
+If DuckDB is behind and retained journal history bridges the gap, replay bounded batches
+until an empty journal read and authoritative sequence agree at the same observation
+point.
 
 A SQLite write immediately after that observation simply makes the projection stale again
-for the next request. That is normal projection behavior, not corruption.
+for the next request. That is normal projection behavior.
 
 ### Full rebuild
 
-If the research projection is missing, damaged, or too far behind for retained journal
-history to bridge the gap, rebuild it from a consistent authoritative SQLite snapshot.
+If the projection is missing, damaged, or too far behind for retained journal history to
+bridge the gap, rebuild it from a consistent authoritative SQLite snapshot.
 
 No unique user data is reconstructed from DuckDB.
 
 ### Fail closed
 
 If the DuckDB watermark claims to be **ahead** of authoritative SQLite state, EchoFlow
-refuses to invent a reconciliation story. That state indicates corruption or an invalid
-store pairing and requires explicit recovery.
+refuses to invent a reconciliation story. That indicates corruption or an invalid store
+pairing and requires explicit recovery.
 
 ## Projection shape
 
-The DuckDB research projection is intentionally narrower than the SQLite schema.
+The DuckDB research projection is intentionally narrower than SQLite.
 
 It stores what fast filtering needs:
 
@@ -240,20 +204,20 @@ It stores what fast filtering needs:
 - collection IDs; and
 - deterministic lexical note terms.
 
-The full mutable note body remains authoritative in SQLite.
+The mutable note body remains authoritative in SQLite.
 
-A projected notebook query therefore follows this pattern:
+A projected notebook query follows this pattern:
 
 1. DuckDB finds matching note IDs quickly;
-2. SQLite batch-loads the authoritative notes by those IDs; and
+2. SQLite batch-loads authoritative notes by those IDs; and
 3. presentation renders only authoritative note content.
 
-The SQLite batch path preserves caller order so a projected result list does not become
-mysteriously reordered by a second database lookup.
+The batch path preserves caller order so projected results do not become mysteriously
+reordered by a second database lookup.
 
 ## Research filters are pre-ranking constraints
 
-Research metadata is not a post-processing decoration when it is used as a filter.
+Research metadata is not merely decoration when used as a filter.
 
 A query such as:
 
@@ -263,11 +227,8 @@ tag = methodology
 collection = Chapter 3
 ```
 
-first resolves the research constraints to a canonical evidence scope. Lexical BM25 or
-semantic vector retrieval then ranks **inside that scope**.
-
-EchoFlow does not retrieve the whole transcript corpus and filter results afterward in
-Python.
+first resolves research constraints to a canonical evidence scope. Lexical BM25 or
+semantic retrieval then ranks **inside that scope**.
 
 The search contract distinguishes:
 
@@ -281,15 +242,14 @@ from:
 evidence_scope = ()
 ```
 
-`None` means no research-state restriction. An empty tuple means the research restriction
-matched no evidence and therefore the search must return no results.
-
-This prevents an empty-filter result from accidentally widening into a corpus-wide search.
+`None` means no research restriction. An empty tuple means the restriction matched no
+evidence, so search returns nothing. This prevents an empty research filter from
+accidentally widening into a corpus-wide query.
 
 ## Semantic segment mapping
 
-Semantic chunks retain their existing JSON provenance, but the semantic DuckDB adapter
-also maintains a derived relational `chunk_segments` mapping.
+Semantic chunks keep JSON provenance, but the semantic DuckDB adapter also maintains a
+derived relational `chunk_segments` mapping.
 
 That relation lets EchoFlow:
 
@@ -297,8 +257,8 @@ That relation lets EchoFlow:
 - resolve lexical segment IDs back to semantic chunks for hybrid search without scanning
   every chunk's JSON metadata.
 
-Existing semantic indexes can derive this relation locally from their own chunk metadata;
-no embedding recomputation is required solely to gain the relational map.
+Existing semantic indexes can derive this relation locally from chunk metadata; no
+embedding recomputation is required solely for the relational map.
 
 ## Workspace service boundary
 
@@ -311,18 +271,15 @@ The service composes:
 
 - verified evidence anchors;
 - authoritative SQLite research state;
-- the deterministic projector;
-- the DuckDB research projection; and
-- transcript search/navigation services.
+- deterministic projection convergence;
+- DuckDB research filtering/summaries; and
+- transcript search/navigation.
 
-This keeps storage topology out of presentation code and preserves one definition of
-research filtering across notebook queries and transcript search.
+Storage topology should remain invisible to presentation code.
 
 ## Performance characteristics
 
-The design is intended to remain boring at larger local-project sizes.
-
-Important properties are:
+The design is intended to remain boring at larger local-project sizes:
 
 - bounded projector batches instead of unbounded replay;
 - idempotent note replacement instead of fragile differential patching;
@@ -331,9 +288,9 @@ Important properties are:
 - batch authoritative note reads instead of one SQLite query per result; and
 - independent rebuildability of every DuckDB projection.
 
-The implementation does **not** currently claim a benchmarked upper bound such as
-"millions of notes in N milliseconds." Representative-corpus qualification should measure
-that before a performance SLA is documented.
+The implementation does **not** yet claim a benchmarked upper bound such as “millions of
+notes in N milliseconds.” Representative-corpus qualification should measure that before
+a performance SLA is documented.
 
 ## Concurrency boundary
 
@@ -343,22 +300,23 @@ idempotent replay and convergence.
 EchoFlow is still primarily a single-user local application. If a future GUI and CLI are
 allowed to mutate the same workspace concurrently at high frequency, add explicit
 multi-process coordination where measurements show it is necessary rather than assuming
-atomic file/database operations eliminate every lost-update scenario.
+atomic database operations eliminate every lost-update scenario.
 
-## Current deliberate limits
+## What comes next
 
-This tranche does not yet provide:
+This storage architecture is now foundation. The next user-facing work should **reuse it**:
 
-- saved-search objects;
-- exportable/citable selected result sets;
-- rich-text note editing;
-- semantic embeddings over note prose;
-- automatic cross-generation re-anchoring;
-- collaborative/multi-user synchronization; or
-- a GUI annotation surface.
+- unified library discovery across transcript evidence and research state;
+- saved searches in authoritative SQLite state;
+- frequent/recent tag rankings as derived convenience views;
+- selected/citable result sets;
+- portable research export;
+- explicit stale-anchor review/re-anchor UX; and
+- a thin graphical annotation/playback shell.
 
-Those features should build on this authority/projection split rather than introducing a
-second research-state store.
+The current system still does not provide rich-text note editing, semantic embeddings over
+note prose, automatic cross-generation re-anchoring, collaborative synchronization, or a
+GUI.
 
 ## Invariants for future maintainers
 
@@ -368,7 +326,7 @@ The following are load-bearing:
    cache.**
 2. **DuckDB research state is a disposable projection and must be reconstructable from
    SQLite.**
-3. **A user mutation and its outbox event commit together.**
+3. **A user mutation and its journal event commit together.**
 4. **The DuckDB watermark advances atomically with projected rows.**
 5. **Projection replay is idempotent.**
 6. **Research joins include canonical generation identity, not segment ID alone.**
@@ -377,5 +335,4 @@ The following are load-bearing:
 9. **Presentation reads authoritative note content from SQLite.**
 10. **Deleting any DuckDB file must never delete unique user-authored knowledge.**
 
-If a refactor makes one of those statements false, it is not merely an implementation
-change. It changes EchoFlow's custody model.
+If a refactor makes one of those statements false, it changes EchoFlow's custody model.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,7 +1,7 @@
 # EchoFlow development docs 🧪🔧
 
-This is where the project stops saying “EchoFlow tries very hard not to melt your
-laptop” and starts showing **how we prove that claim is not merely aspirational prose**.
+This is where the project stops saying “EchoFlow tries very hard not to melt your laptop”
+and starts showing **how we prove that claim is not merely aspirational prose**.
 
 The development docs are for maintainers, contributors, and anyone who enjoys turning
 subtle bad decisions into failing tests.
@@ -10,52 +10,99 @@ subtle bad decisions into failing tests.
 
 | Page | What it is for |
 |---|---|
-| [Testing and regression bisection](testing-and-bisect.md) | the general test strategy, colocation rules, mutation anticipation, and deterministic bisect oracles |
-| [Semantic retrieval qualification](semantic-retrieval-testing.md) | property, negative, boundary, integration, and mutation coverage for the transcript-library V2 search decisions |
-| [Empirical benchmarking and calibration](benchmarking.md) | how EchoFlow measures real execution without turning hosted CI timing into folklore |
+| [Testing and regression bisection](testing-and-bisect.md) | general test strategy, colocation rules, mutation anticipation, and deterministic bisect oracles |
+| [Semantic retrieval qualification](semantic-retrieval-testing.md) | property, negative, boundary, integration, and mutation coverage for lexical/semantic/hybrid search decisions |
+| [Empirical benchmarking and calibration](benchmarking.md) | measuring real execution without turning hosted CI timing into folklore |
+
+## The current quality gate
+
+Normal pull-request qualification includes:
+
+- locked dependency installation and audit;
+- Ruff lint/format/security rules;
+- strict mypy;
+- Vulture dead-code checks;
+- Radon complexity/maintainability reporting;
+- pytest with branch coverage and a **90% aggregate gate**;
+- package build verification;
+- clean-wheel installation; and
+- Linux, macOS, and Windows CI.
+
+PR #64's durable research-state work increased the suite to 979 passing tests while
+keeping the 90% branch-coverage gate. The important point is not the number itself. The
+new tests qualify transactional rollback, projection convergence/rebuild, stale-generation
+isolation, research filtering, workspace composition, CLI behavior, and safe error
+boundaries rather than merely executing lines for coverage.
 
 ## The quality philosophy
 
-EchoFlow has a lot of decision-heavy code: resource admission, model custody, stale-state
-rejection, resume, cleanup ordering, search filtering, rank composition, and privacy
-boundaries.
+EchoFlow has decision-heavy code: resource admission, model custody, stale-state
+rejection, resume, cleanup ordering, search filtering, rank composition, evidence
+anchoring, transactional user state, projection recovery, and privacy boundaries.
 
-Line coverage alone cannot prove those decisions are correct.
-
-The preferred ladder is:
+Line/branch coverage alone cannot prove those decisions are correct.
 
 ```mermaid
 flowchart LR
-    A[Named unit tests] --> B[Negative + boundary cases]
+    A[Named behavioral tests] --> B[Negative and boundary cases]
     B --> C[Property tests]
-    C --> D[Package / integration tests]
-    D --> E[Branch coverage + static gates]
+    C --> D[Integration and package tests]
+    D --> E[Branch coverage and static gates]
     E --> F[Targeted mutation qualification]
-    F --> G[Cross-platform / package evidence]
+    F --> G[Cross-platform package evidence]
     G --> H[Representative real-device evidence]
-
-    classDef fast fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef deep fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef evidence fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A,B,C,D fast
-    class E,F,G deep
-    class H evidence
 ```
 
 Each layer answers a different question. Mutation testing does not replace ordinary
-boundary tests. Hosted CI does not replace physical-device calibration. Benchmarks do
-not silently rewrite planner policy.
+boundary tests. Hosted CI does not replace physical-device calibration. Benchmarks do not
+silently rewrite planner policy.
 
-🦝 **If a comparator changes from `<` to `<=`, we would like a test to notice before the
-raccoon notices in production.**
+## No tautologies
+
+A test should prove an observable contract, not restate the implementation.
+
+Useful tests have a meaningful precondition, perform a real operation, and assert a
+postcondition that could fail if the implementation were wrong. Examples include:
+
+- a failed SQLite mutation leaves neither the user row nor its journal event committed;
+- replaying the same projection changes converges to the same DuckDB state;
+- an old canonical generation does not match a new segment that reuses the same friendly
+  segment ID;
+- an empty research evidence scope returns zero transcript results rather than widening
+  to the whole corpus; and
+- an unexpected internal CLI error is masked while a known public error preserves its
+  intended message and exit code.
+
+Avoid tests of the form “assign X, assert X equals X,” mock-only call counting where no
+behavioral contract depends on the call, or assertions that duplicate a constant from the
+same function under test.
 
 ## Colocation
 
 Tests live with the capability whose contract they protect. Shared fixtures stay at the
 narrowest useful scope. Built distributions exclude test packages.
 
-That convention makes source-to-test navigation boring, which is exactly what we want.
+Hypothesis is preferred for invariants and generated sequences. Explicit fixtures/builders
+are preferred where IDs, hashes, sequences, and evidence relationships are load-bearing.
+Factory-style indirection should be introduced only if entity setup becomes genuinely
+repetitive rather than because object factories are fashionable.
+
+## Performance qualification from here
+
+The next performance work should target product workloads rather than microbenchmarks for
+their own sake:
+
+- incremental transcript-library refresh versus full rebuild;
+- warm/cold unified discovery;
+- tag/collection/note-text constrained lexical and semantic search;
+- one-edit and large-batch research projection catch-up;
+- full research projection rebuild;
+- realistic multi-recording corpus startup and disk cost; and
+- local media seek/playback responsiveness once the GUI exists.
+
+Representative 8/16 GB consumer machines, Apple Silicon, discrete-GPU laptops, and larger
+workstations should calibrate policy. Hosted runner timing remains supporting evidence,
+not a substitute for hardware qualification.
 
 ## Documentation voice
 

--- a/docs/development/benchmarking.md
+++ b/docs/development/benchmarking.md
@@ -3,17 +3,15 @@
 EchoFlow's resource estimates and relative strategy ranks are intentionally conservative
 heuristics until real machines prove them right or wrong.
 
-The benchmarking subsystem exists to collect that evidence **without creating a second
-transcription implementation**.
-
-The important separation is:
+The existing benchmarking subsystem collects transcription evidence **without creating a
+second transcription implementation**. The next performance work extends the same
+measurement philosophy to the library and research workspace rather than adding policy by
+vibes.
 
 > **Benchmarks describe what happened. A later reviewed policy change decides whether
-> those observations justify different planner behavior.**
+> those observations justify different application behavior.**
 
-One fast laptop run does not get to rewrite the product's memory policy by vibes.
-
-## Quick start
+## Quick start: transcription benchmark
 
 ASR models must already be installed through normal model management. Benchmarking never
 authorizes a hidden faster-whisper download.
@@ -29,37 +27,34 @@ Measure a resumed attempt separately:
 uv run python -m echoflow.benchmarking /path/to/recording.wav --resume JOB_ID
 ```
 
-The harness is experimental. Once its schema and behavior survive real-device use, it
-may graduate into the primary `echoflow` command surface.
+The harness is experimental. Once its schema and behavior survive real-device use, it may
+graduate into the primary `echoflow` command surface.
 
 ## What problem are we trying to solve?
 
-The planner currently estimates whether a strategy fits and ranks eligible choices.
-Those estimates should become better because of **measured behavior on representative
-machines**, not because somebody remembers that one GPU sounded fast in a product page.
+There are now two performance questions.
+
+**Execution performance:** does a chosen transcription strategy fit the machine and
+complete at an acceptable cost?
+
+**Workspace performance:** does a growing local evidence library remain interactive when
+it is refreshed, searched, filtered through research state, projected, and eventually
+used through a GUI?
+
+Neither should be tuned from one heroic laptop run.
 
 ```mermaid
 flowchart LR
-    A[Planner prediction] --> B[Real execution]
-    B --> C[Local benchmark report]
-    C --> D[Compare predicted vs observed]
-    D --> E[Reviewed calibration change]
+    A[Conservative prediction] --> B[Representative workload]
+    B --> C[Measured result]
+    C --> D[Compare expected and observed]
+    D --> E[Reviewed calibration or optimization]
     E --> A
-
-    classDef predict fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef measure fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef policy fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A predict
-    class B measure
-    class C,D evidence
-    class E policy
 ```
 
-## What one benchmark report records
+## What one transcription benchmark records
 
-A report describes one execution attempt and currently includes:
+A current report describes one execution attempt and includes:
 
 - EchoFlow and Python versions;
 - path-minimized source provenance: SHA-256, size, modification timestamp, container,
@@ -73,22 +68,10 @@ A report describes one execution attempt and currently includes:
 - aggregate named execution-stage durations/failure counts;
 - segment totals/restored/completed counts when available;
 - canonical transcript artifact size after successful publication; and
-- the ratio between observed peak process-tree RSS and the planner's peak-memory
-  estimate.
+- the ratio between observed peak process-tree RSS and the planner's peak-memory estimate.
 
 Repeated stages are named aggregates rather than fixed columns. Future capabilities can
-add stages such as:
-
-```text
-enhancement.apply
-speaker.diarize
-alignment
-embedding.index
-search.index
-gpu.transfer
-```
-
-without redesigning the benchmark schema.
+add stages without redesigning the report schema.
 
 CPU percentages may exceed 100% because sampled process-tree CPU is summed across cores.
 RSS is also summed across the process tree and may conservatively double-count shared
@@ -98,71 +81,49 @@ pages. These are comparative measurements, not perfect OS accounting.
 
 Benchmarking does not transmit reports. EchoFlow has no benchmark telemetry.
 
-Reports are user-owned JSON files in the selected output directory.
+Reports are user-owned JSON files in the selected output directory. They intentionally
+omit source paths/filenames, model-cache paths, transcript text, research-note text, and
+exception messages unless a future benchmark explicitly requires and documents such
+content.
 
-They intentionally omit:
+They retain source digest and enough provenance to compare equivalent runs. A source
+digest can still be linkable if another party has the same recording, so a benchmark
+report from sensitive media is not automatically anonymous.
 
-- source paths/filenames;
-- model-cache paths;
-- transcript text; and
-- exception messages.
-
-They retain source digest and enough provenance to compare equivalent runs.
-
-A source digest can still be linkable if another party has the same recording, so a
-benchmark report from sensitive media is not automatically anonymous.
-
-Public sharing should use synthetic/redistributable media or a future deliberately
-shareable report format with reduced provenance.
+Public sharing should use synthetic/redistributable media or a deliberately shareable
+report format with reduced provenance.
 
 ## Interruption and resume
 
-Ctrl+C and ordinary Python-level failures persist a partial benchmark report before exit
-when finalization can run.
+Ctrl+C and ordinary Python-level failures persist a partial transcription benchmark report
+before exit when finalization can run.
 
-The report marks the attempt interrupted/failed, includes only the exception type, and
-preserves measurements already recorded.
-
-The transcription checkpoint contract remains authoritative for recovery. Completed
-segments are checkpointed before they count as complete.
-
-A later `--resume` benchmark therefore measures the resumed attempt without redefining
-resume semantics.
+The transcription checkpoint contract remains authoritative for recovery. A later
+`--resume` benchmark measures the resumed attempt without redefining resume semantics.
 
 Hard kills, power loss, kernel termination, or machine crashes cannot run benchmark
 finalization code, so a final benchmark report is not promised for those cases. Durable
-transcription checkpoints/lifecycle state remain the recovery evidence.
+checkpoint/lifecycle state remains the recovery evidence.
 
 ## Three qualification layers
 
 ### 1. Deterministic unit and contract tests
 
-These prove the measurement machinery itself behaves correctly:
-
-- normal transcription uses a no-op observer without semantic changes;
-- repeated stage measurements aggregate correctly;
-- failed stages are recorded without swallowing the primary error;
-- reports omit sensitive paths/transcript text;
-- interruption/failure produce partial reports;
-- process-tree sampling tolerates disappearing child processes;
-- resume uses the checkpointed current contract; and
-- invalid report/schema values fail closed.
+These prove the measurement machinery itself behaves correctly: observers do not change
+product semantics, repeated stages aggregate, failures do not swallow primary errors,
+reports respect privacy minimization, and invalid report values fail closed.
 
 ### 2. Cross-platform CI
 
-Linux, macOS, and Windows GitHub Actions runners exercise tests, packaging,
-clean-wheel behavior, psutil sampling, file handling, native media tools, and CLI
-contracts.
+Linux, macOS, and Windows GitHub Actions exercise tests, packaging, clean-wheel behavior,
+file handling, native media tools, and CLI contracts.
 
-Hosted-runner timing is **not calibration truth**.
-
-Runner generations, virtualization, neighboring workloads, frequency policy, caches, and
-infrastructure can change outside the project. CI is useful for regression evidence, not
-for fitting device policy.
+Hosted-runner timing is **not calibration truth**. Runner generations, virtualization,
+neighboring workloads, caches, and infrastructure can change outside the project.
 
 ### 3. Representative real-device runs
 
-The initial physical matrix should include:
+The physical matrix should include at least:
 
 - an 8 GB Windows consumer machine;
 - a 16 GB commodity Windows/Linux machine;
@@ -170,84 +131,138 @@ The initial physical matrix should include:
 - a discrete-GPU laptop; and
 - a larger 32/64 GB workstation.
 
-For comparisons, hold constant the input bytes, EchoFlow version, managed model revision,
-profile/strategy, enhancement condition, and relevant configuration.
+For comparisons, hold constant relevant input bytes, EchoFlow version, model revision,
+strategy/profile, enhancement condition, corpus generation, and query set. Record
+cold/warm state and prefer repeated trials plus medians/spread over one fastest result.
 
-Record cold/warm cache state. Prefer repeated trials and medians/spread over one heroic
-fastest result.
-
-Thermal throttling, battery/power mode, background applications, storage speed, and OS
-updates are legitimate consumer conditions. Record them as experimental context when
-known instead of pretending they do not exist.
-
-🧜‍♀️ A benchmark without context is just a number wearing a lab coat.
+Thermal throttling, battery mode, background applications, storage speed, and OS updates
+are legitimate consumer conditions. Record them when known rather than pretending they do
+not exist.
 
 ## Raw ASR versus enhancement + ASR
 
 Noise suppression should be qualified by **transcription outcome and total cost**, not
-whether the processed file sounds nicer to a listener.
+whether the processed file sounds nicer.
 
-Use matched conditions:
+Use matched conditions with enhancement off/on under the same managed model/revision and
+strategy. Where reference transcripts exist, compare WER and, where useful, CER.
 
-1. the same managed model/revision/strategy with enhancement off;
-2. the same setup with `--enhance`; and
-3. repeated runs when variance matters.
+Also compare total/stage wall-clock time, real-time factor, CPU/RAM pressure, accelerator
+impact, private disk overhead, checkpoint/resume behavior, and failures across realistic
+acoustic conditions.
 
-Where reference transcripts exist, compare WER and, where useful, CER.
+The current FFmpeg `afftdn` provider is a fixed deterministic condition. Its existence is
+not a claim that it improves every recording.
 
-Also compare:
+## Library and research-workspace qualification
 
-- total/stage wall-clock time;
-- real-time factor;
-- CPU/RAM pressure;
-- accelerator impact;
-- private disk overhead;
-- checkpoint/resume behavior; and
-- failures on silence, clipping, stationary/non-stationary noise, music, and mixed
-  acoustic conditions.
+The merged research workspace creates a second measurement surface. The important tests
+are user-shaped workloads, not raw database microbenchmarks.
 
-The current FFmpeg `afftdn` provider is a fixed deterministic condition. Its existence in
-EchoFlow is not a claim that it improves every recording.
+### Corpus refresh
 
-An automatic enhancement mode should wait until measurements show a sufficiently
-reliable relationship between observable input conditions and end-to-end ASR benefit.
+Today `library rebuild` is an explicit full-repair path. The roadmap proposes incremental
+refresh keyed by stable transcript generation identity such as
+`(document_id, canonical_sha256)`.
 
-## Future alignment, diarization, search, and source-separation measurements
+Measure:
 
-The same observer/stage model can eventually measure newer capabilities without
-inventing parallel harnesses.
+- no-op refresh when nothing changed;
+- one new transcript;
+- one changed canonical generation;
+- one removed transcript;
+- batches of new/changed/removed transcripts; and
+- full rebuild of the same corpus as the comparison baseline.
 
-Useful future dimensions include:
+The goal is to prove that normal corpus growth avoids unnecessary work while full rebuild
+remains deterministic recovery.
 
-- alignment wall time and memory cost;
-- diarization real-time factor/peak memory after the security gate is cleared;
-- embedding-index build cost;
-- semantic-query latency at increasing corpus size;
-- exact-scan break-even points before considering ANN/HNSW; and
-- source-separation cost/recognition benefit on genuine overlap cases.
+### Search and unified discovery
 
-Source separation in particular should be judged on end-to-end evidence quality, not on
-whether separated audio sounds technologically impressive.
+Use fixed query sets over representative corpora and measure both cold and warm behavior:
+
+- lexical BM25 queries;
+- semantic exact-scan queries;
+- hybrid RRF queries;
+- transcript/document/language/speaker constraints;
+- tag/collection/note-text/with-notes research constraints;
+- notebook-only note queries; and
+- future unified discovery across transcript evidence, notes, tags, collections, and saved
+  searches.
+
+Measure latency distribution, not only the best run. The first goal is interactive local
+use, not a marketing benchmark.
+
+### Research projection
+
+Measure:
+
+- one-note mutation plus projector catch-up;
+- edit/tag/collection/delete mutations;
+- bounded batches of 100/1,000/10,000 changes where practical;
+- idempotent replay cost;
+- projection catch-up after restart;
+- journal-gap full rebuild; and
+- projection size relative to authoritative SQLite state.
+
+The benchmark must preserve the architecture: SQLite remains authoritative and DuckDB
+remains rebuildable. A faster benchmark is not permission to bypass that custody model.
+
+### GUI-facing responsiveness
+
+Once the thin GUI exists, include end-to-end user-visible timings for:
+
+- opening a library;
+- typing/search debounce to first stable results;
+- switching transcript/note/tag facets;
+- opening a transcript result;
+- creating/editing a note from selected evidence; and
+- seeking local media to `seek_seconds`.
+
+The GUI should be measured through the same application services it uses in production.
+Do not create a benchmark-only fast path.
+
+## Suggested corpus sizes
+
+Synthetic corpora are useful for repeatability, but should be paired with real dogfood
+where privacy permits.
+
+A practical progression is:
+
+```text
+small      10 transcripts / 1,000 segments / 100 notes
+medium    100 transcripts / 10,000 segments / 3,000 notes
+large   1,000 transcripts / 100,000 segments / 30,000 notes
+```
+
+Those are **qualification shapes, not supported-limit claims**. Increase them only when
+the application remains useful and measurements justify the next scale.
+
+## Semantic and later capability measurements
+
+Useful semantic dimensions include embedding-index build cost, query latency at increasing
+corpus size, research-scope reduction effects, and exact-scan break-even points before
+considering ANN/HNSW.
+
+Later optional work can measure diarization after its security gate clears, source
+separation on genuine overlap, or alternative embedding profiles. Each should be judged
+on end-to-end product benefit, not whether a new model produces an impressive demo.
 
 ## How measurements become policy
 
 The harness is for **measurement first, self-tuning never by accident**.
 
-After a sufficient matrix exists, compare predicted and observed:
-
-- peak system/device memory;
-- real-time factor;
-- model initialization;
-- decode/enhancement/alignment cost;
-- segmentation/inference/checkpoint cost;
-- cold/warm behavior; and
-- accuracy outcomes where reference text exists.
+After a sufficient matrix exists, compare predicted and observed memory, real-time factor,
+initialization, decode/enhancement/alignment cost, segmentation/inference/checkpoint cost,
+cold/warm behavior, library/query latency, projection behavior, and accuracy where
+reference data exists.
 
 Only then should a separate reviewed change propose new constants, safety margins,
-hardware classes, or automatic preprocessing heuristics.
+hardware classes, indexing strategies, automatic preprocessing heuristics, or approximate
+search structures.
 
-Benchmark reports say what happened. Policy changes explain why that evidence justifies
-a different decision.
+Benchmark reports say what happened. Policy changes explain why that evidence justifies a
+different decision.
 
 That separation keeps calibration auditable and prevents the planner from becoming a
 self-modifying raccoon with a stopwatch. 🦝

--- a/docs/documentation-style.md
+++ b/docs/documentation-style.md
@@ -4,8 +4,8 @@ EchoFlow documentation should be **rigorous enough to maintain and pleasant enou
 finish reading**.
 
 The project deals with privacy, provenance, media pipelines, model custody, recovery,
-search, and security. Those subjects deserve precision. They do not require the prose to
-sound like drywall.
+search, research state, and security. Those subjects deserve precision. They do not
+require the prose to sound like drywall.
 
 This guide exists so future documentation changes preserve one recognizable voice
 without turning every page into a novelty README.
@@ -15,13 +15,13 @@ without turning every page into a novelty README.
 **Personality may decorate or clarify a contract. It may not replace one.**
 
 If a sentence controls deletion, privacy, security, provenance, compatibility, recovery,
-or failure behavior, state the exact rule plainly. A joke can follow it. The joke may
-not be the only way to discover what the software does.
+or failure behavior, state the exact rule plainly. A joke can follow it. The joke may not
+be the only way to discover what the software does.
 
 Good:
 
-> Semantic vectors are rebuildable derived state. Deleting them must not delete the
-> canonical transcript or future user-authored annotations.
+> DuckDB research projections are rebuildable derived state. Deleting them must not
+> delete authoritative SQLite notes.
 >
 > The raccoon may rebuild the index. The raccoon may not eat your notes.
 
@@ -35,32 +35,29 @@ That is charming and operationally useless.
 
 ### 💃 1. Human-facing guides: high personality
 
-Examples:
-
-- `docs/README.md`
-- `docs/getting-started.md`
-- `docs/semantic-search.md`
-- future guides for speakers, noisy audio, search, recovery, and privacy
+Examples include `docs/README.md`, `docs/getting-started.md`,
+`docs/semantic-search.md`, `docs/research-notes.md`, and feature guides for speakers,
+time, recovery, and privacy.
 
 These documents should:
 
 - begin with what the user is trying to accomplish;
 - explain unfamiliar terms before using them as shorthand;
-- use examples drawn from real recordings, interviews, meetings, lectures, and research;
-- use occasional playful headings, raccoons, mermaids, dancing women, stars, or other
-  visual punctuation;
+- use examples drawn from recordings, interviews, meetings, lectures, and research;
+- use occasional playful headings or visual punctuation;
 - prefer diagrams over long prose when the idea is structural; and
 - tell the reader *why* EchoFlow behaves a certain way, not merely which command exists.
 
-The user should not have to know what CTranslate2, BM25, RRF, a vector dimension, or a
-cgroup is unless they deliberately open the maintenance hatch.
+The user should not have to know what CTranslate2, BM25, RRF, a vector dimension, a
+projection watermark, or a cgroup is unless they deliberately open the maintenance hatch.
 
 ### 🧜‍♀️ 2. Architecture and development docs: medium personality
 
 These documents are for maintainers and technically curious readers.
 
-They may use exact terms such as `FLOAT[]`, `SearchResponse`, cgroup limits, immutable
-revisions, or reciprocal-rank fusion. They should still provide:
+They may use exact terms such as `FLOAT[]`, `SearchResponse`, `EvidenceAnchor`, SQLite
+WAL, cgroup limits, immutable revisions, or reciprocal-rank fusion. They should still
+provide:
 
 1. a plain-English doorway;
 2. a visual model where one helps;
@@ -86,61 +83,61 @@ Light warmth or a memorable heading is fine. Decorative language must never obsc
 - which advisory or dependency gate is active.
 
 Dated audit records are archival evidence. Do not retroactively rewrite them merely to
-match the current voice.
+match the current voice or product roadmap.
 
 ## Recurring visual language
 
 Use motifs sparingly enough that they stay useful.
 
-- **🦝 Raccoon**: rebuildable machinery, caches, indexes, internal floorboards, or a
-  memorable explanation of what can safely be regenerated.
-- **💃 Dancing woman**: orchestration, bringing multiple components together, or a
-  celebratory transition after a successful workflow.
-- **🧜‍♀️ Mermaid**: occasional decorative interruption, especially around diagrams or
-  deep technical water. It does not need to represent a service.
-- **✨ Sparkles**: optional/enhanced capability, reveal, or conceptual payoff.
+- **🦝 Raccoon**: rebuildable machinery, caches, indexes, or a memorable explanation of
+  what can safely be regenerated.
+- **💃 Dancing woman**: orchestration or a celebratory transition after a workflow.
+- **🧜‍♀️ Mermaid**: occasional decorative interruption, especially around diagrams or deep
+  technical water. It does not represent a service.
+- **✨ Sparkles**: optional/enhanced capability or conceptual payoff.
 - **🔐 Lock**: actual privacy/security boundary, not generic decoration.
 
 Do not put emoji into every diagram node simply because Mermaid and mermaid sound alike.
 The diagram should communicate structure first.
 
-## Mermaid diagrams: make the color mean something
+## Mermaid diagrams: portability before decoration
 
-Black-and-white diagrams are valid but should not be the automatic default when color
-can explain ownership or lifecycle.
+EchoFlow documentation is read in IDE previews, GitHub web/mobile clients, generated
+views, and other Markdown renderers with uneven Mermaid support. A diagram that works only
+in one renderer is not doing enough work.
 
-Prefer a small semantic palette. For example:
+For high-traffic and load-bearing diagrams:
+
+- prefer basic `flowchart LR`, `flowchart TD`, and simple node/edge syntax;
+- avoid HTML labels, embedded markup, exotic shapes, or renderer-specific directives
+  unless they are essential;
+- avoid relying on `classDef`, custom colors, or theme behavior for meaning;
+- keep node labels short and literal;
+- put the important relationship in the edge/node text, not only visual styling; and
+- add a one- or two-sentence **text fallback** below diagrams whose structure carries a
+  load-bearing architectural point.
+
+Portable example:
 
 ```mermaid
 flowchart LR
-    A[Original recording] --> B[Canonical transcript]
-    B --> C[Derived search state]
-    C --> D[Search result]
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A,B evidence
-    class C derived
-    class D result
+    A[Canonical transcript] --> B[Rebuildable search projection]
+    B --> C[Ranked passage]
+    C --> D[Verified canonical evidence]
+    D --> E[Durable research anchor]
 ```
 
-Suggested meanings:
+The text immediately below might say:
 
-| Treatment | Meaning |
-|---|---|
-| warm pink | user-owned / authoritative evidence |
-| blue | compute, machine capability, or rebuildable infrastructure |
-| lavender | processing / enrichment |
-| gold | canonical publication / provenance |
-| green | result, success, or user-facing retrieval |
-| red | failure, refusal, stale state, or safety gate |
+> Canonical transcript evidence feeds rebuildable search; ranked passages are verified
+> against canonical bytes before they may become durable research anchors.
 
-Exact hex values may evolve. Consistency matters more than color-brand perfection.
+Color and custom styling may still be used in a narrow technical page when the renderer is
+known and the diagram remains understandable without it. They are decoration, not the
+semantic contract.
 
-Diagrams must still be understandable from their labels and surrounding prose for
-readers who cannot distinguish the colors.
+If Mermaid fails to render entirely, surrounding prose should still let a reader
+understand the architecture.
 
 ## Jargon has to earn rent
 
@@ -174,20 +171,12 @@ Architecture docs can invert steps 4 and 5, but should still start with purpose.
 
 ## Humor should help memory
 
-A joke earns its place when it:
+A joke earns its place when it makes a distinction memorable, relieves a dense transition,
+gives a difficult concept a concrete mental model, or makes the reader want to continue.
 
-- makes a distinction memorable;
-- relieves a dense transition;
-- gives a difficult concept a concrete mental model; or
-- makes the reader want to continue.
-
-It does not earn its place when it:
-
-- makes an error ambiguous;
-- trivializes a security or privacy failure;
-- appears in every paragraph;
-- relies on an in-group reference to understand the technical point; or
-- sounds like a corporate account trying to impersonate a person.
+It does not earn its place when it makes an error ambiguous, trivializes a security or
+privacy failure, appears in every paragraph, relies on an in-group reference to understand
+the technical point, or sounds like a corporate account impersonating a person.
 
 Camp needs negative space.
 
@@ -219,16 +208,17 @@ The latter may be funny in prose. They are poor anchors for someone searching a 
 
 ## The desired reader experience
 
-A reader should be able to enter EchoFlow knowing almost nothing about local ML and
-leave understanding:
+A reader should be able to enter EchoFlow knowing almost nothing about local ML and leave
+understanding:
 
 - what the application does;
 - what happens to their recording;
 - which artifacts are authoritative;
 - what can safely be rebuilt;
+- what research state survives those rebuilds;
 - what stays local;
-- how to resume and search work; and
+- how to resume, search, and annotate work; and
 - where to go when they want the exact engineering contract.
 
-If they accidentally learn a little systems architecture while a scholarly raccoon
-points at a provenance table, that is considered a feature.
+If they accidentally learn a little systems architecture while a scholarly raccoon points
+at a provenance table, that is considered a feature.

--- a/docs/evidence-navigation.md
+++ b/docs/evidence-navigation.md
@@ -3,34 +3,27 @@
 Search is useful when it finds something. Research gets easier when the result can also
 answer **“where, exactly, did this come from?”**
 
-EchoFlow now has a navigation layer between retrieval and presentation. BM25, semantic
-search, and hybrid retrieval still decide *which passage ranks*. Then EchoFlow goes back
-to the authoritative canonical transcript, verifies that it is still the exact transcript
-that was indexed, and resolves the result onto canonical segments and word timing.
+EchoFlow has a navigation layer between retrieval and presentation. BM25, semantic search,
+and hybrid retrieval decide *which passage ranks*. Then EchoFlow goes back to the
+authoritative canonical transcript, verifies that it is still the exact transcript that
+was indexed, and resolves the result onto canonical segments and word timing.
 
 That distinction is important. A search database may point at evidence. It does not get
 to become the evidence.
 
 ```mermaid
 flowchart LR
-    Q[Your query] --> R[Lexical / semantic / hybrid ranking]
-    R --> P[Ranked passage]
-    P --> V[Verify canonical transcript SHA]
-    V --> E[Canonical segment + word coordinates]
-    E --> H[Human context + highlights]
-    E --> S[Seek coordinate]
-    E --> N[Future note / tag anchor]
-
-    classDef query fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class Q query
-    class R,P derived
-    class V,E evidence
-    class H,S,N view
+    A[Your query] --> B[Lexical semantic hybrid ranking]
+    B --> C[Ranked passage]
+    C --> D[Verify canonical transcript]
+    D --> E[Canonical segments and words]
+    E --> F[Context highlights and seek]
+    E --> G[Durable EvidenceAnchor]
+    G --> H[Notes tags collections]
 ```
+
+Text fallback: retrieval ranks a passage, canonical navigation verifies it, and the same
+verified evidence coordinates can now be used by durable research notes.
 
 🦝 Search may know the neighborhood. The canonical transcript still owns the street
 address.
@@ -43,16 +36,16 @@ The command is still the ordinary library search:
 echoflow library search "housing affordability"
 ```
 
-EchoFlow still returns the same retrieval provenance: source and canonical hashes,
-segment/chunk identities, numeric source-relative time, languages, anonymous speaker
-refs, and lexical/semantic/fused ranks.
+EchoFlow returns retrieval provenance: source and canonical hashes, segment/chunk
+identities, numeric source-relative time, languages, anonymous speaker refs, and
+lexical/semantic/fused ranks.
 
-The result can now also carry a verified **evidence location**:
+The result can also carry a verified **evidence location**:
 
-- the exact canonical transcript generation;
-- the result segment IDs;
-- the source-relative result interval;
-- a deterministic seek coordinate;
+- exact canonical transcript generation;
+- result segment IDs;
+- source-relative result interval;
+- deterministic seek coordinate;
 - canonical word matches when lexical evidence justifies them;
 - current user-assigned speaker display names without replacing anonymous refs; and
 - optional neighboring canonical context.
@@ -72,8 +65,8 @@ For an exact phrase:
 echoflow library search "housing affordability" --phrase
 ```
 
-EchoFlow requires the phrase tokens to be contiguous before marking the canonical words
-as the exact match.
+EchoFlow requires phrase tokens to be contiguous before marking canonical words as the
+exact match.
 
 Semantic retrieval is different. An embedding may decide this passage:
 
@@ -87,19 +80,14 @@ is relevant to:
 people struggling to afford housing
 ```
 
-There may be **no single word** in the passage that means “this is the semantic match.”
-So a semantic-only result gets a verified passage and seek coordinate, but EchoFlow does
-not underline a random noun and pretend the vector model pointed at it.
+There may be no single word in the passage that means “this is the semantic match.” A
+semantic-only result therefore gets a verified passage and seek coordinate, but no fake
+exact-word highlight.
 
-Hybrid retrieval may have both kinds of evidence. When lexical evidence contributed to
-a result, exact lexical highlights can be shown alongside the fused ranking provenance.
-
-💃 Precision is useful. Decorative certainty is not.
+Hybrid retrieval may contain both kinds of evidence. When lexical evidence contributed,
+exact lexical highlights can be shown alongside fused ranking provenance.
 
 ## Give me a little more context
-
-A ranked passage is often easier to understand with the sentence before and after it.
-You can request neighboring canonical segments without changing retrieval ranking:
 
 ```bash
 echoflow library search \
@@ -107,15 +95,12 @@ echoflow library search \
   --context-segments 1
 ```
 
-`--context-segments` accepts `0` through `10`. The default is `0`, so ordinary searches
-stay compact.
+`--context-segments` accepts `0` through `10`. Context expansion happens **after ranking**.
+EchoFlow does not feed neighboring text back into BM25 or semantic scoring and then
+pretend the original ranks still mean the same thing.
 
-Context expansion happens **after ranking**. EchoFlow does not secretly feed the extra
-context back into BM25 or semantic scoring and then pretend the ranks mean the same
-thing.
-
-The returned context marks which segments are actual result evidence and which are only
-neighbors provided for reading.
+The returned context distinguishes actual result evidence from neighboring segments shown
+only for reading.
 
 ## What about speaker names?
 
@@ -125,24 +110,19 @@ If you previously assigned:
 speaker-02 → Dr. Chen
 ```
 
-ordinary search presentation can now show:
+ordinary presentation can show:
 
 ```text
 Dr. Chen (speaker-02)
 ```
 
-The anonymous `speaker-02` remains in the machine-readable evidence. The friendly label
-comes from separate private user-authored state and is resolved only when it matches the
-exact canonical transcript generation behind the result.
-
-So rebuilding a search index does not eat the name, and changing the transcript does not
-silently attach Dr. Chen to tomorrow's unrelated `speaker-02`.
-
-See **[Give the anonymous speakers names](speaker-names.md)** for the full custody model.
+The anonymous `speaker-02` remains machine-readable evidence. The friendly label comes
+from separate durable user state and applies only to the exact canonical transcript
+generation it was created for.
 
 ## Can this jump to the original audio or video?
 
-The application contract now exposes the coordinate a player needs.
+The application contract exposes the coordinate a player needs.
 
 If an exact aligned lexical match begins at:
 
@@ -150,82 +130,96 @@ If an exact aligned lexical match begins at:
 4788.370 seconds
 ```
 
-that becomes the preferred seek point:
+that renders as:
 
 ```text
 01:19:48.370
 ```
 
-If a result has no justified exact word match, the passage start remains the safe seek
-coordinate.
+and becomes the preferred seek point. If a result has no justified exact-word match, the
+passage start remains the safe seek coordinate.
 
-EchoFlow still does not ship the graphical local media player itself. A future GUI can
-consume this service directly rather than reverse-engineering positions from rendered
-text or internal work chunks.
+EchoFlow does not yet ship the graphical local media player. The planned thin GUI can
+consume this coordinate directly instead of reverse-engineering time from rendered text
+or internal work chunks.
 
-## And Susan's notes? 📝
+## Susan's notes now use this exact coordinate system 📝
 
-Notes are still future user-authored state. This feature intentionally stops one layer
-before building the notebook.
+The notebook is no longer future work.
 
-What changed is that the notebook no longer needs to invent its own evidence coordinates.
-A future note can point at the same verified location used by search navigation:
+`ResearchWorkspaceService.add_note()` asks `EvidenceLocator` to resolve a verified
+`EvidenceAnchor` before durable user state is written. The anchor preserves:
 
 ```text
-canonical transcript SHA-256
+document ID
 source SHA-256
-segment ID(s)
-word index/indices when available
+canonical transcript SHA-256
+canonical segment IDs
 numeric start/end seconds
 ```
 
-The note body remains separate durable user knowledge.
+A command-line note therefore attaches to canonical evidence, not a search row:
 
-That means:
+```bash
+echoflow library notes add JOB_ID segment-000042 \
+  --body "Compare this with the 2024 survey." \
+  --tag methodology
+```
 
-- changing clock display formatting does not detach the note;
+A multi-segment note must select contiguous canonical segments. Optional narrower time
+coordinates may refine the anchor inside that verified span.
+
+The note body remains separate durable user knowledge. That means:
+
+- changing timestamp formatting does not detach the note;
 - rebuilding BM25 does not delete the note;
 - rebuilding semantic vectors does not delete the note;
-- changing the canonical transcript can be detected instead of silently teleporting the
+- rebuilding the DuckDB research projection does not delete the note;
+- changing the canonical transcript is detected instead of silently teleporting the
   note; and
-- a GUI, CLI, export adapter, or future citation workflow can all consume one anchoring
-  contract.
+- CLI, future GUI, export, and citation workflows can share one anchoring contract.
 
 ```mermaid
 flowchart TD
-    A[📜 Canonical transcript evidence] --> L[Verified evidence location]
-    L --> R[Search result view]
-    L --> P[Future local player]
-    L --> N[Future user note]
-    I[🦝 Rebuildable indexes] --> R
-    U[User speaker labels] --> R
-
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A,L evidence
-    class I derived
-    class U,N user
-    class R,P view
+    A[Canonical transcript evidence] --> B[Verified evidence location]
+    B --> C[Search result view]
+    B --> D[Durable EvidenceAnchor]
+    D --> E[SQLite note]
+    E --> F[Rebuildable DuckDB research projection]
+    B --> G[Future local player]
 ```
+
+## Research metadata can constrain later retrieval
+
+Once notes/tags/collections exist, they are not merely decorations on already-ranked
+results. EchoFlow can resolve them into a canonical evidence scope before ranking:
+
+```bash
+echoflow library search \
+  "housing affordability" \
+  --tag methodology \
+  --collection "Chapter 3" \
+  --with-notes
+```
+
+This is important. The application does not retrieve a giant corpus and then throw away
+results in Python after the fact.
 
 ## What this deliberately does not do
 
-Evidence navigation does not:
+Evidence navigation still does not:
 
 - change BM25, semantic similarity, or RRF ranking;
 - claim an exact word match for semantic-only relevance;
 - rewrite canonical JSON;
 - bake speaker display names into diarization evidence;
-- create notes, tags, collections, or saved searches yet; or
+- automatically re-anchor notes across changed canonical generations;
+- save searches or curated result sets yet; or
 - ship a graphical media player.
 
-Those are separate product layers. The useful thing about this tranche is that they can
-now share one verified coordinate system instead of each inventing a slightly different
-idea of “where this quote came from.”
+The next product layers can reuse the same verified coordinate system rather than each
+inventing a new idea of “where this quote came from.”
 
 For the retrieval internals, open **[Evidence-first corpus search](architecture/corpus-search.md)**.
-For how the underlying timeline works, see **[Transcript time without calculator
-gymnastics](time-navigation.md)**.
+For durable notebook custody, see **[Your notes should survive the machinery](research-notes.md)**.
+For how the timeline works, see **[Transcript time without calculator gymnastics](time-navigation.md)**.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,10 +2,9 @@
 
 This is the **use-the-thing** guide.
 
-You do not need to understand the architecture to follow it. EchoFlow will make several
-technical decisions for you, including what resources are safely available, which local
-transcription strategy fits, where private working state belongs, and how completed work
-can be resumed or searched later.
+You do not need to understand the architecture to follow it. EchoFlow makes technical
+decisions about resources, private working state, model custody, recovery, transcript
+storage, and search so you can concentrate on the recording and the evidence.
 
 If you want the tour first, visit **[Welcome to EchoFlow](README.md)**.
 
@@ -14,33 +13,22 @@ If you want the tour first, visit **[Welcome to EchoFlow](README.md)**.
 EchoFlow is still pre-production. There is no polished desktop installer yet, so the
 current path uses Python 3.12, `uv`, and the command line.
 
-The workflow itself is local-first:
-
 ```mermaid
 flowchart LR
-    A[Your recording] --> B[Inspect source + computer]
-    B --> C[Choose a safe local plan]
+    A[Your recording] --> B[Inspect source and computer]
+    B --> C[Choose safe local plan]
     C --> D[Transcribe]
     D --> E[Canonical transcript]
-    E --> F[Exports]
+    E --> F[Derived exports]
     E --> G[Private local search]
     G --> H[Verified evidence navigation]
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef compute fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef publish fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A evidence
-    class B,C compute
-    class D process
-    class E,F publish
-    class G,H result
+    H --> I[Durable notes tags collections]
+    I --> G
 ```
 
 The original recording is treated as read-only input. EchoFlow writes working files,
-checkpoints, transcripts, exports, user-authored state, and search state separately.
+checkpoints, transcripts, exports, durable user state, and rebuildable search state
+separately.
 
 ## 1. Install the source build
 
@@ -48,52 +36,31 @@ checkpoints, transcripts, exports, user-authored state, and search state separat
 git clone https://github.com/SSD1805/EchoFlow.git
 cd EchoFlow
 uv sync --locked --extra transcription
-```
-
-Initialize EchoFlow's private application directories:
-
-```bash
 uv run echoflow init
 ```
 
-Then ask EchoFlow to inspect the machine:
+Then inspect the machine:
 
 ```bash
 uv run echoflow doctor
 uv run echoflow runner
 ```
 
-`doctor` checks important local dependencies and configuration. `runner` shows the
-compute and memory EchoFlow can actually use.
-
-You do **not** need to manually translate that into “therefore I should use four threads,
-CUDA device zero, and model X.” That is application work.
+`doctor` checks important local dependencies and configuration. `runner` shows the compute
+and memory EchoFlow can actually use.
 
 ## 2. Install a transcription model
 
-Ask EchoFlow which managed model fits the machine and processing policy:
-
 ```bash
 uv run echoflow models recommend
-```
-
-Then install the model you intend to use. For example:
-
-```bash
 uv run echoflow models install small
 ```
 
-Downloading model weights is a network-bearing action, so EchoFlow makes installation
-explicit. Once a verified managed model is local, transcription uses that immutable
-revision instead of silently reaching out to the network.
-
-🦝 **Raccoon translation:** downloading the toolbox and using the toolbox are different
-things.
+Model acquisition is explicitly network-bearing. Once a verified managed model is local,
+transcription uses that immutable revision instead of silently reaching out to the
+network.
 
 ## 3. Inspect a recording before doing the work
-
-A dry run tells EchoFlow to inspect the media and machine and build a plan without
-starting recognition:
 
 ```bash
 uv run echoflow transcribe interview.m4a --dry-run
@@ -111,37 +78,29 @@ uv run echoflow transcribe interview.m4a --dry-run --json
 uv run echoflow transcribe interview.m4a
 ```
 
-EchoFlow may need to decode or normalize the selected audio stream into a deterministic
-working format. That working audio is private derived state. Your original recording is
-not overwritten.
+EchoFlow may normalize the selected audio stream into deterministic working audio. That
+working audio is private derived state. Your original recording is not overwritten.
 
-The current faster-whisper path also asks for native word timing. Those word intervals
-are validated and rebased onto one source-relative timeline so internal work chunks do
-not reset the published clock.
+The faster-whisper path requests native word timing. Word intervals are validated and
+rebased onto one source-relative timeline so internal work chunks do not reset the
+published clock.
 
-The durable transcript is canonical JSON. If you also want ordinary reading/subtitle
-formats:
+The durable transcript is canonical JSON. If you also want ordinary publication formats:
 
 ```bash
 uv run echoflow transcribe interview.m4a --export txt --export srt --export vtt
 ```
 
-TXT, SRT, and WebVTT are publication views. They can be regenerated from canonical JSON
-without running speech recognition again.
+TXT, SRT, and WebVTT are rebuildable views over canonical transcript evidence.
 
-## 5. If something interrupts the job
-
-Long recordings and laptops occasionally have opinions.
-
-When a job has durable checkpoints, resume it with the original input and job ID:
+## 5. Resume an interrupted job
 
 ```bash
 uv run echoflow transcribe interview.m4a --resume JOB_ID
 ```
 
-Resume is deliberately conservative. EchoFlow rechecks source identity and current
-resources and restores the original execution contract rather than silently switching
-models, streams, preprocessing, or alignment halfway through the evidence trail.
+Resume rechecks source identity and current resources and restores the original execution
+contract rather than silently changing models, streams, preprocessing, or alignment.
 
 ## 6. Optional: clean up a noisy recording
 
@@ -149,65 +108,40 @@ models, streams, preprocessing, or alignment halfway through the evidence trail.
 uv run echoflow transcribe noisy-interview.wav --enhance
 ```
 
-Enhancement is off by default. The processed audio remains private working material and
-does not replace the source recording. EchoFlow verifies that preprocessing did not
-shift the timeline used for transcript evidence.
-
-For the engineering contract, see
-**[Local speech enhancement](architecture/speech-enhancement.md)**.
+Enhancement remains private working material and does not replace source evidence.
+EchoFlow verifies that preprocessing did not shift the transcript timeline.
 
 ## 7. Optional: anonymous speakers
-
-The intended CLI surface is:
 
 ```bash
 uv run echoflow transcribe focus-group.wav --diarize
 ```
 
-Diarization uses anonymous recording-scoped labels such as `speaker-01` and
-`speaker-02`. EchoFlow does not treat them as biometric identities or link them across
-recordings.
+Diarization uses anonymous recording-scoped refs such as `speaker-01` and `speaker-02`.
+EchoFlow does not treat them as biometric identities or link them across recordings.
 
-**Current limitation:** the integrated pyannote path is held behind a dependency security
-gate while the locked Lightning version is affected by a compensated advisory. While
-that gate is active, EchoFlow refuses diarization before model execution/acquisition.
+The integrated pyannote path remains held behind a dependency security gate while its
+locked Lightning version is affected by the compensated advisory described in
+**[SECURITY.md](../SECURITY.md)**.
 
-Once speaker evidence exists in a canonical transcript and the library has been rebuilt,
-you can give one anonymous ref a durable human-facing name:
+When speaker evidence exists, give a ref a durable human-facing display name:
 
 ```bash
 uv run echoflow library speakers list JOB_ID
 uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
-```
-
-You name `speaker-02` once for that canonical transcript generation. You do not edit each
-occurrence by hand.
-
-For a handoff/overlap-aware transcript view:
-
-```bash
 uv run echoflow library speakers transcript JOB_ID
 ```
 
-See **[Give the anonymous speakers names](speaker-names.md)**,
-**[Anonymous speaker diarization](architecture/diarization.md)**, and
-**[SECURITY.md](../SECURITY.md)** for the exact boundaries.
+`Dr. Chen` is display state. `speaker-02` remains evidence.
 
-## 8. Build and search your local transcript library 🔎
-
-Once you have completed canonical transcripts, build the private lexical library:
+## 8. Build and search the local transcript library 🔎
 
 ```bash
 uv run echoflow library rebuild
-```
-
-Search it:
-
-```bash
 uv run echoflow library search "housing insecurity"
 ```
 
-Ask for one neighboring canonical segment on each side:
+Ask for neighboring canonical context without changing ranking:
 
 ```bash
 uv run echoflow library search "housing insecurity" --context-segments 1
@@ -222,13 +156,9 @@ uv run echoflow library search \
   --language en
 ```
 
-If `speaker-02` has a current user label, the human result can show
-`Dr. Chen (speaker-02)` while JSON keeps the raw anonymous ref and exposes the friendly
-label separately.
-
-Lexical results with aligned word evidence can highlight the exact canonical words that
-matched and expose the first match as a source seek coordinate. Semantic-only results
-stay passage-level rather than inventing an exact word.
+Lexical results with aligned word evidence can highlight exact canonical words and expose
+a source seek coordinate. Semantic-only results remain passage-level instead of inventing
+an exact word.
 
 Inspect one transcript's evidence receipt:
 
@@ -236,48 +166,93 @@ Inspect one transcript's evidence receipt:
 uv run echoflow library show JOB_ID
 ```
 
-The search databases are rebuildable projections. The navigation layer re-verifies the
-canonical transcript before presenting precise evidence coordinates.
+## 9. Keep durable notes beside the evidence 📝
 
-Read **[From search result to the exact evidence](evidence-navigation.md)** for the
-human explanation.
+EchoFlow now has a local research notebook backed by authoritative SQLite state. Notes,
+tags, collections, and their evidence anchors survive search-index rebuilds.
 
-## 9. Optional: search by meaning, not only matching words ✨
+List notes:
 
-Lexical search is excellent when the transcript contains the words you remember.
-Semantic search helps when you remember the idea but not the wording.
-
-A query like:
-
-```text
-people struggling to afford housing
+```bash
+uv run echoflow library notes
 ```
 
-may help surface:
+Add a note to a canonical segment:
 
-```text
-I was spending almost seventy percent of my pay on the apartment.
+```bash
+uv run echoflow library notes add JOB_ID segment-000042 \
+  --body "Compare this with the 2024 survey." \
+  --tag methodology \
+  --collection "Chapter 3"
 ```
 
-Those sentences share little vocabulary, but they express a related idea.
+A note may span contiguous canonical segments:
 
-EchoFlow's current semantic foundation uses a local sentence-embedding model and private
-rebuildable vectors. Search results still point back to original canonical transcript
-evidence.
+```bash
+uv run echoflow library notes add JOB_ID \
+  segment-000042 segment-000043 segment-000044 \
+  --body "This exchange belongs in the methods section."
+```
 
-### Is this sent to a hosted AI service?
+EchoFlow verifies the exact canonical transcript generation and segment order before
+accepting the anchor. If the transcript later changes, the old note survives but does not
+silently attach itself to a new generation.
 
-Not during semantic indexing or search in the current implementation. The embedding
-provider loads from a local immutable model snapshot. Acquiring model weights is a
-separate network-bearing action.
+Edit research state explicitly:
 
-### Is semantic search part of the normal install yet?
+```bash
+uv run echoflow library notes edit NOTE_ID --body "Revised note text"
+uv run echoflow library notes set-tags NOTE_ID --tag housing --tag methodology
+uv run echoflow library notes set-collections NOTE_ID --collection "Chapter 3"
+uv run echoflow library notes delete NOTE_ID
+```
 
-Not quite.
+Read **[Your notes should survive the machinery](research-notes.md)** for the full custody
+model.
 
-The locked project dependency graph does not yet include Sentence Transformers, so the
-semantic path currently expects an environment that already supplies a compatible local
-runtime and Multilingual E5 Small snapshot. Lexical search works without any of this.
+## 10. Use research state to constrain transcript search
+
+Search can resolve human tag/collection names into durable IDs and apply the resulting
+evidence scope **before** lexical ranking or semantic vector scoring.
+
+```bash
+uv run echoflow library search \
+  "housing affordability" \
+  --tag methodology \
+  --with-notes
+```
+
+Or require note text and a collection:
+
+```bash
+uv run echoflow library search \
+  "housing affordability" \
+  --note-text "2024 survey" \
+  --collection "Chapter 3"
+```
+
+The user does not choose which database to query. `ResearchWorkspaceService` coordinates
+verified evidence, authoritative SQLite user state, the deterministic projector, and
+rebuildable DuckDB query state.
+
+Projection diagnostics are available when needed:
+
+```bash
+uv run echoflow library research
+uv run echoflow library research sync
+uv run echoflow library research rebuild
+```
+
+Normal users should not need to operate either database directly.
+
+## 11. Optional semantic and hybrid search ✨
+
+Lexical search is the dependency-light default. Semantic search helps when you remember
+the idea but not the wording; hybrid retrieval combines lexical and semantic ranks using
+reciprocal rank fusion.
+
+The semantic foundation remains advanced setup because the locked project dependency
+graph does not yet include Sentence Transformers as a normal semantic extra.
 
 Read **[Semantic search, without the mystery box](semantic-search.md)** for the full
 plain-language explanation.
@@ -285,51 +260,38 @@ plain-language explanation.
 ## What EchoFlow stores 🦝
 
 ```mermaid
-flowchart LR
-    A[Original recording] -->|read only| B[Canonical transcript]
-    B --> C[TXT / SRT / VTT]
-    B --> D[Lexical search state]
-    B --> E[Optional semantic search state]
-    B --> N[Verified navigation views]
-    A --> F[Private working audio + checkpoints]
-    U[User speaker labels] --> N
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef work fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef user fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-
-    class A,B evidence
-    class C,D,E,N derived
-    class F work
-    class U user
+flowchart TD
+    A[Original recording] --> B[Canonical transcript JSON]
+    B --> C[TXT SRT WebVTT]
+    B --> D[DuckDB lexical and semantic projections]
+    B --> E[Verified evidence anchors]
+    E --> F[SQLite notes tags collections]
+    F --> G[DuckDB research projection]
 ```
 
 The useful distinction is not “database versus file.” It is **can this be reconstructed
 without losing something the user authored or relied on as evidence?**
 
-- The original recording is source evidence.
-- Canonical transcript JSON is the authoritative transcript artifact.
-- Speaker display labels are durable user-authored state.
-- Future notes/tags/annotations/collections belong to that same durable class.
-- TXT/SRT/VTT, search indexes, and navigation views are derived and rebuildable.
-- Working audio and most execution material are private processing state.
+- Original recording: source evidence.
+- Canonical transcript JSON: authoritative transcript evidence.
+- Speaker display labels, notes, tags, collections: durable user-authored state.
+- TXT/SRT/VTT, search indexes, research projection, navigation views: derived/rebuildable.
+- Working audio and most execution material: private processing state.
 
-Delete a search index? Rebuild her.
+Delete a search index? Rebuild it.
 
-Delete the only canonical transcript or somebody's annotation? That is data loss.
+Delete the only canonical transcript or somebody's note? That is data loss.
 
-## Where do I go when I want more detail?
+## What comes next?
 
-**[docs/README.md](README.md)** is the documentation lobby.
+The backend research workspace exists. The next product work is increasingly about making
+it pleasant for a normal person:
 
-The **[architecture index](architecture/README.md)** is the maintenance hatch for
-contributors and technically curious readers. It covers resource admission, media and
-timeline semantics, model custody, diarization, enhancement, checkpoints, search, and
-canonical evidence navigation in exact terms.
+1. one unified library-discovery surface across transcripts, notes, tags, and collections;
+2. saved searches plus useful derived frequent/recent navigation;
+3. a thin graphical shell that turns transcript selection into verified note anchors and
+   local seek actions;
+4. portable research export and incremental library refresh; and
+5. consumer-hardware/semantic-install/installer qualification.
 
-The **[security policy](../SECURITY.md)** defines what “local-first” protects and what it
-does not claim.
-
-And if the documentation suddenly starts discussing `FLOAT[]`, cgroup ceilings, or RRF
-constants, you have probably wandered into the engine room. 🧜‍♀️
+For the detailed sequence, see **[ROADMAP.md](../ROADMAP.md)**.

--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -1,55 +1,46 @@
 # Your notes should survive the machinery 📝🦝
 
-EchoFlow can now keep **your research notes, tags, and collections** beside recorded
-evidence without pretending they are part of the transcript itself.
+EchoFlow can keep **your research notes, tags, and collections** beside recorded evidence
+without pretending they are part of the transcript itself.
 
 That distinction matters.
 
-The recording and canonical transcript describe the evidence. A note such as
-“compare this with the 2024 survey” is something **you know, suspect, or want to remember**.
-EchoFlow keeps those two kinds of truth separate while still letting you move between
-them quickly.
+The recording and canonical transcript describe evidence. A note such as “compare this
+with the 2024 survey” is something **you know, suspect, or want to remember**. EchoFlow
+keeps those kinds of truth separate while still letting them meet through exact evidence
+coordinates.
 
 ## The short version
 
 When you attach a note to transcript evidence, EchoFlow stores the note durably and keeps
 its exact evidence address:
 
-- transcript/document identity;
+- document/transcript identity;
 - original source SHA-256;
 - canonical transcript SHA-256;
 - canonical segment IDs; and
 - source-relative start/end seconds.
 
-The note survives search-index rebuilds. The fast query machinery can be deleted and
-reconstructed without deleting your work.
+The note survives search-index and research-projection rebuilds.
 
 ```mermaid
 flowchart LR
-    E[📜 Canonical evidence] --> A[Verified evidence anchor]
-    A --> S[(📝 SQLite\nyour durable research state)]
-    S --> P[Deterministic projector]
-    P --> D[(🦝 DuckDB\nrebuildable query projection)]
-    D --> Q[Fast note/tag-aware search]
-    Q --> E
-
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef durable fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class E,A evidence
-    class S durable
-    class P,D derived
-    class Q result
+    A[Canonical transcript evidence] --> B[Verified EvidenceAnchor]
+    B --> C[SQLite durable research state]
+    C --> D[Monotonic change journal]
+    D --> E[Deterministic projector]
+    E --> F[DuckDB research projection]
+    F --> G[Fast research-aware search]
+    G --> A
 ```
 
-You do not need to operate either database. EchoFlow presents one research workspace.
+You do not need to operate either database. `ResearchWorkspaceService` presents one
+research workspace over the two storage roles.
 
 ## Add a note
 
-A command-line note anchors to real canonical segment IDs rather than a disposable search
-row or a pretty timestamp.
+The current CLI anchors to real canonical segment IDs rather than a disposable search row
+or formatted timestamp:
 
 ```bash
 echoflow library notes add TRANSCRIPT_ID segment-000042 \
@@ -71,10 +62,10 @@ EchoFlow verifies the current canonical transcript bytes before accepting the an
 refuses missing, reordered, or non-contiguous segment selections rather than guessing.
 
 Optional `--start-seconds` and `--end-seconds` may narrow an anchor inside the selected
-canonical segment span. They cannot escape that evidence.
+canonical span. They cannot escape that evidence.
 
-A future graphical interface can turn text selection into the same `EvidenceAnchor`.
-The GUI does not need a second anchoring system.
+The first GUI can turn transcript selection into the same `EvidenceAnchor`, which means
+we do not need a second annotation system for graphical use.
 
 ## Read and query your notebook
 
@@ -84,7 +75,7 @@ List recent notes:
 echoflow library notes
 ```
 
-Filter the notebook itself:
+Filter the notebook:
 
 ```bash
 echoflow library notes \
@@ -99,18 +90,18 @@ Limit notes to one transcript:
 echoflow library notes --transcript TRANSCRIPT_ID
 ```
 
-Machine-readable output keeps the durable evidence identity explicit:
+Machine-readable output keeps durable evidence identity explicit:
 
 ```bash
 echoflow library notes --json
 ```
 
-Note-text matching currently uses deterministic lexical terms. It does not pretend that
-a local embedding model inferred a meaning the note never contained.
+Note-text matching currently uses deterministic lexical terms. It does not pretend a
+local embedding model inferred a meaning the note never contained.
 
-## Use your research state to search the transcript corpus
+## Use research state to search the transcript corpus
 
-The same research metadata can constrain transcript retrieval:
+Research metadata can constrain transcript retrieval before scoring:
 
 ```bash
 echoflow library search "housing affordability" \
@@ -118,7 +109,7 @@ echoflow library search "housing affordability" \
   --with-notes
 ```
 
-Or require terms in your attached notes while searching transcript evidence:
+Or require terms in attached notes while searching transcript evidence:
 
 ```bash
 echoflow library search "housing affordability" \
@@ -126,13 +117,14 @@ echoflow library search "housing affordability" \
   --collection "Chapter 3"
 ```
 
-Research constraints are resolved **before** BM25 ranking or semantic vector scoring.
-EchoFlow does not retrieve an enormous corpus and then filter it in Python.
+EchoFlow resolves tag/collection names to durable IDs, obtains a canonical evidence scope
+from the research projection, and ranks lexical/semantic candidates **inside that
+scope**. It does not retrieve the whole corpus and filter it afterward in Python.
 
-Search results can show associated note count, tags, and collections alongside the
-original speaker/timeline/ranking evidence.
+Search results may show associated note count, tags, and collections alongside original
+speaker/timeline/ranking evidence.
 
-## Edit your research state
+## Edit research state
 
 Replace note text:
 
@@ -148,7 +140,7 @@ echoflow library notes set-tags NOTE_ID \
   --tag methodology
 ```
 
-Replace its collection membership:
+Replace collection membership:
 
 ```bash
 echoflow library notes set-collections NOTE_ID \
@@ -161,8 +153,8 @@ Delete a note explicitly:
 echoflow library notes delete NOTE_ID
 ```
 
-Those commands mutate the durable user-state store. The query projection catches up from
-a monotonic change journal.
+Those commands mutate authoritative SQLite user state. The DuckDB query projection
+catches up from a monotonic change journal.
 
 ## What if the transcript changes?
 
@@ -174,82 +166,92 @@ Suppose an older transcript contains:
 job-abc / canonical aaaa... / segment-000042
 ```
 
-and a regenerated transcript later also contains `segment-000042` but has canonical hash
+and a regenerated transcript later also contains `segment-000042` but canonical hash
 `bbbb...`.
 
 EchoFlow does **not** silently move the old note onto the new evidence.
 
 The old note remains durable and can be shown as belonging to an older transcript
-generation. The fast projection key includes the canonical SHA-256, so it cannot
-accidentally match the new segment merely because the friendly segment ID was reused.
+generation. The projected evidence key includes the canonical SHA-256, so an old note
+cannot accidentally match a new segment merely because the friendly segment ID was
+reused.
 
-That is why the SHA-256 is part of the address rather than decorative provenance.
+## Why two databases?
 
-## Why are there two databases?
+Because they have different jobs and different deletion semantics.
 
-Because they have different jobs.
-
-| Store | Job | Can EchoFlow rebuild it? |
+| Store | Job | Rebuildable? |
 |---|---|---|
-| SQLite research state | your notes/tags/collections and their evidence anchors | **No** |
-| DuckDB research projection | fast derived relationships/lexical note terms for filtering | Yes |
+| SQLite research state | authoritative notes/tags/collections and evidence anchors | **No** |
+| DuckDB research projection | fast derived relationships and lexical note terms | Yes |
 | DuckDB transcript index | transcript terms/segments for lexical ranking | Yes |
 | DuckDB semantic index | chunks/vectors for semantic retrieval | Yes |
 
-SQLite and DuckDB do not attach to one another or share a cross-database transaction.
-EchoFlow coordinates them through stable evidence identities.
+SQLite is a better fit for frequently mutated transactional application state. DuckDB is
+a better fit for local analytical/query workloads. EchoFlow deliberately does **not** make
+both authoritative.
 
-The durable write happens first. Query projection is derived afterward.
+The write path is one-way:
 
-## What if the fast projection disappears?
-
-Nothing unique is lost.
-
-EchoFlow can rebuild the research projection from a consistent SQLite snapshot:
-
-```bash
-echoflow library research rebuild
+```text
+SQLite authority
+      |
+      | monotonic transactional journal
+      v
+Deterministic projector
+      |
+      v
+DuckDB projection
 ```
 
-Normal incremental synchronization is also explicit:
+If the stores disagree, SQLite wins. If DuckDB disappears, rebuild it.
 
-```bash
-echoflow library research sync
-```
+## Projection diagnostics
 
-And you can inspect the two sequence numbers:
+Inspect current sequences:
 
 ```bash
 echoflow library research
 ```
 
-Conceptually:
+Catch up incrementally:
 
-```text
-Research projection current: SQLite 18442, DuckDB 18442
+```bash
+echoflow library research sync
 ```
 
-If DuckDB is behind, EchoFlow replays bounded changes. If retained change history no
-longer reaches far enough back, EchoFlow rebuilds from SQLite. If a projection somehow
-claims to be *ahead* of authoritative SQLite state, EchoFlow fails closed instead of
-inventing a recovery story.
+Rebuild the disposable projection from authoritative SQLite state:
 
-## What this does not do
+```bash
+echoflow library research rebuild
+```
 
-This first durable research-state tranche does not yet provide:
+The DuckDB watermark advances in the same transaction as projected rows, so it cannot
+claim a sequence was applied if those rows did not commit.
 
-- rich-text/WYSIWYG note editing;
-- semantic embeddings over note prose;
-- fuzzy note search;
-- saved-search objects;
-- exportable/citable selected result sets;
-- a graphical click-to-annotate interface; or
-- automatic re-anchoring across changed canonical transcript generations.
+If the projection is too far behind for retained journal history to bridge the gap,
+EchoFlow rebuilds from a consistent SQLite snapshot. If DuckDB claims to be ahead of
+SQLite authority, EchoFlow fails closed.
 
-Those can build on the same storage and evidence-address contracts rather than creating
-parallel state.
+## What comes next for the notebook?
 
-The important promise is already narrower and stronger:
+The storage and evidence-address contracts are built. The next improvements are mostly
+human ergonomics:
+
+- unified library discovery across transcript evidence, notes, tags, and collections;
+- durable saved searches;
+- derived frequent/recent tag and collection suggestions;
+- selected/citable result sets;
+- portable research export;
+- stale-anchor review/re-anchor UX with explicit user confirmation; and
+- a thin graphical click/select-to-annotate surface.
+
+Frequent/recent tag rankings should be **derived views**, not stored counters. The tag is
+durable user state; “used 147 times” is disposable navigation metadata.
+
+The current tranche deliberately does not yet provide rich-text/WYSIWYG editing, semantic
+embeddings over note prose, automatic cross-generation re-anchoring, collaborative sync,
+or a GUI.
 
 > **Your research state is durable. Its fast query representation is disposable. The two
 > can always meet again through exact evidence identities.**

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -23,21 +23,14 @@ The vocabulary differs, but the idea is related.
 
 ```mermaid
 flowchart LR
-    Q[Your search] --> L[Exact words / BM25]
-    Q --> S[Related meaning / semantic embeddings]
-    L --> H[Hybrid rank fusion]
-    S --> H
-    H --> E[Transcript passages + evidence]
-
-    classDef query fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef lexical fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef semantic fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class Q query
-    class L lexical
-    class S,H semantic
-    class E result
+    A[Your query] --> B[Lexical BM25]
+    A --> C[Semantic embeddings]
+    B --> D[Hybrid rank fusion]
+    C --> D
+    B --> E[Transcript passages]
+    C --> E
+    D --> E
+    E --> F[Verified canonical evidence]
 ```
 
 Semantic search is optional. Lexical search remains the default and requires no semantic
@@ -47,91 +40,67 @@ model runtime.
 
 An embedding is a numeric representation of text used for comparison.
 
-EchoFlow turns a search phrase and small transcript passages into vectors, then compares
-those vectors to find passages that sit near the query in the model's learned semantic
-space.
+EchoFlow turns a search phrase and deterministic transcript passages into vectors, then
+compares those vectors to find passages that sit near the query in the model's learned
+semantic space.
 
-The important thing for a user is what an embedding **is not**:
+An embedding is **not**:
 
-- it is not a replacement transcript;
-- it is not a generated summary;
-- it is not a hosted database requirement; and
-- it is not the only place your transcript exists.
+- a replacement transcript;
+- a generated summary;
+- a hosted database requirement; or
+- the only place your transcript exists.
 
-The vector is **derived search data**.
+It is derived search data.
 
 ```mermaid
 flowchart TD
     A[Canonical transcript passage] --> B[Local embedding model]
-    Q[Search phrase] --> B
-    B --> C[Numeric vectors]
-    C --> D[Local similarity comparison]
-    D --> E[Original transcript passages]
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef result fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class A,Q evidence
-    class B,D process
-    class C derived
-    class E result
+    C[Search phrase] --> B
+    B --> D[Numeric vectors]
+    D --> E[Local similarity comparison]
+    E --> F[Original canonical passage coordinates]
 ```
 
-EchoFlow's first qualified semantic profile produces 384-number vectors. Those numbers
-are useful because they let the application compare meaning efficiently. You are not
-expected to read them. Please do not spend your evening trying. 🧜‍♀️
+EchoFlow's current profile produces 384-number vectors. Those numbers are for the
+computer. You are not expected to inspect them manually.
 
-## 💃 What happens when you turn semantic search on?
+## What happens when semantic search is enabled?
 
 EchoFlow builds a private, rebuildable semantic projection from canonical transcripts.
 
 1. Adjacent canonical ASR segments are combined into deterministic search windows.
 2. A local embedding model converts each window into a vector.
-3. EchoFlow stores those vectors in a private DuckDB semantic index.
+3. EchoFlow stores vectors in a private DuckDB semantic index.
 4. Search queries are embedded locally with the same profile.
-5. The index compares the query vector with eligible local passage vectors.
+5. Hard constraints are applied before similarity ranking where possible.
 6. Results point back to the canonical transcript segments that produced them.
+7. `EvidenceLocator` re-verifies canonical bytes before exposing precise evidence.
 
-Your original recording is not modified. Canonical transcript JSON remains the
-user-owned evidence artifact.
+Your original recording is not modified. Canonical transcript JSON remains authoritative
+transcript evidence.
 
-## 🔐 Does transcript text leave my computer?
+## Does transcript text leave my computer?
 
 Not during semantic indexing or search in the current implementation.
 
-EchoFlow's semantic provider loads from a **local model snapshot**. Model loading is
-configured for local-only resolution with remote model code disabled.
+EchoFlow's semantic provider loads from a **local model snapshot**. Model loading uses
+local-only resolution with remote model code disabled.
 
-It helps to separate three different network/privacy questions:
+Separate three questions:
 
 ### Searching or indexing transcripts
 
-Local. Transcript passages are not sent to a hosted embedding API by this
-implementation.
+Local. Transcript passages are not sent to a hosted embedding API by this implementation.
 
 ### Obtaining a model
 
-Potentially network-bearing. If you download model weights from a provider such as
-Hugging Face, that acquisition step uses the network.
+Potentially network-bearing. Downloading model weights from a provider uses the network.
 
 ### Using a model already present locally
 
-Offline. EchoFlow accepts the local immutable snapshot path and does not resolve a
-repository ID while indexing/searching.
-
-That explicit boundary matters. “Uses a machine-learning model” does not automatically
-mean “uploads your transcript to somebody else's server.”
-
-## Why aren't the model weights inside the EchoFlow repository?
-
-Because model weights are large binary dependencies, not application source code.
-
-Vendoring them would make repository size, upgrades, licensing/distribution custody,
-caching, and independent model replacement worse.
-
-EchoFlow instead records the qualified profile/revision used to create semantic state.
+Offline. EchoFlow accepts the local immutable snapshot and does not resolve a remote
+repository while indexing/searching.
 
 ## Why Multilingual E5 Small?
 
@@ -141,46 +110,37 @@ The first qualified semantic profile is:
 intfloat/multilingual-e5-small
 ```
 
-It gives EchoFlow a conservative combination of:
+It offers multilingual retrieval, compact 384-dimensional vectors,
+retrieval-specific query/passage instructions, and practical local inference compared
+with much larger embedding families.
 
-- multilingual retrieval rather than an English-only search space;
-- compact 384-dimensional vectors;
-- retrieval-specific query/passage instructions;
-- practical local inference compared with much larger embedding families; and
-- a mature Sentence Transformers-compatible execution path.
-
-The important product decision is **not** that this particular model is sacred.
-
-The important decision is that one semantic index generation uses one explicit,
-reproducible embedding profile.
+The important product decision is **not** that this exact model is sacred. One semantic
+index generation must use one explicit reproducible profile.
 
 > **The model is not sacred. The profile is.**
 
 EchoFlow records model identity, immutable revision, dimensions, normalization, pooling,
 distance metric, query/passage transforms, embedding schema, and chunking profile.
 
-If the profile changes, the semantic projection is rebuilt instead of silently mixing
-incompatible vector spaces.
+If the profile changes, the semantic projection is rebuilt rather than mixing incompatible
+vector spaces.
 
-## 🦝 What can the raccoon rebuild?
-
-Semantic search creates infrastructure, not new source evidence.
+## What can be rebuilt? 🦝
 
 | Data | Role | Rebuildable? |
 |---|---|---|
 | Original recording | source evidence | **No** |
-| Canonical transcript JSON | authoritative transcript | **No** |
-| Future notes/tags/annotations | user-authored knowledge | **No** |
+| Canonical transcript JSON | authoritative transcript evidence | **No** |
+| Speaker labels, notes, tags, collections | user-authored knowledge | **No** |
+| Future saved searches / curated result sets | user-authored knowledge | **No** |
 | Lexical term statistics | search projection | Yes |
 | Semantic chunks | derived retrieval windows | Yes |
 | Embedding vectors | derived search projection | Yes |
+| Research query projection | derived research acceleration | Yes |
 
-If the semantic database disappears, EchoFlow should be able to rebuild it from
-canonical transcripts.
+If the semantic database disappears, rebuild it from canonical transcripts.
 
-If a future annotation disappears, that is data loss.
-
-Those are intentionally different custody classes.
+If a durable note disappears, that is data loss.
 
 ## Why are transcript passages grouped into chunks?
 
@@ -190,32 +150,45 @@ ASR segments are evidence coordinates, but some are tiny:
 Yeah.
 ```
 
-or:
+Embedding each tiny segment independently can discard useful context. EchoFlow therefore
+combines adjacent canonical segments into deterministic retrieval windows.
 
-```text
-And then we moved.
-```
+Those chunks carry the IDs/timestamps of their source segments and can be recreated later.
+EchoFlow does not split one canonical ASR segment into invented evidence coordinates merely
+to hit a preferred chunk size.
 
-Embedding each tiny segment independently can discard useful context.
-
-EchoFlow therefore combines adjacent canonical segments into deterministic retrieval
-windows. Those chunks carry the IDs/timestamps of their source segments and can be
-recreated later.
-
-EchoFlow does not split one canonical ASR segment into invented evidence coordinates
-merely to hit a preferred chunk size.
-
-## What does hybrid search actually combine?
+## What does hybrid search combine?
 
 BM25 lexical scores and semantic similarity scores are different mathematical things.
 EchoFlow does not pretend they share one universal “relevance percentage.”
 
-Hybrid mode instead combines **rank positions** with reciprocal rank fusion (RRF).
+Hybrid mode combines **rank positions** with reciprocal rank fusion (RRF). The deeper
+contract lives in **[architecture/corpus-search.md](architecture/corpus-search.md)**.
 
-That makes the composition simple, inspectable, and local.
+## Research-aware semantic search
 
-The deeper ranking contract is documented in
-**[architecture/corpus-search.md](architecture/corpus-search.md)**.
+Durable research state can constrain semantic retrieval before vector scoring.
+
+For example:
+
+```bash
+uv run echoflow library search \
+  "people struggling to make rent" \
+  --mode semantic \
+  --tag methodology \
+  --collection "Chapter 3"
+```
+
+`ResearchWorkspaceService` resolves human tag/collection names to durable IDs. The
+rebuildable research projection maps those IDs to canonical evidence scope. Semantic
+candidate selection then happens **inside that scope**.
+
+The semantic adapter also keeps a derived relational `chunk_segments` mapping so it can
+map canonical segment scope to eligible semantic chunks without scanning every chunk's
+JSON metadata.
+
+This is an important boundary: notes/tags/collections do not become embedding truth. They
+are durable user-authored constraints over evidence.
 
 ## Using semantic search
 
@@ -226,8 +199,8 @@ uv run echoflow library rebuild
 uv run echoflow library search "housing insecurity"
 ```
 
-The current semantic foundation expects a compatible Sentence Transformers runtime and
-a local immutable Multilingual E5 Small snapshot.
+The current semantic foundation expects a compatible Sentence Transformers runtime and a
+local immutable Multilingual E5 Small snapshot.
 
 Build semantic state:
 
@@ -237,7 +210,7 @@ uv run echoflow library embeddings build \
   --revision <revision>
 ```
 
-Inspect the exact profile EchoFlow indexed:
+Inspect the indexed profile:
 
 ```bash
 uv run echoflow library embeddings
@@ -264,11 +237,10 @@ uv run echoflow library search \
 
 The locked project dependency graph does not yet include Sentence Transformers.
 
-That means the current semantic tranche proves the architecture and local retrieval
-contract without pretending the optional dependency/model acquisition story is already a
-qualified normal install.
+The current implementation proves the architecture and strict-local retrieval contract
+without pretending dependency/model acquisition is already a qualified normal install.
 
-A later tranche can add:
+A productization tranche still needs:
 
 - an audited/locked semantic dependency extra;
 - managed acquisition of the qualified embedding snapshot;
@@ -278,20 +250,18 @@ A later tranche can add:
 
 Lexical search stays available regardless.
 
-## Advanced provider interoperability
+## Provider interoperability without model roulette
 
 The retrieval core is provider-agnostic through `EmbeddingProvider` and
 `EmbeddingProfile` contracts.
 
-That means another local provider can be implemented without changing canonical
-transcripts, chunk custody, semantic storage, hybrid ranking, or public search results.
+Another local provider can be implemented without changing canonical transcripts, chunk
+custody, semantic storage, hybrid ranking, research evidence scope, or public search
+results.
 
-EchoFlow does **not** currently expose “paste any Hugging Face repository ID and pray”
-as ordinary CLI configuration.
-
-Different embedding models may disagree about dimensions, normalization, pooling,
-query/passage instructions, and distance semantics. Treating them as drop-in equivalents
-would make reproducibility worse.
+EchoFlow does **not** expose “paste any model repository ID and pray” as ordinary CLI
+configuration. Different models can disagree about dimensions, normalization, pooling,
+query/passage instructions, and distance semantics.
 
 Future interoperability should therefore be **qualified interoperability**: another
 provider declares and validates its complete profile, then builds a fresh semantic
@@ -299,34 +269,25 @@ generation.
 
 ## What if a better model appears later?
 
-Nothing about canonical transcript evidence has to migrate.
+Nothing about canonical transcript evidence or durable research state has to migrate.
 
 ```mermaid
 flowchart LR
-    T[Canonical transcripts] --> P1[Embedding profile v1]
-    T --> P2[Embedding profile v2]
-    P1 --> V1[Old rebuildable vectors]
-    P2 --> V2[New rebuildable vectors]
-
-    classDef evidence fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef profile fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef derived fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-
-    class T evidence
-    class P1,P2 profile
-    class V1,V2 derived
+    A[Canonical transcripts] --> B[Embedding profile v1]
+    A --> C[Embedding profile v2]
+    B --> D[Old rebuildable vectors]
+    C --> E[New rebuildable vectors]
 ```
 
 Vectors are derived state. Rebuild them. Keep the evidence.
 
-## 💃 What if I never turn semantic search on?
+## What if I never turn semantic search on?
 
-Then EchoFlow continues to use lexical search.
-
-Your transcripts remain canonical. BM25 remains local. Nothing sulks.
+Then EchoFlow continues to use lexical search. Your transcripts remain canonical, your
+research state remains durable, and BM25 remains local.
 
 Semantic retrieval is an enhancement, not a tax every user must pay.
 
-For exact implementation details, stale-state detection, vector storage, provider
-validation, and RRF provenance, descend into
+For exact implementation details, stale-state detection, vector storage, research
+pre-filtering, provider validation, and RRF provenance, descend into
 **[Evidence-first corpus search](architecture/corpus-search.md)**.

--- a/docs/speaker-names.md
+++ b/docs/speaker-names.md
@@ -10,34 +10,31 @@ speaker-03
 
 That is excellent for provenance and terrible for remembering which person was Dr. Chen.
 
-EchoFlow therefore keeps **two different facts** instead of pretending they are the same thing:
+EchoFlow therefore keeps **two different facts** instead of pretending they are the same:
 
 - `speaker-02` is machine-produced diarization evidence;
-- `Dr. Chen` is a name **you** assigned to that anonymous speaker in this transcript generation.
+- `Dr. Chen` is a name **you** assigned to that anonymous speaker in this transcript
+  generation.
 
 The friendly label never rewrites the evidence underneath it.
 
 ```mermaid
 flowchart LR
-    D[Anonymous diarization evidence] --> R[speaker-02]
-    R --> C[Canonical transcript coordinates]
-    R --> U[User-authored display label]
-    U --> V[Dr. Chen (speaker-02)]
-
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class D,R,C evidence
-    class U user
-    class V view
+    A[Anonymous diarization evidence] --> B[speaker-02]
+    B --> C[Canonical transcript coordinates]
+    B --> D[User display label]
+    D --> E[Dr. Chen plus speaker-02]
 ```
+
+Text fallback: the anonymous speaker ref remains evidence; the human name is separate
+user-authored presentation state bound to that exact transcript generation.
 
 🦝 **The raccoon may rebuild the search index. The raccoon may not eat your names.**
 
 ## Naming a speaker
 
-First make sure the transcript is present in the local library, then inspect its anonymous speaker refs:
+First make sure the transcript is present in the local library, then inspect its anonymous
+speaker refs:
 
 ```bash
 echoflow library speakers list TRANSCRIPT_ID
@@ -49,7 +46,7 @@ Assign a human-readable display label:
 echoflow library speakers name TRANSCRIPT_ID speaker-02 "Dr. Chen"
 ```
 
-EchoFlow will continue to retain `speaker-02` as the evidence reference and can present the friendly form as:
+EchoFlow keeps `speaker-02` as the evidence reference and can present:
 
 ```text
 Dr. Chen (speaker-02)
@@ -63,7 +60,7 @@ echoflow library speakers forget-name TRANSCRIPT_ID speaker-02
 
 Every command also supports `--json` for machine-readable output.
 
-## Why not just replace `speaker-02` with the name?
+## Why not replace `speaker-02` with the name?
 
 Because those statements come from different authorities.
 
@@ -75,15 +72,19 @@ You say:
 
 > I know this person is Dr. Chen, so show me that name while I work.
 
-If EchoFlow overwrote one with the other, it would destroy the distinction between **derived evidence** and **human knowledge**. That distinction matters for reproducibility, correction, auditing, and future annotations.
+Overwriting one with the other would destroy the distinction between machine-produced
+evidence and human knowledge. That distinction matters for reproducibility, correction,
+auditing, search, and durable research notes.
 
 ## What if the transcript changes?
 
-Speaker numbering is meaningful only inside the canonical transcript generation that produced it.
+Speaker numbering is meaningful only inside the canonical transcript generation that
+produced it.
 
-A re-transcription could change where speaker boundaries fall. It could even make tomorrow's `speaker-02` represent somebody different from today's `speaker-02`.
+A re-transcription could change speaker boundaries. Tomorrow's `speaker-02` could even
+represent somebody different from today's `speaker-02`.
 
-So a display label is bound to:
+A display label is therefore bound to:
 
 ```text
 transcript ID
@@ -91,43 +92,38 @@ transcript ID
 + anonymous speaker ref
 ```
 
-If the canonical transcript changes, EchoFlow **keeps the old user-authored label** but refuses to silently apply it to the new generation.
+If the canonical transcript changes, EchoFlow **keeps the old user-authored label** but
+refuses to silently apply it to the new generation.
 
 ```mermaid
 flowchart TD
-    A[Canonical transcript generation A] --> B[speaker-02]
-    B --> C[User label: Dr. Chen]
-    A -->|transcript changes| D[Canonical transcript generation B]
+    A[Canonical generation A] --> B[speaker-02]
+    B --> C[Dr. Chen label]
+    A --> D[Canonical generation B]
     D --> E[speaker-02]
-    C -. retained but stale .-> F[User-authored state]
+    C --> F[Retained historical user state]
     C -. not silently reused .-> E
-
-    classDef old fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef current fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-
-    class A,B old
-    class D,E current
-    class C,F user
 ```
 
-That is slightly fussy on purpose. EchoFlow would rather ask you to confirm a name than confidently attach Dr. Chen to the wrong human.
+That is slightly fussy on purpose. EchoFlow would rather require an explicit human action
+than confidently attach Dr. Chen to the wrong person.
 
 ## What about speaker handoffs inside one transcript segment?
 
 Word-level timing matters here.
 
-A mixed ASR segment may have no single segment-level `speaker_ref` because the speaker changes halfway through. Its individual aligned words can still carry `speaker-01` and `speaker-02` evidence.
+A mixed ASR segment may have no single segment-level `speaker_ref` because the speaker
+changes halfway through. Its individual aligned words can still carry `speaker-01` and
+`speaker-02` evidence.
 
-The speaker-label service inspects **both segment-level and aligned-word speaker evidence**, so those speakers remain available to name even when the enclosing sentence cannot honestly be assigned to one person.
-
-💃 Finer evidence, less lying. A useful trade.
+The speaker-label service inspects **both segment-level and aligned-word speaker evidence**,
+so those speakers remain available to name even when the enclosing sentence cannot
+honestly be assigned to one person.
 
 ## Reading handoffs and overlap without flattening them
 
-A speaker name is only useful if EchoFlow can show it where the evidence actually belongs.
-
-The derived speaker transcript view combines canonical word timing with the preserved speaker-turn timeline:
+The derived speaker transcript view combines canonical word timing with the preserved
+speaker-turn timeline:
 
 ```bash
 echoflow library speakers transcript TRANSCRIPT_ID
@@ -140,41 +136,41 @@ A clean handoff can become two readable spans:
 00:00:05.900  Dr. Chen (speaker-02)          single-speaker  We moved the samples.
 ```
 
-If two diarized speakers are simultaneously active over the same aligned word interval, EchoFlow does not choose a winner:
+If two diarized speakers are simultaneously active over the same aligned word interval,
+EchoFlow does not choose a winner:
 
 ```text
 00:00:12.200  Interviewer (speaker-01)
-              + Dr. Chen (speaker-02)         overlap         Sorry—
+              + Dr. Chen (speaker-02)         overlap         Sorry…
 ```
 
-And if a coarse segment contains more than one speaker but lacks word timing precise enough to assign its text, the view says `mixed-unresolved` rather than pretending the whole sentence belongs to either person.
+If a coarse segment contains more than one speaker but lacks word timing precise enough
+to assign its text, the view says `mixed-unresolved` rather than pretending the whole
+sentence belongs to either person.
 
 ```mermaid
 flowchart LR
-    W[Canonical word timing] --> P[Derived speaker presentation]
-    T[Speaker-turn timeline] --> P
-    N[Your display labels] --> P
-    P --> S[single-speaker]
-    P --> O[overlap]
-    P --> M[mixed-unresolved]
-    P --> U[unattributed]
-
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef user fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-
-    class W,T evidence
-    class N user
-    class P,S,O,M,U view
+    A[Canonical word timing] --> D[Derived speaker presentation]
+    B[Speaker-turn timeline] --> D
+    C[User display labels] --> D
+    D --> E[single-speaker]
+    D --> F[overlap]
+    D --> G[mixed-unresolved]
+    D --> H[unattributed]
 ```
 
-This view is **derived presentation**, not a new canonical transcript. Numeric source-relative seconds and the original anonymous refs remain visible in JSON, along with the canonical transcript SHA-256 that the view came from.
+This view is **derived presentation**, not a new canonical transcript. Numeric
+source-relative seconds and original anonymous refs remain visible in JSON, along with
+the canonical transcript SHA-256 that produced the view.
 
-One conservative rule matters: if a canonical aligned word is unattributed, the presentation layer will not promote it to a single named speaker merely because one diarization turn happens to overlap. Presentation may expose additional **multi-speaker overlap**, but it does not manufacture a stronger single-speaker claim than canonical evidence already made.
+One conservative rule matters: if a canonical aligned word is unattributed, presentation
+will not promote it to one named speaker merely because a diarization turn overlaps.
+Presentation may expose additional multi-speaker overlap, but it does not manufacture a
+stronger single-speaker claim than canonical evidence supports.
 
 ## Do the names show up when I search too?
 
-Yes. Ordinary transcript-library search now consumes the same current display-label state.
+Yes. Ordinary transcript-library search consumes the same current display-label state.
 
 If you assigned:
 
@@ -182,37 +178,51 @@ If you assigned:
 speaker-02 → Dr. Chen
 ```
 
-then a human search result involving that speaker can show:
+then a human search result can show:
 
 ```text
 Dr. Chen (speaker-02)
 ```
 
-Machine-readable output keeps `speaker-02` in `speaker_refs` and exposes the friendly label separately. Ranking and speaker filters still operate on anonymous evidence refs. A human name is presentation, not a new search identity.
+Machine-readable output keeps `speaker-02` in `speaker_refs` and exposes the friendly
+label separately. Ranking and speaker filters still operate on anonymous evidence refs.
 
-The search navigation layer resolves names only for the exact canonical generation behind the result. It also batches the lookup per transcript generation rather than repeatedly rereading private label state for every result row.
+The navigation layer resolves names only for the exact canonical generation behind the
+result and batches label lookup per generation.
 
-See **[From search result to the exact evidence](evidence-navigation.md)** for highlighting, context, and source seek behavior.
+See **[From search result to the exact evidence](evidence-navigation.md)** for
+highlighting, context, source seek behavior, and the evidence coordinate reused by notes.
 
 ## Where are these labels stored?
 
 Speaker names are **private user-authored state**, not rebuildable search state.
 
-They live under EchoFlow's private application state, separate from:
+They currently live under EchoFlow's private application state using the existing atomic
+private-file boundary, separate from:
 
-- the canonical transcript;
+- canonical transcript evidence;
 - the lexical DuckDB index;
-- semantic chunks and vectors; and
+- semantic chunks and vectors;
+- SQLite research notes/tags/collections; and
 - checkpoint/recovery machinery.
 
-Writes use EchoFlow's existing atomic private-file boundary.
+This means rebuilding lexical, semantic, or research query projections must not erase the
+names you assigned.
 
-This means rebuilding lexical or semantic search must not erase the names you assigned.
+A later consolidation into the transactional research-state store is possible if it earns
+its value, but presentation code should continue to use the application service rather
+than depend on the physical adapter.
 
 ## What this does not do
 
-Speaker display labels are not biometric identification. EchoFlow does not infer that `speaker-01` in two different recordings is the same person, and it does not search for somebody's identity from their voice.
+Speaker display labels are not biometric identification. EchoFlow does not infer that
+`speaker-01` in two recordings is the same person, and it does not search for somebody's
+identity from their voice.
 
-Overlap-aware presentation also does not perform source separation. It represents simultaneous speaker evidence honestly using the timeline EchoFlow already has. Separating overlapping audio into estimated sources remains a later and materially heavier capability with its own compute, model-custody, and provenance requirements.
+Overlap-aware presentation also does not perform source separation. It represents
+simultaneous speaker evidence using the timeline EchoFlow already has. Separating
+mixed speech into estimated sources remains later and materially heavier, with its own
+compute, model-custody, and provenance requirements.
 
-For the underlying diarization evidence model, security gate, and overlap rules, see **[Anonymous speaker diarization](architecture/diarization.md)**.
+For the underlying diarization evidence model, security gate, and overlap rules, see
+**[Anonymous speaker diarization](architecture/diarization.md)**.

--- a/docs/time-navigation.md
+++ b/docs/time-navigation.md
@@ -1,36 +1,32 @@
 # 🕰️ Transcript time without calculator gymnastics
 
-A transcript is much more useful when “where did they say that?” has an answer that a
-human can actually use.
+A transcript is much more useful when “where did they say that?” has an answer a human can
+actually use.
 
 EchoFlow keeps **one durable numeric source-relative timeline** and derives familiar
 clock-style coordinates from it.
 
-If a passage begins `4788.37` seconds into a recording, you should not have to divide by
-60 twice in your head. EchoFlow can present that as:
+If a passage begins `4788.37` seconds into a recording, EchoFlow can present:
 
 ```text
 01:19:48.370
 ```
 
-That means **1 hour, 19 minutes, 48 seconds, and 370 milliseconds after the beginning of
-the selected recording audio**.
+That means 1 hour, 19 minutes, 48 seconds, and 370 milliseconds after the beginning of
+the selected recording audio.
 
-🦝 The raccoon has been relieved of manual base-60 arithmetic duties.
+The numeric coordinate is the anchor. The clock string is presentation.
 
 ## What did word timestamps add?
 
-Before word timing, a transcript segment might say:
+Before word timing, a segment might say:
 
 ```text
 01:19:40.000 → 01:20:02.000
 "We eventually realized the housing cost was the real problem."
 ```
 
-That tells you where the sentence-sized segment lives, but not where a particular phrase
-inside it begins.
-
-With native word timing, the canonical transcript can retain finer evidence:
+With native word timing, canonical evidence can retain finer positions:
 
 ```text
 "housing"  → 4788.370 s
@@ -38,7 +34,7 @@ With native word timing, the canonical transcript can retain finer evidence:
 "problem"  → 4791.125 s
 ```
 
-The pretty display is derived from those numeric coordinates:
+and render them as:
 
 ```text
 "housing"  → 01:19:48.370
@@ -46,31 +42,23 @@ The pretty display is derived from those numeric coordinates:
 "problem"  → 01:19:51.125
 ```
 
-The numbers are the anchor. The clock-style strings are the label on the drawer.
-
 ```mermaid
 flowchart LR
-    W[Canonical word evidence\n4788.370 seconds] --> H[Human display\n01:19:48.370]
-    W --> S[Search evidence locator\nseek to 4788.370]
-    W --> P[Future local player]
-    W --> N[Future note anchor]
-
-    classDef truth fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-    class W truth
-    class H,S,P,N view
+    A[Canonical word time 4788.370 seconds] --> B[Human display 01:19:48.370]
+    A --> C[Search seek coordinate]
+    A --> D[Durable note anchor]
+    A --> E[Future local player]
 ```
 
 ## Can search find the exact place now?
 
 Yes, when the retrieval evidence justifies that precision.
 
-The transcript-library navigation layer now reopens the exact canonical transcript,
-verifies its SHA-256, and resolves a ranked search result back to canonical segments and
-aligned words.
+The library navigation layer reopens the exact canonical transcript, verifies its
+SHA-256, and resolves a ranked search result back to canonical segments and aligned words.
 
-For lexical search, matching aligned words can become the exact highlighted evidence and
-the first matched word becomes the preferred source seek coordinate.
+For lexical search, matching aligned words can become exact highlighted evidence and the
+first matched word becomes the preferred source seek coordinate.
 
 For example:
 
@@ -81,60 +69,66 @@ seek_seconds: 4788.370
 seek_timestamp: 01:19:48.370
 ```
 
-Semantic-only retrieval is intentionally less precise. An embedding can say “this
-passage is related to your query” without identifying one exact matching word. EchoFlow
-therefore exposes the verified passage and its start time rather than fabricating a word
-highlight.
-
-Read **[From search result to the exact evidence](evidence-navigation.md)** for context
-expansion, speaker names, and the full search-to-canonical contract.
+Semantic-only retrieval is intentionally less precise. An embedding can say “this passage
+is related” without identifying one exact matching word. EchoFlow therefore exposes the
+verified passage and its start time rather than fabricating a word highlight.
 
 ## Can I click a word and jump to the recording?
 
-**The application coordinate needed for that now exists.**
+**The application coordinate needed for that exists.**
 
 A local player can seek the original recording using numeric `seek_seconds`. Search
-navigation now exposes that coordinate directly, so a future GUI does not need to guess
+navigation exposes that coordinate directly, so the planned GUI does not need to guess
 from rendered text or reconstruct internal work chunks.
 
-EchoFlow does **not yet ship the graphical media-player click handler**. The missing
-piece is presentation, not timeline plumbing.
+EchoFlow does **not yet ship the graphical media-player interaction**. The missing piece
+is presentation, not timeline plumbing.
 
 ## What about notes and annotations? 📝
 
-Notes are planned as **durable user-authored knowledge**, not search-index metadata.
-There is not yet a finished notes editor or annotation store.
+Notes are implemented durable user-authored state.
 
-The evidence-navigation layer now gives that future feature a concrete anchor to reuse:
+`EvidenceAnchor` reuses the same canonical/source-relative coordinate system as search
+navigation:
 
 ```text
+document ID
 source SHA-256
 canonical transcript SHA-256
 canonical segment ID(s)
-word index/indices when available
 numeric start/end seconds
+```
+
+The CLI can add a note to a canonical segment:
+
+```bash
+echoflow library notes add JOB_ID segment-000042 \
+  --body "Compare this with the 2024 survey."
 ```
 
 A note should **not** anchor only to:
 
 ```text
-"01:19:48.370"
+01:19:48.370
 ```
 
-because that is presentation. It also should not anchor only to a semantic-search chunk
-ID because chunks and indexes are rebuildable.
+because that is presentation. It also should not anchor only to a semantic-search chunk ID
+because chunks and indexes are rebuildable.
 
-If the librarian rebuilds the index, the note must remain attached to durable evidence.
-If the canonical transcript changes, EchoFlow should retain the note and report that its
-old anchor needs review rather than silently moving it.
+If an index is rebuilt, the note remains attached to durable evidence. If the canonical
+transcript changes, EchoFlow keeps the note but treats its old generation as stale rather
+than silently moving the annotation.
+
+The first GUI can turn transcript selection into the same verified anchor instead of
+inventing a GUI-only coordinate system.
 
 ## Do internal work chunks reset the clock?
 
 No.
 
-EchoFlow currently uses application-owned work windows that are **10 minutes by default**
-(`600` seconds). Those windows exist so long recordings can be processed and
-checkpointed safely. They are an implementation detail.
+EchoFlow currently uses application-owned work windows up to 600 seconds. Those windows
+exist so long recordings can be processed and checkpointed safely. They are an
+implementation detail.
 
 When a work window starts at `4200` seconds and faster-whisper reports a word at `588.37`
 seconds inside that window, assembly rebases it onto the source timeline:
@@ -145,10 +139,7 @@ seconds inside that window, assembly rebases it onto the source timeline:
                  01:19:48.370
 ```
 
-The published coordinate never resets to zero because EchoFlow happened to create a new
-work file.
-
-💃 Internal segmentation may change costumes. The source timeline does not.
+The published coordinate never resets to zero because EchoFlow created a new work file.
 
 ## What if the camera or media file already has a timecode?
 
@@ -161,32 +152,22 @@ timecode:      10:00:00:00
 creation_time: 2026-04-05T12:34:56Z
 ```
 
-EchoFlow asks FFprobe for `timecode` and `creation_time` at both container and stream
-scope. When present, those declarations are preserved in canonical source provenance,
-including where they came from.
+EchoFlow asks FFprobe for `timecode` and `creation_time` at both container and stream scope.
+When present, those declarations are preserved in canonical source provenance, including
+where they came from.
 
 EchoFlow does **not** silently decide that a camera tag is true. Devices can have wrong
 clocks, copied metadata, conflicting stream tags, or timecode with frame-rate/drop-frame
 semantics that require more information before arithmetic is safe.
 
-So the model stays parallel:
-
 ```mermaid
 flowchart LR
-    M[Original media] --> E[Canonical elapsed time\n0.000 s → ...]
-    M --> T[Declared timecode\nif source provides it]
-    M --> C[Declared creation time\nif source provides it]
-
-    E --> X[Canonical transcript evidence]
-    T --> X
-    C --> X
-
-    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef canonical fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef provenance fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    class M source
-    class E,X canonical
-    class T,C provenance
+    A[Original media] --> B[Canonical elapsed seconds]
+    A --> C[Declared timecode if present]
+    A --> D[Declared creation time if present]
+    B --> E[Canonical transcript evidence]
+    C --> E
+    D --> E
 ```
 
 **Elapsed time answers:** “where is this inside the selected recording?”
@@ -221,16 +202,17 @@ already gives a local player a deterministic seek coordinate.
 | Speaker handoff inside one ASR segment | word evidence can carry the handoff without inventing one segment speaker |
 | Original `timecode` metadata | preserved when FFprobe reports it, with source scope |
 | Original `creation_time` metadata | preserved when FFprobe reports it, with source scope |
-| Click word to play source | seek contract is ready; graphical player interaction is still future UI work |
-| Durable notes/annotations | evidence anchor is ready; editor/storage is still future work |
+| Durable notes/annotations | verified evidence anchors stored with authoritative user state |
+| Click word to play source | seek contract is ready; graphical player interaction is future UI work |
 | SMPTE frame arithmetic | intentionally not inferred without qualified frame semantics |
 
 ## The small rule underneath all of this
 
-**Store evidence coordinates. Derive pretty clocks. Preserve source claims. Do not
-confuse the three.** ✨
+**Store evidence coordinates. Derive pretty clocks. Preserve source claims. Do not confuse
+the three.** ✨
 
 For the exact implementation contract, see
 **[Media normalization and transcript timeline](architecture/media-and-timeline.md)**,
-**[Word-level timestamp alignment](architecture/word-alignment.md)**, and
-**[Evidence-first corpus search](architecture/corpus-search.md)**.
+**[Word-level timestamp alignment](architecture/word-alignment.md)**,
+**[Evidence-first corpus search](architecture/corpus-search.md)**, and
+**[Your notes should survive the machinery](research-notes.md)**.


### PR DESCRIPTION
## Summary

Bring the documentation store forward to the product that exists after PR #64 instead of continuing to describe durable research state as future work.

This is a documentation-only reconciliation pass. It updates the front door, roadmap, architecture index, feature guides, security boundary, development/testing guidance, and performance roadmap so they agree on the current custody model and next product sequence.

## Current state now documented

- canonical transcript JSON remains authoritative transcript evidence
- SQLite is authoritative for durable notes/tags/collections and evidence anchors
- DuckDB lexical, semantic, and research databases remain rebuildable projections
- `ResearchWorkspaceService` is the application-facing seam over verified evidence, durable user state, projection convergence, and research-aware search
- research constraints are applied before lexical ranking / semantic scoring
- stale canonical generations retain user notes without silently re-anchoring them
- projection watermark, incremental replay, rebuild, and fail-closed semantics are documented consistently

## Roadmap

The new near-term sequence is:

1. unified library discovery
2. saved searches + useful derived navigation such as frequent/recent tags
3. first thin GUI over existing services and `EvidenceAnchor`
4. portable research export + incremental library refresh
5. corpus-scale / representative-device qualification
6. semantic dependency/model-custody productization and installer work

Saved searches are treated as durable user-authored SQLite state. Frequent/recent tag rankings are explicitly derived views rather than authoritative counters.

## Diagrams

High-traffic/load-bearing Mermaid diagrams have been simplified toward portable flowchart syntax, and important diagrams now include prose/text fallbacks. The documentation-style guide now treats renderer portability and textual fallback as part of the diagram contract rather than relying on custom styling for meaning.

## Security and testing

- `SECURITY.md` now treats SQLite research authority and the DuckDB research projection as sensitive private local state, while preserving the distinction that only SQLite contains authoritative human work.
- development docs record the 90% branch-coverage gate and explicitly reject tautological coverage tests in favor of observable behavioral contracts.
- benchmarking guidance now includes corpus refresh, research projection, research-aware retrieval, unified discovery, and eventual GUI responsiveness.

## Scope

No production code changes. Dated historical security audits and narrow implementation documents that remain accurate are intentionally left as historical/feature-specific records rather than being rewritten for churn.