### PR TITLE
feat(library): add unified library discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ It does more than run a speech model. EchoFlow inspects the machine it is runnin
 chooses a safe execution strategy, manages local model custody, survives interrupted
 work, preserves source provenance, publishes portable transcripts, keeps word-level
 timing evidence, handles anonymous speaker evidence conservatively, searches a private
-local corpus, navigates results back to verified canonical evidence, and stores durable
-notes/tags/collections separately from rebuildable search machinery.
+local corpus, navigates results back to verified canonical evidence, stores durable
+notes/tags/collections separately from rebuildable search machinery, and now gives those
+capabilities one grouped library-discovery doorway.
 
 The original recording remains read-only source evidence. Canonical transcript JSON is
 the authoritative transcript artifact. Human-authored research state is authoritative
@@ -47,6 +48,7 @@ recording-to-research lifecycle.
 | Evidence navigation | canonical-hash verification, aligned lexical highlights, bounded context expansion, speaker display integration, and deterministic source seek coordinates |
 | Research workspace | authoritative SQLite notes/tags/collections anchored to exact canonical evidence, plus a rebuildable DuckDB research projection |
 | Research-aware search | tag, collection, note-text, and with-notes constraints applied before lexical ranking or semantic scoring |
+| Unified discovery | one grouped query across transcript evidence, notes, tags, and collections with no fabricated cross-type relevance score |
 | Quality | Linux/macOS/Windows CI, strict typing, lint/format/security rules, complexity/dead-code checks, branch coverage, dependency audit, package build, and clean-wheel verification |
 
 The point is not that users should learn every subsystem. It is that most of the annoying
@@ -67,11 +69,14 @@ flowchart LR
     H --> I[Context highlights and seek]
     I --> J[Durable notes tags collections]
     J --> G
+    G --> K[Unified library discovery]
+    J --> K
 ```
 
 Text fallback: the original recording produces a canonical transcript; rebuildable search
 ranks passages; canonical navigation verifies those passages; durable research state is
-attached to exact evidence and can constrain later searches.
+attached to exact evidence and can constrain later searches; unified discovery composes
+transcript evidence and research objects into one grouped human-facing query.
 
 Search ranking is intentionally not source truth. A ranked result points back to canonical
 transcript coordinates, and the navigation layer verifies that canonical generation
@@ -142,19 +147,33 @@ Build the private lexical library:
 uv run echoflow library rebuild
 ```
 
-Search it:
+Search transcript evidence directly:
 
 ```bash
 uv run echoflow library search "housing insecurity"
 ```
 
-Add neighboring canonical context without changing ranking:
+Or use the one-box grouped library doorway:
 
 ```bash
-uv run echoflow library search "housing insecurity" --context-segments 1
+uv run echoflow library find "housing insecurity"
 ```
 
-Research metadata can constrain transcript retrieval before scoring:
+`library find` returns separate transcript-evidence, note, tag, and collection groups.
+Transcript evidence keeps its own lexical/semantic/hybrid ranking provenance. Notes and
+labels remain their own object types rather than receiving a made-up universal score.
+
+Add neighboring canonical context without changing transcript ranking:
+
+```bash
+uv run echoflow library find "housing insecurity" --context-segments 1
+```
+
+If local semantic state is available, `--mode semantic` or `--mode hybrid` changes only
+the transcript-evidence group. Note, tag, and collection lookup remains deterministic
+local text lookup.
+
+Research metadata can also constrain transcript retrieval before scoring:
 
 ```bash
 uv run echoflow library search \
@@ -179,7 +198,8 @@ The CLI currently exposes canonical segment IDs because it needs a real evidence
 A future graphical shell can turn transcript selection into the same verified
 `EvidenceAnchor` without asking a normal person to type IDs.
 
-Read **[Your notes should survive the machinery](docs/research-notes.md)** and
+Read **[Find things across the whole local library](docs/library-discovery.md)**,
+**[Your notes should survive the machinery](docs/research-notes.md)**, and
 **[From search result to the exact evidence](docs/evidence-navigation.md)** for the human
 versions of those contracts.
 
@@ -210,7 +230,7 @@ Read **[Semantic search, without the mystery box](docs/semantic-search.md)**.
 | Lexical search database | private search projection | Yes |
 | Semantic chunks/vectors | private search projection | Yes |
 | Research query projection | derived relationships/terms over durable research state | Yes |
-| Evidence-navigation views | derived presentation over canonical evidence | Yes |
+| Evidence-navigation/discovery views | derived presentation over canonical evidence and durable user state | Yes |
 
 A database is allowed to make evidence useful. It is not allowed to become the only place
 unique evidence or human research exists.
@@ -237,21 +257,22 @@ Poodle is reserved for load-bearing decision logic rather than routine per-commi
 
 ## Where the project goes next
 
-The backend research-state foundation is built. The highest-value next work is no longer
-another database.
+The backend research-state foundation and unified library doorway are built. The
+highest-value next work is now **remembering useful views and reducing navigation
+friction**, not adding another storage engine.
 
 The sequence is now:
 
-1. **Unified library discovery**: one human-facing doorway across transcript evidence,
-   notes, tags, collections, and later saved searches without exposing storage topology.
-2. **Saved searches and useful derived navigation**: durable saved query intent plus
-   derived frequent/recent tags, facets, and citable/selected result sets where they help.
-3. **First thin GUI**: browse/search transcripts, select evidence, add/edit notes and tags,
+1. **Saved searches and useful derived navigation**: durable saved query intent plus
+   derived frequent/recent tags, facets, and selected/citable result sets where they help.
+2. **First thin GUI**: browse/find transcripts, select evidence, add/edit notes and tags,
    and jump to source media by reusing existing application services and evidence anchors.
-4. **Research portability and corpus-scale ergonomics**: durable research export,
+3. **Research portability and corpus-scale ergonomics**: durable research export,
    incremental library refresh, and measured performance on realistic corpora.
-5. **Productization**: qualify semantic installation/model custody, representative
-   consumer hardware, installers, and polished recovery language.
+4. **Representative-device qualification**: verify interaction and processing behavior on
+   ordinary 8/16 GB systems, Apple Silicon, discrete-GPU machines, and larger workstations.
+5. **Productization**: qualify semantic installation/model custody, installers, and
+   polished recovery language.
 
 Source separation for genuinely overlapping speech remains later. It should earn its
 model/compute/provenance cost with measured benefit on real recordings.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,14 +20,15 @@ flowchart LR
     C --> D[Lexical semantic hybrid retrieval]
     D --> E[Verified evidence navigation]
     E --> F[Durable research workspace]
-    F --> G[Unified library discovery]
+    D --> G[Unified library discovery]
+    F --> G
     G --> H[Saved views and derived navigation]
     H --> I[Thin graphical shell]
 ```
 
-Text fallback: transcription, evidence preservation, retrieval, navigation, and durable
-research state are foundation. Unified discovery is next; saved views/derived navigation
-follow; the first GUI should sit on those same services rather than inventing another
+Text fallback: transcription, evidence preservation, retrieval, navigation, durable
+research state, and unified discovery are foundation. Saved views and derived navigation
+are next; the first GUI should sit on those same services rather than inventing another
 application.
 
 # Current foundation
@@ -165,35 +166,39 @@ The custody hierarchy is now:
 
 🦝 The raccoon may rebuild an index. The raccoon may not eat your annotations.
 
+## Unified library discovery
+
+This is now **foundation** too.
+
+`ResearchWorkspaceService.discover()` and `echoflow library find QUERY` provide one human
+query across four typed result groups:
+
+- transcript evidence through existing lexical/semantic/hybrid retrieval and verified
+  canonical navigation;
+- note prose through the research projection followed by authoritative SQLite hydration;
+- matching tag names; and
+- matching collection names.
+
+The discovery layer deliberately does not create a universal relevance score across
+unlike objects. Transcript ranks remain transcript ranks. Notes, tags, and collections
+remain their own object types.
+
+Name matching for tags/collections is deterministic and group-local. Exact names sort
+before prefix/substring matches, then token overlap. That ordering is a disposable view,
+not authoritative state.
+
+Per-group limits, canonical context, stale-note state, speaker presentation, evidence
+identity, and source seek coordinates remain visible through the same application
+contracts a future GUI can consume.
+
 # Near-term product sequence
 
-The next work should make the existing backend **easy to use** rather than reopening
-solved custody/search contracts.
+The next work should make the existing backend **pleasant to remember and navigate** rather
+than reopening solved custody/search contracts.
 
-## 1. Unified library discovery
+## 1. Saved searches and useful derived navigation
 
 This is the next feature tranche.
-
-Today users can search transcript evidence and query notes, but the surfaces still expose
-the history of how the backend was built. The product should provide one human-facing
-library doorway.
-
-Target direction:
-
-- one typed application query that can surface grouped transcript evidence, notes, tags,
-  collections, and eventually saved searches;
-- preserve type-specific semantics rather than inventing one fake score across unlike
-  result kinds;
-- reuse `ResearchWorkspaceService`, `EvidenceLocator`, and existing transcript retrieval;
-- keep storage topology invisible to presentation code;
-- show stable human evidence coordinates while retaining exact canonical IDs in
-  machine-readable output; and
-- leave room for the GUI to consume the exact same discovery service.
-
-A likely CLI shape is `echoflow library find QUERY`, but the application service contract
-matters more than the command spelling.
-
-## 2. Saved searches and useful derived navigation
 
 Saved searches are **durable user-authored workspace state** and belong in authoritative
 SQLite. They should preserve typed query intent, not a blob of rendered CLI text.
@@ -211,7 +216,7 @@ Useful derived navigation should remain disposable. Candidate conveniences inclu
 Do not make every convenience statistic another authoritative table. The durable object
 is the user's tag/search/collection; popularity and recency rankings are views.
 
-## 3. First thin GUI
+## 2. First thin GUI
 
 The GUI has now earned its place because the backend is ahead of the human interface.
 
@@ -235,7 +240,7 @@ where evidence lives.
 Visual direction can be refined later, but the intended shell is light, calm, legible,
 and evidence-first rather than dashboard-heavy.
 
-## 4. Research portability and selected-result export
+## 3. Research portability and selected-result export
 
 Portability is part of EchoFlow's ownership thesis, not decorative export polish.
 
@@ -252,7 +257,7 @@ segment IDs, and numeric start/end seconds where applicable.
 Native XLSX is optional later. CSV already opens in Excel, Numbers, LibreOffice, R,
 pandas, and many research tools without adding a workbook dependency.
 
-## 5. Incremental library refresh and corpus-scale qualification
+## 4. Incremental library refresh and corpus-scale qualification
 
 `library rebuild` remains the correct repair path, but normal growth should not require
 re-reading an entire large corpus because one transcript changed.
@@ -270,10 +275,10 @@ Keep full rebuild as explicit recovery.
 
 Then measure realistic corpora rather than optimizing by instinct. Representative
 qualification should include startup, warm/cold search, filtered lexical/semantic queries,
-notebook queries, one-edit projection catch-up, large-batch projection catch-up, and full
-rebuild behavior.
+unified-discovery latency, notebook queries, one-edit projection catch-up, large-batch
+projection catch-up, and full rebuild behavior.
 
-## 6. Qualify semantic dependency and managed embedding custody
+## 5. Qualify semantic dependency and managed embedding custody
 
 Before semantic search is advertised as a normal source install, qualify a locked
 optional semantic dependency set with:
@@ -289,7 +294,7 @@ optional semantic dependency set with:
 
 Do not bypass `uv.lock` coherence merely to make the feature look finished.
 
-## 7. Representative-device dogfooding and delivery
+## 6. Representative-device dogfooding and delivery
 
 Exercise real multi-recording corpora on at least:
 
@@ -331,8 +336,8 @@ cases before entering the normal product path.
 
 ## Typed query evolution
 
-The unified discovery/search surface should compile into typed query contracts. Do not let
-CLI flags, GUI chips, saved searches, and a future natural-language convenience layer grow
+The unified discovery/search surface compiles into typed query contracts. Do not let CLI
+flags, GUI chips, saved searches, and a future natural-language convenience layer grow
 separate semantics.
 
 Add date/duration/fuzzy/facet constraints only when real use needs them.

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ evidence corpus with durable user-authored research state.
 | Keep durable research notes | stores notes, tags, and collections in authoritative private SQLite state anchored to exact canonical evidence |
 | Query your notebook quickly | projects only query-relevant research relationships and lexical terms into rebuildable DuckDB state |
 | Search transcript evidence through your notes | applies tag/collection/note-text constraints before lexical ranking or semantic scoring |
+| Find related things across the whole workspace | returns grouped transcript evidence, notes, tags, and collections through one discovery query without inventing a cross-type score |
 
 The point is not to make users operate the machinery. The point is to make sensitive local
 transcription and research feel boringly dependable.
@@ -54,6 +55,14 @@ Start with **[Getting started](getting-started.md)**.
 
 It walks through installation, model setup, transcription, resume, exports, search, and
 the current command-line research notebook.
+
+### 🔎 I want one search box for the whole library
+
+Read **[Find things across the whole local library](library-discovery.md)**.
+
+It explains `echoflow library find QUERY`, why transcript evidence/notes/tags/collections
+stay in separate result groups, what semantic mode does and does not affect, and how this
+same application response is intended to feed the first GUI.
 
 ### 📝 I want to keep notes beside the evidence
 
@@ -118,13 +127,16 @@ flowchart LR
     D --> E[Verified evidence navigation]
     E --> F[Research notebook]
     F --> D
-    F --> G[Future unified discovery and GUI]
+    D --> G[Unified library discovery]
+    F --> G
+    G --> H[Future saved views and GUI]
 ```
 
 Text fallback: canonical evidence feeds rebuildable search; search resolves back to
 verified evidence; durable notes/tags/collections attach to that evidence and can constrain
-later retrieval; the next user-facing layer unifies those capabilities rather than
-reimplementing them.
+later retrieval; unified discovery now composes transcript evidence and research objects
+into one grouped human doorway. Saved views and the GUI can build on that response instead
+of reimplementing the backend.
 
 The shared rule is simple:
 
@@ -155,21 +167,21 @@ something has gone very wrong.
 
 The research-navigation sequence that used to live here as future work is now foundation:
 word timing, human/source time semantics, speaker display labels, overlap-aware speaker
-presentation, verified search navigation, and durable notes/tags/collections are all
-implemented.
+presentation, verified search navigation, durable notes/tags/collections, and unified
+library discovery are implemented.
 
 The next layers are intentionally more human-facing:
 
-1. **Unified library discovery** across transcript evidence, notes, tags, collections, and
-   later saved searches.
-2. **Saved searches and useful derived navigation**, including frequent/recent tags and
+1. **Saved searches and useful derived navigation**, including frequent/recent tags and
    facets where they reduce hunting without creating new authoritative counters.
-3. **A thin graphical shell** that can browse/search transcripts, select evidence, create
+2. **A thin graphical shell** that can browse/find transcripts, select evidence, create
    notes, apply tags/collections, and seek local media using existing application services.
-4. **Portable research export and incremental library refresh** so ownership and larger
+3. **Portable research export and incremental library refresh** so ownership and larger
    corpora remain pleasant rather than merely correct.
-5. **Productization** through semantic-install qualification, representative-device
-   dogfooding, installers, and polished recovery/error language.
+4. **Corpus-scale and representative-device qualification** so latency/resource decisions
+   are measured on real workloads rather than guessed.
+5. **Productization** through semantic-install qualification, installers, and polished
+   recovery/error language.
 
 The GUI should be a presentation adapter, not a second implementation of transcription,
 search, time mapping, speaker policy, evidence anchoring, or research-state custody.

--- a/docs/library-discovery.md
+++ b/docs/library-discovery.md
@@ -1,0 +1,192 @@
+# Find things across the whole local library 🔎
+
+A research library stops feeling like a pile of subsystems when one question can look in
+all the places a person actually remembers.
+
+EchoFlow's unified discovery surface does that without pretending every kind of result is
+the same thing.
+
+```bash
+uv run echoflow library find "housing affordability"
+```
+
+One query can return four separate groups:
+
+- **Transcript evidence** ranked through the existing lexical, semantic, or hybrid
+  retrieval path and resolved back to verified canonical evidence.
+- **Your notes** found through the rebuildable research projection, then hydrated from
+  authoritative SQLite state.
+- **Tags** whose names match the query.
+- **Collections** whose names match the query.
+
+A note does not receive a fake BM25 score so it can compete with a transcript passage. A
+tag does not become "82% relevant" because a different subsystem happened to emit a
+number. EchoFlow keeps the result types separate and useful.
+
+## The simple mental model
+
+```mermaid
+flowchart LR
+    Q[One library query] --> T[Transcript evidence]
+    Q --> N[Your notes]
+    Q --> G[Tags]
+    Q --> C[Collections]
+    T --> R[Grouped discovery response]
+    N --> R
+    G --> R
+    C --> R
+```
+
+Text fallback: one human query fans out through existing typed capabilities and returns
+separate transcript, note, tag, and collection groups. The discovery layer composes those
+capabilities; it is not another database.
+
+## Why grouped results?
+
+Different objects answer different questions.
+
+A transcript passage answers:
+
+> Where did somebody actually say this?
+
+A note answers:
+
+> What did I write about this evidence?
+
+A tag answers:
+
+> What label have I already been using for this idea?
+
+A collection answers:
+
+> Which research grouping might I want to open?
+
+Those are related, but they are not interchangeable. Keeping them grouped makes the UI
+more honest and gives a future graphical shell a clean set of sections or tabs.
+
+## Human output
+
+The default terminal view renders separate sections for transcript evidence, notes, tags,
+and collections.
+
+Transcript results retain source-relative seek coordinates, speaker presentation, and
+research-state decoration. Notes retain their current/stale canonical-generation state.
+That means an old note does not disappear merely because a transcript was regenerated.
+It remains visible as an older-generation note until a person explicitly decides what to
+do with it.
+
+## Machine-readable output
+
+```bash
+uv run echoflow library find "housing" --json
+```
+
+The JSON response keeps the same grouping:
+
+```text
+query
+total_count
+groups
+  transcripts
+    retrieval_mode
+    count
+    results
+  notes
+    count
+    results
+  tags
+    count
+    results
+  collections
+    count
+    results
+```
+
+Transcript results keep evidence identity, seek coordinates, speaker refs/display labels,
+ranks, and associated research state. Notes retain authoritative note content plus durable
+evidence anchors.
+
+## Semantic and hybrid discovery
+
+By default, the transcript group uses lexical retrieval:
+
+```bash
+uv run echoflow library find "housing" --mode lexical
+```
+
+If local semantic state has been qualified and built, the transcript group can use:
+
+```bash
+uv run echoflow library find "people struggling to make rent" --mode semantic
+uv run echoflow library find "people struggling to make rent" --mode hybrid
+```
+
+`--mode` affects **transcript evidence only**. Notes, tag names, and collection names stay
+on deterministic local text lookup. EchoFlow does not embed a tag just because the
+transcript side happens to use embeddings.
+
+## Limits and context
+
+`--limit` is a **per-group** limit:
+
+```bash
+uv run echoflow library find "housing" --limit 10
+```
+
+That can return up to ten transcript results, ten notes, ten tags, and ten collections.
+The current maximum is 100 per group.
+
+Transcript evidence can also include bounded canonical context:
+
+```bash
+uv run echoflow library find "housing" --context-segments 1
+```
+
+Context expansion remains post-ranking, exactly as it does for ordinary transcript
+search.
+
+## How label matching works
+
+Tags and collections use deterministic group-local matching. Exact names come first,
+followed by prefix/substring matches and then token overlap. This ordering is only for
+names inside those groups.
+
+It is **not** a universal relevance score and is not persisted as authoritative state.
+Future frequent/recent tag navigation will likewise be derived from durable relationships
+rather than maintained as fragile counters.
+
+## What this reuses
+
+Unified discovery deliberately builds on existing application contracts:
+
+```text
+ResearchWorkspaceService
+  transcript search + verified navigation
+  authoritative note hydration
+  tag / collection state
+        |
+        v
+WorkspaceDiscoveryResponse
+        |
+        +--> CLI today
+        +--> thin GUI later
+```
+
+SQLite remains authoritative for unique human research. DuckDB remains rebuildable query
+acceleration. Canonical transcript JSON remains transcript evidence. `find` changes none
+of those custody rules.
+
+## What comes next
+
+The next useful research-navigation tranche is **saved searches plus derived navigation**:
+
+- durable saved typed query intent;
+- most-used and recently used tags/collections as derived views;
+- useful facets/counts where they reduce hunting;
+- selected/citable result sets; and
+- stale-anchor review affordances.
+
+After that, the first thin GUI can make the same discovery response visual rather than
+inventing another search architecture.
+
+🦝 One doorway. Same floorboards.

--- a/src/echoflow/cli_discovery.py
+++ b/src/echoflow/cli_discovery.py
@@ -1,0 +1,311 @@
+"""CLI presentation for unified transcript and research-workspace discovery."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, cast
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from echoflow.app.app_container import AppContainer
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.research_workspace import (
+    ResearchNoteView,
+    WorkspaceDiscoveryResponse,
+    WorkspaceSearchPassage,
+)
+from echoflow.library.retrieval import RetrievalMode
+from echoflow.media.time_coordinates import format_elapsed_timestamp
+
+ContainerFactory = Callable[[typer.Context], AppContainer]
+
+
+def _root_context(context: typer.Context) -> typer.Context:
+    return cast("typer.Context", context.find_root())
+
+
+def _handle_error(exc: Exception) -> None:
+    if isinstance(exc, EchoFlowError):
+        typer.echo(exc.public_message, err=True)
+        raise typer.Exit(code=exc.exit_code) from None
+    if isinstance(exc, (ValueError, ModuleNotFoundError)):
+        raise typer.BadParameter(str(exc)) from exc
+    typer.echo(
+        f"EchoFlow library discovery failed internally ({type(exc).__name__})",
+        err=True,
+    )
+    raise typer.Exit(code=3) from None
+
+
+def _transcript_dict(result: WorkspaceSearchPassage) -> dict[str, object]:
+    located = result.located
+    passage = located.passage
+    evidence = located.evidence
+    return {
+        "document_id": passage.document_id,
+        "source_sha256": passage.source_sha256,
+        "canonical_sha256": passage.canonical_sha256,
+        "canonical_path": passage.canonical_path,
+        "source_path": passage.source_path,
+        "segment_ids": list(passage.segment_ids),
+        "start_seconds": passage.start_seconds,
+        "end_seconds": passage.end_seconds,
+        "start_timestamp": format_elapsed_timestamp(passage.start_seconds),
+        "end_timestamp": format_elapsed_timestamp(passage.end_seconds),
+        "seek_seconds": evidence.seek_seconds,
+        "seek_timestamp": format_elapsed_timestamp(evidence.seek_seconds),
+        "text": passage.text,
+        "languages": list(passage.languages),
+        "speaker_refs": list(passage.speaker_refs),
+        "speaker_display_labels": {
+            item.speaker_ref: item.display_label
+            for item in located.speakers
+            if item.display_label is not None
+        },
+        "lexical_rank": passage.lexical_rank,
+        "semantic_rank": passage.semantic_rank,
+        "fused_rank": passage.fused_rank,
+        "research_state": {
+            "note_ids": list(result.research.note_ids),
+            "note_count": result.research.note_count,
+            "tags": list(result.research.tags),
+            "collections": list(result.research.collections),
+        },
+    }
+
+
+def _note_dict(view: ResearchNoteView) -> dict[str, object]:
+    note = view.note
+    anchor = note.anchor
+    return {
+        "note_id": note.note_id,
+        "body": note.body,
+        "created_at": note.created_at,
+        "updated_at": note.updated_at,
+        "current": view.current,
+        "tags": list(view.tags),
+        "collections": list(view.collections),
+        "anchor": {
+            "document_id": anchor.document_id,
+            "source_sha256": anchor.source_sha256,
+            "canonical_sha256": anchor.canonical_sha256,
+            "segment_ids": list(anchor.segment_ids),
+            "start_seconds": anchor.start_seconds,
+            "end_seconds": anchor.end_seconds,
+            "start_timestamp": format_elapsed_timestamp(anchor.start_seconds),
+            "end_timestamp": format_elapsed_timestamp(anchor.end_seconds),
+        },
+    }
+
+
+def _response_dict(response: WorkspaceDiscoveryResponse) -> dict[str, object]:
+    retrieval = response.transcripts.navigation.retrieval
+    return {
+        "query": response.query,
+        "total_count": response.total_count,
+        "groups": {
+            "transcripts": {
+                "count": len(response.transcripts.results),
+                "retrieval_mode": retrieval.mode.value,
+                "results": [
+                    _transcript_dict(item) for item in response.transcripts.results
+                ],
+            },
+            "notes": {
+                "count": len(response.notes),
+                "results": [_note_dict(item) for item in response.notes],
+            },
+            "tags": {
+                "count": len(response.tags),
+                "results": [
+                    {"tag_id": item.tag_id, "name": item.name}
+                    for item in response.tags
+                ],
+            },
+            "collections": {
+                "count": len(response.collections),
+                "results": [
+                    {"collection_id": item.collection_id, "name": item.name}
+                    for item in response.collections
+                ],
+            },
+        },
+    }
+
+
+def _research_summary(result: WorkspaceSearchPassage) -> str:
+    details: list[str] = []
+    if result.research.note_count:
+        suffix = "note" if result.research.note_count == 1 else "notes"
+        details.append(f"{result.research.note_count} {suffix}")
+    if result.research.tags:
+        details.append("# " + ", ".join(result.research.tags))
+    if result.research.collections:
+        details.append("in " + ", ".join(result.research.collections))
+    return "\n".join(details) or "—"
+
+
+def _passage_text(result: WorkspaceSearchPassage) -> str:
+    context = result.located.evidence.context_segments
+    if not context:
+        return result.located.passage.text
+    return "\n".join(
+        ("› " if segment.is_result_segment else "  ") + segment.text
+        for segment in context
+    )
+
+
+def _render_transcripts(
+    results: tuple[WorkspaceSearchPassage, ...], console: Console
+) -> None:
+    table = Table(title=f"Transcript evidence ({len(results)})")
+    table.add_column("Evidence", min_width=20)
+    table.add_column("Research", min_width=10)
+    table.add_column("Passage")
+    for result in results:
+        located = result.located
+        passage = located.passage
+        recording = (
+            passage.document_id
+            if passage.source_path is None
+            else Path(passage.source_path).name
+        )
+        speakers = ", ".join(item.display_name for item in located.speakers) or "unknown"
+        evidence = (
+            f"{recording}\n"
+            f"{format_elapsed_timestamp(located.evidence.seek_seconds)}\n"
+            f"{speakers}"
+        )
+        table.add_row(evidence, _research_summary(result), _passage_text(result))
+    console.print(table)
+
+
+def _render_notes(notes: tuple[ResearchNoteView, ...], console: Console) -> None:
+    table = Table(title=f"Your notes ({len(notes)})")
+    table.add_column("Evidence", min_width=20)
+    table.add_column("Labels", min_width=10)
+    table.add_column("Your note")
+    for view in notes:
+        note = view.note
+        anchor = note.anchor
+        evidence = (
+            f"{anchor.document_id}\n"
+            f"{format_elapsed_timestamp(anchor.start_seconds)}\n"
+            f"{'current' if view.current else 'older transcript generation'}"
+        )
+        labels: list[str] = []
+        if view.tags:
+            labels.append("# " + ", ".join(view.tags))
+        if view.collections:
+            labels.append("in " + ", ".join(view.collections))
+        table.add_row(evidence, "\n".join(labels) or "—", note.body)
+    console.print(table)
+
+
+def _render_named_group(
+    title: str,
+    names: tuple[str, ...],
+    console: Console,
+) -> None:
+    table = Table(title=f"{title} ({len(names)})")
+    table.add_column(title[:-1] if title.endswith("s") else title)
+    for name in names:
+        table.add_row(name)
+    console.print(table)
+
+
+def _render_response(response: WorkspaceDiscoveryResponse) -> None:
+    console = Console()
+    console.print(
+        f"EchoFlow library discovery for {response.query!r}: "
+        f"{response.total_count} grouped result(s)"
+    )
+    _render_transcripts(response.transcripts.results, console)
+    _render_notes(response.notes, console)
+    _render_named_group("Tags", tuple(item.name for item in response.tags), console)
+    _render_named_group(
+        "Collections",
+        tuple(item.name for item in response.collections),
+        console,
+    )
+
+
+def _find_library(
+    context: typer.Context,
+    text: str,
+    *,
+    mode: RetrievalMode,
+    limit: int,
+    context_segments: int,
+    json_output: bool,
+    container_factory: ContainerFactory,
+) -> None:
+    try:
+        response = (
+            container_factory(_root_context(context))
+            .research_workspace()
+            .discover(
+                text,
+                mode=mode,
+                limit=limit,
+                context_segments=context_segments,
+            )
+        )
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps(_response_dict(response), sort_keys=True))
+        return
+    _render_response(response)
+
+
+def register_discovery_command(
+    library_app: typer.Typer,
+    container_factory: ContainerFactory,
+) -> None:
+    """Register the one-box grouped discovery surface on the library CLI."""
+
+    @library_app.command("find")
+    def find_library(
+        context: typer.Context,
+        text: str = typer.Argument(..., metavar="QUERY"),
+        mode: Annotated[
+            RetrievalMode,
+            typer.Option(
+                "--mode",
+                help=(
+                    "Choose lexical, semantic, or hybrid retrieval for transcript "
+                    "evidence. Notes and labels remain deterministic local text lookup."
+                ),
+            ),
+        ] = RetrievalMode.LEXICAL,
+        limit: int = typer.Option(
+            20,
+            "--limit",
+            min=1,
+            max=100,
+            help="Maximum results to return in each discovery group.",
+        ),
+        context_segments: int = typer.Option(
+            0,
+            "--context-segments",
+            min=0,
+            max=10,
+            help="Canonical context segments around transcript evidence results.",
+        ),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _find_library(
+            context,
+            text,
+            mode=mode,
+            limit=limit,
+            context_segments=context_segments,
+            json_output=json_output,
+            container_factory=container_factory,
+        )

--- a/src/echoflow/cli_discovery.py
+++ b/src/echoflow/cli_discovery.py
@@ -122,8 +122,7 @@ def _response_dict(response: WorkspaceDiscoveryResponse) -> dict[str, object]:
             "tags": {
                 "count": len(response.tags),
                 "results": [
-                    {"tag_id": item.tag_id, "name": item.name}
-                    for item in response.tags
+                    {"tag_id": item.tag_id, "name": item.name} for item in response.tags
                 ],
             },
             "collections": {
@@ -174,7 +173,9 @@ def _render_transcripts(
             if passage.source_path is None
             else Path(passage.source_path).name
         )
-        speakers = ", ".join(item.display_name for item in located.speakers) or "unknown"
+        speakers = (
+            ", ".join(item.display_name for item in located.speakers) or "unknown"
+        )
         evidence = (
             f"{recording}\n"
             f"{format_elapsed_timestamp(located.evidence.seek_seconds)}\n"

--- a/src/echoflow/cli_library.py
+++ b/src/echoflow/cli_library.py
@@ -11,6 +11,7 @@ from rich.table import Table
 from rich.text import Text
 
 from echoflow.app.app_container import AppContainer
+from echoflow.cli_discovery import register_discovery_command
 from echoflow.cli_research import register_research_commands
 from echoflow.cli_speakers import register_speaker_commands
 from echoflow.core.errors import EchoFlowError
@@ -734,6 +735,7 @@ def register_library_commands(
         )
 
     library_app.add_typer(embeddings_app, name="embeddings")
+    register_discovery_command(library_app, container_factory)
     register_speaker_commands(library_app, container_factory)
     register_research_commands(library_app, container_factory)
     app.add_typer(library_app, name="library")

--- a/src/echoflow/library/research_workspace.py
+++ b/src/echoflow/library/research_workspace.py
@@ -31,6 +31,7 @@ from echoflow.library.research_state import (
 )
 from echoflow.library.retrieval import RetrievalMode
 from echoflow.library.service import TranscriptLibraryService
+from echoflow.library.text import lexical_tokens
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,6 +103,32 @@ class ResearchNoteView:
     collections: tuple[str, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class WorkspaceDiscoveryResponse:
+    """One query returned as typed groups without cross-type score fabrication."""
+
+    query: str
+    transcripts: WorkspaceSearchResponse
+    notes: tuple[ResearchNoteView, ...]
+    tags: tuple[ResearchTag, ...]
+    collections: tuple[ResearchCollection, ...]
+
+    def __post_init__(self) -> None:
+        if not self.query.strip():
+            raise ValueError("discovery query cannot be empty")
+        if self.transcripts.navigation.retrieval.query.text != self.query:
+            raise ValueError("discovery transcript query must preserve discovery text")
+
+    @property
+    def total_count(self) -> int:
+        return (
+            len(self.transcripts.results)
+            + len(self.notes)
+            + len(self.tags)
+            + len(self.collections)
+        )
+
+
 class ResearchWorkspaceService:
     """Present one research workspace across evidence, SQLite, and DuckDB projections."""
 
@@ -167,6 +194,42 @@ class ResearchWorkspaceService:
             navigation=navigation,
             filters=resolved_filters,
             results=results,
+        )
+
+    def discover(
+        self,
+        text: str,
+        *,
+        mode: RetrievalMode = RetrievalMode.LEXICAL,
+        limit: int = 20,
+        context_segments: int = 0,
+    ) -> WorkspaceDiscoveryResponse:
+        """Find evidence and durable research objects through one grouped doorway."""
+        query_text = text.strip()
+        if not query_text:
+            raise ValueError("discovery query cannot be empty")
+        if limit < 1 or limit > 100:
+            raise ValueError("discovery limit must be between 1 and 100")
+        if context_segments < 0 or context_segments > 10:
+            raise ValueError("context_segments must be between 0 and 10")
+
+        transcripts = self.search(
+            SearchQuery(query_text, limit=limit),
+            mode=mode,
+            context_segments=context_segments,
+        )
+        notes = self.notes(
+            filters=ResearchQueryFilters(note_text=query_text),
+            limit=limit,
+        )
+        tags = self._matching_tags(query_text, limit=limit)
+        collections = self._matching_collections(query_text, limit=limit)
+        return WorkspaceDiscoveryResponse(
+            query=query_text,
+            transcripts=transcripts,
+            notes=notes,
+            tags=tags,
+            collections=collections,
         )
 
     def add_note(
@@ -347,6 +410,46 @@ class ResearchWorkspaceService:
             )
             for note in notes
         )
+
+    def _matching_tags(self, text: str, *, limit: int) -> tuple[ResearchTag, ...]:
+        ranked: list[tuple[tuple[int, int, str], str, ResearchTag]] = []
+        for tag in self.state.tags():
+            key = self._name_match_key(tag.name, text)
+            if key is not None:
+                ranked.append((key, tag.tag_id, tag))
+        ranked.sort(key=lambda item: (item[0], item[1]))
+        return tuple(item[2] for item in ranked[:limit])
+
+    def _matching_collections(
+        self, text: str, *, limit: int
+    ) -> tuple[ResearchCollection, ...]:
+        ranked: list[
+            tuple[tuple[int, int, str], str, ResearchCollection]
+        ] = []
+        for collection in self.state.collections():
+            key = self._name_match_key(collection.name, text)
+            if key is not None:
+                ranked.append((key, collection.collection_id, collection))
+        ranked.sort(key=lambda item: (item[0], item[1]))
+        return tuple(item[2] for item in ranked[:limit])
+
+    @staticmethod
+    def _name_match_key(name: str, text: str) -> tuple[int, int, str] | None:
+        normalized_name = " ".join(name.casefold().split())
+        normalized_query = " ".join(text.casefold().split())
+        if normalized_name == normalized_query:
+            return (0, 0, normalized_name)
+        if normalized_name.startswith(normalized_query):
+            return (1, 0, normalized_name)
+        if normalized_query in normalized_name:
+            return (2, 0, normalized_name)
+
+        query_tokens = tuple(dict.fromkeys(lexical_tokens(text)))
+        name_tokens = set(lexical_tokens(name))
+        overlap = sum(token in name_tokens for token in query_tokens)
+        if overlap == 0:
+            return None
+        return (3, -overlap, normalized_name)
 
     @staticmethod
     def _note_view_with_maps(

--- a/src/echoflow/library/research_workspace.py
+++ b/src/echoflow/library/research_workspace.py
@@ -423,9 +423,7 @@ class ResearchWorkspaceService:
     def _matching_collections(
         self, text: str, *, limit: int
     ) -> tuple[ResearchCollection, ...]:
-        ranked: list[
-            tuple[tuple[int, int, str], str, ResearchCollection]
-        ] = []
+        ranked: list[tuple[tuple[int, int, str], str, ResearchCollection]] = []
         for collection in self.state.collections():
             key = self._name_match_key(collection.name, text)
             if key is not None:

--- a/src/echoflow/library/tests/test_workspace_discovery.py
+++ b/src/echoflow/library/tests/test_workspace_discovery.py
@@ -132,7 +132,9 @@ def test_discover_returns_grouped_transcript_and_authoritative_research_results(
     assert navigation.search.call_args.kwargs["mode"] is RetrievalMode.HYBRID
     assert response.query == "housing"
     assert response.transcripts.results[0].located is located
-    assert tuple(view.note.note_id for view in response.notes) == (housing_note.note_id,)
+    assert tuple(view.note.note_id for view in response.notes) == (
+        housing_note.note_id,
+    )
     assert response.notes[0].note.body == "Housing affordability methodology"
     assert response.notes[0].current
     assert tuple(tag.name for tag in response.tags) == ("housing",)
@@ -142,7 +144,9 @@ def test_discover_returns_grouped_transcript_and_authoritative_research_results(
     assert response.total_count == 4
 
 
-def test_discovery_name_matching_is_group_local_and_deterministic(tmp_path: Path) -> None:
+def test_discovery_name_matching_is_group_local_and_deterministic(
+    tmp_path: Path,
+) -> None:
     workspace, state, _, navigation = _workspace(tmp_path)
     state.create_note(
         _anchor(),

--- a/src/echoflow/library/tests/test_workspace_discovery.py
+++ b/src/echoflow/library/tests/test_workspace_discovery.py
@@ -1,0 +1,214 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from echoflow.library.duckdb_research_projection import DuckDbResearchProjection
+from echoflow.library.evidence import EvidenceAnchor
+from echoflow.library.index import IndexedDocument
+from echoflow.library.research_projector import ResearchStateProjector
+from echoflow.library.research_workspace import ResearchWorkspaceService
+from echoflow.library.retrieval import RetrievalMode
+from echoflow.library.sqlite_research_state import SqliteResearchStateStore
+
+
+class PrivateDirectoryStore:
+    def ensure_directory_exists(
+        self, directory_path: str | Path, *, private: bool = False
+    ) -> None:
+        assert private
+        Path(directory_path).mkdir(parents=True, exist_ok=True)
+
+
+def _anchor(
+    *,
+    canonical_digit: str = "1",
+    segment_id: str = "segment-000042",
+) -> EvidenceAnchor:
+    return EvidenceAnchor(
+        document_id="job-1",
+        source_sha256="0" * 64,
+        canonical_sha256=canonical_digit * 64,
+        canonical_path="/private/job-1.json",
+        source_path="/private/interview.wav",
+        segment_ids=(segment_id,),
+        start_seconds=42.0,
+        end_seconds=45.0,
+    )
+
+
+def _document(*, canonical_digit: str = "1") -> IndexedDocument:
+    return IndexedDocument(
+        document_id="job-1",
+        source_sha256="0" * 64,
+        canonical_sha256=canonical_digit * 64,
+        detected_language="en",
+        canonical_path="/private/job-1.json",
+        source_path="/private/interview.wav",
+        segment_count=100,
+    )
+
+
+def _workspace(tmp_path: Path):
+    file_store = PrivateDirectoryStore()
+    state = SqliteResearchStateStore(
+        tmp_path / "state" / "research.sqlite3",
+        file_store,  # type: ignore[arg-type]
+    )
+    projection = DuckDbResearchProjection(
+        tmp_path / "projection" / "research.duckdb",
+        file_store,  # type: ignore[arg-type]
+    )
+    projector = ResearchStateProjector(state, projection, batch_size=1)
+    transcript_library = Mock()
+    transcript_library.documents.return_value = (_document(),)
+    navigation = Mock()
+    evidence_locator = Mock()
+    workspace = ResearchWorkspaceService(
+        transcript_library,
+        evidence_locator,
+        navigation,
+        state,
+        projection,
+        projector,
+    )
+    return workspace, state, transcript_library, navigation
+
+
+def _located(segment_id: str = "segment-000042"):
+    return SimpleNamespace(
+        evidence=SimpleNamespace(
+            document_id="job-1",
+            canonical_sha256="1" * 64,
+            result_segment_ids=(segment_id,),
+        )
+    )
+
+
+def _navigation_result(query, *, mode: RetrievalMode, results=()):
+    return SimpleNamespace(
+        retrieval=SimpleNamespace(query=query, mode=mode),
+        results=results,
+    )
+
+
+def test_discover_returns_grouped_transcript_and_authoritative_research_results(
+    tmp_path: Path,
+) -> None:
+    workspace, state, _, navigation = _workspace(tmp_path)
+    housing_note = state.create_note(
+        _anchor(),
+        "Housing affordability methodology",
+        tags=("housing", "methodology"),
+        collections=("Housing interviews",),
+        note_id="note-housing",
+    )
+    state.create_note(
+        _anchor(segment_id="segment-000043"),
+        "Budget follow up",
+        tags=("budget",),
+        collections=("Finance",),
+        note_id="note-budget",
+    )
+    located = _located()
+
+    def search(query, *, mode: RetrievalMode, context_segments: int):
+        assert context_segments == 2
+        return _navigation_result(query, mode=mode, results=(located,))
+
+    navigation.search.side_effect = search
+
+    response = workspace.discover(
+        "  housing  ",
+        mode=RetrievalMode.HYBRID,
+        limit=10,
+        context_segments=2,
+    )
+
+    searched_query = navigation.search.call_args.args[0]
+    assert searched_query.text == "housing"
+    assert searched_query.limit == 10
+    assert navigation.search.call_args.kwargs["mode"] is RetrievalMode.HYBRID
+    assert response.query == "housing"
+    assert response.transcripts.results[0].located is located
+    assert tuple(view.note.note_id for view in response.notes) == (housing_note.note_id,)
+    assert response.notes[0].note.body == "Housing affordability methodology"
+    assert response.notes[0].current
+    assert tuple(tag.name for tag in response.tags) == ("housing",)
+    assert tuple(collection.name for collection in response.collections) == (
+        "Housing interviews",
+    )
+    assert response.total_count == 4
+
+
+def test_discovery_name_matching_is_group_local_and_deterministic(tmp_path: Path) -> None:
+    workspace, state, _, navigation = _workspace(tmp_path)
+    state.create_note(
+        _anchor(),
+        "housing affordability",
+        tags=("housing", "Housing affordability", "social housing", "affordability"),
+        collections=("Housing affordability", "Housing interviews"),
+        note_id="note-1",
+    )
+    navigation.search.side_effect = lambda query, **kwargs: _navigation_result(
+        query,
+        mode=kwargs["mode"],
+    )
+
+    response = workspace.discover("housing affordability", limit=10)
+
+    assert response.tags[0].name == "Housing affordability"
+    assert {tag.name for tag in response.tags} == {
+        "Housing affordability",
+        "housing",
+        "social housing",
+        "affordability",
+    }
+    assert response.collections[0].name == "Housing affordability"
+    assert {collection.name for collection in response.collections} == {
+        "Housing affordability",
+        "Housing interviews",
+    }
+
+
+def test_discovery_preserves_stale_notes_instead_of_reattaching_or_hiding_them(
+    tmp_path: Path,
+) -> None:
+    workspace, state, transcript_library, navigation = _workspace(tmp_path)
+    note = state.create_note(
+        _anchor(canonical_digit="1"),
+        "Housing observation from the older transcript",
+        tags=("housing",),
+        note_id="note-old",
+    )
+    transcript_library.documents.return_value = (_document(canonical_digit="2"),)
+    navigation.search.side_effect = lambda query, **kwargs: _navigation_result(
+        query,
+        mode=kwargs["mode"],
+    )
+
+    response = workspace.discover("housing")
+
+    assert tuple(view.note.note_id for view in response.notes) == (note.note_id,)
+    assert not response.notes[0].current
+    assert response.notes[0].note.anchor.canonical_sha256 == "1" * 64
+    assert response.tags[0].name == "housing"
+    assert response.transcripts.results == ()
+
+
+def test_discovery_validates_human_query_limits_before_running_retrieval(
+    tmp_path: Path,
+) -> None:
+    workspace, _, _, navigation = _workspace(tmp_path)
+
+    with pytest.raises(ValueError, match="query"):
+        workspace.discover("   ")
+    with pytest.raises(ValueError, match="limit"):
+        workspace.discover("housing", limit=0)
+    with pytest.raises(ValueError, match="limit"):
+        workspace.discover("housing", limit=101)
+    with pytest.raises(ValueError, match="context_segments"):
+        workspace.discover("housing", context_segments=11)
+
+    navigation.search.assert_not_called()

--- a/src/echoflow/tests/test_cli_discovery.py
+++ b/src/echoflow/tests/test_cli_discovery.py
@@ -1,0 +1,228 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import typer
+from typer.testing import CliRunner
+
+from echoflow.cli_library import register_library_commands
+from echoflow.library.evidence import EvidenceAnchor, EvidenceContextSegment, EvidenceLocation
+from echoflow.library.index import SearchQuery
+from echoflow.library.research import (
+    LocatedSearchPassage,
+    ResearchSearchResponse,
+    SpeakerDisplay,
+)
+from echoflow.library.research_state import ResearchCollection, ResearchNote, ResearchTag
+from echoflow.library.research_workspace import (
+    ResearchEvidenceView,
+    ResearchNoteView,
+    ResearchQueryFilters,
+    WorkspaceDiscoveryResponse,
+    WorkspaceSearchPassage,
+    WorkspaceSearchResponse,
+)
+from echoflow.library.retrieval import RetrievalMode, SearchPassage, SearchResponse
+
+
+def _anchor() -> EvidenceAnchor:
+    return EvidenceAnchor(
+        document_id="job-1",
+        source_sha256="0" * 64,
+        canonical_sha256="1" * 64,
+        canonical_path="/private/interview.json",
+        source_path="/private/interview.wav",
+        segment_ids=("segment-000001",),
+        start_seconds=1.5,
+        end_seconds=2.5,
+    )
+
+
+def _discovery_response() -> WorkspaceDiscoveryResponse:
+    query = SearchQuery("housing", limit=20)
+    passage = SearchPassage(
+        document_id="job-1",
+        source_sha256="0" * 64,
+        canonical_sha256="1" * 64,
+        canonical_path="/private/interview.json",
+        source_path=str(Path("/private") / "interview.wav"),
+        chunk_id=None,
+        segment_ids=("segment-000001",),
+        matched_segment_ids=("segment-000001",),
+        start_seconds=1.5,
+        end_seconds=2.5,
+        text="housing affordability matters",
+        languages=("en",),
+        speaker_refs=("speaker-02",),
+        lexical_rank=1,
+        semantic_rank=None,
+        fused_rank=None,
+    )
+    retrieval = SearchResponse(
+        query=query,
+        mode=RetrievalMode.LEXICAL,
+        lexical_backend_id="duckdb-bm25-v1",
+        semantic_backend_id=None,
+        semantic_profile=None,
+        fusion_profile=None,
+        results=(passage,),
+    )
+    context = EvidenceContextSegment(
+        segment_id="segment-000001",
+        start_seconds=1.5,
+        end_seconds=2.5,
+        text="housing affordability matters",
+        speaker_refs=("speaker-02",),
+        words=(),
+        is_result_segment=True,
+        lexical_match=True,
+    )
+    evidence = EvidenceLocation(
+        document_id="job-1",
+        source_sha256="0" * 64,
+        canonical_sha256="1" * 64,
+        canonical_path="/private/interview.json",
+        source_path="/private/interview.wav",
+        result_segment_ids=("segment-000001",),
+        start_seconds=1.5,
+        end_seconds=2.5,
+        seek_seconds=1.5,
+        result_speaker_refs=("speaker-02",),
+        matched_words=(),
+        context_segments=(context,),
+    )
+    located = LocatedSearchPassage(
+        passage=passage,
+        evidence=evidence,
+        speakers=(SpeakerDisplay("speaker-02", "Dr. Chen"),),
+    )
+    navigation = ResearchSearchResponse(retrieval=retrieval, results=(located,))
+    transcript_results = WorkspaceSearchResponse(
+        navigation=navigation,
+        filters=ResearchQueryFilters(),
+        results=(
+            WorkspaceSearchPassage(
+                located,
+                ResearchEvidenceView(
+                    note_ids=("note-1",),
+                    tags=("housing",),
+                    collections=("Housing interviews",),
+                ),
+            ),
+        ),
+    )
+    note = ResearchNote(
+        note_id="note-1",
+        body="Compare housing finding with the 2024 survey",
+        anchor=_anchor(),
+        tag_ids=("tag-housing",),
+        collection_ids=("collection-housing",),
+        created_at="2026-08-18T20:00:00Z",
+        updated_at="2026-08-18T20:00:00Z",
+    )
+    return WorkspaceDiscoveryResponse(
+        query="housing",
+        transcripts=transcript_results,
+        notes=(
+            ResearchNoteView(
+                note=note,
+                current=True,
+                tags=("housing",),
+                collections=("Housing interviews",),
+            ),
+        ),
+        tags=(ResearchTag("tag-housing", "housing"),),
+        collections=(
+            ResearchCollection("collection-housing", "Housing interviews"),
+        ),
+    )
+
+
+def _app(workspace: Mock) -> typer.Typer:
+    app = typer.Typer()
+    container = Mock()
+    container.research_workspace.return_value = workspace
+    container.transcript_library.return_value = Mock()
+    container.semantic_embedding_provider.return_value = Mock()
+    register_library_commands(app, lambda context: container)
+    return app
+
+
+def test_library_find_json_preserves_typed_groups_and_forwards_discovery_options() -> None:
+    workspace = Mock()
+    workspace.discover.return_value = _discovery_response()
+    app = _app(workspace)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "library",
+            "find",
+            "housing",
+            "--mode",
+            "hybrid",
+            "--limit",
+            "7",
+            "--context-segments",
+            "2",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    workspace.discover.assert_called_once_with(
+        "housing",
+        mode=RetrievalMode.HYBRID,
+        limit=7,
+        context_segments=2,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["query"] == "housing"
+    assert payload["total_count"] == 4
+    assert payload["groups"]["transcripts"]["count"] == 1
+    assert payload["groups"]["transcripts"]["results"][0]["seek_seconds"] == 1.5
+    assert payload["groups"]["transcripts"]["results"][0][
+        "speaker_display_labels"
+    ] == {"speaker-02": "Dr. Chen"}
+    assert payload["groups"]["notes"]["results"][0]["body"].startswith("Compare")
+    assert payload["groups"]["notes"]["results"][0]["current"] is True
+    assert payload["groups"]["tags"]["results"] == [
+        {"name": "housing", "tag_id": "tag-housing"}
+    ]
+    assert payload["groups"]["collections"]["results"] == [
+        {
+            "collection_id": "collection-housing",
+            "name": "Housing interviews",
+        }
+    ]
+
+
+def test_library_find_human_view_keeps_result_types_visibly_separate() -> None:
+    workspace = Mock()
+    workspace.discover.return_value = _discovery_response()
+    app = _app(workspace)
+
+    result = CliRunner().invoke(app, ["library", "find", "housing"])
+
+    assert result.exit_code == 0
+    assert "Transcript evidence" in result.stdout
+    assert "Your notes" in result.stdout
+    assert "Tags" in result.stdout
+    assert "Collections" in result.stdout
+    assert "interview.wav" in result.stdout
+    assert "Dr. Chen" in result.stdout
+    assert "housing affordability" in result.stdout
+    assert "Compare housing finding" in result.stdout
+    assert "Housing interviews" in result.stdout
+
+
+def test_library_find_masks_unexpected_internal_errors() -> None:
+    workspace = Mock()
+    workspace.discover.side_effect = RuntimeError("/private/secret/research.sqlite3")
+    app = _app(workspace)
+
+    result = CliRunner().invoke(app, ["library", "find", "housing"])
+
+    assert result.exit_code == 3
+    assert "RuntimeError" in result.stderr
+    assert "secret" not in result.stderr

--- a/src/echoflow/tests/test_cli_discovery.py
+++ b/src/echoflow/tests/test_cli_discovery.py
@@ -6,7 +6,11 @@ import typer
 from typer.testing import CliRunner
 
 from echoflow.cli_library import register_library_commands
-from echoflow.library.evidence import EvidenceAnchor, EvidenceContextSegment, EvidenceLocation
+from echoflow.library.evidence import (
+    EvidenceAnchor,
+    EvidenceContextSegment,
+    EvidenceLocation,
+)
 from echoflow.library.index import SearchQuery
 from echoflow.library.research import (
     LocatedSearchPassage,

--- a/src/echoflow/tests/test_cli_discovery.py
+++ b/src/echoflow/tests/test_cli_discovery.py
@@ -17,7 +17,11 @@ from echoflow.library.research import (
     ResearchSearchResponse,
     SpeakerDisplay,
 )
-from echoflow.library.research_state import ResearchCollection, ResearchNote, ResearchTag
+from echoflow.library.research_state import (
+    ResearchCollection,
+    ResearchNote,
+    ResearchTag,
+)
 from echoflow.library.research_workspace import (
     ResearchEvidenceView,
     ResearchNoteView,

--- a/src/echoflow/tests/test_cli_discovery.py
+++ b/src/echoflow/tests/test_cli_discovery.py
@@ -140,9 +140,7 @@ def _discovery_response() -> WorkspaceDiscoveryResponse:
             ),
         ),
         tags=(ResearchTag("tag-housing", "housing"),),
-        collections=(
-            ResearchCollection("collection-housing", "Housing interviews"),
-        ),
+        collections=(ResearchCollection("collection-housing", "Housing interviews"),),
     )
 
 
@@ -156,7 +154,9 @@ def _app(workspace: Mock) -> typer.Typer:
     return app
 
 
-def test_library_find_json_preserves_typed_groups_and_forwards_discovery_options() -> None:
+def test_library_find_json_preserves_typed_groups_and_forwards_discovery_options() -> (
+    None
+):
     workspace = Mock()
     workspace.discover.return_value = _discovery_response()
     app = _app(workspace)
@@ -189,9 +189,9 @@ def test_library_find_json_preserves_typed_groups_and_forwards_discovery_options
     assert payload["total_count"] == 4
     assert payload["groups"]["transcripts"]["count"] == 1
     assert payload["groups"]["transcripts"]["results"][0]["seek_seconds"] == 1.5
-    assert payload["groups"]["transcripts"]["results"][0][
-        "speaker_display_labels"
-    ] == {"speaker-02": "Dr. Chen"}
+    assert payload["groups"]["transcripts"]["results"][0]["speaker_display_labels"] == {
+        "speaker-02": "Dr. Chen"
+    }
     assert payload["groups"]["notes"]["results"][0]["body"].startswith("Compare")
     assert payload["groups"]["notes"]["results"][0]["current"] is True
     assert payload["groups"]["tags"]["results"] == [


### PR DESCRIPTION
## Summary

Add the first human-facing unified library doorway over the existing transcript and research-workspace foundations.

`echoflow library find QUERY` now returns grouped transcript evidence, notes, tags, and collections without inventing one cross-type relevance score.

## Product behavior

- transcript evidence reuses existing lexical / semantic / hybrid retrieval and verified canonical navigation
- note prose is matched through the rebuildable research projection, then hydrated from authoritative SQLite state
- tag and collection name matching is deterministic and group-local
- stale notes remain visible as older-generation notes instead of being silently re-anchored or hidden
- one `--limit` applies independently to each result group
- `--mode` affects transcript evidence only; note/tag/collection lookup stays deterministic local text lookup
- canonical seek coordinates, speaker display labels, and associated research state remain visible on transcript results

## Architecture

The feature extends `ResearchWorkspaceService`; it does not add another database, index, or storage authority.

`WorkspaceDiscoveryResponse` keeps four typed result groups:

1. transcript evidence
2. authoritative note views
3. tags
4. collections

This is intended to be consumed by the CLI today and the first thin GUI later.

## CLI

```bash
echoflow library find "housing affordability"
echoflow library find "people struggling to make rent" --mode hybrid
echoflow library find "housing" --context-segments 1 --limit 10 --json
```

## Tests

Behavioral coverage includes:

- real SQLite + DuckDB projection-backed discovery
- query normalization and per-group limiting
- mode/context forwarding into transcript retrieval
- authoritative note hydration
- deterministic tag/collection matching
- stale canonical-generation note preservation
- human and JSON grouped CLI rendering
- masking of unexpected internal error details

No tautological coverage-only tests are added.

## Documentation

- add a dedicated unified discovery guide
- expose `library find` in the root README and docs lobby
- advance the roadmap so saved searches + derived navigation are next
- keep frequent/recent tag ranking out of this tranche; that remains derived-navigation work
