### PR TITLE
feat(library): add saved searches and derived navigation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,14 +22,15 @@ flowchart LR
     E --> F[Durable research workspace]
     D --> G[Unified library discovery]
     F --> G
-    G --> H[Saved views and derived navigation]
-    H --> I[Thin graphical shell]
+    G --> H[Saved searches and derived navigation]
+    H --> I[Safe lifecycle controls]
+    I --> J[Thin graphical shell]
 ```
 
 Text fallback: transcription, evidence preservation, retrieval, navigation, durable
-research state, and unified discovery are foundation. Saved views and derived navigation
-are next; the first GUI should sit on those same services rather than inventing another
-application.
+research state, unified discovery, saved searches, and derived navigation are foundation.
+The next work should make retention/deletion semantics explicit and then place a thin GUI
+on those same services rather than inventing another application.
 
 # Current foundation
 
@@ -106,8 +107,16 @@ provenance, source-relative segment and word timestamps, source-declared tempora
 when present, language evidence, optional enhancement provenance, and optional speaker
 turn/word speaker evidence.
 
+By default, user-visible canonical JSON and derived publications are written under the
+platform Downloads directory in `EchoFlow/`. A transcription may select another
+`--output-dir`, and `ECHOFLOW_OUTPUT_DIR` may define another default through an explicitly
+selected EchoFlow configuration file.
+
 TXT, SRT, and WebVTT are deterministic derived publication views. They can be deleted and
 regenerated without rerunning recognition.
+
+See `docs/architecture/library-lifecycle.md` for the exact output, refresh, retention, and
+deletion boundaries.
 
 ## Transcript library, search, and aligned navigation
 
@@ -134,13 +143,19 @@ The local library now includes:
 Search ranking and evidence navigation remain separate operations. A rebuildable index
 ranks a passage; navigation verifies canonical evidence before presenting precision.
 
+`echoflow library rebuild` is a discovery/index-rebuild operation over existing canonical
+JSON. It does not re-transcribe audio. A rescan is useful when the corpus changes, a
+canonical generation changes, a transcript moves/disappears, a rebuildable database is
+lost or damaged, or a later EchoFlow build changes derived index representation.
+
 ## Durable research workspace
 
-This is now **foundation**, not future work.
+This is **foundation**, not future work.
 
 EchoFlow provides:
 
-- authoritative private SQLite state for notes, tags, collections, and evidence anchors;
+- authoritative private SQLite state for notes, tags, collections, evidence anchors, and
+  saved-search intent;
 - exact source/canonical generation identity in durable note anchors;
 - contiguous canonical segment-span validation before a note is accepted;
 - optional sub-segment source-relative start/end coordinates;
@@ -160,7 +175,7 @@ The custody hierarchy is now:
 | Class | Examples | Rule |
 |---|---|---|
 | Authoritative evidence | original recording, canonical transcript JSON | never treat as cache |
-| Authoritative user knowledge | speaker labels, notes, tags, collections, future saved searches/result sets | must survive index rebuilds |
+| Authoritative user knowledge | speaker labels, notes, tags, collections, saved searches, future curated result sets | must survive index rebuilds |
 | Rebuildable projection | lexical index, semantic chunks/vectors, research query projection, derived exports | may be regenerated |
 | Private execution state | normalization, enhancement, checkpoints, temporary segments | lifecycle-managed, not source truth |
 
@@ -168,7 +183,7 @@ The custody hierarchy is now:
 
 ## Unified library discovery
 
-This is now **foundation** too.
+This is **foundation** too.
 
 `ResearchWorkspaceService.discover()` and `echoflow library find QUERY` provide one human
 query across four typed result groups:
@@ -191,34 +206,70 @@ Per-group limits, canonical context, stale-note state, speaker presentation, evi
 identity, and source seek coordinates remain visible through the same application
 contracts a future GUI can consume.
 
+## Saved searches and useful derived navigation
+
+This is now **foundation** as part of PR #67.
+
+Saved searches are durable user-authored workspace state in authoritative SQLite. They
+preserve typed query intent rather than rendered CLI text or a frozen set of search
+results.
+
+A saved search records transcript query semantics, retrieval mode, context width, and
+research constraints. It explicitly does not persist derived `evidence_scope`. Replaying a
+saved search therefore re-resolves current research relationships and current canonical
+evidence through `ResearchWorkspaceService.search()`.
+
+EchoFlow also derives:
+
+- most-used tags from current note/tag relationships;
+- recently used tags;
+- most-used collections; and
+- recently used collections.
+
+Those counts and timestamps are views. EchoFlow does not add authoritative popularity or
+recency counters to tag/collection records.
+
+Current CLI surfaces are:
+
+```bash
+echoflow library saved
+echoflow library saved save "Housing chapter" "rent burden" --tag housing --mode hybrid
+echoflow library saved show "Housing chapter"
+echoflow library saved run "Housing chapter"
+echoflow library saved delete "Housing chapter"
+echoflow library navigation
+```
+
 # Near-term product sequence
 
-The next work should make the existing backend **pleasant to remember and navigate** rather
-than reopening solved custody/search contracts.
+The next work should make the existing backend **safe and pleasant to operate** rather than
+reopening solved custody/search contracts.
 
-## 1. Saved searches and useful derived navigation
+## 1. Safe deletion and explicit retention controls
 
-This is the next feature tranche.
+Deletion must follow custody class rather than treating every local file as equivalent.
 
-Saved searches are **durable user-authored workspace state** and belong in authoritative
-SQLite. They should preserve typed query intent, not a blob of rendered CLI text.
+The first safe-deletion surface should distinguish:
 
-Useful derived navigation should remain disposable. Candidate conveniences include:
+- deleting a rebuildable index/cache;
+- deleting a derived TXT/SRT/VTT publication;
+- deleting private checkpoint/execution state and therefore resume capability;
+- deleting human-authored notes or saved searches;
+- removing a canonical transcript from active library membership without necessarily
+  deleting the evidence file; and
+- destructively deleting canonical transcript evidence.
 
-- most-used tags, derived from current relationships rather than stored counters;
-- recently used tags/collections;
-- facets and counts where they reduce hunting;
-- recent searches if they prove useful;
-- saved search names/descriptions;
-- selected/citable result sets; and
-- stale-anchor review surfaces.
+Canonical-evidence deletion must surface dependent annotations/anchors before committing.
+“Remove from search” must never quietly mean “erase my only transcript and its research.”
 
-Do not make every convenience statistic another authoritative table. The durable object
-is the user's tag/search/collection; popularity and recency rankings are views.
+EchoFlow should not claim secure erasure or crypto-shredding for ordinary files when SSD
+wear levelling, copy-on-write filesystems, snapshots, backups, or sync clients make that
+claim unverifiable. The product can provide precise deletion semantics without promising
+physical-media destruction it cannot prove.
 
 ## 2. First thin GUI
 
-The GUI has now earned its place because the backend is ahead of the human interface.
+The GUI has earned its place because the backend is ahead of the human interface.
 
 The first graphical vertical slice should remain deliberately small and beautiful rather
 than becoming a second application implementation.
@@ -275,8 +326,8 @@ Keep full rebuild as explicit recovery.
 
 Then measure realistic corpora rather than optimizing by instinct. Representative
 qualification should include startup, warm/cold search, filtered lexical/semantic queries,
-unified-discovery latency, notebook queries, one-edit projection catch-up, large-batch
-projection catch-up, and full rebuild behavior.
+unified-discovery latency, notebook queries, saved-search replay, one-edit projection
+catch-up, large-batch projection catch-up, and full rebuild behavior.
 
 ## 5. Qualify semantic dependency and managed embedding custody
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -32,14 +32,18 @@ flowchart LR
     J --> K[Deterministic projector]
     K --> L[DuckDB research projection]
     L --> H
-    J --> M[ResearchWorkspaceService]
-    I --> M
+    J --> M[Saved searches]
+    J --> N[ResearchWorkspaceService]
+    I --> N
+    M --> N
+    N --> O[Unified discovery and navigation]
 ```
 
 Text fallback: source media produces canonical transcript evidence; DuckDB search
 projections rank passages; evidence navigation verifies those passages; SQLite owns
-human-authored research state; a deterministic projector builds disposable DuckDB query
-state; `ResearchWorkspaceService` is the application-facing seam across those boundaries.
+human-authored research state and saved searches; a deterministic projector builds
+disposable DuckDB query state; `ResearchWorkspaceService` is the application-facing seam
+across those boundaries.
 
 The architectural through-line is **custody**. Source evidence, canonical transcript
 truth, private execution state, managed model dependencies, rebuildable indexes, and
@@ -58,6 +62,7 @@ durable human knowledge intentionally have different deletion and recovery seman
 | [Anonymous speaker diarization](diarization.md) | How are speaker turns represented without pretending anonymous labels are identities? |
 | [Corpus search](corpus-search.md) | How do lexical/semantic/hybrid ranking and verified canonical navigation stay separate? |
 | [Durable research state](research-state.md) | Why does SQLite own human research while DuckDB owns rebuildable acceleration, and how do they converge? |
+| [Library lifecycle](library-lifecycle.md) | Where does canonical JSON live, what does a library rebuild actually rescan, and which state is durable versus disposable? |
 | [ROADMAP](../../ROADMAP.md) | What is implemented, what is next, and what remains research? |
 | [SECURITY](../../SECURITY.md) | What does the security boundary actually claim? |
 
@@ -74,7 +79,7 @@ durable human knowledge intentionally have different deletion and recovery seman
 | `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language attribution, word alignment, diarization, assembly, exports |
 | `workspace` | Private job paths and public artifact allocation |
 | `benchmarking` | Privacy-minimized local execution measurement |
-| `library` | Retrieval, canonical evidence navigation, speaker presentation, authoritative research state, and rebuildable research projection |
+| `library` | Retrieval, canonical evidence navigation, speaker presentation, authoritative research state, saved-search intent, unified discovery, derived navigation, and rebuildable projections |
 
 `runner` means the local compute environment visible to the process; it is not a
 distributed task runner. `media.probe` performs inspection, not transcoding.
@@ -101,7 +106,9 @@ The search/research area has deliberately separate responsibilities:
 5. `ResearchStateProjector` owns convergence from authoritative SQLite state into the
    rebuildable research projection.
 6. `ResearchProjectionIndex` owns fast derived research constraints and summaries.
-7. `ResearchWorkspaceService` composes those capabilities for presentation adapters.
+7. `WorkspaceMetadataStore` owns durable saved-search intent and computes disposable
+   frequent/recent navigation from current relationships.
+8. `ResearchWorkspaceService` composes those capabilities for presentation adapters.
 
 That split should survive unified discovery and the GUI. Presentation convenience is not
 permission to merge custody boundaries.
@@ -128,8 +135,13 @@ DuckDB research projection
 If the research projection disappears, rebuild it. If SQLite user state disappears,
 unique human work is lost. That asymmetry is intentional.
 
-See [Durable research state](research-state.md) for the full transaction, watermark,
-rebuild, and fail-closed contract.
+Saved searches share the authoritative SQLite database because they are authored research
+intent. Their runtime evidence scope does not. Replaying a saved search re-resolves the
+current corpus and current research relationships.
+
+See [Durable research state](research-state.md) for the transaction, watermark, rebuild,
+and fail-closed contract. See [Library lifecycle](library-lifecycle.md) for the broader
+retention, output-path, rescan, and deletion boundaries.
 
 ## The custody rules 🦝
 
@@ -140,34 +152,37 @@ These rules are load-bearing:
 3. **Managed model manifests describe verified local execution dependencies.**
 4. **Lexical, semantic, and research DuckDB databases are private rebuildable
    projections.**
-5. **User-authored speaker labels, notes, tags, collections, future saved searches, and
-   curated result sets do not share deletion semantics with indexes.**
+5. **User-authored speaker labels, notes, tags, collections, saved searches, and curated
+   result sets do not share deletion semantics with indexes.**
 6. **Research-state joins include canonical generation identity, not a friendly segment ID
    alone.**
 7. **Precise navigation resolves back to verified canonical evidence rather than trusting
    a stale search projection.**
 8. **Research filters are applied before ranking/scoring when they define eligible
    evidence.**
-9. **A convenience layer may not quietly become the only place unique evidence or user
-   knowledge lives.**
+9. **Saved searches persist typed query intent, not a frozen derived evidence scope.**
+10. **A convenience layer may not quietly become the only place unique evidence or user
+    knowledge lives.**
 
 Search infrastructure is allowed to disappear. User-authored knowledge is not.
 
-## The next architectural seam
+## Current application seam
 
-The next user-facing feature is **unified library discovery**. It should compose existing
-services rather than create another database or search engine.
+Unified discovery, saved searches, and frequent/recent navigation now all compose through
+`ResearchWorkspaceService` rather than creating another search engine or database
+authority.
 
-A future discovery service may return grouped typed results such as transcript evidence,
-notes, tags, collections, and saved searches. It should preserve each result type's own
-semantics rather than inventing one universal relevance score across unlike objects.
+`echoflow library find QUERY` returns typed transcript, note, tag, and collection groups.
+`echoflow library saved ...` stores and replays typed workspace queries. `echoflow library
+navigation` derives useful tag/collection views from current relationships.
 
-Saved searches belong to durable SQLite user state because they are authored workspace
-intent. Frequent/recent tag rankings are derived convenience views and should not become
-precious counters.
+The system deliberately does not invent a universal relevance score across unlike
+objects. Transcript ranks remain transcript ranks. Notes, tags, collections, and saved
+searches retain their own semantics.
 
-The first GUI then becomes a thin presentation adapter over the same discovery,
-`ResearchWorkspaceService`, `EvidenceAnchor`, speaker, time, and playback-seek contracts.
+The next presentation seam is the first thin GUI. It should consume the same discovery,
+`ResearchWorkspaceService`, `EvidenceAnchor`, saved-search, speaker, time, and playback-seek
+contracts. It must not create a second definition of where evidence or user state lives.
 
 ## New abstraction test
 

--- a/docs/architecture/library-lifecycle.md
+++ b/docs/architecture/library-lifecycle.md
@@ -1,0 +1,284 @@
+# Library lifecycle, custody, and refresh
+
+EchoFlow's library contains several kinds of local data that deliberately have different
+retention and recovery rules. A transcript is not a search index, a note is not a cache,
+and an operational log is not evidence.
+
+The central rule is:
+
+> **Canonical transcript JSON is durable user-visible evidence. Library indexes are
+> disposable views over that evidence.**
+
+This distinction explains why EchoFlow can safely rescan or rebuild a library without
+re-transcribing the recording.
+
+## Where canonical transcripts live
+
+By default, EchoFlow publishes user-visible artifacts under the operating system's normal
+Downloads directory:
+
+```text
+Downloads/
+└── EchoFlow/
+    ├── interview.json
+    ├── interview.txt
+    ├── interview.srt
+    └── interview.vtt
+```
+
+The exact platform path is resolved with `platformdirs`; EchoFlow does not assume a
+hard-coded Unix or Windows home layout.
+
+Canonical JSON is the authoritative transcript artifact. TXT, SRT, and VTT are derived
+publication formats and may be regenerated from canonical JSON without rerunning ASR.
+
+A user may choose another output directory for a transcription:
+
+```bash
+echoflow transcribe recording.m4a --output-dir /path/to/research/project
+```
+
+The configured default is `ECHOFLOW_OUTPUT_DIR`. An explicitly selected EchoFlow dotenv
+configuration file can therefore make another location the normal destination across
+commands:
+
+```text
+ECHOFLOW_OUTPUT_DIR=/path/to/research/project
+```
+
+```bash
+echoflow --config /path/to/echoflow.env transcribe recording.m4a
+```
+
+`echoflow init --output-dir ...` initializes a selected public output directory for that
+invocation; it does not silently rewrite a persistent configuration file.
+
+Public transcript output is intentionally kept separate from EchoFlow's private state and
+cache directories. `WorkspacePaths` rejects layouts where the public output tree overlaps
+private state/cache.
+
+Artifact allocation is collision-safe. EchoFlow does not silently overwrite an existing
+canonical transcript with the same friendly filename.
+
+## What `library rebuild` actually means
+
+A library rebuild is a **discovery and indexing operation**.
+
+It does not:
+
+- decode audio;
+- run faster-whisper;
+- perform diarization;
+- rewrite canonical JSON; or
+- replace the original recording.
+
+It reads existing canonical transcript JSON and rebuilds the private analytical structures
+used for search.
+
+Conceptually:
+
+```text
+original recording
+       |
+       | one transcription run
+       v
+canonical transcript JSON       durable evidence
+       |
+       | scan / project
+       v
+DuckDB lexical index             disposable
+DuckDB semantic index            disposable
+DuckDB research projection       disposable
+```
+
+The transcript library discovers canonical JSON from three sources:
+
+1. completed EchoFlow lifecycle records that point to an existing canonical artifact;
+2. the configured EchoFlow output directory; and
+3. file or directory paths explicitly supplied to `echoflow library rebuild`.
+
+An explicit file is treated strictly: if it is claimed as a canonical transcript but
+cannot be loaded, rebuild fails rather than pretending it was harmless noise. Directory
+scans may skip unrelated JSON files that are not EchoFlow canonical transcripts.
+
+## Why would a user ever rescan the transcripts?
+
+Not because transcripts are supposed to disappear. Rescanning exists because **the corpus
+and its derived indexes can drift apart**.
+
+Normal reasons include:
+
+### A new transcript exists
+
+A user transcribes another interview, imports an older EchoFlow canonical JSON, or copies a
+canonical transcript into a research directory. The evidence exists on disk, but an older
+index cannot know about it until the library is refreshed.
+
+### A transcript generation changed
+
+A recording may be deliberately retranscribed after changing the engine/model,
+preprocessing policy, language handling, or another transcription contract. The resulting
+canonical bytes have a different SHA-256 and represent a different evidence generation.
+
+The lexical index should then reflect the new canonical generation. Existing semantic
+vectors are not silently trusted: EchoFlow compares corpus fingerprints and refuses stale
+semantic search until embeddings are rebuilt for the current corpus.
+
+### A transcript was removed or moved
+
+A rebuild re-derives the indexed corpus from what EchoFlow can currently discover. That
+lets a removed transcript disappear from a disposable index without requiring the index
+to become a second authority about whether the evidence still exists.
+
+Moving a canonical transcript outside the configured output directory may require adding
+its new directory explicitly when rebuilding unless EchoFlow already knows the artifact
+through durable job lifecycle state.
+
+### A rebuildable database was deleted, damaged, or became incompatible
+
+Lexical, semantic, and research DuckDB files are not unique user knowledge. If one is
+missing or cannot be trusted, EchoFlow can rebuild it from authoritative evidence/state
+instead of attempting heroic in-place repair.
+
+This is an intentional recovery feature. The rebuildability of the index is what makes it
+safe to treat the index as disposable.
+
+### Search/index implementation changed
+
+A later EchoFlow release may change projection schema, tokenization, chunk mapping, or
+another derived representation. Rebuilding lets the new release regenerate those views
+from canonical evidence rather than migrating every historical cache representation.
+
+## Full rebuild versus incremental refresh
+
+Today, `echoflow library rebuild` is the explicit whole-corpus repair/discovery path.
+
+That is correct but eventually inefficient for a large library when only one transcript
+changed. The planned incremental refresh contract uses stable transcript-generation
+identity such as:
+
+```text
+(document_id, canonical_sha256)
+```
+
+Then normal refresh can behave as:
+
+```text
+new generation       -> upsert
+changed generation   -> replace/upsert
+removed transcript   -> remove
+unchanged transcript -> skip
+```
+
+A full rebuild remains valuable as an explicit recovery operation even after incremental
+refresh exists.
+
+## Saved searches do not save result snapshots
+
+Saved searches are durable **questions**, not frozen answers.
+
+PR #67 stores typed search intent in authoritative SQLite:
+
+- transcript query text;
+- phrase / ANY / ALL semantics;
+- speaker, language, and transcript constraints;
+- sort and result limit;
+- lexical / semantic / hybrid retrieval mode;
+- research tag/collection/note constraints; and
+- canonical context width.
+
+It explicitly refuses to persist a derived `evidence_scope`.
+
+When a saved search runs later, `ResearchWorkspaceService` resolves the current research
+relationships and current canonical evidence again. If qualifying evidence has been added
+since the search was saved, the saved query can find it.
+
+This is why saved searches survive library growth without becoming stale snapshots.
+
+## Frequent and recent navigation is disposable
+
+Frequent/recent tags and collections are computed from current note relationships and note
+update timestamps.
+
+EchoFlow does **not** store authoritative `usage_count` or `last_used_at` counters on tag
+and collection records. Those values are views.
+
+If the derived navigation calculation changes tomorrow, no user-authored state needs to
+be migrated or repaired.
+
+## Retention classes
+
+| Class | Examples | Retention rule |
+|---|---|---|
+| Authoritative source evidence | original recording | user-owned; EchoFlow treats input read-only |
+| Authoritative transcript evidence | canonical JSON | durable user-visible artifact; never an index cache |
+| Authoritative human work | notes, tags, collections, speaker labels, saved searches | durable; losing it loses user work |
+| Derived publications | TXT, SRT, VTT | deletable and regenerable from canonical JSON |
+| Rebuildable analytical state | lexical DuckDB, semantic DuckDB, research DuckDB | may be deleted/rebuilt |
+| Private execution state | checkpoints, normalized/enhanced intermediates, work segments | lifecycle-managed for execution/resume, not evidence authority |
+| Operational logs | structured process log stream | diagnostic only; not transcript evidence |
+
+EchoFlow's structured application logger currently writes to the process stream (`stderr`)
+rather than creating a durable transcript-log archive. Routine local filesystem paths are
+redacted unless path disclosure is explicitly enabled.
+
+That logging policy is independent of canonical transcript retention.
+
+## Safe deletion is a separate product operation
+
+EchoFlow does not yet provide one unified safe-delete command for transcript evidence and
+all dependent state. That should not be faked by teaching users to manually delete random
+SQLite/DuckDB rows.
+
+A future deletion surface needs to distinguish at least:
+
+- **delete a derived index/cache**: safe to rebuild; no unique work should disappear;
+- **delete a publication export**: safe to regenerate from canonical JSON;
+- **delete private execution/checkpoint state**: may remove resume capability but not
+  canonical evidence;
+- **delete a saved search/note/tag relationship**: explicit deletion of human-authored
+  state;
+- **remove a transcript from the active library**: an indexing/membership decision, not
+  necessarily deletion of canonical evidence; and
+- **delete canonical transcript evidence**: destructive user-data deletion that must make
+  dependent notes/anchors and projections explicit before committing.
+
+Secure deletion of arbitrary files on modern SSDs, copy-on-write filesystems, snapshots,
+backups, sync clients, and wear-levelled storage cannot be honestly guaranteed by simply
+overwriting bytes. EchoFlow should therefore use precise language about deletion and
+retention rather than claiming cryptographic shredding it cannot prove.
+
+The safe-delete design should preserve one core invariant: **a command that means “remove
+this from search” must never accidentally mean “erase my only canonical transcript and my
+annotations.”**
+
+## Test contract for this lifecycle
+
+PR #67 exercises the following invariants at multiple layers:
+
+- saved-search typed intent round-trips through SQLite;
+- saved-search names are case-insensitive unique identities without accidental overwrite;
+- derived evidence scopes cannot be persisted as saved-search state;
+- replay re-resolves current research relationships rather than freezing old segment IDs;
+- frequent/recent navigation is derived from current relationships;
+- authoritative tag/collection rows do not grow usage/recency counters;
+- unsupported/corrupt durable metadata fails closed;
+- CLI flags compile to the same typed `SearchQuery` and research-filter contracts;
+- CLI save/list/show/run/delete and navigation surfaces preserve JSON/human behavior; and
+- CLI public errors remain useful while unexpected internal details are masked.
+
+The normal repository Quality workflow then runs Ruff, formatting, strict mypy, Vulture,
+Radon, branch-coverage pytest, distribution build/install verification, and full tests on
+Windows and macOS.
+
+## Load-bearing invariants
+
+1. Canonical JSON is evidence, not cache.
+2. Rescanning/rebuilding indexes never means re-transcribing audio.
+3. Saved searches persist typed intent, never a frozen derived evidence scope.
+4. Frequent/recent navigation remains derived rather than authoritative counters.
+5. Deleting a rebuildable database must not delete canonical evidence or human-authored
+   research state.
+6. Output directories remain user-visible and separate from private state/cache.
+7. Destructive canonical-evidence deletion must be explicit and dependency-aware when that
+   capability is implemented.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/**" = ["S101", "S603"]
+# The navigation adapter interpolates only closed internal table/order fragments selected
+# by code; every runtime/user value remains a bound SQLite parameter.
+"src/echoflow/library/workspace_metadata.py" = ["S608"]
 
 [tool.radon]
 # Report B-or-worse complexity; Ruff enforces the hard score-above-10 gate.

--- a/src/echoflow/app/app_container.py
+++ b/src/echoflow/app/app_container.py
@@ -28,6 +28,7 @@ from echoflow.library.service import TranscriptLibraryService
 from echoflow.library.speaker_label_service import SpeakerLabelService
 from echoflow.library.speaker_labels import SpeakerLabelStore
 from echoflow.library.sqlite_research_state import SqliteResearchStateStore
+from echoflow.library.workspace_metadata import SqliteWorkspaceMetadataStore
 from echoflow.media.probe import FfprobeMediaProbe
 from echoflow.media.selection import AudioStreamSelector
 from echoflow.model_management.catalog import faster_whisper_model_catalog
@@ -162,6 +163,13 @@ def _create_research_state_store(
     )
 
 
+def _create_workspace_metadata_store(
+    research_state: SqliteResearchStateStore,
+    file_manager: FileManagerFacade,
+) -> SqliteWorkspaceMetadataStore:
+    return SqliteWorkspaceMetadataStore(research_state.database_path, file_manager)
+
+
 def _create_research_projection(
     config: AppConfig, file_manager: FileManagerFacade
 ) -> DuckDbResearchProjection:
@@ -278,6 +286,11 @@ class AppContainer(containers.DeclarativeContainer):
         config=config,
         file_manager=file_manager,
     )
+    workspace_metadata_store = providers.Singleton(
+        _create_workspace_metadata_store,
+        research_state=research_state_store,
+        file_manager=file_manager,
+    )
     research_projection = providers.Singleton(
         _create_research_projection,
         config=config,
@@ -314,6 +327,7 @@ class AppContainer(containers.DeclarativeContainer):
         state=research_state_store,
         projection=research_projection,
         projector=research_projector,
+        metadata=workspace_metadata_store,
     )
     checkpoint_store = providers.Factory(
         LocalCheckpointStore, file_manager=file_manager

--- a/src/echoflow/cli_research.py
+++ b/src/echoflow/cli_research.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 from echoflow.app.app_container import AppContainer
+from echoflow.cli_saved_searches import register_saved_search_commands
 from echoflow.core.errors import EchoFlowError
 from echoflow.library.research_projector import ResearchProjectionSyncReport
 from echoflow.library.research_workspace import (
@@ -510,3 +511,4 @@ def register_research_commands(
 ) -> None:
     library_app.add_typer(_build_notes_app(container_factory), name="notes")
     library_app.add_typer(_build_projection_app(container_factory), name="research")
+    register_saved_search_commands(library_app, container_factory)

--- a/src/echoflow/cli_saved_searches.py
+++ b/src/echoflow/cli_saved_searches.py
@@ -100,9 +100,7 @@ def _navigation_dict(navigation: WorkspaceNavigation) -> dict[str, object]:
         "frequent_tags": [
             _navigation_item_dict(item) for item in navigation.frequent_tags
         ],
-        "recent_tags": [
-            _navigation_item_dict(item) for item in navigation.recent_tags
-        ],
+        "recent_tags": [_navigation_item_dict(item) for item in navigation.recent_tags],
         "frequent_collections": [
             _navigation_item_dict(item) for item in navigation.frequent_collections
         ],
@@ -242,7 +240,9 @@ def _list_saved(
         _handle_error(exc)
         return
     if json_output:
-        typer.echo(json.dumps([_saved_search_dict(item) for item in saved], sort_keys=True))
+        typer.echo(
+            json.dumps([_saved_search_dict(item) for item in saved], sort_keys=True)
+        )
         return
     _render_saved_searches(saved)
 

--- a/src/echoflow/cli_saved_searches.py
+++ b/src/echoflow/cli_saved_searches.py
@@ -1,0 +1,508 @@
+"""CLI for durable saved searches and disposable workspace navigation views."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, cast
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from echoflow.app.app_container import AppContainer
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.index import SearchOperator, SearchQuery, SearchSort
+from echoflow.library.research_workspace import (
+    ResearchQueryFilters,
+    ResearchWorkspaceService,
+    WorkspaceSearchResponse,
+)
+from echoflow.library.retrieval import RetrievalMode
+from echoflow.library.workspace_metadata import (
+    NavigationItem,
+    SavedSearch,
+    WorkspaceNavigation,
+)
+from echoflow.media.time_coordinates import format_elapsed_timestamp
+
+ContainerFactory = Callable[[typer.Context], AppContainer]
+
+
+def _root_context(context: typer.Context) -> typer.Context:
+    return cast("typer.Context", context.find_root())
+
+
+def _workspace(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+) -> ResearchWorkspaceService:
+    return container_factory(_root_context(context)).research_workspace()
+
+
+def _handle_error(exc: Exception) -> None:
+    if isinstance(exc, EchoFlowError):
+        typer.echo(exc.public_message, err=True)
+        raise typer.Exit(code=exc.exit_code) from None
+    if isinstance(exc, (ValueError, ModuleNotFoundError)):
+        raise typer.BadParameter(str(exc)) from exc
+    typer.echo(
+        f"EchoFlow saved-search workspace failed internally ({type(exc).__name__})",
+        err=True,
+    )
+    raise typer.Exit(code=3) from None
+
+
+def _saved_search_dict(saved: SavedSearch) -> dict[str, object]:
+    intent = saved.intent
+    query = intent.query
+    return {
+        "saved_search_id": saved.saved_search_id,
+        "name": saved.name,
+        "description": saved.description,
+        "created_at": saved.created_at,
+        "updated_at": saved.updated_at,
+        "intent": {
+            "query": {
+                "text": query.text,
+                "phrase": query.phrase,
+                "operator": query.operator.value,
+                "speaker_refs": list(query.speaker_refs),
+                "languages": list(query.languages),
+                "document_ids": list(query.document_ids),
+                "sort": query.sort.value,
+                "limit": query.limit,
+            },
+            "research_filter": {
+                "tags": list(intent.tags),
+                "collections": list(intent.collections),
+                "note_text": intent.note_text,
+                "with_notes": intent.with_notes,
+            },
+            "retrieval_mode": intent.mode.value,
+            "context_segments": intent.context_segments,
+        },
+    }
+
+
+def _navigation_item_dict(item: NavigationItem) -> dict[str, object]:
+    return {
+        "object_id": item.object_id,
+        "name": item.name,
+        "usage_count": item.usage_count,
+        "last_used_at": item.last_used_at,
+    }
+
+
+def _navigation_dict(navigation: WorkspaceNavigation) -> dict[str, object]:
+    return {
+        "frequent_tags": [
+            _navigation_item_dict(item) for item in navigation.frequent_tags
+        ],
+        "recent_tags": [
+            _navigation_item_dict(item) for item in navigation.recent_tags
+        ],
+        "frequent_collections": [
+            _navigation_item_dict(item) for item in navigation.frequent_collections
+        ],
+        "recent_collections": [
+            _navigation_item_dict(item) for item in navigation.recent_collections
+        ],
+    }
+
+
+def _run_response_dict(
+    saved: SavedSearch,
+    response: WorkspaceSearchResponse,
+) -> dict[str, object]:
+    return {
+        "saved_search": _saved_search_dict(saved),
+        "result_count": len(response.results),
+        "results": [
+            {
+                "document_id": item.located.passage.document_id,
+                "source_sha256": item.located.passage.source_sha256,
+                "canonical_sha256": item.located.passage.canonical_sha256,
+                "canonical_path": item.located.passage.canonical_path,
+                "source_path": item.located.passage.source_path,
+                "segment_ids": list(item.located.passage.segment_ids),
+                "start_seconds": item.located.passage.start_seconds,
+                "end_seconds": item.located.passage.end_seconds,
+                "seek_seconds": item.located.evidence.seek_seconds,
+                "text": item.located.passage.text,
+                "speaker_refs": list(item.located.passage.speaker_refs),
+                "speaker_display_labels": {
+                    speaker.speaker_ref: speaker.display_label
+                    for speaker in item.located.speakers
+                    if speaker.display_label is not None
+                },
+                "research_state": {
+                    "note_ids": list(item.research.note_ids),
+                    "tags": list(item.research.tags),
+                    "collections": list(item.research.collections),
+                },
+            }
+            for item in response.results
+        ],
+    }
+
+
+def _render_saved_searches(saved_searches: tuple[SavedSearch, ...]) -> None:
+    table = Table(title=f"EchoFlow saved searches: {len(saved_searches)}")
+    table.add_column("Name")
+    table.add_column("ID")
+    table.add_column("Query")
+    table.add_column("Mode")
+    table.add_column("Research filters")
+    table.add_column("Updated")
+    for saved in saved_searches:
+        intent = saved.intent
+        filters: list[str] = []
+        if intent.tags:
+            filters.append("# " + ", ".join(intent.tags))
+        if intent.collections:
+            filters.append("in " + ", ".join(intent.collections))
+        if intent.note_text is not None:
+            filters.append(f"note: {intent.note_text}")
+        if intent.with_notes:
+            filters.append("with notes")
+        table.add_row(
+            saved.name,
+            saved.saved_search_id,
+            intent.query.text,
+            intent.mode.value,
+            "\n".join(filters) or "—",
+            saved.updated_at,
+        )
+    Console().print(table)
+
+
+def _render_run(saved: SavedSearch, response: WorkspaceSearchResponse) -> None:
+    table = Table(
+        title=f"{saved.name}: {len(response.results)} current evidence result(s)"
+    )
+    table.add_column("Recording", min_width=14)
+    table.add_column("Evidence time", min_width=12)
+    table.add_column("Research", min_width=10)
+    table.add_column("Passage")
+    for item in response.results:
+        passage = item.located.passage
+        recording = (
+            passage.document_id
+            if passage.source_path is None
+            else Path(passage.source_path).name
+        )
+        research: list[str] = []
+        if item.research.note_count:
+            research.append(f"{item.research.note_count} note(s)")
+        if item.research.tags:
+            research.append("# " + ", ".join(item.research.tags))
+        if item.research.collections:
+            research.append("in " + ", ".join(item.research.collections))
+        table.add_row(
+            recording,
+            format_elapsed_timestamp(item.located.evidence.seek_seconds),
+            "\n".join(research) or "—",
+            passage.text,
+        )
+    Console().print(table)
+
+
+def _render_navigation(navigation: WorkspaceNavigation) -> None:
+    table = Table(title="EchoFlow workspace navigation")
+    table.add_column("View")
+    table.add_column("Name")
+    table.add_column("Uses", justify="right")
+    table.add_column("Last used")
+    groups = (
+        ("frequent tag", navigation.frequent_tags),
+        ("recent tag", navigation.recent_tags),
+        ("frequent collection", navigation.frequent_collections),
+        ("recent collection", navigation.recent_collections),
+    )
+    for label, items in groups:
+        for item in items:
+            table.add_row(label, item.name, str(item.usage_count), item.last_used_at)
+    Console().print(table)
+
+
+def _list_saved(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+    *,
+    limit: int,
+    json_output: bool,
+) -> None:
+    if context.invoked_subcommand is not None:
+        return
+    try:
+        saved = _workspace(context, container_factory).saved_searches(limit=limit)
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps([_saved_search_dict(item) for item in saved], sort_keys=True))
+        return
+    _render_saved_searches(saved)
+
+
+def _show_saved(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+    identifier: str,
+    *,
+    json_output: bool,
+) -> None:
+    try:
+        saved = _workspace(context, container_factory).saved_search(identifier)
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if saved is None:
+        typer.echo("Saved search does not exist", err=True)
+        raise typer.Exit(code=2)
+    if json_output:
+        typer.echo(json.dumps(_saved_search_dict(saved), sort_keys=True))
+        return
+    _render_saved_searches((saved,))
+
+
+def _save_search(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+    name: str,
+    text: str,
+    *,
+    description: str | None,
+    phrase: bool,
+    all_terms: bool,
+    speakers: tuple[str, ...],
+    languages: tuple[str, ...],
+    documents: tuple[str, ...],
+    tags: tuple[str, ...],
+    collections: tuple[str, ...],
+    note_text: str | None,
+    with_notes: bool,
+    sort: SearchSort,
+    mode: RetrievalMode,
+    limit: int,
+    context_segments: int,
+    json_output: bool,
+) -> None:
+    try:
+        saved = _workspace(context, container_factory).save_search(
+            name,
+            SearchQuery(
+                text=text,
+                phrase=phrase,
+                operator=SearchOperator.ALL if all_terms else SearchOperator.ANY,
+                speaker_refs=speakers,
+                languages=languages,
+                document_ids=documents,
+                sort=sort,
+                limit=limit,
+            ),
+            filters=ResearchQueryFilters(
+                tags=tags,
+                collections=collections,
+                note_text=note_text,
+                with_notes=with_notes,
+            ),
+            mode=mode,
+            context_segments=context_segments,
+            description=description,
+        )
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps(_saved_search_dict(saved), sort_keys=True))
+        return
+    typer.echo(f"Saved {saved.name!r} as {saved.saved_search_id}.")
+
+
+def _run_saved(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+    identifier: str,
+    *,
+    json_output: bool,
+) -> None:
+    try:
+        workspace = _workspace(context, container_factory)
+        saved = workspace.saved_search(identifier)
+        if saved is None:
+            typer.echo("Saved search does not exist", err=True)
+            raise typer.Exit(code=2)
+        response = workspace.run_saved_search(saved.saved_search_id)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps(_run_response_dict(saved, response), sort_keys=True))
+        return
+    _render_run(saved, response)
+
+
+def _delete_saved(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+    identifier: str,
+) -> None:
+    try:
+        workspace = _workspace(context, container_factory)
+        saved = workspace.saved_search(identifier)
+        if saved is None:
+            typer.echo("Saved search does not exist", err=True)
+            raise typer.Exit(code=2)
+        workspace.delete_saved_search(saved.saved_search_id)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    typer.echo(f"Deleted saved search {saved.name!r} from durable user state.")
+
+
+def _show_navigation(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+    *,
+    limit: int,
+    json_output: bool,
+) -> None:
+    try:
+        navigation = _workspace(context, container_factory).workspace_navigation(
+            limit=limit
+        )
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps(_navigation_dict(navigation), sort_keys=True))
+        return
+    _render_navigation(navigation)
+
+
+def register_saved_search_commands(
+    library_app: typer.Typer,
+    container_factory: ContainerFactory,
+) -> None:
+    """Register durable saved searches and derived navigation on ``library``."""
+    saved_app = typer.Typer(
+        help="Save and replay typed research searches.",
+        invoke_without_command=True,
+        no_args_is_help=False,
+    )
+
+    @saved_app.callback()
+    def saved_root(
+        context: typer.Context,
+        limit: int = typer.Option(100, "--limit", min=1, max=10_000),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _list_saved(
+            context,
+            container_factory,
+            limit=limit,
+            json_output=json_output,
+        )
+
+    @saved_app.command("save")
+    def save_search(
+        context: typer.Context,
+        name: str = typer.Argument(..., metavar="NAME"),
+        text: str = typer.Argument(..., metavar="QUERY"),
+        description: str | None = typer.Option(None, "--description"),
+        phrase: bool = typer.Option(False, "--phrase"),
+        all_terms: bool = typer.Option(False, "--all-terms"),
+        speakers: Annotated[list[str] | None, typer.Option("--speaker")] = None,
+        languages: Annotated[list[str] | None, typer.Option("--language")] = None,
+        documents: Annotated[list[str] | None, typer.Option("--transcript")] = None,
+        tags: Annotated[list[str] | None, typer.Option("--tag")] = None,
+        collections: Annotated[list[str] | None, typer.Option("--collection")] = None,
+        note_text: str | None = typer.Option(None, "--note-text"),
+        with_notes: bool = typer.Option(False, "--with-notes"),
+        sort: Annotated[SearchSort, typer.Option("--sort")] = SearchSort.RELEVANCE,
+        mode: Annotated[RetrievalMode, typer.Option("--mode")] = RetrievalMode.LEXICAL,
+        limit: int = typer.Option(100, "--limit", min=1, max=1_000),
+        context_segments: int = typer.Option(
+            0,
+            "--context-segments",
+            min=0,
+            max=10,
+        ),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _save_search(
+            context,
+            container_factory,
+            name,
+            text,
+            description=description,
+            phrase=phrase,
+            all_terms=all_terms,
+            speakers=tuple(speakers or ()),
+            languages=tuple(languages or ()),
+            documents=tuple(documents or ()),
+            tags=tuple(tags or ()),
+            collections=tuple(collections or ()),
+            note_text=note_text,
+            with_notes=with_notes,
+            sort=sort,
+            mode=mode,
+            limit=limit,
+            context_segments=context_segments,
+            json_output=json_output,
+        )
+
+    @saved_app.command("show")
+    def show_saved(
+        context: typer.Context,
+        identifier: str = typer.Argument(..., metavar="ID_OR_NAME"),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _show_saved(
+            context,
+            container_factory,
+            identifier,
+            json_output=json_output,
+        )
+
+    @saved_app.command("run")
+    def run_saved(
+        context: typer.Context,
+        identifier: str = typer.Argument(..., metavar="ID_OR_NAME"),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _run_saved(
+            context,
+            container_factory,
+            identifier,
+            json_output=json_output,
+        )
+
+    @saved_app.command("delete")
+    def delete_saved(
+        context: typer.Context,
+        identifier: str = typer.Argument(..., metavar="ID_OR_NAME"),
+    ) -> None:
+        _delete_saved(context, container_factory, identifier)
+
+    @library_app.command("navigation")
+    def navigation(
+        context: typer.Context,
+        limit: int = typer.Option(10, "--limit", min=1, max=100),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _show_navigation(
+            context,
+            container_factory,
+            limit=limit,
+            json_output=json_output,
+        )
+
+    library_app.add_typer(saved_app, name="saved")

--- a/src/echoflow/library/research_workspace.py
+++ b/src/echoflow/library/research_workspace.py
@@ -32,6 +32,12 @@ from echoflow.library.research_state import (
 from echoflow.library.retrieval import RetrievalMode
 from echoflow.library.service import TranscriptLibraryService
 from echoflow.library.text import lexical_tokens
+from echoflow.library.workspace_metadata import (
+    SavedSearch,
+    SavedSearchIntent,
+    WorkspaceMetadataStore,
+    WorkspaceNavigation,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,6 +146,7 @@ class ResearchWorkspaceService:
         state: ResearchStateStore,
         projection: ResearchProjectionIndex,
         projector: ResearchStateProjector,
+        metadata: WorkspaceMetadataStore | None = None,
     ) -> None:
         self.transcript_library = transcript_library
         self.evidence_locator = evidence_locator
@@ -147,6 +154,7 @@ class ResearchWorkspaceService:
         self.state = state
         self.projection = projection
         self.projector = projector
+        self.metadata = metadata
 
     def search(
         self,
@@ -231,6 +239,65 @@ class ResearchWorkspaceService:
             tags=tags,
             collections=collections,
         )
+
+    def save_search(
+        self,
+        name: str,
+        query: SearchQuery,
+        *,
+        filters: ResearchQueryFilters | None = None,
+        mode: RetrievalMode = RetrievalMode.LEXICAL,
+        context_segments: int = 0,
+        description: str | None = None,
+        saved_search_id: str | None = None,
+    ) -> SavedSearch:
+        """Persist typed search intent, never a rendered CLI command or result scope."""
+        resolved_filters = filters or ResearchQueryFilters()
+        intent = SavedSearchIntent(
+            query=query,
+            mode=mode,
+            context_segments=context_segments,
+            tags=resolved_filters.tags,
+            collections=resolved_filters.collections,
+            note_text=resolved_filters.note_text,
+            with_notes=resolved_filters.with_notes,
+        )
+        return self._metadata_store().create_saved_search(
+            name,
+            intent,
+            description=description,
+            saved_search_id=saved_search_id,
+        )
+
+    def saved_search(self, identifier: str) -> SavedSearch | None:
+        return self._metadata_store().saved_search(identifier)
+
+    def saved_searches(self, *, limit: int = 1_000) -> tuple[SavedSearch, ...]:
+        return self._metadata_store().saved_searches(limit=limit)
+
+    def delete_saved_search(self, identifier: str) -> None:
+        saved = self._require_saved_search(identifier)
+        self._metadata_store().delete_saved_search(saved.saved_search_id)
+
+    def run_saved_search(self, identifier: str) -> WorkspaceSearchResponse:
+        """Replay durable intent through the same current workspace-search path."""
+        saved = self._require_saved_search(identifier)
+        intent = saved.intent
+        return self.search(
+            intent.query,
+            filters=ResearchQueryFilters(
+                tags=intent.tags,
+                collections=intent.collections,
+                note_text=intent.note_text,
+                with_notes=intent.with_notes,
+            ),
+            mode=intent.mode,
+            context_segments=intent.context_segments,
+        )
+
+    def workspace_navigation(self, *, limit: int = 10) -> WorkspaceNavigation:
+        """Return disposable frequent/recent views over current research relationships."""
+        return self._metadata_store().navigation(limit=limit)
 
     def add_note(
         self,
@@ -471,6 +538,17 @@ class ResearchWorkspaceService:
                 collection_names[collection_id] for collection_id in note.collection_ids
             ),
         )
+
+    def _metadata_store(self) -> WorkspaceMetadataStore:
+        if self.metadata is None:
+            raise ResearchStateError("Saved-search workspace state is not configured")
+        return self.metadata
+
+    def _require_saved_search(self, identifier: str) -> SavedSearch:
+        saved = self._metadata_store().saved_search(identifier)
+        if saved is None:
+            raise ResearchStateError("Saved search does not exist")
+        return saved
 
     def _document(self, document_id: str) -> IndexedDocument:
         document = next(

--- a/src/echoflow/library/tests/test_saved_search_workspace.py
+++ b/src/echoflow/library/tests/test_saved_search_workspace.py
@@ -163,9 +163,7 @@ def test_workspace_navigation_reads_live_relationships_not_saved_counters(
         ("methods", 2),
         ("housing", 1),
     ]
-    assert [
-        (item.name, item.usage_count) for item in after.frequent_collections
-    ] == [
+    assert [(item.name, item.usage_count) for item in after.frequent_collections] == [
         ("Appendix", 1),
         ("Chapter 1", 1),
     ]

--- a/src/echoflow/library/tests/test_saved_search_workspace.py
+++ b/src/echoflow/library/tests/test_saved_search_workspace.py
@@ -1,0 +1,171 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from echoflow.library.duckdb_research_projection import DuckDbResearchProjection
+from echoflow.library.evidence import EvidenceAnchor
+from echoflow.library.index import IndexedDocument, SearchQuery
+from echoflow.library.research_projector import ResearchStateProjector
+from echoflow.library.research_workspace import (
+    ResearchQueryFilters,
+    ResearchWorkspaceService,
+)
+from echoflow.library.retrieval import RetrievalMode
+from echoflow.library.sqlite_research_state import SqliteResearchStateStore
+from echoflow.library.workspace_metadata import SqliteWorkspaceMetadataStore
+
+
+class PrivateDirectoryStore:
+    def ensure_directory_exists(
+        self, directory_path: str | Path, *, private: bool = False
+    ) -> None:
+        assert private
+        Path(directory_path).mkdir(parents=True, exist_ok=True)
+
+
+def _anchor(segment_id: str) -> EvidenceAnchor:
+    return EvidenceAnchor(
+        document_id="job-1",
+        source_sha256="0" * 64,
+        canonical_sha256="1" * 64,
+        canonical_path="/private/job-1.json",
+        source_path="/private/job-1.wav",
+        segment_ids=(segment_id,),
+        start_seconds=1.0,
+        end_seconds=2.0,
+    )
+
+
+def _workspace(tmp_path: Path):
+    file_store = PrivateDirectoryStore()
+    state_path = tmp_path / "state" / "research.sqlite3"
+    state = SqliteResearchStateStore(
+        state_path,
+        file_store,  # type: ignore[arg-type]
+    )
+    metadata = SqliteWorkspaceMetadataStore(
+        state_path,
+        file_store,  # type: ignore[arg-type]
+    )
+    projection = DuckDbResearchProjection(
+        tmp_path / "projection" / "research.duckdb",
+        file_store,  # type: ignore[arg-type]
+    )
+    projector = ResearchStateProjector(state, projection, batch_size=1)
+    transcript_library = Mock()
+    transcript_library.documents.return_value = (
+        IndexedDocument(
+            document_id="job-1",
+            source_sha256="0" * 64,
+            canonical_sha256="1" * 64,
+            detected_language="en",
+            canonical_path="/private/job-1.json",
+            source_path="/private/job-1.wav",
+            segment_count=10,
+        ),
+    )
+    navigation = Mock()
+    navigation.search.return_value = SimpleNamespace(results=())
+    workspace = ResearchWorkspaceService(
+        transcript_library,
+        Mock(),
+        navigation,
+        state,
+        projection,
+        projector,
+        metadata,
+    )
+    return workspace, state, navigation
+
+
+def test_saved_search_replays_typed_intent_against_current_research_scope(
+    tmp_path: Path,
+) -> None:
+    workspace, state, navigation = _workspace(tmp_path)
+    state.create_note(
+        _anchor("segment-000001"),
+        "first note",
+        tags=("housing",),
+        note_id="note-1",
+    )
+    saved = workspace.save_search(
+        "Housing evidence",
+        SearchQuery("rent burden", document_ids=("job-1",), limit=25),
+        filters=ResearchQueryFilters(tags=("housing",), with_notes=True),
+        mode=RetrievalMode.HYBRID,
+        context_segments=2,
+        description="Reusable housing evidence query",
+        saved_search_id="search-housing",
+    )
+
+    assert saved.intent.query.evidence_scope is None
+    assert saved.intent.tags == ("housing",)
+    assert saved.intent.with_notes
+    assert saved.intent.mode is RetrievalMode.HYBRID
+    assert saved.intent.context_segments == 2
+
+    workspace.run_saved_search("Housing evidence")
+    first_runtime_query = navigation.search.call_args.args[0]
+    assert first_runtime_query.evidence_scope == (
+        ("job-1", "1" * 64, "segment-000001"),
+    )
+    assert navigation.search.call_args.kwargs == {
+        "mode": RetrievalMode.HYBRID,
+        "context_segments": 2,
+    }
+
+    state.create_note(
+        _anchor("segment-000002"),
+        "second note",
+        tags=("housing",),
+        note_id="note-2",
+    )
+    workspace.run_saved_search(saved.saved_search_id)
+    second_runtime_query = navigation.search.call_args.args[0]
+
+    assert saved.intent.query.evidence_scope is None
+    assert second_runtime_query.evidence_scope == (
+        ("job-1", "1" * 64, "segment-000001"),
+        ("job-1", "1" * 64, "segment-000002"),
+    )
+
+
+def test_workspace_navigation_reads_live_relationships_not_saved_counters(
+    tmp_path: Path,
+) -> None:
+    workspace, state, _ = _workspace(tmp_path)
+    first = state.create_note(
+        _anchor("segment-000001"),
+        "one",
+        tags=("housing",),
+        collections=("Chapter 1",),
+        note_id="note-1",
+    )
+    state.create_note(
+        _anchor("segment-000002"),
+        "two",
+        tags=("housing", "methods"),
+        collections=("Chapter 1",),
+        note_id="note-2",
+    )
+
+    before = workspace.workspace_navigation()
+    assert before.frequent_tags[0].name == "housing"
+    assert before.frequent_tags[0].usage_count == 2
+    assert before.frequent_collections[0].name == "Chapter 1"
+    assert before.frequent_collections[0].usage_count == 2
+
+    state.set_note_tags(first.note_id, ("methods",))
+    state.set_note_collections(first.note_id, ("Appendix",))
+    after = workspace.workspace_navigation()
+
+    assert [(item.name, item.usage_count) for item in after.frequent_tags] == [
+        ("methods", 2),
+        ("housing", 1),
+    ]
+    assert [
+        (item.name, item.usage_count) for item in after.frequent_collections
+    ] == [
+        ("Appendix", 1),
+        ("Chapter 1", 1),
+    ]

--- a/src/echoflow/library/tests/test_workspace_metadata.py
+++ b/src/echoflow/library/tests/test_workspace_metadata.py
@@ -1,0 +1,232 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from echoflow.library.evidence import EvidenceAnchor
+from echoflow.library.index import SearchOperator, SearchQuery, SearchSort
+from echoflow.library.retrieval import RetrievalMode
+from echoflow.library.sqlite_research_state import SqliteResearchStateStore
+from echoflow.library.workspace_metadata import (
+    SavedSearchIntent,
+    SqliteWorkspaceMetadataStore,
+)
+
+
+class PrivateDirectoryStore:
+    def ensure_directory_exists(
+        self, directory_path: str | Path, *, private: bool = False
+    ) -> None:
+        assert private
+        Path(directory_path).mkdir(parents=True, exist_ok=True)
+
+
+def _stores(tmp_path: Path):
+    path = tmp_path / "state" / "research.sqlite3"
+    file_store = PrivateDirectoryStore()
+    research = SqliteResearchStateStore(
+        path,
+        file_store,  # type: ignore[arg-type]
+    )
+    metadata = SqliteWorkspaceMetadataStore(
+        path,
+        file_store,  # type: ignore[arg-type]
+    )
+    return research, metadata, path
+
+
+def _anchor(segment: int) -> EvidenceAnchor:
+    return EvidenceAnchor(
+        document_id="job-1",
+        source_sha256="0" * 64,
+        canonical_sha256="1" * 64,
+        canonical_path="/private/job-1.json",
+        source_path="/private/job-1.wav",
+        segment_ids=(f"segment-{segment:06d}",),
+        start_seconds=float(segment),
+        end_seconds=float(segment + 1),
+    )
+
+
+def _intent(*, text: str = "housing affordability") -> SavedSearchIntent:
+    return SavedSearchIntent(
+        query=SearchQuery(
+            text=text,
+            phrase=True,
+            operator=SearchOperator.ALL,
+            speaker_refs=("speaker-02",),
+            languages=("en",),
+            document_ids=("job-1",),
+            sort=SearchSort.TIMELINE,
+            limit=17,
+        ),
+        mode=RetrievalMode.HYBRID,
+        context_segments=2,
+        tags=("methodology",),
+        collections=("Chapter 3",),
+        note_text="rent burden",
+        with_notes=True,
+    )
+
+
+def test_saved_search_round_trip_preserves_typed_intent(tmp_path: Path) -> None:
+    _, metadata, _ = _stores(tmp_path)
+    intent = _intent()
+
+    created = metadata.create_saved_search(
+        "Housing chapter",
+        intent,
+        description="Interview evidence for the housing chapter",
+        saved_search_id="search-housing",
+    )
+
+    assert created.intent == intent
+    assert metadata.saved_search("search-housing") == created
+    assert metadata.saved_search("  HOUSING CHAPTER  ") == created
+    assert metadata.saved_searches() == (created,)
+
+    replacement = SavedSearchIntent(
+        query=SearchQuery("tenant protections", limit=25),
+        mode=RetrievalMode.LEXICAL,
+        tags=("policy",),
+    )
+    updated = metadata.update_saved_search(
+        created.saved_search_id,
+        name="Tenant protections",
+        description=None,
+        intent=replacement,
+    )
+
+    assert updated.saved_search_id == created.saved_search_id
+    assert updated.created_at == created.created_at
+    assert updated.updated_at >= created.updated_at
+    assert updated.intent == replacement
+    assert metadata.saved_search("tenant protections") == updated
+    assert metadata.saved_search("Housing chapter") is None
+
+    metadata.delete_saved_search(updated.saved_search_id)
+    assert metadata.saved_searches() == ()
+
+
+def test_saved_search_rejects_derived_evidence_scope() -> None:
+    with pytest.raises(ValueError, match="derived evidence scope"):
+        SavedSearchIntent(
+            query=SearchQuery(
+                "housing",
+                evidence_scope=(("job-1", "1" * 64, "segment-000001"),),
+            )
+        )
+
+
+def test_saved_search_names_are_casefold_unique_without_overwrite(tmp_path: Path) -> None:
+    _, metadata, _ = _stores(tmp_path)
+    original = metadata.create_saved_search(
+        "Methods",
+        _intent(text="methodology"),
+        saved_search_id="search-1",
+    )
+
+    with pytest.raises(Exception, match="already exists"):
+        metadata.create_saved_search(
+            "  METHODS  ",
+            _intent(text="different"),
+            saved_search_id="search-2",
+        )
+
+    assert metadata.saved_searches() == (original,)
+
+
+def test_navigation_derives_usage_and_recency_from_current_relationships(
+    tmp_path: Path,
+) -> None:
+    research, metadata, _ = _stores(tmp_path)
+    research.create_note(
+        _anchor(1),
+        "First",
+        tags=("housing", "methodology"),
+        collections=("Chapter 1",),
+        note_id="note-1",
+    )
+    research.create_note(
+        _anchor(2),
+        "Second",
+        tags=("housing",),
+        collections=("Appendix",),
+        note_id="note-2",
+    )
+    research.create_note(
+        _anchor(3),
+        "Third",
+        tags=("housing",),
+        collections=("Chapter 1",),
+        note_id="note-3",
+    )
+
+    navigation = metadata.navigation(limit=10)
+
+    assert [(item.name, item.usage_count) for item in navigation.frequent_tags] == [
+        ("housing", 3),
+        ("methodology", 1),
+    ]
+    assert navigation.recent_tags[0].name == "housing"
+    assert [
+        (item.name, item.usage_count) for item in navigation.frequent_collections
+    ] == [
+        ("Chapter 1", 2),
+        ("Appendix", 1),
+    ]
+    assert navigation.recent_collections[0].name == "Chapter 1"
+
+    research.set_note_tags("note-3", ("methodology",))
+    refreshed = metadata.navigation(limit=10)
+
+    assert [(item.name, item.usage_count) for item in refreshed.frequent_tags] == [
+        ("housing", 2),
+        ("methodology", 2),
+    ]
+    assert refreshed.recent_tags[0].name == "methodology"
+
+
+def test_navigation_is_bounded_and_does_not_persist_counters(tmp_path: Path) -> None:
+    research, metadata, path = _stores(tmp_path)
+    research.create_note(
+        _anchor(1),
+        "One",
+        tags=("a", "b"),
+        collections=("one", "two"),
+        note_id="note-1",
+    )
+
+    assert len(metadata.navigation(limit=1).frequent_tags) == 1
+    assert len(metadata.navigation(limit=1).frequent_collections) == 1
+    with pytest.raises(ValueError, match="navigation limit"):
+        metadata.navigation(limit=0)
+
+    with sqlite3.connect(path) as connection:
+        columns = {
+            str(row[1])
+            for row in connection.execute("PRAGMA table_info(tags)").fetchall()
+        }
+        collection_columns = {
+            str(row[1])
+            for row in connection.execute("PRAGMA table_info(collections)").fetchall()
+        }
+    assert "usage_count" not in columns
+    assert "last_used_at" not in columns
+    assert "usage_count" not in collection_columns
+    assert "last_used_at" not in collection_columns
+
+
+def test_workspace_metadata_rejects_unsupported_schema(tmp_path: Path) -> None:
+    _, _, path = _stores(tmp_path)
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE workspace_metadata SET schema_version = 999 WHERE singleton = 1"
+        )
+        connection.commit()
+
+    with pytest.raises(Exception, match="schema is unsupported"):
+        SqliteWorkspaceMetadataStore(
+            path,
+            PrivateDirectoryStore(),  # type: ignore[arg-type]
+        )

--- a/src/echoflow/library/tests/test_workspace_metadata.py
+++ b/src/echoflow/library/tests/test_workspace_metadata.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from echoflow.library.errors import ResearchStateError
 from echoflow.library.evidence import EvidenceAnchor
 from echoflow.library.index import SearchOperator, SearchQuery, SearchSort
 from echoflow.library.retrieval import RetrievalMode
@@ -126,7 +127,7 @@ def test_saved_search_names_are_casefold_unique_without_overwrite(tmp_path: Path
         saved_search_id="search-1",
     )
 
-    with pytest.raises(Exception, match="already exists"):
+    with pytest.raises(ResearchStateError, match="already exists"):
         metadata.create_saved_search(
             "  METHODS  ",
             _intent(text="different"),
@@ -180,9 +181,11 @@ def test_navigation_derives_usage_and_recency_from_current_relationships(
     research.set_note_tags("note-3", ("methodology",))
     refreshed = metadata.navigation(limit=10)
 
+    # Frequency ties deliberately fall through to recency. The newly-used
+    # methodology relationship therefore sorts ahead of housing at count 2.
     assert [(item.name, item.usage_count) for item in refreshed.frequent_tags] == [
-        ("housing", 2),
         ("methodology", 2),
+        ("housing", 2),
     ]
     assert refreshed.recent_tags[0].name == "methodology"
 
@@ -225,7 +228,7 @@ def test_workspace_metadata_rejects_unsupported_schema(tmp_path: Path) -> None:
         )
         connection.commit()
 
-    with pytest.raises(Exception, match="schema is unsupported"):
+    with pytest.raises(ResearchStateError, match="schema is unsupported"):
         SqliteWorkspaceMetadataStore(
             path,
             PrivateDirectoryStore(),  # type: ignore[arg-type]

--- a/src/echoflow/library/tests/test_workspace_metadata.py
+++ b/src/echoflow/library/tests/test_workspace_metadata.py
@@ -119,7 +119,9 @@ def test_saved_search_rejects_derived_evidence_scope() -> None:
         )
 
 
-def test_saved_search_names_are_casefold_unique_without_overwrite(tmp_path: Path) -> None:
+def test_saved_search_names_are_casefold_unique_without_overwrite(
+    tmp_path: Path,
+) -> None:
     _, metadata, _ = _stores(tmp_path)
     original = metadata.create_saved_search(
         "Methods",

--- a/src/echoflow/library/workspace_metadata.py
+++ b/src/echoflow/library/workspace_metadata.py
@@ -1,0 +1,623 @@
+"""Durable saved searches and disposable workspace navigation views.
+
+Saved searches are human-authored research state and therefore live in the same
+private SQLite authority as notes, tags, and collections. Navigation rankings are
+derived from current relationships and timestamps; they are never authoritative
+counters.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol, cast, runtime_checkable
+from uuid import uuid4
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.errors import ResearchStateError
+from echoflow.library.index import SearchOperator, SearchQuery, SearchSort
+from echoflow.library.retrieval import RetrievalMode
+
+_METADATA_SCHEMA_VERSION = 1
+_MAX_ID_CHARS = 200
+_MAX_NAME_CHARS = 200
+_MAX_DESCRIPTION_CHARS = 4_000
+_MAX_LIST_RESULTS = 10_000
+_MAX_NAVIGATION_RESULTS = 100
+
+
+@dataclass(frozen=True, slots=True)
+class SavedSearchIntent:
+    """Typed workspace-search intent safe to persist and replay later."""
+
+    query: SearchQuery
+    mode: RetrievalMode = RetrievalMode.LEXICAL
+    context_segments: int = 0
+    tags: tuple[str, ...] = ()
+    collections: tuple[str, ...] = ()
+    note_text: str | None = None
+    with_notes: bool = False
+
+    def __post_init__(self) -> None:
+        if self.query.evidence_scope is not None:
+            raise ValueError(
+                "saved searches cannot persist a derived evidence scope"
+            )
+        if self.context_segments < 0 or self.context_segments > 10:
+            raise ValueError("context_segments must be between 0 and 10")
+        for name, values in (("tags", self.tags), ("collections", self.collections)):
+            if any(not value.strip() for value in values):
+                raise ValueError(f"{name} cannot contain blank values")
+            normalized = tuple(value.strip().casefold() for value in values)
+            if len(normalized) != len(set(normalized)):
+                raise ValueError(f"{name} cannot contain duplicates")
+        if self.note_text is not None and not self.note_text.strip():
+            raise ValueError("note_text cannot be blank")
+
+
+@dataclass(frozen=True, slots=True)
+class SavedSearch:
+    """One durable named query authored by the user."""
+
+    saved_search_id: str
+    name: str
+    description: str | None
+    intent: SavedSearchIntent
+    created_at: str
+    updated_at: str
+
+    def __post_init__(self) -> None:
+        if not self.saved_search_id.strip():
+            raise ValueError("saved_search_id cannot be empty")
+        if not self.name.strip():
+            raise ValueError("saved search name cannot be empty")
+        if self.description is not None and not self.description.strip():
+            raise ValueError("saved search description cannot be blank")
+        if not self.created_at.strip() or not self.updated_at.strip():
+            raise ValueError("saved search timestamps cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationItem:
+    """Disposable usage/recency view over one durable tag or collection."""
+
+    object_id: str
+    name: str
+    usage_count: int
+    last_used_at: str
+
+    def __post_init__(self) -> None:
+        if not self.object_id.strip() or not self.name.strip():
+            raise ValueError("navigation item identity and name cannot be empty")
+        if self.usage_count < 1:
+            raise ValueError("navigation usage_count must be positive")
+        if not self.last_used_at.strip():
+            raise ValueError("navigation last_used_at cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceNavigation:
+    """Useful derived navigation without creating new authoritative counters."""
+
+    frequent_tags: tuple[NavigationItem, ...]
+    recent_tags: tuple[NavigationItem, ...]
+    frequent_collections: tuple[NavigationItem, ...]
+    recent_collections: tuple[NavigationItem, ...]
+
+
+@runtime_checkable
+class WorkspaceMetadataStore(Protocol):
+    """Port for durable saved searches plus rebuildable/derived navigation views."""
+
+    def create_saved_search(
+        self,
+        name: str,
+        intent: SavedSearchIntent,
+        *,
+        description: str | None = None,
+        saved_search_id: str | None = None,
+    ) -> SavedSearch: ...
+
+    def update_saved_search(
+        self,
+        saved_search_id: str,
+        *,
+        name: str,
+        description: str | None,
+        intent: SavedSearchIntent,
+    ) -> SavedSearch: ...
+
+    def delete_saved_search(self, saved_search_id: str) -> None: ...
+
+    def saved_search(self, identifier: str) -> SavedSearch | None: ...
+
+    def saved_searches(self, *, limit: int = 1_000) -> tuple[SavedSearch, ...]: ...
+
+    def navigation(self, *, limit: int = 10) -> WorkspaceNavigation: ...
+
+
+class SqliteWorkspaceMetadataStore:
+    """SQLite adapter sharing the authoritative research-state database file."""
+
+    def __init__(self, database_path: Path, file_manager: FileManagerFacade) -> None:
+        self.database_path = database_path.expanduser().resolve(strict=False)
+        self.file_manager = file_manager
+        self.file_manager.ensure_directory_exists(
+            self.database_path.parent,
+            private=True,
+        )
+        self._initialize()
+
+    def create_saved_search(
+        self,
+        name: str,
+        intent: SavedSearchIntent,
+        *,
+        description: str | None = None,
+        saved_search_id: str | None = None,
+    ) -> SavedSearch:
+        resolved_id = self._validate_identifier(
+            saved_search_id or f"search-{uuid4().hex}",
+            "saved_search_id",
+        )
+        resolved_name = self._validate_name(name)
+        resolved_description = self._normalize_description(description)
+        now = self._now()
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_unique_name(connection, resolved_name, excluding_id=None)
+            connection.execute(
+                """
+                INSERT INTO saved_searches (
+                    saved_search_id, name, normalized_name, description,
+                    query_text, phrase, operator, speaker_refs_json,
+                    languages_json, document_ids_json, sort, result_limit,
+                    retrieval_mode, context_segments, tags_json,
+                    collections_json, note_text, with_notes, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                self._row_values(
+                    resolved_id,
+                    resolved_name,
+                    resolved_description,
+                    intent,
+                    created_at=now,
+                    updated_at=now,
+                ),
+            )
+            saved = self._saved_search_by_id(connection, resolved_id)
+            connection.commit()
+        if saved is None:
+            raise ResearchStateError("Saved search could not be read back")
+        return saved
+
+    def update_saved_search(
+        self,
+        saved_search_id: str,
+        *,
+        name: str,
+        description: str | None,
+        intent: SavedSearchIntent,
+    ) -> SavedSearch:
+        resolved_id = self._validate_identifier(saved_search_id, "saved_search_id")
+        resolved_name = self._validate_name(name)
+        resolved_description = self._normalize_description(description)
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            if self._saved_search_by_id(connection, resolved_id) is None:
+                raise ResearchStateError("Saved search does not exist")
+            self._require_unique_name(
+                connection,
+                resolved_name,
+                excluding_id=resolved_id,
+            )
+            current = connection.execute(
+                "SELECT created_at FROM saved_searches WHERE saved_search_id = ?",
+                (resolved_id,),
+            ).fetchone()
+            if current is None:
+                raise ResearchStateError("Saved search does not exist")
+            values = self._row_values(
+                resolved_id,
+                resolved_name,
+                resolved_description,
+                intent,
+                created_at=str(current[0]),
+                updated_at=self._now(),
+            )
+            changed = connection.execute(
+                """
+                UPDATE saved_searches SET
+                    name = ?, normalized_name = ?, description = ?,
+                    query_text = ?, phrase = ?, operator = ?,
+                    speaker_refs_json = ?, languages_json = ?, document_ids_json = ?,
+                    sort = ?, result_limit = ?, retrieval_mode = ?,
+                    context_segments = ?, tags_json = ?, collections_json = ?,
+                    note_text = ?, with_notes = ?, created_at = ?, updated_at = ?
+                WHERE saved_search_id = ?
+                """,
+                values[1:] + (resolved_id,),
+            ).rowcount
+            if changed != 1:
+                raise ResearchStateError("Saved search does not exist")
+            saved = self._saved_search_by_id(connection, resolved_id)
+            connection.commit()
+        if saved is None:
+            raise ResearchStateError("Updated saved search could not be read back")
+        return saved
+
+    def delete_saved_search(self, saved_search_id: str) -> None:
+        resolved_id = self._validate_identifier(saved_search_id, "saved_search_id")
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            changed = connection.execute(
+                "DELETE FROM saved_searches WHERE saved_search_id = ?",
+                (resolved_id,),
+            ).rowcount
+            if changed != 1:
+                raise ResearchStateError("Saved search does not exist")
+            connection.commit()
+
+    def saved_search(self, identifier: str) -> SavedSearch | None:
+        resolved = self._validate_identifier(identifier, "saved search identifier")
+        with self._connection() as connection:
+            exact = self._saved_search_by_id(connection, resolved)
+            if exact is not None:
+                return exact
+            row = connection.execute(
+                """
+                SELECT saved_search_id FROM saved_searches
+                WHERE normalized_name = ?
+                """,
+                (resolved.strip().casefold(),),
+            ).fetchone()
+            if row is None:
+                return None
+            return self._saved_search_by_id(connection, str(row[0]))
+
+    def saved_searches(self, *, limit: int = 1_000) -> tuple[SavedSearch, ...]:
+        if limit < 1 or limit > _MAX_LIST_RESULTS:
+            raise ValueError("saved search list limit must be between 1 and 10000")
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT saved_search_id FROM saved_searches
+                ORDER BY updated_at DESC, normalized_name, saved_search_id
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+            return tuple(
+                saved
+                for row in rows
+                if (saved := self._saved_search_by_id(connection, str(row[0])))
+                is not None
+            )
+
+    def navigation(self, *, limit: int = 10) -> WorkspaceNavigation:
+        if limit < 1 or limit > _MAX_NAVIGATION_RESULTS:
+            raise ValueError("navigation limit must be between 1 and 100")
+        with self._connection() as connection:
+            frequent_tags = self._navigation_rows(
+                connection,
+                kind="tag",
+                order="usage",
+                limit=limit,
+            )
+            recent_tags = self._navigation_rows(
+                connection,
+                kind="tag",
+                order="recent",
+                limit=limit,
+            )
+            frequent_collections = self._navigation_rows(
+                connection,
+                kind="collection",
+                order="usage",
+                limit=limit,
+            )
+            recent_collections = self._navigation_rows(
+                connection,
+                kind="collection",
+                order="recent",
+                limit=limit,
+            )
+        return WorkspaceNavigation(
+            frequent_tags=frequent_tags,
+            recent_tags=recent_tags,
+            frequent_collections=frequent_collections,
+            recent_collections=recent_collections,
+        )
+
+    def _initialize(self) -> None:
+        with self._connection() as connection:
+            connection.execute("PRAGMA journal_mode = WAL")
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS workspace_metadata (
+                    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                    schema_version INTEGER NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS saved_searches (
+                    saved_search_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    normalized_name TEXT NOT NULL UNIQUE,
+                    description TEXT,
+                    query_text TEXT NOT NULL,
+                    phrase INTEGER NOT NULL CHECK (phrase IN (0, 1)),
+                    operator TEXT NOT NULL,
+                    speaker_refs_json TEXT NOT NULL,
+                    languages_json TEXT NOT NULL,
+                    document_ids_json TEXT NOT NULL,
+                    sort TEXT NOT NULL,
+                    result_limit INTEGER NOT NULL,
+                    retrieval_mode TEXT NOT NULL,
+                    context_segments INTEGER NOT NULL,
+                    tags_json TEXT NOT NULL,
+                    collections_json TEXT NOT NULL,
+                    note_text TEXT,
+                    with_notes INTEGER NOT NULL CHECK (with_notes IN (0, 1)),
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS saved_searches_updated_idx
+                    ON saved_searches(updated_at DESC, saved_search_id);
+                """
+            )
+            connection.execute(
+                """
+                INSERT OR IGNORE INTO workspace_metadata (singleton, schema_version)
+                VALUES (1, ?)
+                """,
+                (_METADATA_SCHEMA_VERSION,),
+            )
+            row = connection.execute(
+                "SELECT schema_version FROM workspace_metadata WHERE singleton = 1"
+            ).fetchone()
+            if row is None or int(row[0]) != _METADATA_SCHEMA_VERSION:
+                raise ResearchStateError(
+                    "Workspace metadata schema is unsupported by this EchoFlow build"
+                )
+            connection.commit()
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        connection: sqlite3.Connection | None = None
+        try:
+            connection = sqlite3.connect(self.database_path, timeout=5.0)
+            connection.execute("PRAGMA foreign_keys = ON")
+            connection.execute("PRAGMA busy_timeout = 5000")
+            connection.execute("PRAGMA synchronous = FULL")
+            yield connection
+        except sqlite3.Error as exc:
+            if connection is not None:
+                connection.rollback()
+            raise ResearchStateError(
+                "Workspace metadata database operation failed",
+                cause=exc,
+            ) from exc
+        finally:
+            if connection is not None:
+                connection.close()
+
+    @staticmethod
+    def _row_values(
+        saved_search_id: str,
+        name: str,
+        description: str | None,
+        intent: SavedSearchIntent,
+        *,
+        created_at: str,
+        updated_at: str,
+    ) -> tuple[object, ...]:
+        query = intent.query
+        return (
+            saved_search_id,
+            name,
+            name.casefold(),
+            description,
+            query.text,
+            int(query.phrase),
+            query.operator.value,
+            SqliteWorkspaceMetadataStore._encode_tuple(query.speaker_refs),
+            SqliteWorkspaceMetadataStore._encode_tuple(query.languages),
+            SqliteWorkspaceMetadataStore._encode_tuple(query.document_ids),
+            query.sort.value,
+            query.limit,
+            intent.mode.value,
+            intent.context_segments,
+            SqliteWorkspaceMetadataStore._encode_tuple(intent.tags),
+            SqliteWorkspaceMetadataStore._encode_tuple(intent.collections),
+            intent.note_text,
+            int(intent.with_notes),
+            created_at,
+            updated_at,
+        )
+
+    def _saved_search_by_id(
+        self,
+        connection: sqlite3.Connection,
+        saved_search_id: str,
+    ) -> SavedSearch | None:
+        row = connection.execute(
+            """
+            SELECT saved_search_id, name, description, query_text, phrase, operator,
+                   speaker_refs_json, languages_json, document_ids_json, sort,
+                   result_limit, retrieval_mode, context_segments, tags_json,
+                   collections_json, note_text, with_notes, created_at, updated_at
+            FROM saved_searches
+            WHERE saved_search_id = ?
+            """,
+            (saved_search_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        try:
+            query = SearchQuery(
+                text=str(row[3]),
+                phrase=bool(row[4]),
+                operator=SearchOperator(str(row[5])),
+                speaker_refs=self._decode_tuple(row[6], "speaker_refs"),
+                languages=self._decode_tuple(row[7], "languages"),
+                document_ids=self._decode_tuple(row[8], "document_ids"),
+                sort=SearchSort(str(row[9])),
+                limit=int(row[10]),
+            )
+            intent = SavedSearchIntent(
+                query=query,
+                mode=RetrievalMode(str(row[11])),
+                context_segments=int(row[12]),
+                tags=self._decode_tuple(row[13], "tags"),
+                collections=self._decode_tuple(row[14], "collections"),
+                note_text=None if row[15] is None else str(row[15]),
+                with_notes=bool(row[16]),
+            )
+            return SavedSearch(
+                saved_search_id=str(row[0]),
+                name=str(row[1]),
+                description=None if row[2] is None else str(row[2]),
+                intent=intent,
+                created_at=str(row[17]),
+                updated_at=str(row[18]),
+            )
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise ResearchStateError("Saved search state is corrupt", cause=exc) from exc
+
+    @staticmethod
+    def _encode_tuple(values: tuple[str, ...]) -> str:
+        return json.dumps(list(values), ensure_ascii=False, separators=(",", ":"))
+
+    @staticmethod
+    def _decode_tuple(value: object, name: str) -> tuple[str, ...]:
+        decoded = json.loads(str(value))
+        if not isinstance(decoded, list) or any(
+            not isinstance(item, str) for item in decoded
+        ):
+            raise ValueError(f"saved search {name} state is invalid")
+        return tuple(decoded)
+
+    @staticmethod
+    def _require_unique_name(
+        connection: sqlite3.Connection,
+        name: str,
+        *,
+        excluding_id: str | None,
+    ) -> None:
+        row = connection.execute(
+            """
+            SELECT saved_search_id FROM saved_searches
+            WHERE normalized_name = ?
+            """,
+            (name.casefold(),),
+        ).fetchone()
+        if row is not None and str(row[0]) != excluding_id:
+            raise ResearchStateError("A saved search with that name already exists")
+
+    @staticmethod
+    def _navigation_rows(
+        connection: sqlite3.Connection,
+        *,
+        kind: str,
+        order: str,
+        limit: int,
+    ) -> tuple[NavigationItem, ...]:
+        if kind == "tag":
+            id_column = "t.tag_id"
+            name_column = "t.name"
+            normalized_column = "t.normalized_name"
+            from_clause = (
+                "tags t JOIN note_tags rel ON rel.tag_id = t.tag_id "
+                "JOIN notes n ON n.note_id = rel.note_id"
+            )
+        elif kind == "collection":
+            id_column = "c.collection_id"
+            name_column = "c.name"
+            normalized_column = "c.normalized_name"
+            from_clause = (
+                "collections c "
+                "JOIN collection_notes rel ON rel.collection_id = c.collection_id "
+                "JOIN notes n ON n.note_id = rel.note_id"
+            )
+        else:
+            raise ValueError("unsupported workspace navigation kind")
+
+        if order == "usage":
+            order_clause = (
+                "usage_count DESC, last_used_at DESC, normalized_name, object_id"
+            )
+        elif order == "recent":
+            order_clause = (
+                "last_used_at DESC, usage_count DESC, normalized_name, object_id"
+            )
+        else:
+            raise ValueError("unsupported workspace navigation order")
+
+        rows = connection.execute(
+            f"""
+            SELECT {id_column} AS object_id,
+                   {name_column} AS name,
+                   {normalized_column} AS normalized_name,
+                   COUNT(rel.note_id) AS usage_count,
+                   MAX(n.updated_at) AS last_used_at
+            FROM {from_clause}
+            GROUP BY object_id, name, normalized_name
+            ORDER BY {order_clause}
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return tuple(
+            NavigationItem(
+                object_id=str(row[0]),
+                name=str(row[1]),
+                usage_count=int(cast("int", row[3])),
+                last_used_at=str(row[4]),
+            )
+            for row in rows
+        )
+
+    @staticmethod
+    def _validate_identifier(value: str, name: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError(f"{name} cannot be blank")
+        if len(stripped) > _MAX_ID_CHARS:
+            raise ValueError(f"{name} is too long")
+        if any(character in stripped for character in ("\r", "\n", "\x00")):
+            raise ValueError(f"{name} contains unsupported control characters")
+        return stripped
+
+    @staticmethod
+    def _validate_name(value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("saved search name cannot be blank")
+        if len(stripped) > _MAX_NAME_CHARS:
+            raise ValueError("saved search name is too long")
+        if any(character in stripped for character in ("\r", "\n", "\x00")):
+            raise ValueError(
+                "saved search name contains unsupported control characters"
+            )
+        return stripped
+
+    @staticmethod
+    def _normalize_description(value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            return None
+        if len(stripped) > _MAX_DESCRIPTION_CHARS:
+            raise ValueError("saved search description is too long")
+        if "\x00" in stripped:
+            raise ValueError("saved search description cannot contain NUL characters")
+        return stripped
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(UTC).isoformat(timespec="microseconds")

--- a/src/echoflow/library/workspace_metadata.py
+++ b/src/echoflow/library/workspace_metadata.py
@@ -45,9 +45,7 @@ class SavedSearchIntent:
 
     def __post_init__(self) -> None:
         if self.query.evidence_scope is not None:
-            raise ValueError(
-                "saved searches cannot persist a derived evidence scope"
-            )
+            raise ValueError("saved searches cannot persist a derived evidence scope")
         if self.context_segments < 0 or self.context_segments > 10:
             raise ValueError("context_segments must be between 0 and 10")
         for name, values in (("tags", self.tags), ("collections", self.collections)):
@@ -486,7 +484,9 @@ class SqliteWorkspaceMetadataStore:
                 updated_at=str(row[18]),
             )
         except (TypeError, ValueError, json.JSONDecodeError) as exc:
-            raise ResearchStateError("Saved search state is corrupt", cause=exc) from exc
+            raise ResearchStateError(
+                "Saved search state is corrupt", cause=exc
+            ) from exc
 
     @staticmethod
     def _encode_tuple(values: tuple[str, ...]) -> str:

--- a/src/echoflow/tests/test_cli_saved_searches.py
+++ b/src/echoflow/tests/test_cli_saved_searches.py
@@ -1,0 +1,250 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import typer
+from typer.testing import CliRunner
+
+from echoflow.cli_library import register_library_commands
+from echoflow.library.errors import ResearchStateError
+from echoflow.library.index import SearchOperator, SearchQuery, SearchSort
+from echoflow.library.research_workspace import ResearchQueryFilters
+from echoflow.library.retrieval import RetrievalMode
+from echoflow.library.workspace_metadata import (
+    NavigationItem,
+    SavedSearch,
+    SavedSearchIntent,
+    WorkspaceNavigation,
+)
+
+
+def _saved_search() -> SavedSearch:
+    return SavedSearch(
+        saved_search_id="search-housing",
+        name="Housing chapter",
+        description="Interview evidence for the housing chapter",
+        intent=SavedSearchIntent(
+            query=SearchQuery(
+                "rent burden",
+                phrase=True,
+                operator=SearchOperator.ALL,
+                speaker_refs=("speaker-02",),
+                languages=("en",),
+                document_ids=("job-1",),
+                sort=SearchSort.TIMELINE,
+                limit=17,
+            ),
+            mode=RetrievalMode.HYBRID,
+            context_segments=2,
+            tags=("housing",),
+            collections=("Chapter 3",),
+            note_text="methodology",
+            with_notes=True,
+        ),
+        created_at="2026-08-19T01:00:00+00:00",
+        updated_at="2026-08-19T02:00:00+00:00",
+    )
+
+
+def _navigation() -> WorkspaceNavigation:
+    housing = NavigationItem(
+        object_id="tag-housing",
+        name="housing",
+        usage_count=3,
+        last_used_at="2026-08-19T02:00:00+00:00",
+    )
+    chapter = NavigationItem(
+        object_id="collection-chapter-3",
+        name="Chapter 3",
+        usage_count=2,
+        last_used_at="2026-08-19T01:30:00+00:00",
+    )
+    return WorkspaceNavigation(
+        frequent_tags=(housing,),
+        recent_tags=(housing,),
+        frequent_collections=(chapter,),
+        recent_collections=(chapter,),
+    )
+
+
+def _app(workspace: Mock) -> typer.Typer:
+    app = typer.Typer()
+    container = Mock()
+    container.research_workspace.return_value = workspace
+    register_library_commands(app, lambda context: container)
+    return app
+
+
+def test_saved_search_save_compiles_cli_options_into_typed_workspace_intent() -> None:
+    workspace = Mock()
+    workspace.save_search.return_value = _saved_search()
+
+    result = CliRunner().invoke(
+        _app(workspace),
+        [
+            "library",
+            "saved",
+            "save",
+            "Housing chapter",
+            "rent burden",
+            "--description",
+            "Interview evidence for the housing chapter",
+            "--phrase",
+            "--all-terms",
+            "--speaker",
+            "speaker-02",
+            "--language",
+            "en",
+            "--transcript",
+            "job-1",
+            "--tag",
+            "housing",
+            "--collection",
+            "Chapter 3",
+            "--note-text",
+            "methodology",
+            "--with-notes",
+            "--sort",
+            "timeline",
+            "--mode",
+            "hybrid",
+            "--limit",
+            "17",
+            "--context-segments",
+            "2",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    call = workspace.save_search.call_args
+    assert call.args[0] == "Housing chapter"
+    query = call.args[1]
+    assert query == SearchQuery(
+        "rent burden",
+        phrase=True,
+        operator=SearchOperator.ALL,
+        speaker_refs=("speaker-02",),
+        languages=("en",),
+        document_ids=("job-1",),
+        sort=SearchSort.TIMELINE,
+        limit=17,
+    )
+    assert call.kwargs["filters"] == ResearchQueryFilters(
+        tags=("housing",),
+        collections=("Chapter 3",),
+        note_text="methodology",
+        with_notes=True,
+    )
+    assert call.kwargs["mode"] is RetrievalMode.HYBRID
+    assert call.kwargs["context_segments"] == 2
+    assert call.kwargs["description"] == "Interview evidence for the housing chapter"
+    payload = json.loads(result.stdout)
+    assert payload["saved_search_id"] == "search-housing"
+    assert payload["intent"]["query"]["text"] == "rent burden"
+    assert payload["intent"]["research_filter"]["tags"] == ["housing"]
+
+
+def test_saved_search_list_and_show_expose_typed_intent() -> None:
+    workspace = Mock()
+    saved = _saved_search()
+    workspace.saved_searches.return_value = (saved,)
+    workspace.saved_search.return_value = saved
+    app = _app(workspace)
+    runner = CliRunner()
+
+    listed = runner.invoke(app, ["library", "saved", "--limit", "5", "--json"])
+    shown = runner.invoke(
+        app,
+        ["library", "saved", "show", "Housing chapter", "--json"],
+    )
+
+    assert listed.exit_code == shown.exit_code == 0
+    workspace.saved_searches.assert_called_once_with(limit=5)
+    workspace.saved_search.assert_called_once_with("Housing chapter")
+    assert json.loads(listed.stdout)[0]["intent"]["retrieval_mode"] == "hybrid"
+    assert json.loads(shown.stdout)["intent"]["context_segments"] == 2
+
+
+def test_saved_search_run_resolves_name_then_replays_stable_id() -> None:
+    workspace = Mock()
+    saved = _saved_search()
+    workspace.saved_search.return_value = saved
+    workspace.run_saved_search.return_value = SimpleNamespace(results=())
+
+    result = CliRunner().invoke(
+        _app(workspace),
+        ["library", "saved", "run", "Housing chapter", "--json"],
+    )
+
+    assert result.exit_code == 0
+    workspace.saved_search.assert_called_once_with("Housing chapter")
+    workspace.run_saved_search.assert_called_once_with("search-housing")
+    payload = json.loads(result.stdout)
+    assert payload["saved_search"]["name"] == "Housing chapter"
+    assert payload["result_count"] == 0
+    assert payload["results"] == []
+
+
+def test_saved_search_delete_is_explicit_durable_state_mutation() -> None:
+    workspace = Mock()
+    workspace.saved_search.return_value = _saved_search()
+
+    result = CliRunner().invoke(
+        _app(workspace),
+        ["library", "saved", "delete", "Housing chapter"],
+    )
+
+    assert result.exit_code == 0
+    workspace.delete_saved_search.assert_called_once_with("search-housing")
+    assert "durable user state" in result.stdout
+
+
+def test_navigation_json_is_a_derived_view_with_counts_and_recency() -> None:
+    workspace = Mock()
+    workspace.workspace_navigation.return_value = _navigation()
+
+    result = CliRunner().invoke(
+        _app(workspace),
+        ["library", "navigation", "--limit", "7", "--json"],
+    )
+
+    assert result.exit_code == 0
+    workspace.workspace_navigation.assert_called_once_with(limit=7)
+    payload = json.loads(result.stdout)
+    assert payload["frequent_tags"] == [
+        {
+            "last_used_at": "2026-08-19T02:00:00+00:00",
+            "name": "housing",
+            "object_id": "tag-housing",
+            "usage_count": 3,
+        }
+    ]
+    assert payload["recent_collections"][0]["name"] == "Chapter 3"
+
+
+def test_saved_search_cli_reports_missing_public_and_internal_failures_safely() -> None:
+    runner = CliRunner()
+
+    missing = Mock()
+    missing.saved_search.return_value = None
+    missing_result = runner.invoke(
+        _app(missing),
+        ["library", "saved", "show", "missing"],
+    )
+
+    public = Mock()
+    public.saved_searches.side_effect = ResearchStateError("Saved-search state unavailable")
+    public_result = runner.invoke(_app(public), ["library", "saved"])
+
+    internal = Mock()
+    internal.workspace_navigation.side_effect = RuntimeError("private path /secret")
+    internal_result = runner.invoke(_app(internal), ["library", "navigation"])
+
+    assert missing_result.exit_code == 2
+    assert "Saved search does not exist" in missing_result.output
+    assert public_result.exit_code == 2
+    assert "Saved-search state unavailable" in public_result.output
+    assert internal_result.exit_code == 3
+    assert "failed internally (RuntimeError)" in internal_result.output
+    assert "/secret" not in internal_result.output

--- a/src/echoflow/tests/test_cli_saved_searches.py
+++ b/src/echoflow/tests/test_cli_saved_searches.py
@@ -234,7 +234,9 @@ def test_saved_search_cli_reports_missing_public_and_internal_failures_safely() 
     )
 
     public = Mock()
-    public.saved_searches.side_effect = ResearchStateError("Saved-search state unavailable")
+    public.saved_searches.side_effect = ResearchStateError(
+        "Saved-search state unavailable"
+    )
     public_result = runner.invoke(_app(public), ["library", "saved"])
 
     internal = Mock()


### PR DESCRIPTION
## Summary

Add durable typed saved searches and disposable frequent/recent navigation over the unified research workspace introduced through #66.

Saved searches preserve the user's question. They do not freeze a result snapshot or derived evidence scope.

## Architecture

- saved searches are authoritative user-authored state in the same private SQLite research database as notes/tags/collections
- saved searches persist typed `SearchQuery` intent plus research filters, retrieval mode, and context width
- derived `evidence_scope` is explicitly rejected from saved state so replay cannot freeze stale projected segment identities
- running a saved search routes back through `ResearchWorkspaceService.search()` and re-resolves current research constraints and canonical evidence
- tag/collection frequency and recency are derived directly from current note relationships; no authoritative popularity counters are stored
- a separate `workspace_metadata` schema marker allows saved-search storage to evolve without pretending the DuckDB projections own human work

## Application / CLI

Adds workspace methods for save/list/get/delete/run plus derived navigation, wired through the existing DI container.

```bash
echoflow library saved
echoflow library saved save "Housing chapter" "rent burden" --tag housing --mode hybrid
echoflow library saved show "Housing chapter"
echoflow library saved run "Housing chapter"
echoflow library saved delete "Housing chapter"
echoflow library navigation
```

Both saved searches and navigation support JSON output where applicable.

## Documentation

Adds `docs/architecture/library-lifecycle.md`, which documents:

- canonical JSON custody and default/custom output directories
- what `library rebuild` does and why a user would rescan a corpus
- full rebuild versus planned incremental refresh
- saved-query-versus-saved-result semantics
- derived navigation semantics
- operational-log versus transcript-evidence retention
- the future safe-deletion boundary and why EchoFlow does not claim unverifiable secure erasure

Also reconciles `ROADMAP.md` and the architecture index so saved searches/derived navigation are foundation rather than future work, and records safe deletion/retention controls as the next custody-sensitive backend tranche.

## Tests added

Storage/service tests cover:

- typed saved-search round trip
- case-insensitive unique names without overwrite
- refusal to persist derived evidence scopes
- live replay against newly changed research relationships
- frequent/recent tag and collection derivation
- proof that no usage/recency counters are persisted onto authoritative tag/collection rows
- workspace metadata schema guard

CLI tests cover:

- CLI flags compiling into the shared typed `SearchQuery` and research-filter contracts
- save/list/show/run/delete behavior
- stable-ID replay after name resolution
- derived navigation JSON
- missing-state/public-error behavior and masking of unexpected internal details

## Quality status

The prior matrix run passed the full test suite, wheel build, and clean-install verification on both macOS and Windows. Linux then stopped at Ruff S608 because the navigation adapter composes SQL from closed internal table/order fragments. All runtime/user values remain bound SQLite parameters; the Ruff exception is now narrowly scoped and documented in `pyproject.toml`.

The PR remains draft while the Quality matrix runs against the reconciled implementation, tests, lint policy, and documentation.