### PR TITLE
feat(library): add safe deletion and retention controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,56 +6,50 @@ EchoFlow is a local-first Python application for turning recordings into durable
 searchable evidence and keeping research work attached to that evidence without handing
 the corpus to a hosted transcription service.
 
-It does more than run a speech model. EchoFlow inspects the machine it is running on,
-chooses a safe execution strategy, manages local model custody, survives interrupted
-work, preserves source provenance, publishes portable transcripts, keeps word-level
-timing evidence, handles anonymous speaker evidence conservatively, searches a private
-local corpus, navigates results back to verified canonical evidence, stores durable
-notes/tags/collections separately from rebuildable search machinery, and now gives those
-capabilities one grouped library-discovery doorway.
+It does more than run a speech model. EchoFlow inspects the machine, chooses a safe local
+execution strategy, manages model custody, survives interrupted work, preserves source
+provenance, publishes portable transcripts, keeps word-level timing and anonymous-speaker
+evidence, searches a private corpus, verifies results against canonical evidence, stores
+human research separately from rebuildable indexes, saves reusable research questions,
+and now gives deletion the same explicit custody rules as creation.
 
-The original recording remains read-only source evidence. Canonical transcript JSON is
-the authoritative transcript artifact. Human-authored research state is authoritative
-user knowledge. DuckDB search and research projections are acceleration structures that
-may be deleted and rebuilt.
+Canonical transcript JSON is authoritative transcript evidence. Human-authored research
+state is authoritative user knowledge. DuckDB search/research projections and publication
+formats are rebuildable. The original recording is read-only throughout normal processing
+and can only be deleted through a separate explicit provenance-checked operation.
 
 > **EchoFlow's product rule:** do complicated work locally, keep the evidence
 > understandable, portable, and owned by the user.
 
-For the human-friendly documentation lobby, start at **[docs/README.md](docs/README.md)**.
-For the shortest path from clone to transcript, use
-**[Getting started](docs/getting-started.md)**.
+Start with **[docs/README.md](docs/README.md)** for human-facing documentation or
+**[Getting started](docs/getting-started.md)** for the shortest clone-to-transcript path.
 
 ## What can it do right now?
 
-EchoFlow is pre-production, but the backend now covers most of the local
+EchoFlow is pre-production, but the backend covers most of the local
 recording-to-research lifecycle.
 
 | Area | Current foundation |
 |---|---|
 | Local transcription | faster-whisper CPU/int8 and CUDA-capable strategies with explicit managed model revisions |
-| Hardware awareness | process-visible CPU/RAM, affinity/cgroup limits, accelerator topology, engine capability negotiation, and resource admission |
-| Media handling | FFprobe inspection, deterministic audio-stream selection, FFmpeg canonicalization, exact source-relative frame windows |
-| Word timing | native faster-whisper word timestamps validated, rebased to source-relative time, and preserved through resume |
-| Time provenance | human `HH:MM:SS.mmm` elapsed coordinates plus source-declared `timecode` / `creation_time` provenance when available |
-| Reliability | durable private checkpoints, validated resume, contiguous checkpoint ordering, bounded accelerated prefetch |
+| Hardware awareness | process-visible CPU/RAM, affinity/cgroup limits, accelerator topology, engine capability negotiation, resource admission |
+| Media handling | FFprobe inspection, deterministic stream selection, FFmpeg canonicalization, exact source-relative work windows |
+| Word/time evidence | source-relative word timestamps, preserved temporal provenance, deterministic human elapsed coordinates |
+| Reliability | private checkpoints, validated resume, contiguous checkpoint ordering, bounded accelerated prefetch |
 | Languages | multilingual decoding plus conservative local text-language attribution |
-| Speakers | optional anonymous recording-scoped diarization, word-level handoffs, durable display labels, and honest overlap/mixed presentation; diarization remains security-held when its locked dependency gate is unsafe |
-| Difficult audio | optional deterministic local FFmpeg noise suppression with provenance and timeline-preservation checks |
-| Model custody | explicit inventory, recommendation, install, local revalidation, immutable revision pinning, and exact-revision removal |
-| Transcript output | canonical JSON plus deterministic TXT, SRT, and WebVTT derived views |
-| Search | private local BM25 lexical retrieval, optional semantic retrieval, and inspectable hybrid RRF ranking |
-| Evidence navigation | canonical-hash verification, aligned lexical highlights, bounded context expansion, speaker display integration, and deterministic source seek coordinates |
-| Research workspace | authoritative SQLite notes/tags/collections anchored to exact canonical evidence, plus a rebuildable DuckDB research projection |
-| Research-aware search | tag, collection, note-text, and with-notes constraints applied before lexical ranking or semantic scoring |
-| Unified discovery | one grouped query across transcript evidence, notes, tags, and collections with no fabricated cross-type relevance score |
-| Quality | Linux/macOS/Windows CI, strict typing, lint/format/security rules, complexity/dead-code checks, branch coverage, dependency audit, package build, and clean-wheel verification |
+| Speakers | optional anonymous recording-scoped diarization, word-level handoffs, durable display labels, honest overlap/mixed presentation |
+| Difficult audio | optional deterministic FFmpeg noise suppression with provenance/timeline checks |
+| Model custody | explicit inventory, recommendation, install, revalidation, immutable revision pinning/removal |
+| Transcript output | canonical JSON plus deterministic TXT, SRT, WebVTT publication views |
+| Search | private BM25 lexical retrieval, optional semantic retrieval, hybrid reciprocal-rank fusion |
+| Evidence navigation | canonical-hash verification, aligned highlights, bounded context, speaker presentation, source seek coordinates |
+| Research workspace | authoritative SQLite notes/tags/collections plus rebuildable DuckDB research projection |
+| Unified discovery | grouped transcript/note/tag/collection query without fabricated cross-type scores |
+| Saved searches | durable typed query intent that re-resolves current evidence instead of freezing result snapshots |
+| Safe lifecycle | typed plan-bound deletion scopes plus private execution-state retention that preserves evidence/human work by default |
+| Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, package verification |
 
-The point is not that users should learn every subsystem. It is that most of the annoying
-choices around local transcription, provenance, search, and research-state custody are
-becoming application behavior instead of homework.
-
-## The journey from recording to something useful
+## From recording to useful evidence
 
 ```mermaid
 flowchart LR
@@ -69,18 +63,17 @@ flowchart LR
     H --> I[Context highlights and seek]
     I --> J[Durable notes tags collections]
     J --> G
-    G --> K[Unified library discovery]
+    G --> K[Unified discovery]
     J --> K
+    K --> L[Saved searches navigation]
+    E --> M[Custody-aware deletion planning]
+    J --> M
+    D --> M
 ```
 
-Text fallback: the original recording produces a canonical transcript; rebuildable search
-ranks passages; canonical navigation verifies those passages; durable research state is
-attached to exact evidence and can constrain later searches; unified discovery composes
-transcript evidence and research objects into one grouped human-facing query.
-
-Search ranking is intentionally not source truth. A ranked result points back to canonical
-transcript coordinates, and the navigation layer verifies that canonical generation
-before presenting precise word evidence or accepting a durable note anchor.
+Search ranking is not source truth. A result points back to canonical transcript
+coordinates, and navigation verifies that generation before presenting precise evidence
+or accepting a durable note anchor.
 
 ## Install the current source build
 
@@ -104,7 +97,7 @@ uv run echoflow transcribe interview.m4a --dry-run
 uv run echoflow transcribe interview.m4a
 ```
 
-Add derived publication formats when useful:
+Add publication formats when useful:
 
 ```bash
 uv run echoflow transcribe interview.m4a --export txt --export srt --export vtt
@@ -116,64 +109,33 @@ Resume a validated interrupted job with the original input and job ID:
 uv run echoflow transcribe interview.m4a --resume JOB_ID
 ```
 
-Model acquisition is explicit and network-bearing. Transcription itself does not silently
+Model acquisition is explicit and network-bearing. Transcription does not silently
 download faster-whisper weights. Resume rechecks source identity and current resource
-admission rather than silently changing the original execution contract.
+admission rather than silently changing the execution contract.
 
 ## Optional anonymous speakers
 
 ```bash
 uv run echoflow transcribe interview.wav --diarize
-```
-
-Diarization produces anonymous recording-scoped refs such as `speaker-01`; it does not
-perform biometric identity or cross-recording speaker linking. After a transcript is in
-the library, a user can assign a durable display label:
-
-```bash
 uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
 uv run echoflow library speakers transcript JOB_ID
 ```
 
-`Dr. Chen` is user-authored presentation state. `speaker-02` remains the evidence ref.
-The current pyannote dependency path remains security-held while its locked Lightning
-version is affected by the compensated advisory described in **[SECURITY.md](SECURITY.md)**.
+A display name is user-authored presentation state. Anonymous speaker refs remain the
+evidence identity. EchoFlow does not perform biometric identity inference or silent
+cross-recording speaker linking.
 
-## Search, navigate, and annotate the local library
+## Search, navigate, annotate, and save useful questions
 
-Build the private lexical library:
+Build the private lexical library and search it:
 
 ```bash
 uv run echoflow library rebuild
-```
-
-Search transcript evidence directly:
-
-```bash
 uv run echoflow library search "housing insecurity"
-```
-
-Or use the one-box grouped library doorway:
-
-```bash
-uv run echoflow library find "housing insecurity"
-```
-
-`library find` returns separate transcript-evidence, note, tag, and collection groups.
-Transcript evidence keeps its own lexical/semantic/hybrid ranking provenance. Notes and
-labels remain their own object types rather than receiving a made-up universal score.
-
-Add neighboring canonical context without changing transcript ranking:
-
-```bash
 uv run echoflow library find "housing insecurity" --context-segments 1
 ```
 
-If local semantic state is available, `--mode semantic` or `--mode hybrid` changes only
-the transcript-evidence group. Note, tag, and collection lookup remains deterministic
-local text lookup.
-
-Research metadata can also constrain transcript retrieval before scoring:
+Research metadata can constrain transcript retrieval before scoring:
 
 ```bash
 uv run echoflow library search \
@@ -187,34 +149,73 @@ The notebook itself is durable user state:
 
 ```bash
 uv run echoflow library notes
-
 uv run echoflow library notes add JOB_ID segment-000042 \
   --body "Compare this with the 2024 survey." \
   --tag methodology \
   --collection "Chapter 3"
 ```
 
-The CLI currently exposes canonical segment IDs because it needs a real evidence address.
-A future graphical shell can turn transcript selection into the same verified
-`EvidenceAnchor` without asking a normal person to type IDs.
+Saved searches persist the question, not today's answer:
 
-Read **[Find things across the whole local library](docs/library-discovery.md)**,
-**[Your notes should survive the machinery](docs/research-notes.md)**, and
-**[From search result to the exact evidence](docs/evidence-navigation.md)** for the human
-versions of those contracts.
+```bash
+uv run echoflow library saved save "Housing chapter" "rent burden" \
+  --tag housing --mode hybrid
+uv run echoflow library saved
+uv run echoflow library saved run "Housing chapter"
+uv run echoflow library navigation
+```
 
-### Optional semantic and hybrid search
+## Delete exactly what you mean
 
-Semantic search can find related wording while lexical search remains the dependency-light
-default. Hybrid retrieval combines BM25 and dense ranks using reciprocal rank fusion
-instead of pretending their raw scores share one scale.
+Deletion is dry-run first. This only removes the transcript from rebuildable active search
+state:
 
-The current semantic foundation uses a strict-local Multilingual E5 Small profile and
-private rebuildable vectors. The locked base project still does not declare Sentence
-Transformers as a normal semantic extra, so semantic setup remains advanced rather than
-part of the ordinary source install.
+```bash
+uv run echoflow library delete JOB_ID --scope library-view
+```
 
-Read **[Semantic search, without the mystery box](docs/semantic-search.md)**.
+The plan prints every action, preserved attached notes, affected document-scoped saved
+searches, and a confirmation token. Nothing changes until the same request is repeated
+with that token:
+
+```bash
+uv run echoflow library delete JOB_ID \
+  --scope library-view \
+  --confirm 'delete:...'
+```
+
+Available transcript-scoped custody operations include:
+
+```text
+library-view          remove rebuildable retrieval membership
+derived-artifacts     delete regenerable TXT/SRT/VTT
+execution-state       delete private checkpoints/intermediates
+canonical-transcript  delete canonical JSON plus disposable descendants
+research-notes        delete notes anchored to this exact canonical generation
+saved-searches        delete saved searches explicitly constrained to this transcript
+source-recording      delete original recording only with --allow-source + provenance match
+```
+
+`canonical-transcript` does **not** imply `research-notes`, `saved-searches`, or
+`source-recording`. Shared tags/collections are never cascade-deleted merely because one
+transcript or note disappears.
+
+Age-based retention is narrower still:
+
+```bash
+uv run echoflow library retention --execution-days 30
+```
+
+It can delete only old private job workspaces. Completed jobs are eligible by default;
+failed/interrupted jobs require `--include-incomplete` because cleanup removes resume
+capability. Running jobs are never eligible. Canonical transcripts, human research, source
+media, and lightweight lifecycle manifests are preserved.
+
+EchoFlow does not claim that ordinary file deletion proves secure physical erasure on
+SSDs, snapshots, backups, sync history, or copy-on-write storage.
+
+Read **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)** for
+the exact contract.
 
 ## What belongs to you? 🦝
 
@@ -223,61 +224,45 @@ Read **[Semantic search, without the mystery box](docs/semantic-search.md)**.
 | Original recording | source evidence | **No** |
 | Canonical transcript JSON | authoritative transcript evidence | **No** |
 | Speaker display labels | user-authored knowledge | **No** |
-| Research notes, tags, collections, evidence anchors | user-authored knowledge | **No** |
-| Future saved searches / curated result sets | user-authored knowledge | **No** |
+| Notes, tags, collections, evidence anchors | user-authored knowledge | **No** |
+| Saved searches | user-authored query intent | **No** |
 | TXT/SRT/WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
-| Lexical search database | private search projection | Yes |
-| Semantic chunks/vectors | private search projection | Yes |
-| Research query projection | derived relationships/terms over durable research state | Yes |
-| Evidence-navigation/discovery views | derived presentation over canonical evidence and durable user state | Yes |
+| Lexical/semantic search state | private search projections | Yes |
+| Research query projection | rebuildable view over durable research state | Yes |
 
 A database is allowed to make evidence useful. It is not allowed to become the only place
 unique evidence or human research exists.
 
 ## For maintainers
 
-Start with **[docs/architecture/README.md](docs/architecture/README.md)**. Particularly
-useful references are:
-
-- **[Processing capabilities](docs/architecture/processing-capabilities.md)** for the
-  end-to-end capability map;
-- **[Corpus search](docs/architecture/corpus-search.md)** for lexical/semantic/hybrid
-  retrieval and canonical navigation;
-- **[Durable research state](docs/architecture/research-state.md)** for SQLite authority,
-  the monotonic change journal, DuckDB projection, watermark, and research filtering;
-- **[Model management](docs/architecture/model-management.md)** for explicit model
-  acquisition and immutable revision custody; and
-- **[SECURITY.md](SECURITY.md)** for the actual local-first threat boundary.
+Start with **[docs/architecture/README.md](docs/architecture/README.md)**, especially
+**[Corpus search](docs/architecture/corpus-search.md)**,
+**[Durable research state](docs/architecture/research-state.md)**,
+**[Library lifecycle](docs/architecture/library-lifecycle.md)**,
+**[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and
+**[SECURITY.md](SECURITY.md)**.
 
 Normal qualification includes Ruff lint/format/security rules, strict mypy, Vulture,
-Radon, branch coverage, locked dependency verification/auditing, package builds,
-clean-wheel verification, and Linux/macOS/Windows CI. Targeted mutation testing with
-Poodle is reserved for load-bearing decision logic rather than routine per-commit work.
+Radon, branch coverage, locked dependency audit, package builds, clean-wheel verification,
+and Linux/macOS/Windows CI. Targeted mutation testing is reserved for load-bearing logic.
 
 ## Where the project goes next
 
-The backend research-state foundation and unified library doorway are built. The
-highest-value next work is now **remembering useful views and reducing navigation
-friction**, not adding another storage engine.
+Safe lifecycle controls now sit beside the research/search foundation. The next sequence
+is:
 
-The sequence is now:
+1. **Incremental library refresh** so ordinary growth upserts/removes changed canonical
+   generations and full rebuild becomes the repair lever.
+2. **First thin GUI** consuming the existing evidence, research, saved-search, and custody
+   services.
+3. **Research portability** with evidence-bearing CSV/JSONL/Markdown and eventual workspace
+   export.
+4. **Semantic dependency/model qualification** for a normal install path.
+5. **Representative-device qualification and productization** across 8/16 GB systems,
+   Apple Silicon, discrete GPUs, and larger workstations.
 
-1. **Saved searches and useful derived navigation**: durable saved query intent plus
-   derived frequent/recent tags, facets, and selected/citable result sets where they help.
-2. **First thin GUI**: browse/find transcripts, select evidence, add/edit notes and tags,
-   and jump to source media by reusing existing application services and evidence anchors.
-3. **Research portability and corpus-scale ergonomics**: durable research export,
-   incremental library refresh, and measured performance on realistic corpora.
-4. **Representative-device qualification**: verify interaction and processing behavior on
-   ordinary 8/16 GB systems, Apple Silicon, discrete-GPU machines, and larger workstations.
-5. **Productization**: qualify semantic installation/model custody, installers, and
-   polished recovery language.
-
-Source separation for genuinely overlapping speech remains later. It should earn its
-model/compute/provenance cost with measured benefit on real recordings.
-
-See **[ROADMAP.md](ROADMAP.md)** for the detailed sequence and deliberate limits.
+See **[ROADMAP.md](ROADMAP.md)** for the detailed sequence.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,14 +4,12 @@ EchoFlow is becoming a **private local workspace for recorded evidence**.
 
 Its job is not to out-engine every speech-recognition runtime. Its job is to make local
 transcription dependable, resumable, inspectable, searchable, navigable, annotatable, and
-portable on ordinary computers while keeping source evidence and user-authored knowledge
+portable on ordinary computers while keeping source evidence and human-authored knowledge
 under clear custody.
 
-Modern EchoFlow restarted on August 2, 2026. The project has already moved from “can we
-transcribe a file?” to “can a person build and use a private local evidence library without
-giving the corpus away?”
-
-That is now the useful product boundary.
+Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe
+a file?” to “can a person build, research, and safely maintain a private evidence library
+without giving the corpus away?”
 
 ```mermaid
 flowchart LR
@@ -20,416 +18,274 @@ flowchart LR
     C --> D[Lexical semantic hybrid retrieval]
     D --> E[Verified evidence navigation]
     E --> F[Durable research workspace]
-    D --> G[Unified library discovery]
+    D --> G[Unified discovery]
     F --> G
     G --> H[Saved searches and derived navigation]
-    H --> I[Safe lifecycle controls]
-    I --> J[Thin graphical shell]
+    H --> I[Safe deletion and retention]
+    I --> J[Incremental refresh]
+    J --> K[Thin graphical shell]
 ```
-
-Text fallback: transcription, evidence preservation, retrieval, navigation, durable
-research state, unified discovery, saved searches, and derived navigation are foundation.
-The next work should make retention/deletion semantics explicit and then place a thin GUI
-on those same services rather than inventing another application.
 
 # Current foundation
 
-The backend is broad enough that the next work is increasingly about **human workflow,
-qualification, packaging, and interface quality**, not inventing another transcription
-pipeline.
+The backend is broad enough that near-term work should improve **human workflow,
+qualification, delivery, and ordinary-library ergonomics**, not reopen solved custody or
+search contracts.
 
 ## Local execution and media processing
 
-EchoFlow currently provides:
+EchoFlow currently provides process-visible CPU/memory inspection, physical accelerator
+topology, resource-admitted faster-whisper strategies, deterministic FFprobe inspection,
+audio-stream selection, canonical mono 16 kHz PCM16 normalization when needed, exact work
+windows, optional deterministic noise suppression with provenance, and bounded preparation
+overlap while preserving checkpoint order.
 
-- process-visible CPU and memory inspection, including relevant affinity/cgroup limits;
-- physical accelerator topology kept separate from actual engine/runtime capability;
-- resource-admitted faster-whisper CPU/int8 and CUDA-capable strategies;
-- explicit refusal instead of silent substitution for infeasible user-selected strategies;
-- dedicated/shared/unified accelerator-memory accounting;
-- FFprobe inspection with file-only protocol access and complete source SHA-256;
-- deterministic audio-stream selection;
-- FFmpeg canonicalization to mono 16 kHz PCM16 WAV when required;
-- exact integer-frame work windows;
-- optional deterministic FFmpeg noise suppression with provenance and timeline checks; and
-- bounded one-segment CPU preparation overlap during accelerated inference while preserving
-  ordered checkpoints.
-
-Performance ranks and memory estimates remain conservative heuristics pending
+Performance ranks and memory estimates remain conservative heuristics pending broader
 representative-device qualification.
 
 ## Reliability, model custody, and timeline evidence
 
-The execution contract includes:
-
-- explicit faster-whisper model inventory/recommendation/installation;
-- immutable resolved model revisions and local revalidation;
-- no silent ASR model download during transcription;
-- private per-work-unit checkpoints and validated resume;
-- source/model/stream/preprocessing/execution/alignment contract binding;
-- contiguous-prefix checkpoint semantics;
-- native faster-whisper word timestamps rebased onto one source-relative canonical
-  timeline;
-- aligned word evidence persisted through checkpoint/resume;
-- deterministic `HH:MM:SS.mmm` human elapsed presentation without 24-hour wrapping; and
-- preservation of source-declared `timecode` and `creation_time` metadata when FFprobe
-  reports it.
+The execution contract includes explicit model inventory/recommendation/installation,
+immutable resolved model revisions, no silent ASR model download during transcription,
+private checkpoints and validated resume, source/model/stream/preprocessing/execution
+binding, source-relative word timestamps, deterministic elapsed-time presentation, and
+source-declared temporal metadata when FFprobe reports it.
 
 Numeric source-relative seconds remain authoritative navigation coordinates. Human clock
-strings are presentation. Source-declared media clocks are parallel provenance unless a
-future media qualification proves a trustworthy mapping.
+strings are presentation.
 
 ## Language and speaker evidence
 
-EchoFlow supports:
+EchoFlow supports multilingual decoding, conservative local language attribution, optional
+recording-scoped anonymous diarization, deterministic speaker refs, word-level speaker
+projection where timing supports it, overlap-aware presentation, and durable human display
+labels without biometric identity inference or silent cross-recording linkage.
 
-- multilingual faster-whisper decoding;
-- conservative local text-language attribution that may leave ambiguous text unlabeled;
-- optional recording-scoped anonymous speaker diarization;
-- deterministic anonymous speaker refs;
-- word-level speaker projection when timing evidence supports it;
-- conservative null/mixed behavior instead of forcing one speaker across a handoff;
-- durable user-authored display labels such as `speaker-02 → Dr. Chen`; and
-- derived overlap-aware presentation distinguishing `single-speaker`, `overlap`,
-  `mixed-unresolved`, and `unattributed` states.
-
-Speaker display names are bound to the exact canonical transcript generation. EchoFlow
-does not perform biometric identity inference or silently link anonymous speakers across
-recordings.
-
-The pyannote execution path remains **security-held** while its locked Lightning
-dependency is affected by the compensated advisory described in `SECURITY.md`.
+The pyannote execution path remains security-held while its locked Lightning dependency is
+affected by the compensated advisory documented in `SECURITY.md`.
 
 ## Canonical transcript and publications
 
-Canonical JSON is authoritative transcript evidence. It carries source/execution
-provenance, source-relative segment and word timestamps, source-declared temporal tags
-when present, language evidence, optional enhancement provenance, and optional speaker
-turn/word speaker evidence.
+Canonical JSON is authoritative transcript evidence with source/execution provenance,
+source-relative timestamps, language evidence, optional enhancement provenance, and
+optional speaker evidence.
 
-By default, user-visible canonical JSON and derived publications are written under the
-platform Downloads directory in `EchoFlow/`. A transcription may select another
-`--output-dir`, and `ECHOFLOW_OUTPUT_DIR` may define another default through an explicitly
-selected EchoFlow configuration file.
+By default, public artifacts live under the platform Downloads `EchoFlow/` directory. A
+transcription can choose `--output-dir`, and an explicit EchoFlow configuration may define
+`ECHOFLOW_OUTPUT_DIR`.
 
-TXT, SRT, and WebVTT are deterministic derived publication views. They can be deleted and
-regenerated without rerunning recognition.
+TXT, SRT, and WebVTT are deterministic derived publications. They are not transcript
+authority.
 
-See `docs/architecture/library-lifecycle.md` for the exact output, refresh, retention, and
-deletion boundaries.
+## Transcript library, retrieval, and evidence navigation
 
-## Transcript library, search, and aligned navigation
+The local library includes a database-neutral lexical contract, DuckDB document/segment/
+term projections, deterministic BM25-style ranking, phrase/ANY/ALL and typed filters,
+canonical/source SHA-256 identity, deterministic semantic chunks, strict-local E5
+embeddings, reciprocal-rank hybrid retrieval, stale-vector refusal, verified canonical
+navigation, aligned-word highlighting where justified, neighboring context, and stable
+source seek coordinates.
 
-The local library now includes:
+Search ranking and evidence navigation remain separate. An index ranks a passage;
+navigation verifies the canonical evidence before presenting precision.
 
-- a database-neutral lexical search contract;
-- private DuckDB document/segment/term projections;
-- deterministic offline BM25-style ranking;
-- phrase, ANY/ALL, speaker, language, transcript, and timeline constraints;
-- canonical transcript SHA-256 plus source-media SHA-256;
-- deterministic segment-anchored semantic search chunks;
-- a provider-neutral embedding contract and strict-local Multilingual E5 Small profile;
-- private numeric semantic vectors and exact local dense similarity;
-- reciprocal-rank hybrid BM25 + dense retrieval;
-- stale-vector refusal when canonical transcript bytes change;
-- verified canonical evidence lookup after ranking;
-- exact aligned-word highlighting when lexical evidence justifies it;
-- semantic-only passage navigation without fabricated exact-word matches;
-- bounded neighboring canonical context expansion;
-- deterministic seek coordinates for future local media playback; and
-- current speaker display labels layered onto presentation while raw anonymous refs remain
-  visible evidence.
-
-Search ranking and evidence navigation remain separate operations. A rebuildable index
-ranks a passage; navigation verifies canonical evidence before presenting precision.
-
-`echoflow library rebuild` is a discovery/index-rebuild operation over existing canonical
-JSON. It does not re-transcribe audio. A rescan is useful when the corpus changes, a
-canonical generation changes, a transcript moves/disappears, a rebuildable database is
-lost or damaged, or a later EchoFlow build changes derived index representation.
+`echoflow library rebuild` reads existing canonical JSON and rebuilds discovery/index
+projections. It never re-runs ASR.
 
 ## Durable research workspace
 
-This is **foundation**, not future work.
+Authoritative SQLite owns notes, tags, collections, evidence anchors, and saved-search
+intent. Exact canonical generation identity is retained in anchors. A monotonic
+transactional journal drives a rebuildable DuckDB research projection with bounded,
+idempotent replay and fail-closed convergence rules.
 
-EchoFlow provides:
+`ResearchWorkspaceService` is the shared application seam for CLI and future GUI adapters.
+Research filters apply before transcript ranking when they define eligible evidence.
 
-- authoritative private SQLite state for notes, tags, collections, evidence anchors, and
-  saved-search intent;
-- exact source/canonical generation identity in durable note anchors;
-- contiguous canonical segment-span validation before a note is accepted;
-- optional sub-segment source-relative start/end coordinates;
-- durable stale-generation retention rather than silent note teleportation;
-- a monotonic transactional SQLite change journal;
-- bounded idempotent projection replay;
-- a rebuildable DuckDB research projection with an atomic convergence watermark;
-- fail-closed handling when a projection claims to be ahead of authority;
-- deterministic full rebuild when retained journal history cannot bridge a gap;
-- note/tag/collection notebook filtering;
-- tag/collection/note-text/with-notes constraints applied before transcript ranking or
-  semantic scoring; and
-- one `ResearchWorkspaceService` application boundary for CLI and future GUI adapters.
-
-The custody hierarchy is now:
+The custody hierarchy is:
 
 | Class | Examples | Rule |
 |---|---|---|
-| Authoritative evidence | original recording, canonical transcript JSON | never treat as cache |
-| Authoritative user knowledge | speaker labels, notes, tags, collections, saved searches, future curated result sets | must survive index rebuilds |
-| Rebuildable projection | lexical index, semantic chunks/vectors, research query projection, derived exports | may be regenerated |
-| Private execution state | normalization, enhancement, checkpoints, temporary segments | lifecycle-managed, not source truth |
+| Authoritative evidence | original recording, canonical JSON | never treat as cache; destructive deletion must be explicit |
+| Authoritative human knowledge | speaker labels, notes, tags, collections, saved searches | must survive index rebuilds and unrelated deletion |
+| Rebuildable projection | lexical/semantic/research DuckDB, derived exports | may be regenerated |
+| Private execution state | checkpoints, normalization/enhancement intermediates | lifecycle-managed; not source truth |
+| Lightweight lifecycle metadata | job manifests/discovery pointers | retained when heavyweight execution state is cleaned |
 
-🦝 The raccoon may rebuild an index. The raccoon may not eat your annotations.
+## Unified discovery, saved searches, and navigation
 
-## Unified library discovery
+`echoflow library find QUERY` returns typed transcript, note, tag, and collection groups
+without fabricating one cross-type relevance score.
 
-This is **foundation** too.
+Saved searches are durable **questions**, not result snapshots. They preserve typed query
+semantics and explicitly refuse derived `evidence_scope`; replay re-resolves current
+research relationships and current canonical evidence.
 
-`ResearchWorkspaceService.discover()` and `echoflow library find QUERY` provide one human
-query across four typed result groups:
+Frequent/recent tag and collection navigation is derived from current relationships. It
+does not create authoritative popularity counters.
 
-- transcript evidence through existing lexical/semantic/hybrid retrieval and verified
-  canonical navigation;
-- note prose through the research projection followed by authoritative SQLite hydration;
-- matching tag names; and
-- matching collection names.
+## Safe deletion and retention controls
 
-The discovery layer deliberately does not create a universal relevance score across
-unlike objects. Transcript ranks remain transcript ranks. Notes, tags, and collections
-remain their own object types.
+This is now **foundation**.
 
-Name matching for tags/collections is deterministic and group-local. Exact names sort
-before prefix/substring matches, then token overlap. That ordering is a disposable view,
-not authoritative state.
-
-Per-group limits, canonical context, stale-note state, speaker presentation, evidence
-identity, and source seek coordinates remain visible through the same application
-contracts a future GUI can consume.
-
-## Saved searches and useful derived navigation
-
-This is now **foundation** as part of PR #67.
-
-Saved searches are durable user-authored workspace state in authoritative SQLite. They
-preserve typed query intent rather than rendered CLI text or a frozen set of search
-results.
-
-A saved search records transcript query semantics, retrieval mode, context width, and
-research constraints. It explicitly does not persist derived `evidence_scope`. Replaying a
-saved search therefore re-resolves current research relationships and current canonical
-evidence through `ResearchWorkspaceService.search()`.
-
-EchoFlow also derives:
-
-- most-used tags from current note/tag relationships;
-- recently used tags;
-- most-used collections; and
-- recently used collections.
-
-Those counts and timestamps are views. EchoFlow does not add authoritative popularity or
-recency counters to tag/collection records.
-
-Current CLI surfaces are:
+`LibraryCustodyService` provides a plan-first typed deletion system. The CLI is a dry run
+unless the exact plan token is returned with `--confirm`:
 
 ```bash
-echoflow library saved
-echoflow library saved save "Housing chapter" "rent burden" --tag housing --mode hybrid
-echoflow library saved show "Housing chapter"
-echoflow library saved run "Housing chapter"
-echoflow library saved delete "Housing chapter"
-echoflow library navigation
+echoflow library delete TRANSCRIPT_ID --scope library-view
+echoflow library delete TRANSCRIPT_ID --scope canonical-transcript
+echoflow library delete TRANSCRIPT_ID --scope research-notes
+echoflow library delete TRANSCRIPT_ID --scope saved-searches
+echoflow library delete TRANSCRIPT_ID --scope source-recording --allow-source
+echoflow library retention --execution-days 30
 ```
+
+Deletion scopes separate:
+
+- active-library membership/rebuildable retrieval state;
+- regenerable TXT/SRT/VTT publications;
+- private checkpoints/intermediates;
+- canonical transcript evidence;
+- notes attached to the exact canonical generation;
+- saved searches explicitly constrained to the transcript; and
+- the original recording.
+
+`canonical-transcript` expands only across disposable descendants: library view, derived
+publications, and private execution state. It does **not** imply note, saved-search, or
+source deletion.
+
+A confirmation token binds the exact canonical generation, requested/effective scopes,
+mutation set, and relevant preserved note/saved-search dependency list. Canonical bytes are
+re-hashed before mutation. Source deletion requires a second explicit switch and current
+source bytes must still match transcription provenance.
+
+Age-based retention is intentionally narrower. It deletes only old private job workspaces;
+completed jobs are eligible by default, failed/interrupted jobs require
+`--include-incomplete`, and running jobs are never eligible. Canonical evidence, human
+research, source media, and lightweight lifecycle manifests survive retention cleanup.
+
+EchoFlow does not claim secure erasure on storage where SSD wear levelling, snapshots,
+copy-on-write history, backups, or sync/versioning make that guarantee unverifiable.
+
+See `docs/architecture/safe-deletion-retention.md` and
+`docs/architecture/library-lifecycle.md` for exact semantics.
+
+## Test/quality debt repaired after saved-search merge
+
+The saved-search/navigation PR was merged while its Linux branch-coverage gate was still
+below the repository threshold even though all 1,000 tests passed. This tranche adds the
+missing edge/failure and human-rendering tests instead of lowering the 90% requirement.
+
+Coverage additions exercise invalid durable saved-search objects, storage bounds, corrupt
+persisted state, missing mutation targets, closed navigation dispatch, human CLI rendering,
+and safe missing-state behavior. The custody tranche adds its own positive, negative,
+stale-plan, provenance, partial-state, and retention tests.
 
 # Near-term product sequence
 
-The next work should make the existing backend **safe and pleasant to operate** rather than
-reopening solved custody/search contracts.
+## 1. Incremental library refresh and corpus-scale qualification
 
-## 1. Safe deletion and explicit retention controls
+A whole-corpus rebuild remains the correct repair path, but normal growth should not
+require re-reading every transcript when one generation changes.
 
-Deletion must follow custody class rather than treating every local file as equivalent.
+Add incremental refresh keyed by stable generation identity, likely
+`(document_id, canonical_sha256)`:
 
-The first safe-deletion surface should distinguish:
+```text
+new generation       -> upsert
+changed generation   -> replace/upsert
+removed transcript   -> remove
+unchanged transcript -> skip
+```
 
-- deleting a rebuildable index/cache;
-- deleting a derived TXT/SRT/VTT publication;
-- deleting private checkpoint/execution state and therefore resume capability;
-- deleting human-authored notes or saved searches;
-- removing a canonical transcript from active library membership without necessarily
-  deleting the evidence file; and
-- destructively deleting canonical transcript evidence.
+Keep full rebuild as explicit repair/recovery. Normal GUI-era UX should feel like “the
+library noticed my transcript,” not “please rebuild a database.”
 
-Canonical-evidence deletion must surface dependent annotations/anchors before committing.
-“Remove from search” must never quietly mean “erase my only transcript and its research.”
-
-EchoFlow should not claim secure erasure or crypto-shredding for ordinary files when SSD
-wear levelling, copy-on-write filesystems, snapshots, backups, or sync clients make that
-claim unverifiable. The product can provide precise deletion semantics without promising
-physical-media destruction it cannot prove.
+Then qualify realistic corpora: startup, cold/warm search, filtered lexical/semantic
+queries, unified discovery, saved-search replay, projection catch-up, incremental refresh,
+and full repair rebuild.
 
 ## 2. First thin GUI
 
 The GUI has earned its place because the backend is ahead of the human interface.
 
-The first graphical vertical slice should remain deliberately small and beautiful rather
-than becoming a second application implementation.
+The first graphical slice should browse/open transcripts, use unified discovery, show
+speaker/time evidence, create/edit/delete notes, apply tags/collections with derived
+suggestions, browse saved searches, jump to source-relative media coordinates, and expose
+the same typed deletion/retention plans.
 
-It should support:
-
-- browse/open local transcripts;
-- unified library search/discovery;
-- readable transcript evidence with speaker/time context;
-- click or select evidence and create/edit/delete a note;
-- apply/create tags and collections, with frequent/recent suggestions;
-- browse notes and saved searches; and
-- jump to the existing source-relative seek coordinate in local media playback.
-
-The GUI must consume existing application services and `EvidenceAnchor`. It must not own a
-second search engine, second note schema, second speaker policy, or second definition of
-where evidence lives.
-
-Visual direction can be refined later, but the intended shell is light, calm, legible,
-and evidence-first rather than dashboard-heavy.
+It must consume existing application services. It must not invent a second search engine,
+note schema, speaker policy, custody model, or evidence location rule.
 
 ## 3. Research portability and selected-result export
 
-Portability is part of EchoFlow's ownership thesis, not decorative export polish.
+Portability is part of the ownership thesis. Target CSV, JSON/JSONL, and Markdown first,
+then a whole-workspace/user-state export manifest when the durable schema is ready.
 
-Target first formats:
+Exports should retain document ID, source/canonical SHA-256, segment IDs, and numeric
+evidence coordinates where applicable.
 
-- CSV for ordinary tabular interoperability;
-- JSON/JSONL for machine-readable structure;
-- Markdown for human-readable research bundles; and
-- a whole-workspace/user-state export manifest when the schema is ready.
+## 4. Qualify semantic dependency and managed embedding custody
 
-Exports should retain evidence coordinates such as document ID, source/canonical SHA-256,
-segment IDs, and numeric start/end seconds where applicable.
+Before semantic search is advertised as a normal source install, qualify one locked
+optional semantic dependency set with managed immutable E5 snapshot acquisition, private
+cache placement, disk/resource admission, no silent search-time download, offline
+execution after installation, and clean-wheel/platform qualification.
 
-Native XLSX is optional later. CSV already opens in Excel, Numbers, LibreOffice, R,
-pandas, and many research tools without adding a workbook dependency.
+## 5. Representative-device dogfooding and delivery
 
-## 4. Incremental library refresh and corpus-scale qualification
+Exercise real corpora on 8 GB Windows, 16 GB commodity hardware, Apple Silicon, a
+discrete-GPU laptop, and larger 32/64 GB workstations. Measure real-time factor,
+cold/warm model behavior, thermal/memory pressure, private disk cost, enhancement benefit,
+embedding build cost, refresh cost, and interactive query latency.
 
-`library rebuild` remains the correct repair path, but normal growth should not require
-re-reading an entire large corpus because one transcript changed.
-
-Add an incremental refresh path keyed by stable transcript generation identity, likely
-`document_id + canonical_sha256`, using the existing lexical index `upsert/remove`
-capabilities:
-
-- new transcript → upsert;
-- changed canonical generation → replace/upsert;
-- removed transcript → remove;
-- unchanged transcript → skip.
-
-Keep full rebuild as explicit recovery.
-
-Then measure realistic corpora rather than optimizing by instinct. Representative
-qualification should include startup, warm/cold search, filtered lexical/semantic queries,
-unified-discovery latency, notebook queries, saved-search replay, one-edit projection
-catch-up, large-batch projection catch-up, and full rebuild behavior.
-
-## 5. Qualify semantic dependency and managed embedding custody
-
-Before semantic search is advertised as a normal source install, qualify a locked
-optional semantic dependency set with:
-
-- one explicit semantic extra;
-- managed acquisition of the exact qualified E5 snapshot;
-- immutable revision custody;
-- private cache placement;
-- disk/resource admission;
-- no silent model download during search/indexing;
-- offline execution after installation; and
-- clean-wheel/platform qualification.
-
-Do not bypass `uv.lock` coherence merely to make the feature look finished.
-
-## 6. Representative-device dogfooding and delivery
-
-Exercise real multi-recording corpora on at least:
-
-- 8 GB Windows consumer hardware;
-- 16 GB commodity hardware;
-- Apple Silicon;
-- a discrete-GPU laptop; and
-- larger 32/64 GB workstations.
-
-Measure real-time factor, cold/warm model behavior, thermal effects, memory pressure,
-private disk cost, enhancement cost/benefit, embedding build cost, library refresh cost,
-and interactive query latency.
-
-Use those measurements to calibrate strategy recommendations and installer defaults.
-
-A pre-1.0 delivery milestone should include polished recovery/error language and an
-installer/package path that does not require a developer environment.
+A pre-1.0 delivery milestone should include polished recovery/error language and a package
+or installer path that does not require a developer environment.
 
 # Conditional later capabilities
 
 ## Deeper original-media clock qualification
 
-Only add production/media-clock mapping when real recordings require it. Candidate work
-includes non-zero stream origins, rational frame/timecode rates, drop-frame semantics,
-PTS/DTS mapping, and explicit synchronization relationships across independent sources.
-
-“Metadata exists” and “metadata is trustworthy enough to map onto transcript evidence”
-remain different states.
+Only add production/media-clock mapping when real recordings require it: non-zero stream
+origins, rational frame/timecode rates, drop-frame semantics, PTS/DTS mapping, and explicit
+synchronization across independent sources.
 
 ## Speech/source separation for overlapping speakers
 
 Source separation remains later than honest overlap representation. It adds substantial
-compute/model custody, uncertainty, derived-audio provenance, and failure modes.
-
-It should demonstrate measurable end-to-end recognition benefit on representative overlap
-cases before entering the normal product path.
-
-# Other engineering work, when evidence asks for it
+compute/model custody, uncertainty, derived-audio provenance, and failure modes. It should
+demonstrate measurable end-to-end recognition benefit before entering the normal path.
 
 ## Typed query evolution
 
-The unified discovery/search surface compiles into typed query contracts. Do not let CLI
-flags, GUI chips, saved searches, and a future natural-language convenience layer grow
-separate semantics.
-
-Add date/duration/fuzzy/facet constraints only when real use needs them.
+Do not let CLI flags, GUI chips, saved searches, and a future natural-language convenience
+layer grow separate semantics. Add date/duration/fuzzy/facet constraints only when real
+usage requires them.
 
 ## Bounded failure recovery
 
 Audio bisection/retry should be added only if representative long-recording failures show
 it is needed. Do not front-load a recovery labyrinth for hypothetical failures.
 
-## Pre-production durable-contract policy
+## Durable-contract policy
 
-EchoFlow has not yet had a released/dogfooded durable compatibility boundary. Internal
-durable contracts therefore use one current canonical shape rather than accumulating
-migration branches for every unreleased intermediate state.
-
-Unsupported schema versions still fail closed. When a real compatibility obligation
-exists, migrations should be introduced against actual persisted fixtures from that
-boundary.
+EchoFlow has not yet had a released/dogfooded compatibility boundary. Internal durable
+contracts therefore use one current canonical shape rather than accumulating migrations
+for unreleased intermediate states. Unsupported schema versions still fail closed.
 
 # Research candidates, not promises
 
-Interesting later investigations include:
-
-- independent forced alignment or phoneme-level timing if native word timing proves
-  insufficient;
-- finer intra-clause/romanized language attribution;
-- character n-gram/fuzzy retrieval for ASR names/acronyms/misspellings;
-- a small local cross-encoder reranker if measured benefit justifies it;
-- resource-admitted HNSW only when exact-search latency justifies approximation;
-- constrained deterministic natural-language query grammar;
-- optional local query translation that shows the interpreted typed query;
-- optional summarization only over an explicitly selected/citable evidence set;
-- explicit user-authored cross-recording person relationships, without biometric identity
-  inference;
-- additional ASR engines when they provide a concrete advantage; and
-- additional accelerator backends when a real engine can consume them.
+Interesting later investigations include independent forced alignment, finer language
+attribution, character n-gram/fuzzy retrieval for ASR names, a small local reranker if
+measured benefit justifies it, resource-admitted HNSW only when exact search latency
+justifies approximation, deterministic natural-language query grammar, optional local
+query translation that exposes the interpreted typed query, citation-bound local
+summarization over explicit evidence sets, user-authored cross-recording person
+relationships without biometric inference, additional ASR engines, and additional
+accelerator backends when concrete advantage exists.
 
 The order can change when security review, dogfooding, hardware evidence, or complexity
-contradicts an assumption.
-
-The stable direction is narrower:
+contradicts an assumption. The stable direction is narrower:
 
 > **Make sensitive local transcription boringly dependable. Make its evidence easy to
 > navigate and annotate. Do not give the corpus away.** 💃

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,19 +38,72 @@ private state. EchoFlow does not claim secure erasure.
 Public transcript artifacts remain ordinary user files. At-rest encryption is an OS,
 volume, or storage responsibility today.
 
+## Custody deletion and retention boundary
+
+Normal transcription, indexing, research, and navigation continue to treat the original
+recording as read-only source evidence. Deletion is a separate explicit custody operation,
+not a side effect of processing or library rebuild.
+
+`echoflow library delete` is plan-first. Without `--confirm`, it reports the exact current
+canonical generation, effective deletion scopes, concrete mutations, preserved attached
+notes, affected document-scoped saved searches, and a confirmation value. Execution
+recomputes the plan and refuses a stale confirmation.
+
+The `canonical-transcript` scope may remove canonical JSON plus its disposable descendants:
+active lexical/semantic retrieval state, regenerable TXT/SRT/VTT publications, and the
+private execution workspace. It does not imply deletion of attached research notes,
+saved searches, or source media.
+
+Deleting the original recording requires all of the following:
+
+- explicit `source-recording` scope;
+- the separate `--allow-source` safety switch;
+- an available source path; and
+- current source integrity equal to the source SHA-256 recorded for transcription.
+
+If bytes at the source path changed, EchoFlow refuses to delete them. A historical
+transcription provenance record is therefore not treated as authorization to delete new
+bytes that later occupied the same path.
+
+Immediately before canonical deletion, EchoFlow re-reads the canonical JSON and verifies
+its SHA-256 against the indexed generation. A changed or missing canonical artifact fails
+closed before any mutation.
+
+Age-based retention is narrower than explicit deletion. It can delete only private
+per-job execution workspaces. Completed jobs are eligible by default; failed/interrupted
+jobs require explicit inclusion because cleanup removes resume capability; running jobs
+are never eligible. Retention preserves canonical/public evidence, user-authored research
+state, source media, and lightweight lifecycle manifests.
+
+SQLite, DuckDB, public files, private workspaces, and arbitrary source paths cannot share
+one cross-filesystem ACID transaction. The custody executor therefore validates destructive
+inputs first and orders rebuildable/regenerable state before unique human-authored state.
+A later failure may leave earlier disposable cleanup already applied, but should not erase
+unique research first and hope filesystem cleanup succeeds afterward.
+
+The confirmation value is a plan-change detection primitive, not an authentication secret.
+It does not authorize a caller who lacks normal filesystem/application access.
+
+EchoFlow's deletion APIs remove paths/state through normal operating-system and database
+mechanisms. They do **not** claim cryptographically or physically verifiable secure erasure
+from SSD wear-levelled blocks, copy-on-write history, snapshots, backups, sync/version
+history, controller caches, or forensic recovery outside the active namespace.
+
 ## Research-state privacy boundary
 
-Research notes, tags, collections, and evidence anchors are durable private user-authored
-state. They may reveal participant identities, research hypotheses, interpretations,
-case themes, or other information that is at least as sensitive as transcript text.
+Research notes, tags, collections, evidence anchors, and saved searches are durable private
+user-authored state. They may reveal participant identities, research hypotheses,
+interpretations, case themes, or other information that is at least as sensitive as
+transcript text.
 
-EchoFlow stores this state in an authoritative private SQLite database. The database may
-contain:
+EchoFlow stores research state in an authoritative private SQLite database. The database
+may contain:
 
 - note prose;
 - tag and collection names;
 - note-to-tag and note-to-collection relationships;
-- exact source/canonical evidence anchors; and
+- exact source/canonical evidence anchors;
+- saved typed query intent; and
 - the monotonic change journal used to drive projection convergence.
 
 The separate DuckDB research database is a **rebuildable private projection**, not public
@@ -67,13 +120,14 @@ never delete SQLite user state.
 Neither database is encrypted by EchoFlow today. They rely on the private filesystem
 boundary described above and any OS/volume encryption the user configures.
 
-Research indexing/search does not upload notes, tags, collections, evidence anchors, or
-projection contents. EchoFlow has no hosted note synchronization or research telemetry.
+Research indexing/search does not upload notes, tags, collections, evidence anchors,
+saved searches, or projection contents. EchoFlow has no hosted note synchronization or
+research telemetry.
 
-If a canonical transcript generation changes, existing notes remain durable historical
-state and are not silently re-anchored onto new evidence. Future saved searches and
-curated result sets should inherit the same durable-user-state privacy class unless their
-contract explicitly says otherwise.
+If a canonical transcript generation changes or is explicitly deleted, existing notes
+remain durable historical state unless the user separately selects the `research-notes`
+deletion scope. They are not silently re-anchored or cascade-deleted. Saved searches are
+also preserved unless their own explicit deletion scope is selected.
 
 ## Supported versions
 
@@ -209,7 +263,7 @@ cannot be switched on/off or changed during resume because preprocessing identit
 part of the contract digest.
 
 After canonical publication, checkpoint payloads are removed on a best-effort basis.
-Interrupted jobs retain them. Ordinary deletion is not secure erasure.
+Interrupted jobs retain them. Ordinary filesystem deletion is not secure erasure.
 
 ## Canonical transcript provenance
 
@@ -267,10 +321,10 @@ currently provide:
 - hard CPU/RAM/disk runtime cages;
 - adversarial-media sandboxing;
 - application-level encryption;
-- secure deletion;
+- cryptographically or physically verifiable secure erasure;
 - malicious same-user TOCTOU protection; or
 - protection from a compromised account or local administrator.
 
-Resource admission, private-storage controls, and the authority/projection custody split
-are meaningful safety boundaries, but none of the stronger properties above should be
-inferred from “local-first.”
+Resource admission, private-storage controls, custody-aware deletion/retention, and the
+authority/projection split are meaningful safety boundaries, but none of the stronger
+properties above should be inferred from “local-first.”

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,48 +4,47 @@ EchoFlow is a **local-first workspace for recorded evidence**.
 
 It can inspect a recording, choose a safe way to run on the computer you actually have,
 transcribe locally, survive interruptions, preserve provenance, enrich the transcript,
-search a private corpus, navigate a result back to verified canonical evidence, and keep
-your own research notes attached to that evidence without giving them to a cloud service.
+search a private corpus, navigate results back to verified canonical evidence, keep your
+research notes attached to that evidence, save reusable research questions, and now clean
+up local state without making “delete” mean five different dangerous things at once.
 
 You do **not** need to understand CUDA, DuckDB, SQLite, BM25, vector spaces, immutable
-model revisions, or why a raccoon has been granted library privileges to use the product.
-Those details exist because somebody has to care about them. EchoFlow would like that
-somebody to be EchoFlow.
+model revisions, or why a raccoon has been granted library privileges. Those details exist
+because somebody has to care about them. EchoFlow would like that somebody to be EchoFlow.
 
-> **The short version:** your recording stays yours, the canonical transcript remains
-> inspectable evidence, your notes and labels remain your knowledge, and most machinery
-> built around those things can be thrown away and rebuilt.
+> **The short version:** your recording stays yours, canonical JSON remains inspectable
+> evidence, your notes and saved searches remain your knowledge, and most machinery built
+> around those things can be thrown away and rebuilt.
 
 ## What can EchoFlow do today?
 
 EchoFlow is still pre-production, but the backend is no longer a toy transcription script.
-The current foundation covers the local journey from media to a searchable, navigable
-evidence corpus with durable user-authored research state.
 
 | You want to… | EchoFlow currently… |
 |---|---|
-| Transcribe a recording privately | runs faster-whisper locally from a verified managed model |
+| Transcribe privately | runs faster-whisper locally from a verified managed model |
 | Avoid melting a smaller laptop | inspects process-visible CPU, RAM, and compatible acceleration before choosing a strategy |
-| Survive an interruption | checkpoints completed work and validates the original contract on resume |
-| Keep the original recording intact | treats source media as read-only evidence and writes processing artifacts separately |
-| Handle video files | deterministically selects an audio stream and transcribes the audio-bearing source |
-| Clean up a noisy recording | optionally applies deterministic local noise suppression with provenance and timeline checks |
-| Work with multiple languages | supports multilingual decoding plus conservative local language attribution |
+| Survive interruption | checkpoints completed work and validates the original contract on resume |
+| Keep the original recording intact | treats source media as read-only during normal processing and writes artifacts separately |
+| Handle video | deterministically selects an audio stream |
+| Clean noisy audio | optionally applies deterministic local suppression with provenance/timeline checks |
+| Work across languages | supports multilingual decoding plus conservative local language attribution |
 | Distinguish speakers | preserves optional anonymous recording-scoped speaker evidence without claiming identity |
-| Give speakers useful display names | stores user-assigned labels separately from canonical diarization evidence |
-| Read awkward handoffs honestly | distinguishes clean speaker spans, overlap, mixed/unresolved text, and unattributed text |
-| Publish useful transcript formats | produces canonical JSON plus rebuildable TXT, SRT, and WebVTT views |
-| Find an exact phrase later | builds a private local lexical/BM25 transcript library |
-| Find an idea when wording changed | supports optional local semantic retrieval |
-| Combine both search styles | uses inspectable reciprocal-rank fusion |
-| Follow a search result back to evidence | verifies the canonical transcript, resolves exact lexical words when justified, expands context, and exposes a source seek coordinate |
-| Keep durable research notes | stores notes, tags, and collections in authoritative private SQLite state anchored to exact canonical evidence |
-| Query your notebook quickly | projects only query-relevant research relationships and lexical terms into rebuildable DuckDB state |
-| Search transcript evidence through your notes | applies tag/collection/note-text constraints before lexical ranking or semantic scoring |
-| Find related things across the whole workspace | returns grouped transcript evidence, notes, tags, and collections through one discovery query without inventing a cross-type score |
+| Name speakers for yourself | stores display labels separately from canonical diarization evidence |
+| Publish useful formats | produces canonical JSON plus rebuildable TXT/SRT/WebVTT |
+| Find exact wording | builds a private lexical/BM25 library |
+| Find related meaning | supports optional local semantic retrieval and hybrid RRF |
+| Follow a result to evidence | verifies canonical generation, resolves justified lexical words, expands context, exposes source seek coordinates |
+| Keep durable research notes | stores notes/tags/collections in authoritative private SQLite anchored to exact canonical evidence |
+| Search through research state | applies tag/collection/note-text constraints before transcript scoring |
+| Find related things across the workspace | returns grouped transcript/note/tag/collection results without inventing one score |
+| Reuse a research question | saves typed query intent and re-resolves current evidence on replay |
+| Find frequently/recently used research labels | derives navigation views without persisting fake popularity counters |
+| Remove something safely | plans typed deletion scopes before mutation and binds confirmation to the exact plan |
+| Clean old execution state | plans age-based private-workspace retention without deleting canonical evidence or human work |
 
 The point is not to make users operate the machinery. The point is to make sensitive local
-transcription and research feel boringly dependable.
+transcription and research boringly dependable.
 
 ## Pick your doorway
 
@@ -53,52 +52,38 @@ transcription and research feel boringly dependable.
 
 Start with **[Getting started](getting-started.md)**.
 
-It walks through installation, model setup, transcription, resume, exports, search, and
-the current command-line research notebook.
-
 ### 🔎 I want one search box for the whole library
 
 Read **[Find things across the whole local library](library-discovery.md)**.
 
-It explains `echoflow library find QUERY`, why transcript evidence/notes/tags/collections
-stay in separate result groups, what semantic mode does and does not affect, and how this
-same application response is intended to feed the first GUI.
-
-### 📝 I want to keep notes beside the evidence
+### 📝 I want notes beside the evidence
 
 Read **[Your notes should survive the machinery](research-notes.md)**.
-
-It explains durable evidence anchors, notes/tags/collections, notebook queries,
-research-aware transcript search, stale transcript generations, and why deleting a search
-index cannot delete your research work.
 
 ### 🔎 I found something. Show me the actual evidence.
 
 Read **[From search result to the exact evidence](evidence-navigation.md)**.
 
-It explains canonical hash verification, exact lexical word highlighting, semantic
-restraint, neighboring context, speaker display names, source seek coordinates, and the
-durable anchor research notes reuse.
-
 ### 🕰️ I want to understand transcript time and jumping around
 
 Read **[Transcript time without calculator gymnastics](time-navigation.md)**.
-
-It explains source-relative timing, human elapsed display, source-declared media metadata,
-and why playback should seek by canonical numeric coordinates.
 
 ### 👥 I want `speaker-02` to have a human name
 
 Read **[Give the anonymous speakers names](speaker-names.md)**.
 
-It explains why `speaker-02` remains evidence while `Dr. Chen` is durable user-authored
-presentation state.
+### ✨ I want semantic search without a mystery box
 
-### ✨ I want to understand semantic search
+Read **[Semantic search, without the mystery box](semantic-search.md)**.
 
-Read **[Semantic search, without the mystery box](semantic-search.md)** for the
-plain-language explanation of lexical, semantic, and hybrid search, including what an
-embedding is and what stays local.
+### 🧹 I want to delete or clean something without regretting it
+
+Read **[Safe deletion and retention](architecture/safe-deletion-retention.md)**.
+
+Deletion is dry-run first. EchoFlow separates removing a transcript from search, deleting
+regenerable publications, deleting private checkpoints, deleting canonical JSON, deleting
+attached notes, deleting document-scoped saved searches, and deleting the original source.
+Those are not synonyms.
 
 ### 🔐 I care about privacy and security boundaries
 
@@ -108,14 +93,10 @@ Read **[SECURITY.md](../SECURITY.md)**. Security claims should be boring enough 
 
 Open the **[architecture maintenance hatch](architecture/README.md)**.
 
-Those documents contain the exact contracts for media handling, execution strategy,
-model custody, checkpoints, diarization, enhancement, transcript retrieval, evidence
-navigation, and durable research-state projection.
-
 ### 🧪 I am here to break things professionally
 
 The [development docs](development/) cover benchmarking, test design, bisect strategy,
-semantic retrieval qualification, and targeted mutation testing.
+semantic qualification, and targeted mutation testing.
 
 ## The EchoFlow family portrait
 
@@ -127,21 +108,19 @@ flowchart LR
     D --> E[Verified evidence navigation]
     E --> F[Research notebook]
     F --> D
-    D --> G[Unified library discovery]
+    D --> G[Unified discovery]
     F --> G
-    G --> H[Future saved views and GUI]
+    G --> H[Saved searches navigation]
+    C --> I[Typed custody planning]
+    F --> I
+    B --> I
+    H --> J[Incremental refresh and GUI]
 ```
 
 Text fallback: canonical evidence feeds rebuildable search; search resolves back to
-verified evidence; durable notes/tags/collections attach to that evidence and can constrain
-later retrieval; unified discovery now composes transcript evidence and research objects
-into one grouped human doorway. Saved views and the GUI can build on that response instead
-of reimplementing the backend.
-
-The shared rule is simple:
-
-**Do complicated work locally. Keep the evidence understandable, portable, and owned by
-the user.**
+verified evidence; durable notes/tags/collections attach to evidence; saved searches retain
+questions; custody operations plan exact destructive consequences; incremental refresh and
+the GUI can reuse those same application contracts.
 
 ## What belongs to you, and what can the raccoon rebuild? 🦝
 
@@ -150,52 +129,74 @@ the user.**
 | Original recording | source evidence | **No** |
 | Canonical transcript JSON | authoritative transcript artifact | **No** |
 | Speaker display labels | user-authored knowledge | **No** |
-| Research notes, tags, collections, evidence anchors | user-authored knowledge | **No** |
-| Future saved searches / selected result sets | user-authored knowledge | **No** |
+| Research notes, tags, collections, anchors | user-authored knowledge | **No** |
+| Saved searches | user-authored query intent | **No** |
 | TXT / SRT / WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
-| Checkpoint machinery after successful publication | execution/recovery state | Usually disposable after completion |
+| Checkpoint workspace after publication | execution/recovery state | Usually disposable |
+| Lightweight lifecycle manifest | discovery/execution metadata | Small; retained by workspace cleanup |
 | Lexical search database | derived search projection | Yes |
 | Semantic chunks and vectors | derived search projection | Yes |
-| Research query projection | derived relationships/terms over durable research state | Yes |
-| Search context/highlight views | derived presentation over canonical evidence | Yes |
+| Research query projection | derived view over durable research state | Yes |
 
-If deleting a search or research projection destroys unique user-authored information,
-something has gone very wrong.
+If deleting a search projection destroys unique human-authored information, something has
+gone very wrong.
+
+## What “delete” means now
+
+EchoFlow's deletion command is a plan by default:
+
+```bash
+echoflow library delete JOB_ID --scope library-view
+```
+
+It returns the exact action set and a confirmation token. Repeating the same request with
+`--confirm TOKEN` applies only if the current plan still matches.
+
+`canonical-transcript` automatically includes only disposable descendants: active search
+membership, TXT/SRT/VTT, and private execution state. It does not imply deleting attached
+notes, document-scoped saved searches, or source media.
+
+Source deletion requires both `source-recording` and `--allow-source`, and the current
+source must still match transcription provenance. EchoFlow does not claim that ordinary
+filesystem deletion proves secure physical erasure.
+
+Retention is narrower:
+
+```bash
+echoflow library retention --execution-days 30
+```
+
+It can age-delete only private job workspaces. Running jobs are never eligible;
+failed/interrupted jobs require `--include-incomplete` because cleanup removes resume
+capability. Canonical evidence, research state, source media, and lifecycle manifests are
+preserved.
 
 ## Where the product is going next
 
-The research-navigation sequence that used to live here as future work is now foundation:
-word timing, human/source time semantics, speaker display labels, overlap-aware speaker
-presentation, verified search navigation, durable notes/tags/collections, and unified
-library discovery are implemented.
+The research-navigation and safe-lifecycle sequence is now foundation: verified search,
+durable notes/tags/collections, unified discovery, saved searches, derived navigation, and
+typed deletion/retention are implemented.
 
-The next layers are intentionally more human-facing:
+The next layers are:
 
-1. **Saved searches and useful derived navigation**, including frequent/recent tags and
-   facets where they reduce hunting without creating new authoritative counters.
-2. **A thin graphical shell** that can browse/find transcripts, select evidence, create
-   notes, apply tags/collections, and seek local media using existing application services.
-3. **Portable research export and incremental library refresh** so ownership and larger
-   corpora remain pleasant rather than merely correct.
-4. **Corpus-scale and representative-device qualification** so latency/resource decisions
-   are measured on real workloads rather than guessed.
-5. **Productization** through semantic-install qualification, installers, and polished
-   recovery/error language.
+1. **Incremental library refresh** so ordinary corpus growth does not require full rebuild.
+2. **A thin graphical shell** that consumes existing search, evidence, research, saved
+   search, custody, and refresh services.
+3. **Portable research export** with evidence-bearing CSV/JSONL/Markdown and eventual
+   workspace export.
+4. **Semantic dependency/model qualification** for a normal install path.
+5. **Corpus-scale and representative-device qualification/productization**.
 
-The GUI should be a presentation adapter, not a second implementation of transcription,
-search, time mapping, speaker policy, evidence anchoring, or research-state custody.
-
-For the fuller sequencing and deliberate limits, see **[ROADMAP.md](../ROADMAP.md)**.
+For detailed sequencing and limits, see **[ROADMAP.md](../ROADMAP.md)**.
 
 ## Why the docs have different personalities
 
 - **Welcome/onboarding docs** explain the product in ordinary language.
-- **Feature guides** explain *why* a capability exists before exposing implementation
-  detail.
-- **Architecture docs** keep exact contracts, but provide a plain-English doorway.
+- **Feature guides** explain why a capability exists before implementation detail.
+- **Architecture docs** keep exact contracts with a plain-English doorway.
 - **Security, audit, schema, and command contracts** prioritize unambiguous language.
 
-The detailed editorial rules live in **[documentation-style.md](documentation-style.md)**.
+The editorial rules live in **[documentation-style.md](documentation-style.md)**.
 
 💃 **You are now allowed to leave the documentation lobby.**

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -7,15 +7,14 @@ exist, what each capability owns, what it refuses to own, and which invariants m
 survive refactors**.
 
 If you are trying to transcribe a file rather than maintain the system, use
-**[Getting started](../getting-started.md)**. There is no prize for learning cgroup
-accounting before lunch.
+**[Getting started](../getting-started.md)**.
 
 ## The shape of the system
 
-EchoFlow is built around narrow local capabilities instead of one universal pipeline or
-generic plugin framework. The composition root lives in
-`src/echoflow/app/app_container.py` and wires concrete implementations with Dependency
-Injector.
+EchoFlow is composed from narrow local capabilities in
+`src/echoflow/app/app_container.py`. The through-line is custody: source evidence,
+canonical transcript truth, private execution state, rebuildable projections, and durable
+human knowledge deliberately do not share deletion or recovery semantics.
 
 ```mermaid
 flowchart LR
@@ -37,32 +36,33 @@ flowchart LR
     I --> N
     M --> N
     N --> O[Unified discovery and navigation]
+    E --> P[LibraryCustodyService]
+    G --> P
+    J --> P
+    D --> P
+    P --> Q[Plan-bound deletion and retention]
 ```
 
-Text fallback: source media produces canonical transcript evidence; DuckDB search
-projections rank passages; evidence navigation verifies those passages; SQLite owns
-human-authored research state and saved searches; a deterministic projector builds
-disposable DuckDB query state; `ResearchWorkspaceService` is the application-facing seam
-across those boundaries.
-
-The architectural through-line is **custody**. Source evidence, canonical transcript
-truth, private execution state, managed model dependencies, rebuildable indexes, and
-durable human knowledge intentionally have different deletion and recovery semantics.
+Text fallback: canonical JSON is evidence; DuckDB ranks rebuildable views; canonical
+navigation verifies evidence; SQLite owns human research; `ResearchWorkspaceService`
+composes research interactions; `LibraryCustodyService` plans and applies deletion or
+private-state retention without merging those ownership classes.
 
 ## Where to look
 
 | Page | What question it answers |
 |---|---|
-| [Processing capabilities](processing-capabilities.md) | How does the whole local transcription/research system fit together? |
+| [Processing capabilities](processing-capabilities.md) | How does the local transcription/research system fit together? |
 | [Adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) | How does EchoFlow decide what this machine can safely run? |
-| [Media and timeline](media-and-timeline.md) | What source did we inspect, which audio stream did we use, and what do timestamps mean? |
-| [Word-level timestamp alignment](word-alignment.md) | How do engine-produced word timings become source-relative evidence? |
+| [Media and timeline](media-and-timeline.md) | Which source/stream did we use, and what do timestamps mean? |
+| [Word-level timestamp alignment](word-alignment.md) | How do engine timings become source-relative evidence? |
 | [Local model management](model-management.md) | Which model revision is allowed to execute, and how did it get here? |
 | [Speech enhancement](speech-enhancement.md) | How can preprocessing affect ASR without becoming source truth? |
 | [Anonymous speaker diarization](diarization.md) | How are speaker turns represented without pretending anonymous labels are identities? |
-| [Corpus search](corpus-search.md) | How do lexical/semantic/hybrid ranking and verified canonical navigation stay separate? |
-| [Durable research state](research-state.md) | Why does SQLite own human research while DuckDB owns rebuildable acceleration, and how do they converge? |
-| [Library lifecycle](library-lifecycle.md) | Where does canonical JSON live, what does a library rebuild actually rescan, and which state is durable versus disposable? |
+| [Corpus search](corpus-search.md) | How do lexical/semantic/hybrid ranking and verified navigation stay separate? |
+| [Durable research state](research-state.md) | Why does SQLite own human research while DuckDB owns rebuildable acceleration? |
+| [Library lifecycle](library-lifecycle.md) | Where does canonical JSON live, what does rebuild rescan, and which state is durable? |
+| [Safe deletion and retention](safe-deletion-retention.md) | What exactly can be deleted, what is preserved, and how is destructive intent confirmed? |
 | [ROADMAP](../../ROADMAP.md) | What is implemented, what is next, and what remains research? |
 | [SECURITY](../../SECURITY.md) | What does the security boundary actually claim? |
 
@@ -75,51 +75,40 @@ durable human knowledge intentionally have different deletion and recovery seman
 | `interfaces` | Local filesystem/storage adapters and private-storage policy |
 | `media` | Read-only source inspection and deterministic audio-stream selection |
 | `runner` | Process-visible CPU/memory inspection and execution-budget policy |
-| `model_management` | Explicit local model inventory, acquisition, verification, provenance, and removal |
-| `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language attribution, word alignment, diarization, assembly, exports |
+| `model_management` | Model inventory, acquisition, verification, provenance, removal |
+| `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language, alignment, diarization, assembly, exports |
 | `workspace` | Private job paths and public artifact allocation |
 | `benchmarking` | Privacy-minimized local execution measurement |
-| `library` | Retrieval, canonical evidence navigation, speaker presentation, authoritative research state, saved-search intent, unified discovery, derived navigation, and rebuildable projections |
-
-`runner` means the local compute environment visible to the process; it is not a
-distributed task runner. `media.probe` performs inspection, not transcoding.
+| `library` | Retrieval, evidence navigation, research authority/projections, saved searches, discovery, and typed custody/deletion/retention policy |
 
 ## Capability boundaries
 
-EchoFlow prefers a small object with one clear job over a grand abstraction that owns
-everything vaguely adjacent to it.
+EchoFlow prefers a small object with one clear job over a universal manager.
 
-External/configuration/durable-data boundaries may use Pydantic where parsing and
-serialization are valuable. Small internal immutable values generally use frozen/slotted
-dataclasses. Services use narrow `Protocol` capabilities when substitution is real and
-useful.
+The search/research/custody area deliberately separates responsibilities:
 
-The search/research area has deliberately separate responsibilities:
-
-1. `TranscriptLibraryService` and retrieval services discover/rank rebuildable transcript
-   passages.
-2. `EvidenceLocator` verifies and resolves those passages back to canonical evidence.
+1. `TranscriptLibraryService` discovers and ranks rebuildable transcript passages.
+2. `EvidenceLocator` verifies ranked passages against canonical evidence.
 3. `SpeakerLabelService` owns durable recording-scoped human display names without
    rewriting diarization evidence.
-4. `ResearchStateStore` owns durable human-authored notes, tags, collections, and
-   evidence anchors.
-5. `ResearchStateProjector` owns convergence from authoritative SQLite state into the
-   rebuildable research projection.
+4. `ResearchStateStore` owns durable notes, tags, collections, and exact evidence anchors.
+5. `ResearchStateProjector` converges authoritative SQLite state into a disposable DuckDB
+   research projection.
 6. `ResearchProjectionIndex` owns fast derived research constraints and summaries.
 7. `WorkspaceMetadataStore` owns durable saved-search intent and computes disposable
-   frequent/recent navigation from current relationships.
-8. `ResearchWorkspaceService` composes those capabilities for presentation adapters.
+   navigation views.
+8. `ResearchWorkspaceService` composes those capabilities for CLI and future GUI adapters.
+9. `LibraryCustodyService` owns typed deletion planning/execution and age-based private
+   execution-state retention. It does not become a second research or transcript authority.
 
-That split should survive unified discovery and the GUI. Presentation convenience is not
-permission to merge custody boundaries.
+That split should survive the GUI. Presentation convenience is not permission to merge
+custody boundaries.
 
 ## Why SQLite and DuckDB both exist
 
-The two engines serve different workloads and different custody classes.
-
 SQLite is authoritative for irreplaceable, frequently mutated user research. DuckDB is
-used for rebuildable analytical/query projections over transcript and research data.
-There is **one authority**, not two masters.
+used for rebuildable analytical/query projections. There is one authority, not two
+masters.
 
 ```text
 SQLite authority
@@ -132,76 +121,75 @@ ResearchStateProjector
 DuckDB research projection
 ```
 
-If the research projection disappears, rebuild it. If SQLite user state disappears,
-unique human work is lost. That asymmetry is intentional.
+If a research projection disappears, rebuild it. If SQLite user state disappears, unique
+human work is lost. That asymmetry is intentional.
 
-Saved searches share the authoritative SQLite database because they are authored research
-intent. Their runtime evidence scope does not. Replaying a saved search re-resolves the
-current corpus and current research relationships.
-
-See [Durable research state](research-state.md) for the transaction, watermark, rebuild,
-and fail-closed contract. See [Library lifecycle](library-lifecycle.md) for the broader
-retention, output-path, rescan, and deletion boundaries.
+Saved searches live in authoritative SQLite because they are authored intent. Their
+runtime evidence scope does not. Replaying a saved search re-resolves the current corpus
+and current research relationships.
 
 ## The custody rules 🦝
 
 These rules are load-bearing:
 
-1. **Original media is source evidence and treated as read-only input.**
-2. **Canonical transcript JSON is authoritative transcript evidence.**
+1. **Original media is source evidence and read-only during normal processing.** Explicit
+   source deletion is a separate provenance-checked operation, never an implied cleanup.
+2. **Canonical transcript JSON is authoritative transcript evidence.** It is deleted only
+   through an explicit plan-bound canonical scope.
 3. **Managed model manifests describe verified local execution dependencies.**
-4. **Lexical, semantic, and research DuckDB databases are private rebuildable
-   projections.**
-5. **User-authored speaker labels, notes, tags, collections, saved searches, and curated
-   result sets do not share deletion semantics with indexes.**
-6. **Research-state joins include canonical generation identity, not a friendly segment ID
+4. **Lexical, semantic, and research DuckDB databases are rebuildable projections.**
+5. **Speaker labels, notes, tags, collections, and saved searches are human-authored
+   authority and do not inherit index deletion semantics.**
+6. **Research joins include canonical generation identity, not a friendly segment ID
    alone.**
-7. **Precise navigation resolves back to verified canonical evidence rather than trusting
-   a stale search projection.**
-8. **Research filters are applied before ranking/scoring when they define eligible
-   evidence.**
+7. **Precise navigation resolves to verified canonical evidence rather than trusting a
+   stale search projection.**
+8. **Research filters apply before ranking/scoring when they define eligible evidence.**
 9. **Saved searches persist typed query intent, not a frozen derived evidence scope.**
-10. **A convenience layer may not quietly become the only place unique evidence or user
-    knowledge lives.**
+10. **Canonical deletion preserves attached notes and document-scoped saved searches unless
+    their own destructive scopes are explicitly selected.**
+11. **Age-based retention can delete only private job workspaces.** It preserves canonical
+    evidence, human research, and lightweight lifecycle manifests.
+12. **EchoFlow does not claim secure erasure it cannot prove.**
 
-Search infrastructure is allowed to disappear. User-authored knowledge is not.
+Search infrastructure may disappear. User-authored knowledge may not disappear by
+accident.
 
-## Current application seam
+## Current application seams
 
-Unified discovery, saved searches, and frequent/recent navigation now all compose through
-`ResearchWorkspaceService` rather than creating another search engine or database
-authority.
+Unified discovery, saved searches, frequent/recent navigation, and research interactions
+compose through `ResearchWorkspaceService`.
 
-`echoflow library find QUERY` returns typed transcript, note, tag, and collection groups.
-`echoflow library saved ...` stores and replays typed workspace queries. `echoflow library
-navigation` derives useful tag/collection views from current relationships.
+Custody-sensitive operations compose separately through `LibraryCustodyService`:
 
-The system deliberately does not invent a universal relevance score across unlike
-objects. Transcript ranks remain transcript ranks. Notes, tags, collections, and saved
-searches retain their own semantics.
+```bash
+echoflow library delete TRANSCRIPT_ID --scope library-view
+echoflow library delete TRANSCRIPT_ID --scope canonical-transcript
+echoflow library retention --execution-days 30
+```
 
-The next presentation seam is the first thin GUI. It should consume the same discovery,
-`ResearchWorkspaceService`, `EvidenceAnchor`, saved-search, speaker, time, and playback-seek
-contracts. It must not create a second definition of where evidence or user state lives.
+Deletion and retention are dry-run by default. Applying a reviewed operation requires the
+plan-bound token returned by the dry run. The token binds the canonical generation,
+effective scopes, concrete actions, and relevant preserved note/saved-search dependencies,
+so a changed plan cannot reuse an old confirmation.
+
+The next backend seam is **incremental library refresh**. Normal corpus growth should
+upsert/remove changed transcript generations automatically; full `library rebuild` should
+remain the repair lever. The first thin GUI should then consume the same search, evidence,
+research, saved-search, custody, and refresh services instead of inventing parallel rules.
 
 ## New abstraction test
 
 Before adding a manager, framework, registry, adapter hierarchy, generalized plugin
-system, or “database wrapper,” ask which concrete capability or invariant it protects.
+system, or database wrapper, ask which concrete capability or invariant it protects.
 
 File count is not an architectural problem. Repeated policy, unclear ownership, and
 unprovable invariants are.
 
 ## Documentation contract
 
-Architecture pages should provide:
-
-- a plain-English doorway;
-- a visual model when structure matters;
-- the exact implementation contract;
-- ownership/failure semantics; and
-- explicit current limits or future seams.
+Architecture pages should provide a plain-English doorway, a structural model when useful,
+the exact implementation contract, ownership/failure semantics, and explicit current
+limits or future seams.
 
 See **[documentation-style.md](../documentation-style.md)** for the editorial contract.
-
-The code can be serious without the prose developing a fear of joy. 💃

--- a/docs/architecture/library-lifecycle.md
+++ b/docs/architecture/library-lifecycle.md
@@ -1,6 +1,6 @@
-# Library lifecycle, custody, and refresh
+# Library lifecycle, custody, refresh, and deletion
 
-EchoFlow's library contains several kinds of local data that deliberately have different
+EchoFlow's library contains several kinds of local data with deliberately different
 retention and recovery rules. A transcript is not a search index, a note is not a cache,
 and an operational log is not evidence.
 
@@ -9,8 +9,14 @@ The central rule is:
 > **Canonical transcript JSON is durable user-visible evidence. Library indexes are
 > disposable views over that evidence.**
 
-This distinction explains why EchoFlow can safely rescan or rebuild a library without
-re-transcribing the recording.
+A second rule now governs destructive operations:
+
+> **Removing evidence from search must never silently erase canonical evidence,
+> user-authored research knowledge, or an original recording.**
+
+These distinctions explain why EchoFlow can rescan or rebuild a library without
+re-transcribing a recording, and why deletion is exposed as a typed plan instead of a
+generic filesystem command.
 
 ## Where canonical transcripts live
 
@@ -140,9 +146,6 @@ Lexical, semantic, and research DuckDB files are not unique user knowledge. If o
 missing or cannot be trusted, EchoFlow can rebuild it from authoritative evidence/state
 instead of attempting heroic in-place repair.
 
-This is an intentional recovery feature. The rebuildability of the index is what makes it
-safe to treat the index as disposable.
-
 ### Search/index implementation changed
 
 A later EchoFlow release may change projection schema, tokenization, chunk mapping, or
@@ -177,7 +180,7 @@ refresh exists.
 
 Saved searches are durable **questions**, not frozen answers.
 
-PR #67 stores typed search intent in authoritative SQLite:
+EchoFlow stores typed search intent in authoritative SQLite:
 
 - transcript query text;
 - phrase / ANY / ALL semantics;
@@ -187,13 +190,14 @@ PR #67 stores typed search intent in authoritative SQLite:
 - research tag/collection/note constraints; and
 - canonical context width.
 
-It explicitly refuses to persist a derived `evidence_scope`.
+Saved searches explicitly refuse a derived `evidence_scope`.
 
-When a saved search runs later, `ResearchWorkspaceService` resolves the current research
+When a saved search runs later, `ResearchWorkspaceService` resolves current research
 relationships and current canonical evidence again. If qualifying evidence has been added
 since the search was saved, the saved query can find it.
 
-This is why saved searches survive library growth without becoming stale snapshots.
+If a transcript is later removed or deleted, a saved search constrained to that
+`document_id` is reported as affected by the deletion plan but is not itself deleted.
 
 ## Frequent and recent navigation is disposable
 
@@ -210,66 +214,177 @@ be migrated or repaired.
 
 | Class | Examples | Retention rule |
 |---|---|---|
-| Authoritative source evidence | original recording | user-owned; EchoFlow treats input read-only |
-| Authoritative transcript evidence | canonical JSON | durable user-visible artifact; never an index cache |
-| Authoritative human work | notes, tags, collections, speaker labels, saved searches | durable; losing it loses user work |
-| Derived publications | TXT, SRT, VTT | deletable and regenerable from canonical JSON |
-| Rebuildable analytical state | lexical DuckDB, semantic DuckDB, research DuckDB | may be deleted/rebuilt |
-| Private execution state | checkpoints, normalized/enhanced intermediates, work segments | lifecycle-managed for execution/resume, not evidence authority |
+| Authoritative source evidence | original recording | user-owned; EchoFlow treats input read-only except an explicit provenance-checked source-deletion request |
+| Authoritative transcript evidence | canonical JSON | durable user-visible artifact; explicit deletion only |
+| Authoritative human work | notes, tags, collections, speaker labels, saved searches | durable; explicit deletion only |
+| Derived publications | TXT, SRT, VTT | regenerable; may be deleted explicitly |
+| Rebuildable analytical state | lexical DuckDB, semantic DuckDB, research DuckDB | may be removed/rebuilt |
+| Private execution state | checkpoints, normalized/enhanced intermediates, work segments | lifecycle-managed; age-based retention is allowed only through a reviewed plan |
+| Lifecycle metadata | compact job manifests | retained by execution-workspace cleanup because they can preserve discovery pointers |
 | Operational logs | structured process log stream | diagnostic only; not transcript evidence |
 
 EchoFlow's structured application logger currently writes to the process stream (`stderr`)
 rather than creating a durable transcript-log archive. Routine local filesystem paths are
 redacted unless path disclosure is explicitly enabled.
 
-That logging policy is independent of canonical transcript retention.
+## Safe deletion is now a typed product operation
 
-## Safe deletion is a separate product operation
+The detailed design is in
+[`safe-deletion-retention.md`](safe-deletion-retention.md).
 
-EchoFlow does not yet provide one unified safe-delete command for transcript evidence and
-all dependent state. That should not be faked by teaching users to manually delete random
-SQLite/DuckDB rows.
+The user-facing surface is plan-first:
 
-A future deletion surface needs to distinguish at least:
+```bash
+echoflow library delete TRANSCRIPT_ID --scope library-view
+```
 
-- **delete a derived index/cache**: safe to rebuild; no unique work should disappear;
-- **delete a publication export**: safe to regenerate from canonical JSON;
-- **delete private execution/checkpoint state**: may remove resume capability but not
-  canonical evidence;
-- **delete a saved search/note/tag relationship**: explicit deletion of human-authored
-  state;
-- **remove a transcript from the active library**: an indexing/membership decision, not
-  necessarily deletion of canonical evidence; and
-- **delete canonical transcript evidence**: destructive user-data deletion that must make
-  dependent notes/anchors and projections explicit before committing.
+Without `--confirm`, no mutation occurs. The plan shows exact actions, affected durable
+objects, preserved notes, and a token bound to the current canonical generation and action
+set.
 
-Secure deletion of arbitrary files on modern SSDs, copy-on-write filesystems, snapshots,
-backups, sync clients, and wear-levelled storage cannot be honestly guaranteed by simply
-overwriting bytes. EchoFlow should therefore use precise language about deletion and
-retention rather than claiming cryptographic shredding it cannot prove.
+Applying the plan requires the same request plus that exact token:
 
-The safe-delete design should preserve one core invariant: **a command that means “remove
-this from search” must never accidentally mean “erase my only canonical transcript and my
-annotations.”**
+```bash
+echoflow library delete TRANSCRIPT_ID \
+  --scope library-view \
+  --confirm 'delete:...'
+```
 
-## Test contract for this lifecycle
+The typed scopes are:
 
-PR #67 exercises the following invariants at multiple layers:
+- `library-view`;
+- `derived-artifacts`;
+- `execution-state`;
+- `canonical-transcript`;
+- `research-notes`;
+- `saved-searches`; and
+- `source-recording`.
 
-- saved-search typed intent round-trips through SQLite;
-- saved-search names are case-insensitive unique identities without accidental overwrite;
-- derived evidence scopes cannot be persisted as saved-search state;
-- replay re-resolves current research relationships rather than freezing old segment IDs;
-- frequent/recent navigation is derived from current relationships;
-- authoritative tag/collection rows do not grow usage/recency counters;
-- unsupported/corrupt durable metadata fails closed;
-- CLI flags compile to the same typed `SearchQuery` and research-filter contracts;
-- CLI save/list/show/run/delete and navigation surfaces preserve JSON/human behavior; and
-- CLI public errors remain useful while unexpected internal details are masked.
+`canonical-transcript` automatically expands to removal from the active library,
+regenerable derived publications, and private execution state. It does **not** imply `research-notes`, `saved-searches`, or `source-recording`.
 
-The normal repository Quality workflow then runs Ruff, formatting, strict mypy, Vulture,
-Radon, branch-coverage pytest, distribution build/install verification, and full tests on
-Windows and macOS.
+That means deleting canonical JSON without the research scope leaves notes in authoritative
+SQLite. Their exact `(document_id, canonical_sha256, segment_id)` anchors remain, but the
+evidence becomes unavailable/current=false once that generation is no longer in the active
+library.
+
+Source deletion is even narrower: it requires both the explicit `source-recording` scope
+and `--allow-source`, and EchoFlow refuses if current source bytes no longer match the
+recorded source provenance.
+
+## Why the semantic index is cleared when one transcript leaves the library
+
+The current semantic index is bound to a corpus fingerprint and exposes whole-corpus
+rebuild/clear semantics.
+
+Removing one lexical document while retaining semantic vectors from the old corpus would
+leave derived state whose fingerprint still claims deleted evidence. EchoFlow therefore
+clears the semantic corpus when a transcript is removed from the active library.
+
+This is conservative and rebuildable. A future incremental semantic index may support
+generation-scoped removal while keeping the same custody service contract.
+
+## Retention controls are intentionally narrower than deletion
+
+Age-based retention currently applies only to private job workspaces:
+
+```bash
+echoflow library retention --execution-days 30
+```
+
+The command is also a dry run until the matching plan token is supplied with `--confirm`.
+
+Default policy:
+
+```text
+execution_days = 30
+include_incomplete = false
+```
+
+Completed private workspaces older than the cutoff are eligible. Failed/interrupted
+workspaces require `--include-incomplete` because deleting them removes resume capability.
+Running jobs are never eligible.
+
+Retention cleanup preserves:
+
+- canonical JSON;
+- derived public exports;
+- source recordings;
+- notes/tags/collections;
+- speaker labels;
+- saved searches; and
+- lightweight lifecycle manifests.
+
+Preserving lifecycle manifests matters for canonical transcripts written to custom output
+directories. A manifest can remain a discovery pointer even after heavyweight
+checkpoints/intermediates are gone.
+
+## Deletion ordering and partial-failure semantics
+
+SQLite, DuckDB, public files, private workspaces, and arbitrary source media cannot
+participate in one cross-filesystem ACID transaction.
+
+EchoFlow therefore validates destructive inputs first and then orders mutations from most
+recoverable to most unique:
+
+1. rebuildable lexical/semantic state;
+2. regenerable publication exports;
+3. private execution workspace;
+4. canonical transcript evidence;
+5. explicitly requested source media;
+6. explicitly requested document-scoped saved searches; and
+7. explicitly requested research notes.
+
+Immediately before a canonical deletion, EchoFlow re-hashes the canonical JSON and refuses
+the operation if those bytes no longer match the indexed `canonical_sha256`.
+
+The confirmation token is not an authentication secret. It is a change-detection primitive
+that binds approval to one exact mutation set.
+
+## Secure erasure is not claimed
+
+Deleting a path through the operating system does not prove that bytes are unrecoverable
+from SSD wear leveling, copy-on-write history, snapshots, backups, sync/version history,
+controller caches, or forensic tooling.
+
+EchoFlow therefore reports deletion precisely and sets
+`secure_erasure_guaranteed = false` in machine-readable deletion output.
+
+## Test contract
+
+The merged saved-search implementation now has additional regression coverage for:
+
+- invalid durable intent/value objects;
+- list bounds and missing mutation targets;
+- invalid identifiers/names/descriptions;
+- corrupt persisted JSON and enum state;
+- closed navigation dispatch;
+- human list/show/save/run/delete rendering;
+- every derived navigation group; and
+- missing run/delete behavior without mutation.
+
+The safe-deletion/retention tranche adds tests for:
+
+- canonical scope expansion;
+- note preservation by default;
+- saved-search impact reporting and separate explicit deletion;
+- exact confirmation-token matching;
+- canonical SHA revalidation before mutation;
+- explicit research/source deletion;
+- source provenance refusal;
+- library-view-only removal;
+- semantic invalidation;
+- derived-export cleanup;
+- execution-workspace cleanup;
+- completed-only retention defaults;
+- explicit incomplete retention;
+- resume-capability impact;
+- stale retention-plan refusal;
+- malformed/timezone lifecycle edge cases; and
+- human/JSON CLI safety.
+
+The repository Quality workflow runs Ruff, formatting, strict mypy, Vulture, Radon,
+branch-coverage pytest, distribution build/install verification, and full platform tests.
 
 ## Load-bearing invariants
 
@@ -280,5 +395,9 @@ Windows and macOS.
 5. Deleting a rebuildable database must not delete canonical evidence or human-authored
    research state.
 6. Output directories remain user-visible and separate from private state/cache.
-7. Destructive canonical-evidence deletion must be explicit and dependency-aware when that
-   capability is implemented.
+7. Canonical deletion is plan-bound, exact-generation-aware, and does not cascade into
+   human-authored notes.
+8. Source media remains read-only unless a separate explicit, provenance-checked deletion
+   scope is chosen.
+9. Age-based retention cannot delete canonical evidence or research knowledge.
+10. EchoFlow never claims secure erasure it cannot prove.

--- a/docs/architecture/safe-deletion-retention.md
+++ b/docs/architecture/safe-deletion-retention.md
@@ -1,0 +1,279 @@
+# Safe deletion and retention controls
+
+EchoFlow treats deletion as a custody decision, not a filesystem shortcut.
+
+The deletion surface therefore starts with a typed plan. A plan identifies the exact
+canonical generation, every mutation EchoFlow intends to make, durable research objects
+that will be preserved, saved searches whose results may change, and a confirmation token
+bound to that exact plan. No deletion occurs until the same request is repeated with the
+matching token.
+
+This design protects the central library invariant:
+
+> **Removing evidence from search must never silently erase canonical transcript evidence,
+> user-authored research knowledge, or an original recording.**
+
+## CLI
+
+Plan an operation:
+
+```bash
+echoflow library delete TRANSCRIPT_ID --scope library-view
+```
+
+The command is a dry run unless `--confirm` is supplied. The human and JSON forms both
+include the plan-bound confirmation token.
+
+Apply exactly the reviewed plan:
+
+```bash
+echoflow library delete TRANSCRIPT_ID \
+  --scope library-view \
+  --confirm 'delete:...'
+```
+
+Scopes can be repeated:
+
+```bash
+echoflow library delete TRANSCRIPT_ID \
+  --scope research-notes \
+  --scope source-recording \
+  --allow-source
+```
+
+Source deletion has a second safety gate: `--allow-source` is required and EchoFlow refuses
+to delete the recording unless the current source bytes still match the source SHA-256
+recorded when the transcript was created.
+
+Private execution-state retention uses the same plan/apply contract:
+
+```bash
+echoflow library retention --execution-days 30
+echoflow library retention --execution-days 30 --confirm 'retention:...'
+```
+
+By default only completed job workspaces are eligible. Failed and interrupted workspaces
+are included only with `--include-incomplete`, because deleting those workspaces removes
+resume capability. Running jobs are never eligible.
+
+## Typed deletion scopes
+
+`DeletionScope` deliberately separates meanings that a generic "delete transcript" button
+would otherwise collapse.
+
+| Scope | Effect | Does not do |
+|---|---|---|
+| `library-view` | removes the document from the lexical index and clears a built semantic corpus whose fingerprint would otherwise reference it | does not delete canonical JSON, exports, notes, lifecycle metadata, or source media |
+| `derived-artifacts` | deletes sibling TXT/SRT/VTT publications that can be regenerated from canonical JSON | does not touch canonical JSON |
+| `execution-state` | deletes the exact private job workspace containing checkpoints/intermediates | preserves the lightweight lifecycle manifest and all public evidence |
+| `canonical-transcript` | deletes canonical JSON and automatically expands to `library-view`, `derived-artifacts`, and `execution-state` | does not delete notes or the source recording |
+| `research-notes` | deletes notes anchored to the exact current canonical generation | does not delete tags/collections globally and is never implied by canonical deletion |
+| `saved-searches` | deletes saved searches that explicitly constrain `document_ids` to this transcript | does not delete global saved searches and is never implied by canonical deletion |
+| `source-recording` | deletes the original recording only after the explicit source gate and provenance check | is never implied by any other scope |
+
+`canonical-transcript` is cumulative only across disposable descendants. The unique human/source custody classes, `research-notes`, `saved-searches`, and
+`source-recording`, always require their own explicit scopes.
+
+## Why notes survive canonical deletion
+
+Notes are user-authored knowledge. Their evidence anchor contains:
+
+```text
+document_id
+canonical_sha256
+segment_id(s)
+source-relative time coordinates
+```
+
+If canonical JSON is explicitly deleted without the `research-notes` scope, those
+notes remain in authoritative SQLite. They become historical/stale anchors because their
+exact canonical generation is no longer present in the active transcript index.
+
+That is intentional. EchoFlow prefers:
+
+```text
+note survives + evidence is reported unavailable
+```
+
+over:
+
+```text
+canonical deletion cascades into silent loss of human work
+```
+
+A later UI can present this as an "evidence unavailable" note while still showing the
+recorded document/generation identity.
+
+## Saved searches are preserved unless their own scope is selected
+
+Saved searches persist typed intent rather than result snapshots. A saved search that
+explicitly constrains `document_ids` to a transcript being removed is listed in the
+deletion plan as affected. By default it is preserved, so replay later re-resolves the
+current library and may return fewer or no results.
+
+If the user also selects `saved-searches`, only those document-scoped saved searches are
+deleted. Global saved searches are not guessed to be dependent merely because they might
+currently return the transcript. This keeps deletion explicit rather than semantic-by-guess.
+
+## Semantic deletion is corpus-wide today
+
+The current semantic index is generation-bound to one corpus fingerprint and exposes
+atomic rebuild/clear operations rather than per-document mutation.
+
+Therefore removing one transcript from the active library:
+
+1. removes that document from the lexical index; and
+2. clears a built semantic index.
+
+That is intentionally conservative. Keeping vectors whose state fingerprint still claims
+the removed generation would create stale derived state. Semantic search can be rebuilt
+later from the remaining canonical corpus.
+
+A future incremental semantic index may support generation-scoped removal without changing
+the deletion service contract.
+
+## Canonical integrity is rechecked before mutation
+
+The deletion plan binds to `canonical_sha256`. Immediately before executing any action,
+EchoFlow re-reads the canonical JSON scheduled for deletion and recomputes SHA-256.
+
+If the bytes changed after indexing, execution fails before any mutation. The user must
+rebuild/review the current generation and obtain a new plan.
+
+This prevents a stale confirmation token from authorizing deletion of different canonical
+bytes that happen to occupy the same path.
+
+The token is not an authentication secret. It is a change-detection/confirmation primitive
+that binds the user's approval to the exact planned mutation set.
+
+## Source deletion has an additional provenance boundary
+
+Original recordings are treated read-only throughout normal EchoFlow processing.
+
+A source recording can be deleted only when all of the following are true:
+
+1. `source-recording` is an explicitly requested scope;
+2. `--allow-source` is supplied;
+3. a source path is available;
+4. the source still exists; and
+5. current source integrity is `matches-recorded-source`.
+
+If a recording changed since transcription, EchoFlow refuses deletion. That prevents a
+transcript's old provenance record from becoming authorization to delete new bytes at the
+same path.
+
+## Retention is restricted to private execution workspaces
+
+Automatic age-based retention is intentionally narrower than explicit deletion.
+
+`RetentionPolicy` currently governs only private job workspaces:
+
+```text
+state/
+└── jobs/
+    └── JOB_ID/
+        ├── checkpoints/
+        └── intermediates/
+```
+
+It never age-deletes:
+
+- canonical JSON;
+- TXT/SRT/VTT;
+- source recordings;
+- notes/tags/collections;
+- speaker labels;
+- saved searches;
+- lexical/semantic research meaning; or
+- lightweight job lifecycle manifests.
+
+Keeping lifecycle manifests matters because they can retain the discovery pointer to a
+canonical transcript written to a custom output directory. Deleting the heavy workspace
+while preserving that small manifest frees resumable/intermediate state without making
+valid evidence harder to rediscover.
+
+## Retention defaults
+
+The default CLI policy is:
+
+```text
+execution_days = 30
+include_incomplete = false
+```
+
+A completed workspace older than the cutoff is eligible.
+
+Failed/interrupted workspaces remain available for resume unless the user explicitly opts
+into `--include-incomplete`. Running jobs are never eligible, regardless of age.
+
+Retention plans are recalculated at execution time. If candidates changed, the old token
+no longer matches and EchoFlow refuses to apply the stale plan.
+
+## Filesystem and failure semantics
+
+EchoFlow cannot make SQLite, DuckDB, arbitrary public files, private workspaces, and source
+media participate in one cross-filesystem ACID transaction.
+
+The executor therefore orders operations by custody risk:
+
+1. rebuildable index state;
+2. regenerable publication artifacts;
+3. private execution workspace;
+4. canonical transcript evidence;
+5. explicitly requested source media;
+6. explicitly requested document-scoped saved searches; and
+7. explicitly requested research notes.
+
+Unique human-authored state is ordered last. If an earlier filesystem mutation fails,
+notes and saved searches remain intact rather than being sacrificed before a recoverable
+cleanup step.
+
+Before the first mutation, destructive canonical inputs are revalidated.
+
+If a later filesystem operation fails, earlier disposable mutations may already have
+occurred. Those can be rebuilt. EchoFlow deliberately avoids deleting unique evidence
+first and hoping cleanup succeeds afterward.
+
+## Secure erasure is not claimed
+
+Deletion means EchoFlow asks the operating system/filesystem to remove the selected file
+or directory.
+
+It does **not** mean EchoFlow can prove the bytes are unrecoverable from:
+
+- SSD wear-levelled blocks;
+- copy-on-write filesystem history;
+- snapshots;
+- backups;
+- cloud sync/version history;
+- storage-controller caches; or
+- forensic recovery outside the active filesystem namespace.
+
+Both human and JSON CLI output therefore state that secure erasure is not guaranteed.
+
+## Test contract
+
+The custody tests cover:
+
+- canonical scope expansion;
+- preservation of notes by default;
+- saved-search impact reporting and separate explicit deletion;
+- exact confirmation-token matching;
+- canonical SHA revalidation before any mutation;
+- explicit research deletion;
+- explicit source deletion and provenance refusal;
+- library-view-only removal;
+- semantic invalidation;
+- derived-export cleanup;
+- private execution-workspace cleanup;
+- default completed-only retention;
+- explicit incomplete-job retention;
+- resume-capability impact reporting;
+- stale retention-plan refusal;
+- timezone/malformed lifecycle edge cases;
+- human and JSON CLI behavior; and
+- safe public/internal error presentation.
+
+Additional saved-search tests added alongside this work cover value-object validation,
+storage bounds, corrupt persisted JSON/enums, missing mutation targets, closed navigation
+dispatch, and human rendering paths that were under-covered in the merged saved-search PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,11 @@ max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/**" = ["S101", "S603"]
+# Custody tests use synthetic non-secret confirmation values and synthetic /tmp lifecycle
+# paths to exercise path/plan behavior. Scope the false-positive exceptions to these two
+# test modules rather than weakening the production or repository-wide security rules.
+"src/echoflow/library/tests/test_custody.py" = ["S106", "S108"]
+"src/echoflow/tests/test_cli_custody.py" = ["S106"]
 # The navigation adapter interpolates only closed internal table/order fragments selected
 # by code; every runtime/user value remains a bound SQLite parameter.
 "src/echoflow/library/workspace_metadata.py" = ["S608"]

--- a/src/echoflow/app/app_container.py
+++ b/src/echoflow/app/app_container.py
@@ -16,6 +16,7 @@ from echoflow.core.ilogger import ILogger
 from echoflow.core.logger import configure_logging
 from echoflow.core.performance_tracker import PerformanceTracker
 from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.library.custody import LibraryCustodyService
 from echoflow.library.duckdb_index import DuckDbTranscriptIndex
 from echoflow.library.duckdb_research_projection import DuckDbResearchProjection
 from echoflow.library.duckdb_semantic import DuckDbSemanticIndex
@@ -311,6 +312,17 @@ class AppContainer(containers.DeclarativeContainer):
         file_manager=file_manager,
         semantic_index=semantic_index,
         embedding_provider_factory=embedding_provider_factory,
+    )
+    library_custody = providers.Singleton(
+        LibraryCustodyService,
+        transcript_library=transcript_library,
+        lexical_index=transcript_index,
+        semantic_index=semantic_index,
+        lifecycle_store=job_lifecycle_store,
+        research_state=research_state_store,
+        workspace_metadata=workspace_metadata_store,
+        paths=workspace_paths,
+        file_manager=file_manager,
     )
     evidence_locator = providers.Singleton(EvidenceLocator, file_manager=file_manager)
     research_navigation = providers.Singleton(

--- a/src/echoflow/cli_custody.py
+++ b/src/echoflow/cli_custody.py
@@ -1,0 +1,355 @@
+"""CLI for custody-aware deletion and private execution-state retention."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Annotated, cast
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from echoflow.app.app_container import AppContainer
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.custody import (
+    DeletionAction,
+    DeletionPlan,
+    DeletionReceipt,
+    DeletionScope,
+    LibraryCustodyService,
+    RetentionCandidate,
+    RetentionPlan,
+    RetentionPolicy,
+    RetentionReceipt,
+)
+
+ContainerFactory = Callable[[typer.Context], AppContainer]
+
+
+def _root_context(context: typer.Context) -> typer.Context:
+    return cast("typer.Context", context.find_root())
+
+
+def _service(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+) -> LibraryCustodyService:
+    return container_factory(_root_context(context)).library_custody()
+
+
+def _action_dict(action: DeletionAction) -> dict[str, object]:
+    return {
+        "target": action.target.value,
+        "object_id": action.object_id,
+        "description": action.description,
+        "path": action.path,
+    }
+
+
+def _deletion_plan_dict(plan: DeletionPlan) -> dict[str, object]:
+    return {
+        "document_id": plan.document_id,
+        "canonical_sha256": plan.canonical_sha256,
+        "requested_scopes": [item.value for item in plan.requested_scopes],
+        "effective_scopes": [item.value for item in plan.effective_scopes],
+        "actions": [_action_dict(item) for item in plan.actions],
+        "preserved_note_ids": list(plan.preserved_note_ids),
+        "affected_saved_search_ids": list(plan.affected_saved_search_ids),
+        "confirmation_token": plan.confirmation_token,
+        "secure_erasure_guaranteed": False,
+        "executed": False,
+    }
+
+
+def _deletion_receipt_dict(receipt: DeletionReceipt) -> dict[str, object]:
+    return {
+        "document_id": receipt.document_id,
+        "confirmation_token": receipt.confirmation_token,
+        "executed_targets": [item.value for item in receipt.executed_targets],
+        "preserved_note_ids": list(receipt.preserved_note_ids),
+        "affected_saved_search_ids": list(receipt.affected_saved_search_ids),
+        "secure_erasure_guaranteed": False,
+        "executed": True,
+    }
+
+
+def _candidate_dict(candidate: RetentionCandidate) -> dict[str, object]:
+    return {
+        "job_id": candidate.job_id,
+        "status": candidate.status.value,
+        "updated_at": candidate.updated_at,
+        "workspace_path": candidate.workspace_path,
+        "resume_capability_lost": candidate.resume_capability_lost,
+    }
+
+
+def _retention_plan_dict(plan: RetentionPlan) -> dict[str, object]:
+    return {
+        "policy": {
+            "execution_days": plan.policy.execution_days,
+            "include_incomplete": plan.policy.include_incomplete,
+        },
+        "candidates": [_candidate_dict(item) for item in plan.candidates],
+        "confirmation_token": plan.confirmation_token,
+        "preserves_canonical_transcripts": True,
+        "preserves_research_knowledge": True,
+        "preserves_lifecycle_manifests": True,
+        "executed": False,
+    }
+
+
+def _retention_receipt_dict(receipt: RetentionReceipt) -> dict[str, object]:
+    return {
+        "confirmation_token": receipt.confirmation_token,
+        "discarded_job_ids": list(receipt.discarded_job_ids),
+        "preserves_canonical_transcripts": True,
+        "preserves_research_knowledge": True,
+        "preserves_lifecycle_manifests": True,
+        "executed": True,
+    }
+
+
+def _render_deletion_plan(plan: DeletionPlan) -> None:
+    table = Table(title=f"EchoFlow deletion plan: {plan.document_id}")
+    table.add_column("Target")
+    table.add_column("Action")
+    table.add_column("Path")
+    for action in plan.actions:
+        table.add_row(
+            action.target.value,
+            action.description,
+            action.path or "private database state",
+        )
+    Console().print(table)
+    typer.echo(
+        "Requested scopes: "
+        + ", ".join(item.value for item in plan.requested_scopes)
+    )
+    if plan.effective_scopes != plan.requested_scopes:
+        typer.echo(
+            "Effective scopes: "
+            + ", ".join(item.value for item in plan.effective_scopes)
+        )
+    if plan.preserved_note_ids:
+        typer.echo(
+            f"Preserved attached notes: {len(plan.preserved_note_ids)} "
+            "(they remain as historical anchors if canonical evidence is removed)."
+        )
+    if plan.affected_saved_search_ids:
+        typer.echo(
+            f"Document-scoped saved searches affected: "
+            f"{len(plan.affected_saved_search_ids)}."
+        )
+    typer.echo("Secure erasure is not guaranteed by this operation.")
+    typer.echo(f"Confirmation token: {plan.confirmation_token}")
+    typer.echo(
+        "No changes made. Re-run the same command with --confirm TOKEN to apply."
+    )
+
+
+def _render_deletion_receipt(receipt: DeletionReceipt) -> None:
+    targets = ", ".join(item.value for item in receipt.executed_targets) or "none"
+    typer.echo(f"Deletion applied for {receipt.document_id}: {targets}.")
+    if receipt.preserved_note_ids:
+        typer.echo(f"Preserved {len(receipt.preserved_note_ids)} attached note(s).")
+    typer.echo("No secure-erasure guarantee is made.")
+
+
+def _render_retention_plan(plan: RetentionPlan) -> None:
+    table = Table(title="EchoFlow private execution-state retention plan")
+    table.add_column("Job")
+    table.add_column("Status")
+    table.add_column("Updated")
+    table.add_column("Resume lost?")
+    table.add_column("Private workspace")
+    for item in plan.candidates:
+        table.add_row(
+            item.job_id,
+            item.status.value,
+            item.updated_at,
+            "yes" if item.resume_capability_lost else "no",
+            item.workspace_path,
+        )
+    Console().print(table)
+    typer.echo(
+        "This policy deletes only private job workspaces. Canonical transcripts, "
+        "research knowledge, and lifecycle manifests are preserved."
+    )
+    typer.echo(f"Confirmation token: {plan.confirmation_token}")
+    typer.echo(
+        "No changes made. Re-run the same command with --confirm TOKEN to apply."
+    )
+
+
+def _render_retention_receipt(receipt: RetentionReceipt) -> None:
+    typer.echo(
+        f"Deleted {len(receipt.discarded_job_ids)} private execution workspace(s). "
+        "Canonical evidence and user-authored research state were preserved."
+    )
+
+
+def _handle_error(exc: Exception) -> None:
+    if isinstance(exc, EchoFlowError):
+        typer.echo(exc.public_message, err=True)
+        raise typer.Exit(code=exc.exit_code) from None
+    if isinstance(exc, ValueError):
+        raise typer.BadParameter(str(exc)) from exc
+    typer.echo(
+        f"EchoFlow custody operation failed internally ({type(exc).__name__})",
+        err=True,
+    )
+    raise typer.Exit(code=3) from None
+
+
+def _delete(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+    document_id: str,
+    *,
+    scopes: tuple[DeletionScope, ...],
+    allow_source: bool,
+    confirm: str | None,
+    json_output: bool,
+) -> None:
+    try:
+        service = _service(context, container_factory)
+        if confirm is None:
+            plan = service.plan_deletion(
+                document_id,
+                scopes,
+                allow_source=allow_source,
+            )
+            if json_output:
+                typer.echo(json.dumps(_deletion_plan_dict(plan), sort_keys=True))
+                return
+            _render_deletion_plan(plan)
+            return
+        receipt = service.execute_deletion(
+            document_id,
+            scopes,
+            confirmation_token=confirm,
+            allow_source=allow_source,
+        )
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps(_deletion_receipt_dict(receipt), sort_keys=True))
+        return
+    _render_deletion_receipt(receipt)
+
+
+def _retention(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+    *,
+    execution_days: int,
+    include_incomplete: bool,
+    confirm: str | None,
+    json_output: bool,
+) -> None:
+    try:
+        service = _service(context, container_factory)
+        policy = RetentionPolicy(
+            execution_days=execution_days,
+            include_incomplete=include_incomplete,
+        )
+        if confirm is None:
+            plan = service.plan_retention(policy)
+            if json_output:
+                typer.echo(json.dumps(_retention_plan_dict(plan), sort_keys=True))
+                return
+            _render_retention_plan(plan)
+            return
+        receipt = service.execute_retention(
+            policy,
+            confirmation_token=confirm,
+        )
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps(_retention_receipt_dict(receipt), sort_keys=True))
+        return
+    _render_retention_receipt(receipt)
+
+
+def register_custody_commands(
+    library_app: typer.Typer,
+    container_factory: ContainerFactory,
+) -> None:
+    """Register deletion planning/execution and private retention controls."""
+
+    @library_app.command("delete")
+    def delete_transcript(
+        context: typer.Context,
+        document_id: str = typer.Argument(..., metavar="TRANSCRIPT_ID"),
+        scopes: Annotated[
+            list[DeletionScope] | None,
+            typer.Option(
+                "--scope",
+                help=(
+                    "Custody scope. Repeat to combine. canonical-transcript expands "
+                    "to library-view, derived-artifacts, and execution-state."
+                ),
+            ),
+        ] = None,
+        allow_source: bool = typer.Option(
+            False,
+            "--allow-source",
+            help=(
+                "Permit an explicitly requested source-recording deletion only when "
+                "the current source still matches transcription provenance."
+            ),
+        ),
+        confirm: str | None = typer.Option(
+            None,
+            "--confirm",
+            help="Apply only if this exact plan-bound token still matches.",
+        ),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _delete(
+            context,
+            container_factory,
+            document_id,
+            scopes=tuple(scopes or (DeletionScope.LIBRARY_VIEW,)),
+            allow_source=allow_source,
+            confirm=confirm,
+            json_output=json_output,
+        )
+
+    @library_app.command("retention")
+    def retention(
+        context: typer.Context,
+        execution_days: int = typer.Option(
+            30,
+            "--execution-days",
+            min=0,
+            max=36_500,
+            help="Delete terminal private job workspaces at least this many days old.",
+        ),
+        include_incomplete: bool = typer.Option(
+            False,
+            "--include-incomplete",
+            help=(
+                "Also include failed/interrupted workspaces, which removes resume "
+                "capability. Running jobs are never eligible."
+            ),
+        ),
+        confirm: str | None = typer.Option(
+            None,
+            "--confirm",
+            help="Apply only if this exact retention plan token still matches.",
+        ),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _retention(
+            context,
+            container_factory,
+            execution_days=execution_days,
+            include_incomplete=include_incomplete,
+            confirm=confirm,
+            json_output=json_output,
+        )

--- a/src/echoflow/cli_custody.py
+++ b/src/echoflow/cli_custody.py
@@ -123,8 +123,7 @@ def _render_deletion_plan(plan: DeletionPlan) -> None:
         )
     Console().print(table)
     typer.echo(
-        "Requested scopes: "
-        + ", ".join(item.value for item in plan.requested_scopes)
+        "Requested scopes: " + ", ".join(item.value for item in plan.requested_scopes)
     )
     if plan.effective_scopes != plan.requested_scopes:
         typer.echo(

--- a/src/echoflow/cli_research.py
+++ b/src/echoflow/cli_research.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 from echoflow.app.app_container import AppContainer
+from echoflow.cli_custody import register_custody_commands
 from echoflow.cli_saved_searches import register_saved_search_commands
 from echoflow.core.errors import EchoFlowError
 from echoflow.library.research_projector import ResearchProjectionSyncReport
@@ -512,3 +513,4 @@ def register_research_commands(
     library_app.add_typer(_build_notes_app(container_factory), name="notes")
     library_app.add_typer(_build_projection_app(container_factory), name="research")
     register_saved_search_commands(library_app, container_factory)
+    register_custody_commands(library_app, container_factory)

--- a/src/echoflow/library/custody.py
+++ b/src/echoflow/library/custody.py
@@ -1,0 +1,672 @@
+"""Plan and execute custody-aware deletion and private-state retention."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.errors import CustodyOperationError
+from echoflow.library.index import IndexedDocument, TranscriptIndex
+from echoflow.library.research_state import ResearchNote, ResearchStateStore
+from echoflow.library.semantic import SemanticIndex
+from echoflow.library.service import (
+    LibraryEvidenceReceipt,
+    SourceIntegrity,
+    TranscriptLibraryService,
+)
+from echoflow.library.workspace_metadata import WorkspaceMetadataStore
+from echoflow.workspace.lifecycle import (
+    JobLifecycleRecord,
+    JobLifecycleStore,
+    JobStatus,
+)
+from echoflow.workspace.models import WorkspacePaths
+
+_DERIVED_EXPORT_SUFFIXES = (".txt", ".srt", ".vtt")
+_MAX_RESEARCH_OBJECTS = 10_000
+
+
+class DeletionScope(StrEnum):
+    """User-selected custody boundary for one transcript deletion plan."""
+
+    LIBRARY_VIEW = "library-view"
+    DERIVED_ARTIFACTS = "derived-artifacts"
+    EXECUTION_STATE = "execution-state"
+    CANONICAL_TRANSCRIPT = "canonical-transcript"
+    RESEARCH_NOTES = "research-notes"
+    SAVED_SEARCHES = "saved-searches"
+    SOURCE_RECORDING = "source-recording"
+
+
+class DeletionTarget(StrEnum):
+    LEXICAL_INDEX = "lexical-index"
+    SEMANTIC_INDEX = "semantic-index"
+    DERIVED_ARTIFACT = "derived-artifact"
+    EXECUTION_STATE = "execution-state"
+    RESEARCH_NOTE = "research-note"
+    SAVED_SEARCH = "saved-search"
+    CANONICAL_TRANSCRIPT = "canonical-transcript"
+    SOURCE_RECORDING = "source-recording"
+
+
+@dataclass(frozen=True, slots=True)
+class DeletionAction:
+    """One exact mutation in a reviewed deletion plan."""
+
+    target: DeletionTarget
+    object_id: str
+    description: str
+    path: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.object_id.strip():
+            raise ValueError("deletion action object_id cannot be empty")
+        if not self.description.strip():
+            raise ValueError("deletion action description cannot be empty")
+        if self.path is not None and not self.path.strip():
+            raise ValueError("deletion action path cannot be blank")
+
+
+@dataclass(frozen=True, slots=True)
+class DeletionPlan:
+    """A reviewable, plan-bound description of every deletion side effect."""
+
+    document_id: str
+    canonical_sha256: str
+    requested_scopes: tuple[DeletionScope, ...]
+    effective_scopes: tuple[DeletionScope, ...]
+    actions: tuple[DeletionAction, ...]
+    preserved_note_ids: tuple[str, ...]
+    affected_saved_search_ids: tuple[str, ...]
+    confirmation_token: str
+
+    def __post_init__(self) -> None:
+        if not self.document_id.strip():
+            raise ValueError("deletion plan document_id cannot be empty")
+        if len(self.canonical_sha256) != 64 or any(
+            character not in "0123456789abcdef" for character in self.canonical_sha256
+        ):
+            raise ValueError(
+                "deletion plan canonical_sha256 must be a lowercase digest"
+            )
+        if not self.requested_scopes or not self.effective_scopes:
+            raise ValueError("deletion plan must contain at least one scope")
+        if len(self.requested_scopes) != len(set(self.requested_scopes)):
+            raise ValueError("requested deletion scopes must be unique")
+        if len(self.effective_scopes) != len(set(self.effective_scopes)):
+            raise ValueError("effective deletion scopes must be unique")
+        if not self.confirmation_token.strip():
+            raise ValueError("deletion confirmation token cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class DeletionReceipt:
+    """Completed mutations after a plan-bound confirmation succeeded."""
+
+    document_id: str
+    confirmation_token: str
+    executed_targets: tuple[DeletionTarget, ...]
+    preserved_note_ids: tuple[str, ...]
+    affected_saved_search_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionPolicy:
+    """Automatic-retention policy restricted to private execution workspaces."""
+
+    execution_days: int = 30
+    include_incomplete: bool = False
+
+    def __post_init__(self) -> None:
+        if self.execution_days < 0 or self.execution_days > 36_500:
+            raise ValueError("execution retention days must be between 0 and 36500")
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionCandidate:
+    job_id: str
+    status: JobStatus
+    updated_at: str
+    workspace_path: str
+    resume_capability_lost: bool
+
+    def __post_init__(self) -> None:
+        if not self.job_id.strip() or not self.workspace_path.strip():
+            raise ValueError("retention candidate identity and path cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionPlan:
+    """A plan that can delete only private job workspaces, never public evidence."""
+
+    policy: RetentionPolicy
+    candidates: tuple[RetentionCandidate, ...]
+    confirmation_token: str
+
+    def __post_init__(self) -> None:
+        if not self.confirmation_token.strip():
+            raise ValueError("retention confirmation token cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionReceipt:
+    confirmation_token: str
+    discarded_job_ids: tuple[str, ...]
+
+
+class LibraryCustodyService:
+    """Coordinate deletion without collapsing distinct evidence custody classes."""
+
+    def __init__(
+        self,
+        transcript_library: TranscriptLibraryService,
+        lexical_index: TranscriptIndex,
+        semantic_index: SemanticIndex | None,
+        lifecycle_store: JobLifecycleStore,
+        research_state: ResearchStateStore,
+        workspace_metadata: WorkspaceMetadataStore,
+        paths: WorkspacePaths,
+        file_manager: FileManagerFacade,
+    ) -> None:
+        self.transcript_library = transcript_library
+        self.lexical_index = lexical_index
+        self.semantic_index = semantic_index
+        self.lifecycle_store = lifecycle_store
+        self.research_state = research_state
+        self.workspace_metadata = workspace_metadata
+        self.paths = paths
+        self.file_manager = file_manager
+
+    def plan_deletion(
+        self,
+        document_id: str,
+        scopes: tuple[DeletionScope, ...],
+        *,
+        allow_source: bool = False,
+    ) -> DeletionPlan:
+        requested = self._normalized_scopes(scopes)
+        effective = self._effective_scopes(requested)
+        receipt = self.transcript_library.inspect(document_id)
+        document = receipt.document
+        canonical_sha256 = self._canonical_digest(document)
+        self._validate_source_request(receipt, effective, allow_source=allow_source)
+
+        notes = self._generation_notes(document_id, canonical_sha256)
+        saved_search_ids = self._affected_saved_search_ids(document_id)
+        preserved_note_ids = (
+            ()
+            if DeletionScope.RESEARCH_NOTES in effective
+            else tuple(note.note_id for note in notes)
+        )
+        actions = self._deletion_actions(
+            document,
+            canonical_sha256=canonical_sha256,
+            scopes=effective,
+            note_ids=tuple(note.note_id for note in notes),
+            saved_search_ids=saved_search_ids,
+        )
+        token = self._deletion_token(
+            document_id,
+            canonical_sha256,
+            requested,
+            effective,
+            actions,
+            preserved_note_ids,
+            saved_search_ids,
+        )
+        return DeletionPlan(
+            document_id=document_id,
+            canonical_sha256=canonical_sha256,
+            requested_scopes=requested,
+            effective_scopes=effective,
+            actions=actions,
+            preserved_note_ids=preserved_note_ids,
+            affected_saved_search_ids=saved_search_ids,
+            confirmation_token=token,
+        )
+
+    def execute_deletion(
+        self,
+        document_id: str,
+        scopes: tuple[DeletionScope, ...],
+        *,
+        confirmation_token: str,
+        allow_source: bool = False,
+    ) -> DeletionReceipt:
+        plan = self.plan_deletion(document_id, scopes, allow_source=allow_source)
+        if confirmation_token != plan.confirmation_token:
+            raise CustodyOperationError(
+                "Deletion plan changed or confirmation token is invalid; "
+                "review the plan again"
+            )
+        self._validate_destructive_inputs(plan)
+        executed: list[DeletionTarget] = []
+        for action in plan.actions:
+            self._execute_action(action)
+            executed.append(action.target)
+        return DeletionReceipt(
+            document_id=plan.document_id,
+            confirmation_token=plan.confirmation_token,
+            executed_targets=tuple(executed),
+            preserved_note_ids=plan.preserved_note_ids,
+            affected_saved_search_ids=plan.affected_saved_search_ids,
+        )
+
+    def plan_retention(
+        self,
+        policy: RetentionPolicy,
+        *,
+        now: datetime | None = None,
+    ) -> RetentionPlan:
+        current = self._aware_now(now)
+        cutoff = current - timedelta(days=policy.execution_days)
+        candidates = tuple(
+            candidate
+            for record in self.lifecycle_store.list_records()
+            if (
+                candidate := self._retention_candidate(
+                    record,
+                    cutoff=cutoff,
+                    include_incomplete=policy.include_incomplete,
+                )
+            )
+            is not None
+        )
+        ordered = tuple(
+            sorted(candidates, key=lambda item: (item.updated_at, item.job_id))
+        )
+        return RetentionPlan(
+            policy=policy,
+            candidates=ordered,
+            confirmation_token=self._retention_token(policy, ordered),
+        )
+
+    def execute_retention(
+        self,
+        policy: RetentionPolicy,
+        *,
+        confirmation_token: str,
+        now: datetime | None = None,
+    ) -> RetentionReceipt:
+        plan = self.plan_retention(policy, now=now)
+        if confirmation_token != plan.confirmation_token:
+            raise CustodyOperationError(
+                "Retention plan changed or confirmation token is invalid; "
+                "review the plan again"
+            )
+        discarded: list[str] = []
+        for candidate in plan.candidates:
+            workspace = Path(candidate.workspace_path)
+            self._validate_workspace_path(workspace)
+            if workspace.is_dir():
+                self.file_manager.delete_directory(workspace)
+                discarded.append(candidate.job_id)
+        return RetentionReceipt(
+            confirmation_token=plan.confirmation_token,
+            discarded_job_ids=tuple(discarded),
+        )
+
+    @staticmethod
+    def _normalized_scopes(
+        scopes: tuple[DeletionScope, ...],
+    ) -> tuple[DeletionScope, ...]:
+        if not scopes:
+            raise ValueError("at least one deletion scope is required")
+        selected = set(scopes)
+        return tuple(scope for scope in DeletionScope if scope in selected)
+
+    @staticmethod
+    def _effective_scopes(
+        requested: tuple[DeletionScope, ...],
+    ) -> tuple[DeletionScope, ...]:
+        expanded = set(requested)
+        if DeletionScope.CANONICAL_TRANSCRIPT in expanded:
+            expanded.update(
+                {
+                    DeletionScope.LIBRARY_VIEW,
+                    DeletionScope.DERIVED_ARTIFACTS,
+                    DeletionScope.EXECUTION_STATE,
+                }
+            )
+        return tuple(scope for scope in DeletionScope if scope in expanded)
+
+    @staticmethod
+    def _canonical_digest(document: IndexedDocument) -> str:
+        if document.canonical_sha256 is None:
+            raise CustodyOperationError(
+                "Transcript index predates canonical hashing; rebuild the library "
+                "before deletion"
+            )
+        return document.canonical_sha256
+
+    @staticmethod
+    def _validate_source_request(
+        receipt: LibraryEvidenceReceipt,
+        scopes: tuple[DeletionScope, ...],
+        *,
+        allow_source: bool,
+    ) -> None:
+        if DeletionScope.SOURCE_RECORDING not in scopes:
+            return
+        if not allow_source:
+            raise CustodyOperationError(
+                "Source recording deletion requires the explicit allow-source "
+                "safety switch"
+            )
+        if receipt.document.source_path is None:
+            raise CustodyOperationError("Source recording path is unavailable")
+        if receipt.source_integrity is not SourceIntegrity.MATCHES:
+            raise CustodyOperationError(
+                "Source recording no longer matches the bytes used for transcription; "
+                "refusing deletion"
+            )
+
+    def _generation_notes(
+        self, document_id: str, canonical_sha256: str
+    ) -> tuple[ResearchNote, ...]:
+        return tuple(
+            note
+            for note in self.research_state.notes(
+                document_id=document_id,
+                limit=_MAX_RESEARCH_OBJECTS,
+            )
+            if note.anchor.canonical_sha256 == canonical_sha256
+        )
+
+    def _affected_saved_search_ids(self, document_id: str) -> tuple[str, ...]:
+        return tuple(
+            saved.saved_search_id
+            for saved in self.workspace_metadata.saved_searches(
+                limit=_MAX_RESEARCH_OBJECTS
+            )
+            if document_id in saved.intent.query.document_ids
+        )
+
+    def _deletion_actions(
+        self,
+        document: IndexedDocument,
+        *,
+        canonical_sha256: str,
+        scopes: tuple[DeletionScope, ...],
+        note_ids: tuple[str, ...],
+        saved_search_ids: tuple[str, ...],
+    ) -> tuple[DeletionAction, ...]:
+        actions: list[DeletionAction] = []
+        if DeletionScope.LIBRARY_VIEW in scopes:
+            actions.extend(self._library_actions(document.document_id))
+        if DeletionScope.DERIVED_ARTIFACTS in scopes:
+            actions.extend(self._derived_artifact_actions(document))
+        if DeletionScope.EXECUTION_STATE in scopes:
+            action = self._execution_action(document.document_id)
+            if action is not None:
+                actions.append(action)
+        if DeletionScope.CANONICAL_TRANSCRIPT in scopes:
+            actions.append(
+                DeletionAction(
+                    target=DeletionTarget.CANONICAL_TRANSCRIPT,
+                    object_id=canonical_sha256,
+                    path=document.canonical_path,
+                    description="delete canonical transcript evidence",
+                )
+            )
+        if DeletionScope.SOURCE_RECORDING in scopes:
+            source_path = document.source_path
+            if source_path is None:
+                raise CustodyOperationError("Source recording path is unavailable")
+            actions.append(
+                DeletionAction(
+                    target=DeletionTarget.SOURCE_RECORDING,
+                    object_id=document.source_sha256,
+                    path=source_path,
+                    description="delete the original source recording",
+                )
+            )
+        if DeletionScope.SAVED_SEARCHES in scopes:
+            actions.extend(self._saved_search_actions(saved_search_ids))
+        if DeletionScope.RESEARCH_NOTES in scopes:
+            actions.extend(self._research_actions(note_ids))
+        return tuple(actions)
+
+    def _library_actions(self, document_id: str) -> tuple[DeletionAction, ...]:
+        actions = [
+            DeletionAction(
+                target=DeletionTarget.LEXICAL_INDEX,
+                object_id=document_id,
+                description="remove transcript from the rebuildable lexical index",
+            )
+        ]
+        if self.semantic_index is not None and self.semantic_index.state() is not None:
+            actions.append(
+                DeletionAction(
+                    target=DeletionTarget.SEMANTIC_INDEX,
+                    object_id="semantic-corpus",
+                    description=(
+                        "clear the rebuildable semantic corpus because its fingerprint "
+                        "would otherwise reference removed evidence"
+                    ),
+                )
+            )
+        return tuple(actions)
+
+    def _derived_artifact_actions(
+        self, document: IndexedDocument
+    ) -> tuple[DeletionAction, ...]:
+        canonical = Path(document.canonical_path)
+        actions: list[DeletionAction] = []
+        for suffix in _DERIVED_EXPORT_SUFFIXES:
+            candidate = canonical.with_suffix(suffix)
+            if self.file_manager.file_exists(candidate):
+                actions.append(
+                    DeletionAction(
+                        target=DeletionTarget.DERIVED_ARTIFACT,
+                        object_id=suffix.removeprefix("."),
+                        path=str(candidate),
+                        description=f"delete regenerable {suffix} publication export",
+                    )
+                )
+        return tuple(actions)
+
+    def _execution_action(self, document_id: str) -> DeletionAction | None:
+        record = next(
+            (
+                item
+                for item in self.lifecycle_store.list_records()
+                if item.job_id.value == document_id
+            ),
+            None,
+        )
+        if record is None:
+            return None
+        workspace = self.paths.jobs_dir / document_id
+        if not workspace.is_dir():
+            return None
+        self._validate_workspace_path(workspace)
+        return DeletionAction(
+            target=DeletionTarget.EXECUTION_STATE,
+            object_id=document_id,
+            path=str(workspace),
+            description=(
+                "delete private checkpoints/intermediates while preserving lifecycle "
+                "metadata and public evidence"
+            ),
+        )
+
+    @staticmethod
+    def _research_actions(note_ids: tuple[str, ...]) -> tuple[DeletionAction, ...]:
+        return tuple(
+            DeletionAction(
+                target=DeletionTarget.RESEARCH_NOTE,
+                object_id=note_id,
+                description="delete authoritative user-authored note",
+            )
+            for note_id in note_ids
+        )
+
+    @staticmethod
+    def _saved_search_actions(
+        saved_search_ids: tuple[str, ...],
+    ) -> tuple[DeletionAction, ...]:
+        return tuple(
+            DeletionAction(
+                target=DeletionTarget.SAVED_SEARCH,
+                object_id=saved_search_id,
+                description="delete authoritative document-scoped saved search",
+            )
+            for saved_search_id in saved_search_ids
+        )
+
+    def _validate_destructive_inputs(self, plan: DeletionPlan) -> None:
+        for action in plan.actions:
+            if action.target is DeletionTarget.CANONICAL_TRANSCRIPT:
+                self._validate_canonical_path(action, plan.canonical_sha256)
+            elif (
+                action.target is DeletionTarget.EXECUTION_STATE
+                and action.path is not None
+            ):
+                self._validate_workspace_path(Path(action.path))
+
+    def _validate_canonical_path(
+        self, action: DeletionAction, canonical_sha256: str
+    ) -> None:
+        if action.path is None:
+            raise CustodyOperationError("Canonical deletion path is unavailable")
+        path = Path(action.path)
+        if not self.file_manager.file_exists(path):
+            raise CustodyOperationError(
+                "Canonical transcript disappeared before deletion"
+            )
+        digest = hashlib.sha256(self.file_manager.read_file(path)).hexdigest()
+        if digest != canonical_sha256:
+            raise CustodyOperationError(
+                "Canonical transcript changed after indexing; rebuild and review "
+                "deletion again"
+            )
+
+    def _execute_action(self, action: DeletionAction) -> None:
+        if action.target is DeletionTarget.LEXICAL_INDEX:
+            self.lexical_index.remove(action.object_id)
+            return
+        if action.target is DeletionTarget.SEMANTIC_INDEX:
+            if self.semantic_index is not None:
+                self.semantic_index.clear()
+            return
+        if action.target is DeletionTarget.RESEARCH_NOTE:
+            self.research_state.delete_note(action.object_id)
+            return
+        if action.target is DeletionTarget.SAVED_SEARCH:
+            self.workspace_metadata.delete_saved_search(action.object_id)
+            return
+        if action.target is DeletionTarget.EXECUTION_STATE:
+            if action.path is not None and Path(action.path).is_dir():
+                self.file_manager.delete_directory(action.path)
+            return
+        if action.path is not None and self.file_manager.file_exists(action.path):
+            self.file_manager.delete_file(action.path)
+
+    def _retention_candidate(
+        self,
+        record: JobLifecycleRecord,
+        *,
+        cutoff: datetime,
+        include_incomplete: bool,
+    ) -> RetentionCandidate | None:
+        if record.status is JobStatus.RUNNING:
+            return None
+        if record.status is not JobStatus.COMPLETED and not include_incomplete:
+            return None
+        updated = self._parse_timestamp(record.updated_at)
+        if updated > cutoff:
+            return None
+        workspace = self.paths.jobs_dir / record.job_id.value
+        if not workspace.is_dir():
+            return None
+        self._validate_workspace_path(workspace)
+        return RetentionCandidate(
+            job_id=record.job_id.value,
+            status=record.status,
+            updated_at=record.updated_at,
+            workspace_path=str(workspace),
+            resume_capability_lost=record.status is not JobStatus.COMPLETED,
+        )
+
+    def _validate_workspace_path(self, workspace: Path) -> None:
+        jobs_dir = self.paths.jobs_dir.resolve(strict=False)
+        resolved = workspace.expanduser().resolve(strict=False)
+        if resolved.parent != jobs_dir:
+            raise CustodyOperationError(
+                "Refusing to delete a workspace outside EchoFlow's private "
+                "jobs directory"
+            )
+
+    @staticmethod
+    def _parse_timestamp(value: str) -> datetime:
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise CustodyOperationError(
+                "Job lifecycle timestamp is invalid; refusing retention cleanup",
+                cause=exc,
+            ) from exc
+        if parsed.tzinfo is None:
+            raise CustodyOperationError(
+                "Job lifecycle timestamp lacks timezone; refusing retention cleanup"
+            )
+        return parsed.astimezone(UTC)
+
+    @staticmethod
+    def _aware_now(value: datetime | None) -> datetime:
+        current = datetime.now(UTC) if value is None else value
+        if current.tzinfo is None:
+            raise ValueError("retention clock must be timezone-aware")
+        return current.astimezone(UTC)
+
+    @staticmethod
+    def _deletion_token(
+        document_id: str,
+        canonical_sha256: str,
+        requested: tuple[DeletionScope, ...],
+        effective: tuple[DeletionScope, ...],
+        actions: tuple[DeletionAction, ...],
+        preserved_note_ids: tuple[str, ...],
+        affected_saved_search_ids: tuple[str, ...],
+    ) -> str:
+        parts = [
+            "delete-v1",
+            document_id,
+            canonical_sha256,
+            *(f"requested:{scope.value}" for scope in requested),
+            *(f"effective:{scope.value}" for scope in effective),
+            *(f"preserved-note:{note_id}" for note_id in preserved_note_ids),
+            *(
+                f"affected-saved-search:{saved_search_id}"
+                for saved_search_id in affected_saved_search_ids
+            ),
+            *(
+                f"action:{item.target.value}:{item.object_id}:{item.path or ''}"
+                for item in actions
+            ),
+        ]
+        digest = hashlib.sha256("\n".join(parts).encode()).hexdigest()
+        return f"delete:{document_id}:{canonical_sha256[:12]}:{digest[:16]}"
+
+    @staticmethod
+    def _retention_token(
+        policy: RetentionPolicy,
+        candidates: tuple[RetentionCandidate, ...],
+    ) -> str:
+        parts = [
+            "retention-v1",
+            str(policy.execution_days),
+            str(policy.include_incomplete),
+            *(
+                f"{item.job_id}:{item.status.value}:{item.updated_at}:"
+                f"{item.workspace_path}"
+                for item in candidates
+            ),
+        ]
+        digest = hashlib.sha256("\n".join(parts).encode()).hexdigest()
+        return f"retention:{digest[:24]}"

--- a/src/echoflow/library/errors.py
+++ b/src/echoflow/library/errors.py
@@ -41,3 +41,9 @@ class ResearchProjectionError(TranscriptLibraryError):
     """Disposable research-state projection cannot be reconciled safely."""
 
     exit_code = 2
+
+
+class CustodyOperationError(TranscriptLibraryError):
+    """A deletion or retention request cannot be executed safely as planned."""
+
+    exit_code = 2

--- a/src/echoflow/library/tests/test_custody.py
+++ b/src/echoflow/library/tests/test_custody.py
@@ -1,0 +1,603 @@
+import hashlib
+import shutil
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from echoflow.library.custody import (
+    DeletionScope,
+    DeletionTarget,
+    LibraryCustodyService,
+    RetentionPolicy,
+)
+from echoflow.library.errors import CustodyOperationError
+from echoflow.library.evidence import EvidenceAnchor
+from echoflow.library.index import IndexedDocument, SearchQuery
+from echoflow.library.research_state import ResearchNote
+from echoflow.library.service import LibraryEvidenceReceipt, SourceIntegrity
+from echoflow.library.workspace_metadata import SavedSearch, SavedSearchIntent
+from echoflow.workspace.lifecycle import JobLifecycleRecord, JobStatus
+from echoflow.workspace.models import JobId, WorkspacePaths
+
+
+class LocalFiles:
+    def file_exists(self, path: str | Path) -> bool:
+        return Path(path).is_file()
+
+    def read_file(self, path: str | Path) -> bytes:
+        return Path(path).read_bytes()
+
+    def delete_file(self, path: str | Path) -> None:
+        Path(path).unlink()
+
+    def delete_directory(self, path: str | Path) -> None:
+        shutil.rmtree(path)
+
+
+def _document(
+    tmp_path: Path,
+    *,
+    source_integrity: SourceIntegrity = SourceIntegrity.MATCHES,
+):
+    output = tmp_path / "output"
+    output.mkdir()
+    canonical = output / "interview.json"
+    canonical.write_bytes(b'{"canonical":"evidence"}\n')
+    canonical_sha = hashlib.sha256(canonical.read_bytes()).hexdigest()
+    source = tmp_path / "recording.wav"
+    source.write_bytes(b"source-audio")
+    source_sha = hashlib.sha256(source.read_bytes()).hexdigest()
+    document = IndexedDocument(
+        document_id="job-1",
+        source_sha256=source_sha,
+        detected_language="en",
+        canonical_path=str(canonical),
+        source_path=str(source),
+        segment_count=2,
+        canonical_sha256=canonical_sha,
+    )
+    receipt = LibraryEvidenceReceipt(
+        document=document,
+        source_integrity=source_integrity,
+        current_source_sha256=source_sha,
+    )
+    return document, receipt, canonical, source
+
+
+def _note(note_id: str, canonical_sha256: str) -> ResearchNote:
+    return ResearchNote(
+        note_id=note_id,
+        body=f"body {note_id}",
+        anchor=EvidenceAnchor(
+            document_id="job-1",
+            source_sha256="0" * 64,
+            canonical_sha256=canonical_sha256,
+            canonical_path="/evidence/interview.json",
+            source_path="/evidence/recording.wav",
+            segment_ids=("segment-000001",),
+            start_seconds=1.0,
+            end_seconds=2.0,
+        ),
+        tag_ids=(),
+        collection_ids=(),
+        created_at="2026-08-01T00:00:00+00:00",
+        updated_at="2026-08-01T00:00:00+00:00",
+    )
+
+
+def _saved(saved_id: str, document_ids: tuple[str, ...]) -> SavedSearch:
+    return SavedSearch(
+        saved_search_id=saved_id,
+        name=saved_id,
+        description=None,
+        intent=SavedSearchIntent(
+            query=SearchQuery("housing", document_ids=document_ids),
+        ),
+        created_at="2026-08-01T00:00:00+00:00",
+        updated_at="2026-08-01T00:00:00+00:00",
+    )
+
+
+def _record(
+    job_id: str,
+    *,
+    status: JobStatus,
+    updated_at: str,
+    artifact_path: Path | None = None,
+) -> JobLifecycleRecord:
+    return JobLifecycleRecord(
+        job_id=JobId(job_id),
+        input_path=Path("/tmp/recording.wav"),
+        output_dir=Path("/tmp/output"),
+        status=status,
+        started_at="2026-07-01T00:00:00+00:00",
+        updated_at=updated_at,
+        process_id=None,
+        process_started_at=None,
+        artifact_path=artifact_path,
+    )
+
+
+def _service(
+    tmp_path: Path,
+    *,
+    source_integrity: SourceIntegrity = SourceIntegrity.MATCHES,
+):
+    document, receipt, canonical, source = _document(
+        tmp_path,
+        source_integrity=source_integrity,
+    )
+    paths = WorkspacePaths(
+        state_dir=tmp_path / "state",
+        cache_dir=tmp_path / "cache",
+        model_dir=tmp_path / "cache" / "models",
+        output_dir=tmp_path / "output",
+    )
+    workspace = paths.jobs_dir / "job-1"
+    workspace.mkdir(parents=True)
+    (workspace / "checkpoint.bin").write_bytes(b"checkpoint")
+
+    library = Mock()
+    library.inspect.return_value = receipt
+    lexical = Mock()
+    semantic = Mock()
+    semantic.state.return_value = object()
+
+    lifecycle = Mock()
+    lifecycle.list_records.return_value = (
+        _record(
+            "job-1",
+            status=JobStatus.COMPLETED,
+            updated_at="2026-08-01T00:00:00+00:00",
+            artifact_path=canonical,
+        ),
+    )
+    current_note = _note("note-current", document.canonical_sha256 or "")
+    old_note = _note("note-old-generation", "f" * 64)
+    research = Mock()
+    research.notes.return_value = (current_note, old_note)
+
+    metadata = Mock()
+    metadata.saved_searches.return_value = (
+        _saved("search-scoped", ("job-1",)),
+        _saved("search-global", ()),
+    )
+    service = LibraryCustodyService(
+        transcript_library=library,
+        lexical_index=lexical,
+        semantic_index=semantic,
+        lifecycle_store=lifecycle,
+        research_state=research,
+        workspace_metadata=metadata,
+        paths=paths,
+        file_manager=LocalFiles(),  # type: ignore[arg-type]
+    )
+    return service, lexical, semantic, research, document, canonical, source, workspace
+
+
+def test_canonical_deletion_plan_expands_only_disposable_descendants(
+    tmp_path: Path,
+) -> None:
+    (
+        service,
+        _,
+        _,
+        _,
+        document,
+        canonical,
+        source,
+        workspace,
+    ) = _service(tmp_path)
+    canonical.with_suffix(".txt").write_text("derived")
+    canonical.with_suffix(".srt").write_text("derived")
+
+    plan = service.plan_deletion(
+        "job-1",
+        (DeletionScope.CANONICAL_TRANSCRIPT,),
+    )
+
+    assert plan.requested_scopes == (DeletionScope.CANONICAL_TRANSCRIPT,)
+    assert plan.effective_scopes == (
+        DeletionScope.LIBRARY_VIEW,
+        DeletionScope.DERIVED_ARTIFACTS,
+        DeletionScope.EXECUTION_STATE,
+        DeletionScope.CANONICAL_TRANSCRIPT,
+    )
+    assert [action.target for action in plan.actions] == [
+        DeletionTarget.LEXICAL_INDEX,
+        DeletionTarget.SEMANTIC_INDEX,
+        DeletionTarget.DERIVED_ARTIFACT,
+        DeletionTarget.DERIVED_ARTIFACT,
+        DeletionTarget.EXECUTION_STATE,
+        DeletionTarget.CANONICAL_TRANSCRIPT,
+    ]
+    assert plan.preserved_note_ids == ("note-current",)
+    assert plan.affected_saved_search_ids == ("search-scoped",)
+    assert source.is_file()
+    assert workspace.is_dir()
+    assert document.canonical_sha256[:12] in plan.confirmation_token
+
+
+def test_deletion_requires_exact_current_plan_and_preserves_notes_by_default(
+    tmp_path: Path,
+) -> None:
+    service, lexical, semantic, research, _, canonical, source, workspace = _service(
+        tmp_path
+    )
+    derived = canonical.with_suffix(".vtt")
+    derived.write_text("derived")
+    plan = service.plan_deletion(
+        "job-1",
+        (DeletionScope.CANONICAL_TRANSCRIPT,),
+    )
+
+    with pytest.raises(CustodyOperationError, match="confirmation token"):
+        service.execute_deletion(
+            "job-1",
+            (DeletionScope.CANONICAL_TRANSCRIPT,),
+            confirmation_token="delete:stale",
+        )
+
+    lexical.remove.assert_not_called()
+    receipt = service.execute_deletion(
+        "job-1",
+        (DeletionScope.CANONICAL_TRANSCRIPT,),
+        confirmation_token=plan.confirmation_token,
+    )
+
+    lexical.remove.assert_called_once_with("job-1")
+    semantic.clear.assert_called_once_with()
+    research.delete_note.assert_not_called()
+    assert receipt.preserved_note_ids == ("note-current",)
+    assert not canonical.exists()
+    assert not derived.exists()
+    assert not workspace.exists()
+    assert source.exists()
+
+
+def test_canonical_integrity_is_rechecked_before_any_mutation(tmp_path: Path) -> None:
+    service, lexical, _, research, _, canonical, _, _ = _service(tmp_path)
+    plan = service.plan_deletion(
+        "job-1",
+        (DeletionScope.CANONICAL_TRANSCRIPT,),
+    )
+    canonical.write_text('{"changed":true}\n')
+
+    with pytest.raises(CustodyOperationError, match="changed after indexing"):
+        service.execute_deletion(
+            "job-1",
+            (DeletionScope.CANONICAL_TRANSCRIPT,),
+            confirmation_token=plan.confirmation_token,
+        )
+
+    lexical.remove.assert_not_called()
+    research.delete_note.assert_not_called()
+    assert canonical.exists()
+
+
+def test_research_and_source_are_separate_explicit_destructive_scopes(
+    tmp_path: Path,
+) -> None:
+    service, lexical, semantic, research, _, canonical, source, _ = _service(tmp_path)
+    scopes = (
+        DeletionScope.RESEARCH_NOTES,
+        DeletionScope.SOURCE_RECORDING,
+    )
+
+    with pytest.raises(CustodyOperationError, match="allow-source"):
+        service.plan_deletion("job-1", scopes)
+
+    plan = service.plan_deletion("job-1", scopes, allow_source=True)
+    assert plan.preserved_note_ids == ()
+    assert [action.target for action in plan.actions] == [
+        DeletionTarget.SOURCE_RECORDING,
+        DeletionTarget.RESEARCH_NOTE,
+    ]
+
+    service.execute_deletion(
+        "job-1",
+        scopes,
+        allow_source=True,
+        confirmation_token=plan.confirmation_token,
+    )
+
+    research.delete_note.assert_called_once_with("note-current")
+    lexical.remove.assert_not_called()
+    semantic.clear.assert_not_called()
+    assert canonical.exists()
+    assert not source.exists()
+
+
+def test_source_deletion_refuses_changed_or_unverifiable_input(tmp_path: Path) -> None:
+    service, *_ = _service(
+        tmp_path,
+        source_integrity=SourceIntegrity.CHANGED,
+    )
+
+    with pytest.raises(CustodyOperationError, match="no longer matches"):
+        service.plan_deletion(
+            "job-1",
+            (DeletionScope.SOURCE_RECORDING,),
+            allow_source=True,
+        )
+
+
+def test_library_view_only_removes_indexes_and_never_files(tmp_path: Path) -> None:
+    service, lexical, semantic, research, _, canonical, source, workspace = _service(
+        tmp_path
+    )
+    plan = service.plan_deletion("job-1", (DeletionScope.LIBRARY_VIEW,))
+
+    assert [action.target for action in plan.actions] == [
+        DeletionTarget.LEXICAL_INDEX,
+        DeletionTarget.SEMANTIC_INDEX,
+    ]
+    service.execute_deletion(
+        "job-1",
+        (DeletionScope.LIBRARY_VIEW,),
+        confirmation_token=plan.confirmation_token,
+    )
+
+    lexical.remove.assert_called_once_with("job-1")
+    semantic.clear.assert_called_once_with()
+    research.delete_note.assert_not_called()
+    assert canonical.exists()
+    assert source.exists()
+    assert workspace.exists()
+
+
+def test_retention_defaults_to_old_completed_private_workspaces_only(
+    tmp_path: Path,
+) -> None:
+    service, _, _, _, _, canonical, _, _ = _service(tmp_path)
+    now = datetime(2026, 8, 19, tzinfo=UTC)
+    lifecycle = service.lifecycle_store
+
+    old_completed = service.paths.jobs_dir / "completed-old"
+    old_failed = service.paths.jobs_dir / "failed-old"
+    recent_completed = service.paths.jobs_dir / "completed-recent"
+    running = service.paths.jobs_dir / "running-old"
+    for path in (old_completed, old_failed, recent_completed, running):
+        path.mkdir(parents=True)
+        (path / "private.bin").write_bytes(b"x")
+
+    lifecycle.list_records.return_value = (
+        _record(
+            "completed-old",
+            status=JobStatus.COMPLETED,
+            updated_at=(now - timedelta(days=40)).isoformat(),
+            artifact_path=canonical,
+        ),
+        _record(
+            "failed-old",
+            status=JobStatus.FAILED,
+            updated_at=(now - timedelta(days=40)).isoformat(),
+        ),
+        _record(
+            "completed-recent",
+            status=JobStatus.COMPLETED,
+            updated_at=(now - timedelta(days=2)).isoformat(),
+            artifact_path=canonical,
+        ),
+        _record(
+            "running-old",
+            status=JobStatus.RUNNING,
+            updated_at=(now - timedelta(days=90)).isoformat(),
+        ),
+    )
+
+    plan = service.plan_retention(RetentionPolicy(execution_days=30), now=now)
+
+    assert [item.job_id for item in plan.candidates] == ["completed-old"]
+    assert not plan.candidates[0].resume_capability_lost
+    receipt = service.execute_retention(
+        RetentionPolicy(execution_days=30),
+        confirmation_token=plan.confirmation_token,
+        now=now,
+    )
+
+    assert receipt.discarded_job_ids == ("completed-old",)
+    assert not old_completed.exists()
+    assert old_failed.exists()
+    assert recent_completed.exists()
+    assert running.exists()
+    assert canonical.exists()
+
+
+def test_retention_incomplete_cleanup_is_explicit_and_plan_bound(
+    tmp_path: Path,
+) -> None:
+    service, *_ = _service(tmp_path)
+    now = datetime(2026, 8, 19, tzinfo=UTC)
+    failed = service.paths.jobs_dir / "failed-old"
+    failed.mkdir(parents=True)
+    service.lifecycle_store.list_records.return_value = (
+        _record(
+            "failed-old",
+            status=JobStatus.INTERRUPTED,
+            updated_at=(now - timedelta(days=31)).isoformat(),
+        ),
+    )
+    policy = RetentionPolicy(execution_days=30, include_incomplete=True)
+    plan = service.plan_retention(policy, now=now)
+
+    assert len(plan.candidates) == 1
+    assert plan.candidates[0].resume_capability_lost
+
+    failed.rmdir()
+    refreshed = service.plan_retention(policy, now=now)
+    assert refreshed.candidates == ()
+    assert refreshed.confirmation_token != plan.confirmation_token
+    with pytest.raises(CustodyOperationError, match="Retention plan changed"):
+        service.execute_retention(
+            policy,
+            confirmation_token=plan.confirmation_token,
+            now=now,
+        )
+
+
+def test_retention_rejects_naive_clock_and_malformed_lifecycle_time(
+    tmp_path: Path,
+) -> None:
+    service, *_ = _service(tmp_path)
+    with pytest.raises(ValueError, match="timezone-aware"):
+        service.plan_retention(
+            RetentionPolicy(),
+            now=datetime(2026, 8, 19),
+        )
+
+    workspace = service.paths.jobs_dir / "bad-time"
+    workspace.mkdir(parents=True)
+    service.lifecycle_store.list_records.return_value = (
+        _record(
+            "bad-time",
+            status=JobStatus.COMPLETED,
+            updated_at="not-a-time",
+        ),
+    )
+    with pytest.raises(CustodyOperationError, match="timestamp is invalid"):
+        service.plan_retention(
+            RetentionPolicy(execution_days=0),
+            now=datetime(2026, 8, 19, tzinfo=UTC),
+        )
+
+
+def test_deletion_token_binds_preserved_notes_and_document_scoped_searches(
+    tmp_path: Path,
+) -> None:
+    service, _, _, research, document, *_ = _service(tmp_path)
+    first = service.plan_deletion("job-1", (DeletionScope.CANONICAL_TRANSCRIPT,))
+
+    research.notes.return_value = (
+        _note("note-current", document.canonical_sha256 or ""),
+        _note("note-new", document.canonical_sha256 or ""),
+    )
+    second = service.plan_deletion("job-1", (DeletionScope.CANONICAL_TRANSCRIPT,))
+    assert second.confirmation_token != first.confirmation_token
+
+    service.workspace_metadata.saved_searches.return_value = (
+        _saved("search-scoped", ("job-1",)),
+        _saved("search-new", ("job-1",)),
+    )
+    third = service.plan_deletion("job-1", (DeletionScope.CANONICAL_TRANSCRIPT,))
+    assert third.confirmation_token != second.confirmation_token
+
+
+def test_saved_search_deletion_is_separate_explicit_authority_scope(
+    tmp_path: Path,
+) -> None:
+    service, lexical, semantic, research, _, canonical, source, _ = _service(tmp_path)
+    scopes = (DeletionScope.SAVED_SEARCHES,)
+    plan = service.plan_deletion("job-1", scopes)
+
+    assert [action.target for action in plan.actions] == [DeletionTarget.SAVED_SEARCH]
+    assert plan.affected_saved_search_ids == ("search-scoped",)
+
+    service.execute_deletion(
+        "job-1",
+        scopes,
+        confirmation_token=plan.confirmation_token,
+    )
+
+    service.workspace_metadata.delete_saved_search.assert_called_once_with(
+        "search-scoped"
+    )
+    research.delete_note.assert_not_called()
+    lexical.remove.assert_not_called()
+    semantic.clear.assert_not_called()
+    assert canonical.exists()
+    assert source.exists()
+
+
+def test_deletion_scope_validation_and_optional_semantic_state(tmp_path: Path) -> None:
+    service, _, semantic, _, _, _, _, _ = _service(tmp_path)
+    with pytest.raises(ValueError, match="at least one deletion scope"):
+        service.plan_deletion("job-1", ())
+
+    semantic.state.return_value = None
+    plan = service.plan_deletion(
+        "job-1",
+        (DeletionScope.LIBRARY_VIEW, DeletionScope.LIBRARY_VIEW),
+    )
+    assert plan.requested_scopes == (DeletionScope.LIBRARY_VIEW,)
+    assert [action.target for action in plan.actions] == [DeletionTarget.LEXICAL_INDEX]
+
+
+def test_deletion_refuses_unhashed_canonical_and_missing_source_path(
+    tmp_path: Path,
+) -> None:
+    service, *_ = _service(tmp_path)
+    receipt = service.transcript_library.inspect.return_value
+    service.transcript_library.inspect.return_value = LibraryEvidenceReceipt(
+        document=IndexedDocument(
+            document_id=receipt.document.document_id,
+            source_sha256=receipt.document.source_sha256,
+            detected_language=receipt.document.detected_language,
+            canonical_path=receipt.document.canonical_path,
+            source_path=receipt.document.source_path,
+            segment_count=receipt.document.segment_count,
+            canonical_sha256=None,
+        ),
+        source_integrity=receipt.source_integrity,
+        current_source_sha256=receipt.current_source_sha256,
+    )
+    with pytest.raises(CustodyOperationError, match="predates canonical hashing"):
+        service.plan_deletion("job-1", (DeletionScope.LIBRARY_VIEW,))
+
+    document = receipt.document
+    service.transcript_library.inspect.return_value = LibraryEvidenceReceipt(
+        document=IndexedDocument(
+            document_id=document.document_id,
+            source_sha256=document.source_sha256,
+            detected_language=document.detected_language,
+            canonical_path=document.canonical_path,
+            source_path=None,
+            segment_count=document.segment_count,
+            canonical_sha256=document.canonical_sha256,
+        ),
+        source_integrity=SourceIntegrity.UNKNOWN,
+        current_source_sha256=None,
+    )
+    with pytest.raises(CustodyOperationError, match="path is unavailable"):
+        service.plan_deletion(
+            "job-1",
+            (DeletionScope.SOURCE_RECORDING,),
+            allow_source=True,
+        )
+
+
+def test_retention_policy_and_value_objects_reject_invalid_state() -> None:
+    from echoflow.library.custody import (
+        DeletionAction,
+        DeletionPlan,
+        RetentionCandidate,
+        RetentionPlan,
+    )
+
+    with pytest.raises(ValueError, match="retention days"):
+        RetentionPolicy(execution_days=-1)
+    with pytest.raises(ValueError, match="retention days"):
+        RetentionPolicy(execution_days=36_501)
+    with pytest.raises(ValueError, match="identity and path"):
+        RetentionCandidate("", JobStatus.COMPLETED, "time", "/private", False)
+    with pytest.raises(ValueError, match="confirmation token"):
+        RetentionPlan(RetentionPolicy(), (), "")
+    with pytest.raises(ValueError, match="object_id"):
+        DeletionAction(DeletionTarget.LEXICAL_INDEX, "", "remove")
+    with pytest.raises(ValueError, match="description"):
+        DeletionAction(DeletionTarget.LEXICAL_INDEX, "job-1", "")
+    with pytest.raises(ValueError, match="path"):
+        DeletionAction(DeletionTarget.DERIVED_ARTIFACT, "txt", "delete", "")
+    with pytest.raises(ValueError, match="lowercase digest"):
+        DeletionPlan(
+            "job-1",
+            "Z" * 64,
+            (DeletionScope.LIBRARY_VIEW,),
+            (DeletionScope.LIBRARY_VIEW,),
+            (),
+            (),
+            (),
+            "token",
+        )

--- a/src/echoflow/library/tests/test_saved_search_edges.py
+++ b/src/echoflow/library/tests/test_saved_search_edges.py
@@ -1,0 +1,184 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from echoflow.library.errors import ResearchStateError
+from echoflow.library.index import SearchQuery
+from echoflow.library.workspace_metadata import (
+    NavigationItem,
+    SavedSearch,
+    SavedSearchIntent,
+    SqliteWorkspaceMetadataStore,
+)
+
+
+class PrivateDirectoryStore:
+    def ensure_directory_exists(
+        self, directory_path: str | Path, *, private: bool = False
+    ) -> None:
+        assert private
+        Path(directory_path).mkdir(parents=True, exist_ok=True)
+
+
+def _store(tmp_path: Path) -> SqliteWorkspaceMetadataStore:
+    return SqliteWorkspaceMetadataStore(
+        tmp_path / "state" / "research.sqlite3",
+        PrivateDirectoryStore(),  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"context_segments": -1}, "context_segments"),
+        ({"context_segments": 11}, "context_segments"),
+        ({"tags": ("housing", "HOUSING")}, "duplicates"),
+        ({"collections": ("",)}, "blank"),
+        ({"note_text": "   "}, "note_text"),
+    ],
+)
+def test_saved_search_intent_rejects_invalid_durable_state(
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        SavedSearchIntent(
+            query=SearchQuery("evidence"), **kwargs  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"saved_search_id": "   "},
+        {"name": ""},
+        {"description": "   "},
+        {"created_at": ""},
+        {"updated_at": ""},
+    ],
+)
+def test_saved_search_value_object_rejects_missing_identity(
+    kwargs: dict[str, str],
+) -> None:
+    values = {
+        "saved_search_id": "search-1",
+        "name": "Evidence",
+        "description": None,
+        "intent": SavedSearchIntent(query=SearchQuery("evidence")),
+        "created_at": "2026-08-19T00:00:00+00:00",
+        "updated_at": "2026-08-19T00:00:00+00:00",
+    }
+    values.update(kwargs)
+    with pytest.raises(ValueError):
+        SavedSearch(**values)  # type: ignore[arg-type]
+
+
+def test_navigation_item_rejects_invalid_derived_view() -> None:
+    with pytest.raises(ValueError, match="identity"):
+        NavigationItem("", "name", 1, "2026-08-19T00:00:00+00:00")
+    with pytest.raises(ValueError, match="positive"):
+        NavigationItem("tag-1", "name", 0, "2026-08-19T00:00:00+00:00")
+    with pytest.raises(ValueError, match="last_used_at"):
+        NavigationItem("tag-1", "name", 1, "")
+
+
+def test_saved_search_store_bounds_and_missing_mutations_fail_closed(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(ValueError, match="list limit"):
+        store.saved_searches(limit=0)
+    with pytest.raises(ValueError, match="list limit"):
+        store.saved_searches(limit=10_001)
+    with pytest.raises(ResearchStateError, match="does not exist"):
+        store.update_saved_search(
+            "missing",
+            name="Missing",
+            description=None,
+            intent=SavedSearchIntent(query=SearchQuery("missing")),
+        )
+    with pytest.raises(ResearchStateError, match="does not exist"):
+        store.delete_saved_search("missing")
+
+
+def test_saved_search_store_rejects_invalid_identifiers_names_and_description(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    intent = SavedSearchIntent(query=SearchQuery("evidence"))
+
+    with pytest.raises(ValueError, match="too long"):
+        store.create_saved_search("x" * 201, intent)
+    with pytest.raises(ValueError, match="control"):
+        store.create_saved_search("bad\nname", intent)
+    with pytest.raises(ValueError, match="too long"):
+        store.create_saved_search(
+            "valid",
+            intent,
+            saved_search_id="x" * 201,
+        )
+    with pytest.raises(ValueError, match="control"):
+        store.saved_search("bad\nidentifier")
+    with pytest.raises(ValueError, match="too long"):
+        store.create_saved_search(
+            "valid",
+            intent,
+            description="x" * 4_001,
+        )
+    with pytest.raises(ValueError, match="NUL"):
+        store.create_saved_search(
+            "valid",
+            intent,
+            description="bad\x00description",
+        )
+
+
+def test_saved_search_corrupt_json_and_enum_state_fail_closed(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    created = store.create_saved_search(
+        "Evidence",
+        SavedSearchIntent(query=SearchQuery("evidence")),
+        saved_search_id="search-1",
+    )
+    with sqlite3.connect(store.database_path) as connection:
+        connection.execute(
+            "UPDATE saved_searches SET tags_json = ? WHERE saved_search_id = ?",
+            ("not-json", created.saved_search_id),
+        )
+        connection.commit()
+
+    with pytest.raises(ResearchStateError, match="corrupt"):
+        store.saved_search(created.saved_search_id)
+
+    with sqlite3.connect(store.database_path) as connection:
+        connection.execute(
+            "UPDATE saved_searches SET tags_json = ?, operator = ? "
+            "WHERE saved_search_id = ?",
+            ("[]", "not-an-operator", created.saved_search_id),
+        )
+        connection.commit()
+
+    with pytest.raises(ResearchStateError, match="corrupt"):
+        store.saved_search(created.saved_search_id)
+
+
+def test_navigation_private_dispatch_rejects_unknown_closed_fragments(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    with sqlite3.connect(store.database_path) as connection:
+        with pytest.raises(ValueError, match="navigation kind"):
+            store._navigation_rows(  # noqa: SLF001
+                connection,
+                kind="unknown",
+                order="usage",
+                limit=1,
+            )
+        with pytest.raises(ValueError, match="navigation order"):
+            store._navigation_rows(  # noqa: SLF001
+                connection,
+                kind="tag",
+                order="unknown",
+                limit=1,
+            )

--- a/src/echoflow/library/tests/test_saved_search_edges.py
+++ b/src/echoflow/library/tests/test_saved_search_edges.py
@@ -44,7 +44,8 @@ def test_saved_search_intent_rejects_invalid_durable_state(
 ) -> None:
     with pytest.raises(ValueError, match=message):
         SavedSearchIntent(
-            query=SearchQuery("evidence"), **kwargs  # type: ignore[arg-type]
+            query=SearchQuery("evidence"),
+            **kwargs,  # type: ignore[arg-type]
         )
 
 

--- a/src/echoflow/tests/test_cli_custody.py
+++ b/src/echoflow/tests/test_cli_custody.py
@@ -1,0 +1,257 @@
+import json
+from unittest.mock import Mock
+
+import typer
+from typer.testing import CliRunner
+
+from echoflow.cli_library import register_library_commands
+from echoflow.library.custody import (
+    DeletionAction,
+    DeletionPlan,
+    DeletionReceipt,
+    DeletionScope,
+    DeletionTarget,
+    RetentionCandidate,
+    RetentionPlan,
+    RetentionPolicy,
+    RetentionReceipt,
+)
+from echoflow.library.errors import CustodyOperationError
+from echoflow.workspace.lifecycle import JobStatus
+
+
+def _app(service: Mock) -> typer.Typer:
+    app = typer.Typer()
+    container = Mock()
+    container.library_custody.return_value = service
+    register_library_commands(app, lambda context: container)
+    return app
+
+
+def _deletion_plan() -> DeletionPlan:
+    return DeletionPlan(
+        document_id="job-1",
+        canonical_sha256="a" * 64,
+        requested_scopes=(DeletionScope.CANONICAL_TRANSCRIPT,),
+        effective_scopes=(
+            DeletionScope.LIBRARY_VIEW,
+            DeletionScope.DERIVED_ARTIFACTS,
+            DeletionScope.EXECUTION_STATE,
+            DeletionScope.CANONICAL_TRANSCRIPT,
+        ),
+        actions=(
+            DeletionAction(
+                target=DeletionTarget.LEXICAL_INDEX,
+                object_id="job-1",
+                description="remove from index",
+            ),
+            DeletionAction(
+                target=DeletionTarget.CANONICAL_TRANSCRIPT,
+                object_id="a" * 64,
+                description="delete canonical evidence",
+                path="/output/interview.json",
+            ),
+        ),
+        preserved_note_ids=("note-1",),
+        affected_saved_search_ids=("search-1",),
+        confirmation_token="delete:job-1:aaaaaaaaaaaa:token",
+    )
+
+
+def _retention_plan() -> RetentionPlan:
+    return RetentionPlan(
+        policy=RetentionPolicy(execution_days=30, include_incomplete=True),
+        candidates=(
+            RetentionCandidate(
+                job_id="job-1",
+                status=JobStatus.INTERRUPTED,
+                updated_at="2026-07-01T00:00:00+00:00",
+                workspace_path="/private/jobs/job-1",
+                resume_capability_lost=True,
+            ),
+        ),
+        confirmation_token="retention:token",
+    )
+
+
+def test_delete_defaults_to_dry_run_library_view_and_json() -> None:
+    service = Mock()
+    plan = _deletion_plan()
+    service.plan_deletion.return_value = plan
+
+    result = CliRunner().invoke(
+        _app(service),
+        ["library", "delete", "job-1", "--json"],
+    )
+
+    assert result.exit_code == 0
+    service.plan_deletion.assert_called_once_with(
+        "job-1",
+        (DeletionScope.LIBRARY_VIEW,),
+        allow_source=False,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["executed"] is False
+    assert payload["secure_erasure_guaranteed"] is False
+    assert payload["preserved_note_ids"] == ["note-1"]
+    assert payload["affected_saved_search_ids"] == ["search-1"]
+
+
+def test_delete_human_plan_explains_preservation_and_confirmation() -> None:
+    service = Mock()
+    service.plan_deletion.return_value = _deletion_plan()
+
+    result = CliRunner().invoke(
+        _app(service),
+        [
+            "library",
+            "delete",
+            "job-1",
+            "--scope",
+            "canonical-transcript",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Preserved attached notes: 1" in result.output
+    assert "Secure erasure is not guaranteed" in result.output
+    assert "Confirmation token:" in result.output
+    assert "No changes made" in result.output
+
+
+def test_delete_confirm_executes_exact_typed_scopes_and_source_switch() -> None:
+    service = Mock()
+    service.execute_deletion.return_value = DeletionReceipt(
+        document_id="job-1",
+        confirmation_token="delete:token",
+        executed_targets=(
+            DeletionTarget.RESEARCH_NOTE,
+            DeletionTarget.SOURCE_RECORDING,
+        ),
+        preserved_note_ids=(),
+        affected_saved_search_ids=(),
+    )
+
+    result = CliRunner().invoke(
+        _app(service),
+        [
+            "library",
+            "delete",
+            "job-1",
+            "--scope",
+            "research-notes",
+            "--scope",
+            "source-recording",
+            "--allow-source",
+            "--confirm",
+            "delete:token",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    service.execute_deletion.assert_called_once_with(
+        "job-1",
+        (
+            DeletionScope.RESEARCH_NOTES,
+            DeletionScope.SOURCE_RECORDING,
+        ),
+        confirmation_token="delete:token",
+        allow_source=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["executed"] is True
+    assert payload["executed_targets"] == [
+        "research-note",
+        "source-recording",
+    ]
+
+
+def test_retention_dry_run_and_apply_share_typed_policy() -> None:
+    service = Mock()
+    service.plan_retention.return_value = _retention_plan()
+    service.execute_retention.return_value = RetentionReceipt(
+        confirmation_token="retention:token",
+        discarded_job_ids=("job-1",),
+    )
+    app = _app(service)
+    runner = CliRunner()
+
+    planned = runner.invoke(
+        app,
+        [
+            "library",
+            "retention",
+            "--execution-days",
+            "30",
+            "--include-incomplete",
+            "--json",
+        ],
+    )
+    applied = runner.invoke(
+        app,
+        [
+            "library",
+            "retention",
+            "--execution-days",
+            "30",
+            "--include-incomplete",
+            "--confirm",
+            "retention:token",
+            "--json",
+        ],
+    )
+
+    assert planned.exit_code == applied.exit_code == 0
+    service.plan_retention.assert_called_once_with(
+        RetentionPolicy(execution_days=30, include_incomplete=True)
+    )
+    service.execute_retention.assert_called_once_with(
+        RetentionPolicy(execution_days=30, include_incomplete=True),
+        confirmation_token="retention:token",
+    )
+    plan_payload = json.loads(planned.stdout)
+    assert plan_payload["candidates"][0]["resume_capability_lost"] is True
+    assert plan_payload["preserves_canonical_transcripts"] is True
+    assert json.loads(applied.stdout)["discarded_job_ids"] == ["job-1"]
+
+
+def test_retention_human_plan_states_the_custody_boundary() -> None:
+    service = Mock()
+    service.plan_retention.return_value = _retention_plan()
+
+    result = CliRunner().invoke(
+        _app(service),
+        ["library", "retention", "--include-incomplete"],
+    )
+
+    assert result.exit_code == 0
+    assert "deletes only private job workspaces" in result.output
+    assert "lifecycle manifests are preserved" in result.output
+    assert "Resume lost?" in result.output
+
+
+def test_custody_cli_reports_public_errors_and_masks_internal_details() -> None:
+    runner = CliRunner()
+
+    public = Mock()
+    public.plan_deletion.side_effect = CustodyOperationError(
+        "Deletion plan changed; review again"
+    )
+    public_result = runner.invoke(
+        _app(public),
+        ["library", "delete", "job-1"],
+    )
+
+    internal = Mock()
+    internal.plan_retention.side_effect = RuntimeError("secret /private/path")
+    internal_result = runner.invoke(
+        _app(internal),
+        ["library", "retention"],
+    )
+
+    assert public_result.exit_code == 2
+    assert "Deletion plan changed; review again" in public_result.output
+    assert internal_result.exit_code == 3
+    assert "failed internally (RuntimeError)" in internal_result.output
+    assert "/private/path" not in internal_result.output

--- a/src/echoflow/tests/test_cli_saved_search_rendering.py
+++ b/src/echoflow/tests/test_cli_saved_search_rendering.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import typer
+from typer.testing import CliRunner
+
+from echoflow.cli_library import register_library_commands
+from echoflow.library.index import SearchQuery
+from echoflow.library.workspace_metadata import (
+    NavigationItem,
+    SavedSearch,
+    SavedSearchIntent,
+    WorkspaceNavigation,
+)
+
+
+def _saved() -> SavedSearch:
+    return SavedSearch(
+        saved_search_id="search-1",
+        name="Housing",
+        description="Chapter evidence",
+        intent=SavedSearchIntent(
+            query=SearchQuery("rent burden"),
+            tags=("housing",),
+            collections=("Chapter 1",),
+            note_text="methods",
+            with_notes=True,
+        ),
+        created_at="2026-08-19T00:00:00+00:00",
+        updated_at="2026-08-19T01:00:00+00:00",
+    )
+
+
+def _app(workspace: Mock) -> typer.Typer:
+    app = typer.Typer()
+    container = Mock()
+    container.research_workspace.return_value = workspace
+    register_library_commands(app, lambda context: container)
+    return app
+
+
+def test_saved_search_human_list_show_save_run_and_delete_paths() -> None:
+    workspace = Mock()
+    saved = _saved()
+    workspace.saved_searches.return_value = (saved,)
+    workspace.saved_search.return_value = saved
+    workspace.save_search.return_value = saved
+    workspace.run_saved_search.return_value = SimpleNamespace(results=())
+    app = _app(workspace)
+    runner = CliRunner()
+
+    listed = runner.invoke(app, ["library", "saved"])
+    shown = runner.invoke(app, ["library", "saved", "show", "Housing"])
+    created = runner.invoke(
+        app,
+        ["library", "saved", "save", "Housing", "rent burden"],
+    )
+    run = runner.invoke(app, ["library", "saved", "run", "Housing"])
+    deleted = runner.invoke(app, ["library", "saved", "delete", "Housing"])
+
+    assert listed.exit_code == shown.exit_code == 0
+    assert created.exit_code == run.exit_code == deleted.exit_code == 0
+    assert "EchoFlow saved searches" in listed.output
+    assert "housing" in listed.output
+    assert "Chapter 1" in listed.output
+    assert "with notes" in listed.output
+    assert "Saved 'Housing' as search-1." in created.output
+    assert "0 current evidence result(s)" in run.output
+    assert "Deleted saved search 'Housing' from durable user state." in deleted.output
+
+
+def test_saved_search_human_navigation_renders_every_group() -> None:
+    item = NavigationItem(
+        object_id="tag-1",
+        name="housing",
+        usage_count=3,
+        last_used_at="2026-08-19T01:00:00+00:00",
+    )
+    collection = NavigationItem(
+        object_id="collection-1",
+        name="Chapter 1",
+        usage_count=2,
+        last_used_at="2026-08-19T00:30:00+00:00",
+    )
+    workspace = Mock()
+    workspace.workspace_navigation.return_value = WorkspaceNavigation(
+        frequent_tags=(item,),
+        recent_tags=(item,),
+        frequent_collections=(collection,),
+        recent_collections=(collection,),
+    )
+
+    result = CliRunner().invoke(
+        _app(workspace),
+        ["library", "navigation"],
+    )
+
+    assert result.exit_code == 0
+    assert "EchoFlow workspace navigation" in result.output
+    assert "frequent tag" in result.output
+    assert "recent tag" in result.output
+    assert "frequent collection" in result.output
+    assert "recent collection" in result.output
+
+
+def test_saved_search_missing_run_and_delete_fail_without_mutation() -> None:
+    workspace = Mock()
+    workspace.saved_search.return_value = None
+    app = _app(workspace)
+    runner = CliRunner()
+
+    run = runner.invoke(app, ["library", "saved", "run", "missing"])
+    deleted = runner.invoke(app, ["library", "saved", "delete", "missing"])
+
+    assert run.exit_code == deleted.exit_code == 2
+    assert "Saved search does not exist" in run.output
+    assert "Saved search does not exist" in deleted.output
+    workspace.run_saved_search.assert_not_called()
+    workspace.delete_saved_search.assert_not_called()


### PR DESCRIPTION
## Summary

Add custody-aware safe deletion and retention controls on top of the local evidence/research foundation, while repaying the saved-search coverage debt that remained when #67 was merged.

Deletion is now a typed plan-first operation. A dry run names the exact canonical generation, effective scopes, concrete mutations, preserved attached notes, affected document-scoped saved searches, and a confirmation token. Execution recomputes the plan and refuses a stale token.

## Typed deletion scopes

- `library-view`: remove rebuildable lexical membership and invalidate a built semantic corpus
- `derived-artifacts`: delete regenerable TXT/SRT/VTT publications
- `execution-state`: delete the private job workspace while preserving lifecycle metadata
- `canonical-transcript`: delete canonical JSON plus only its disposable descendants
- `research-notes`: explicitly delete notes anchored to the exact canonical generation
- `saved-searches`: explicitly delete saved searches constrained to this transcript
- `source-recording`: explicitly delete the original recording only with the second `--allow-source` gate and current provenance match

`canonical-transcript` does **not** imply notes, saved searches, or source-media deletion.

## Safety / custody rules

- canonical deletion is bound to indexed `canonical_sha256` and re-hashes the file immediately before mutation
- a changed/disappeared canonical generation fails closed before any action
- the confirmation token also binds the preserved-note and affected-saved-search dependency list, so new human work invalidates an older approval
- attached notes survive canonical deletion by default and remain historical exact-generation anchors
- global saved searches are never guessed to depend on a transcript; only explicit `document_ids` constraints are reported/deleted
- source deletion requires both explicit source scope and `--allow-source`, and refuses if current bytes no longer match transcription provenance
- semantic state is cleared conservatively because the current semantic index is whole-corpus/fingerprint bound rather than per-document mutable
- unique human-authored state is ordered after rebuildable/filesystem cleanup in the non-atomic cross-store executor
- EchoFlow continues to make no secure-erasure claim

## Retention

Add plan-bound private execution-state retention:

```bash
echoflow library retention --execution-days 30
```

Defaults:

- completed private job workspaces only
- failed/interrupted workspaces require `--include-incomplete` because cleanup removes resume capability
- running jobs are never eligible
- canonical JSON, public exports, source media, notes/tags/collections, saved searches, speaker labels, and lightweight lifecycle manifests are never age-deleted

Lifecycle manifests deliberately survive workspace cleanup because they can retain discovery pointers to canonical artifacts in custom output directories.

## Saved-search test debt from #67

#67 was merged after 1,000 tests passed but while the Linux branch-coverage gate was still at 89.04% against the repository's 90% requirement. This PR does not lower that threshold.

Additional tests cover:

- invalid durable saved-search intent/value objects
- list bounds and missing update/delete targets
- invalid identifiers, names, descriptions, controls, and NULs
- corrupt persisted JSON and enum state
- closed navigation dispatch
- human list/show/save/run/delete rendering
- all frequent/recent navigation groups
- missing run/delete without mutation

The custody suite adds positive/negative/edge coverage for stale tokens, canonical integrity changes, explicit research/source deletion, source provenance refusal, semantic invalidation, derived/export/workspace cleanup, retention age/status rules, resume-loss signaling, and malformed/timezone lifecycle state.

## Documentation

Adds `docs/architecture/safe-deletion-retention.md` and reconciles:

- `docs/architecture/library-lifecycle.md`
- `docs/architecture/README.md`
- `ROADMAP.md`
- root `README.md`
- `docs/README.md`
- `SECURITY.md`

`SECURITY.md` now distinguishes ordinary custody deletion from cryptographically/physically verifiable secure erasure, documents the explicit source-deletion provenance gate, and records the private-workspace-only retention boundary.

The roadmap now treats safe lifecycle controls as foundation. Incremental library refresh is the next backend seam, followed by the first thin GUI consuming the same evidence/research/custody services.

## Quality

Current head: `4fec483f332773205146576ce5536766b908c54f`

Quality #615 completed successfully on the current head:

- locked dependency audit: passed
- Ruff lint/security rules: passed
- Ruff formatting: passed
- strict mypy: passed
- Vulture dead-code check: passed
- Radon complexity/maintainability reporting: passed
- pytest branch-coverage gate: passed **without lowering the repository's 90% threshold**
- distribution build: passed
- clean-wheel install verification: passed
- macOS platform smoke: passed, including the enlarged test suite and package verification
- Windows platform smoke: passed, including the enlarged test suite and package verification

This repairs the coverage debt left by the already-merged #67 while keeping the new custody feature behind the same repository-wide quality gates. The PR remains draft for review rather than being merged automatically.