### PR TITLE
feat(library): add incremental library refresh

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,9 @@ flowchart LR
     H --> I[Safe deletion and retention]
     I --> J[Incremental refresh]
     J --> K[Thin graphical shell]
+    K --> L[Desktop packaging and first-run]
+    L --> M[Backup restore and portability]
+    M --> N[Release qualification]
 ```
 
 # Current foundation
@@ -170,26 +173,21 @@ copy-on-write history, backups, or sync/versioning make that guarantee unverifia
 See `docs/architecture/safe-deletion-retention.md` and
 `docs/architecture/library-lifecycle.md` for exact semantics.
 
-## Test/quality debt repaired after saved-search merge
+## Incremental library refresh
 
-The saved-search/navigation PR was merged while its Linux branch-coverage gate was still
-below the repository threshold even though all 1,000 tests passed. This tranche adds the
-missing edge/failure and human-rendering tests instead of lowering the 90% requirement.
+This is now **foundation**.
 
-Coverage additions exercise invalid durable saved-search objects, storage bounds, corrupt
-persisted state, missing mutation targets, closed navigation dispatch, human CLI rendering,
-and safe missing-state behavior. The custody tranche adds its own positive, negative,
-stale-plan, provenance, partial-state, and retention tests.
+`echoflow library refresh` reconciles the currently discoverable canonical corpus against
+the rebuildable lexical index without rewriting unchanged transcript generations.
+Generation identity remains `(document_id, canonical_sha256)`.
 
-# Near-term product sequence
+Normal refresh uses stored canonical size and modification time only as a cheap change
+detector. If the signature and tracked source path are unchanged, the canonical JSON is
+not opened. If a candidate changed, EchoFlow re-reads and re-hashes that canonical before
+planning the lexical delta. `--verify` deliberately bypasses the metadata fast path and
+re-hashes/schema-validates every tracked canonical transcript.
 
-## 1. Incremental library refresh and corpus-scale qualification
-
-A whole-corpus rebuild remains the correct repair path, but normal growth should not
-require re-reading every transcript when one generation changes.
-
-Add incremental refresh keyed by stable generation identity, likely
-`(document_id, canonical_sha256)`:
+The lexical delta is applied atomically:
 
 ```text
 new generation       -> upsert
@@ -198,49 +196,125 @@ removed transcript   -> remove
 unchanged transcript -> skip
 ```
 
-Keep full rebuild as explicit repair/recovery. Normal GUI-era UX should feel like “the
-library noticed my transcript,” not “please rebuild a database.”
+Tracked external imports remain discoverable while their indexed path exists, moved
+canonicals can be reconciled when the old path is gone, and duplicate live paths for one
+document identity fail closed. Corrupt tracked canonical state also fails closed before
+lexical mutation.
 
-Then qualify realistic corpora: startup, cold/warm search, filtered lexical/semantic
-queries, unified discovery, saved-search replay, projection catch-up, incremental refresh,
-and full repair rebuild.
+The current semantic index remains whole-corpus/fingerprint bound. A refresh that changes
+semantic-relevant corpus identity invalidates the semantic projection rather than leaving
+stale vectors behind. Timestamp-only metadata churn with identical canonical bytes does
+not discard valid embeddings.
 
-## 2. First thin GUI
+The regression contract is deterministic rather than timing-based:
+
+```text
+100 unchanged tracked transcripts -> 0 canonical reads
+1 changed transcript               -> 1 canonical read
+```
+
+Full `library rebuild` remains the explicit repair/recovery lever. A normal user should not
+need to rebuild a database merely because one new transcript appeared.
+
+See `docs/architecture/incremental-library-refresh.md` for the exact reconciliation and
+verification contract.
+
+## Test/quality debt repaired after saved-search merge
+
+The saved-search/navigation PR was merged while its Linux branch-coverage gate was still
+below the repository threshold even though all 1,000 tests passed. The subsequent safe
+lifecycle tranche added the missing edge/failure and human-rendering tests instead of
+lowering the 90% requirement.
+
+Coverage additions exercise invalid durable saved-search objects, storage bounds, corrupt
+persisted state, missing mutation targets, closed navigation dispatch, human CLI rendering,
+and safe missing-state behavior. The custody tranche adds its own positive, negative,
+stale-plan, provenance, partial-state, and retention tests.
+
+# Near-term product sequence
+
+## 1. First thin GUI
 
 The GUI has earned its place because the backend is ahead of the human interface.
 
-The first graphical slice should browse/open transcripts, use unified discovery, show
-speaker/time evidence, create/edit/delete notes, apply tags/collections with derived
-suggestions, browse saved searches, jump to source-relative media coordinates, and expose
-the same typed deletion/retention plans.
+The first graphical slice should browse/import/open transcripts, launch transcription and
+show job progress, use unified discovery, show speaker/time evidence, create/edit/delete
+notes, apply tags/collections with derived suggestions, browse saved searches, jump to
+source-relative media coordinates, and expose the same typed deletion/retention plans.
 
-It must consume existing application services. It must not invent a second search engine,
-note schema, speaker policy, custody model, or evidence location rule.
+Library refresh should occur through the existing service after successful transcription or
+import and at appropriate application lifecycle points. An explicit Refresh action remains
+useful. Do not introduce an always-on filesystem watcher until real product evidence shows
+it is needed.
 
-## 3. Research portability and selected-result export
+The GUI must consume existing application services. It must not invent a second search
+engine, note schema, speaker policy, custody model, refresh implementation, or evidence
+location rule.
 
-Portability is part of the ownership thesis. Target CSV, JSON/JSONL, and Markdown first,
-then a whole-workspace/user-state export manifest when the durable schema is ready.
+## 2. Desktop packaging, first-run setup, updates, and uninstall
 
-Exports should retain document ID, source/canonical SHA-256, segment IDs, and numeric
-evidence coordinates where applicable.
+A Python wheel proves EchoFlow is distributable to Python. It does not make EchoFlow a
+consumer desktop application.
+
+Produce an intentional desktop delivery path for supported platforms:
+
+- a normal Windows installer/application entry point;
+- a signed/notarized macOS application bundle and normal installer/disk-image flow; and
+- a deliberate Linux desktop package rather than requiring a repository clone.
+
+The package must account for the Python runtime, FFmpeg/FFprobe, native transcription
+runtime dependencies, application assets, and optional capabilities without requiring the
+user to assemble a developer environment.
+
+First run should initialize private/public paths, run health checks, inspect hardware, and
+recommend an explicit model download with honest disk/resource requirements. Do not hide
+network-bearing model acquisition inside transcription or search.
+
+Application update and uninstall semantics are custody-sensitive. Updating EchoFlow must
+preserve durable schemas/state or fail safely. Uninstalling the program must not silently
+delete canonical transcripts, research SQLite state, speaker labels, saved searches, or
+other user-owned evidence/knowledge. Program removal and user-data destruction are separate
+operations.
+
+## 3. Backup, restore, research portability, and selected-result export
+
+Portability is part of the ownership thesis. A user should be able to back up or move the
+irreplaceable EchoFlow workspace without treating disposable indexes as authority.
+
+Backup/restore should cover canonical transcript evidence and authoritative user state,
+including research SQLite data, saved searches, and speaker display labels. Rebuildable
+DuckDB lexical/semantic/research projections should be regenerated rather than becoming
+backup authority.
+
+For research export, target CSV, JSON/JSONL, and Markdown first, then a whole-workspace or
+user-state export manifest when the durable schema is ready. Exports should retain document
+ID, source/canonical SHA-256, segment IDs, and numeric evidence coordinates where
+applicable.
 
 ## 4. Qualify semantic dependency and managed embedding custody
 
-Before semantic search is advertised as a normal source install, qualify one locked
+Before semantic search is advertised as a normal packaged capability, qualify one locked
 optional semantic dependency set with managed immutable E5 snapshot acquisition, private
 cache placement, disk/resource admission, no silent search-time download, offline
-execution after installation, and clean-wheel/platform qualification.
+execution after installation, and packaged-platform qualification.
 
-## 5. Representative-device dogfooding and delivery
+## 5. Representative-device release qualification
 
-Exercise real corpora on 8 GB Windows, 16 GB commodity hardware, Apple Silicon, a
-discrete-GPU laptop, and larger 32/64 GB workstations. Measure real-time factor,
-cold/warm model behavior, thermal/memory pressure, private disk cost, enhancement benefit,
-embedding build cost, refresh cost, and interactive query latency.
+Exercise real corpora and the packaged application on 8 GB Windows, 16 GB commodity
+hardware, Apple Silicon, a discrete-GPU laptop, and larger 32/64 GB workstations. Measure
+real-time factor, cold/warm model behavior, thermal/memory pressure, private disk cost,
+enhancement benefit, embedding build cost, refresh cost, interactive query latency, and GUI
+responsiveness.
 
-A pre-1.0 delivery milestone should include polished recovery/error language and a package
-or installer path that does not require a developer environment.
+Release qualification should also cover Unicode/space-heavy paths, external drives,
+permission failures, low-disk conditions, interrupted model downloads, crash/resume,
+upgrade migrations, uninstall/reinstall, offline operation, accessibility/keyboard use, and
+corruption/recovery language.
+
+The pre-1.0 milestone is not “the tests pass from a checkout.” It is “a normal person can
+install EchoFlow, understand first run, process sensitive recordings, recover from common
+failure, move or back up their durable work, update the app safely, and remove the program
+without losing evidence.”
 
 # Conditional later capabilities
 

--- a/docs/architecture/incremental-library-refresh.md
+++ b/docs/architecture/incremental-library-refresh.md
@@ -1,0 +1,160 @@
+# Incremental library refresh
+
+EchoFlow's canonical transcript JSON is durable evidence. The lexical and semantic
+indexes are private, rebuildable views over that evidence.
+
+Normal library maintenance should therefore be cheap when nothing changed and exact when
+something did.
+
+The user-facing operations are deliberately different:
+
+| Operation | Input | What changes |
+|---|---|---|
+| `transcribe` | source media | creates a new canonical transcript generation |
+| `library refresh` | existing canonical JSON | reconciles changed library membership and lexical projection |
+| `library refresh --verify` | existing canonical JSON | re-hashes and validates every tracked canonical before reconciling |
+| `library rebuild` | existing canonical JSON | replaces the complete lexical projection as a repair/recovery operation |
+
+Refresh never runs ASR, rewrites canonical JSON, or changes the source recording.
+
+## Generation identity and the fast path
+
+The authoritative generation identity remains:
+
+```text
+(document_id, canonical_sha256)
+```
+
+A SHA-256 requires reading the file. Re-hashing every transcript on every normal refresh
+would make the database writes incremental while leaving canonical I/O whole-corpus.
+EchoFlow therefore stores two additional **derived change-detector fields** in the lexical
+projection:
+
+```text
+canonical_size_bytes
+canonical_modified_ns
+```
+
+On a normal refresh, a tracked canonical file can be skipped without opening it when:
+
+1. its canonical path is unchanged;
+2. its size is unchanged;
+3. its filesystem modification time is unchanged; and
+4. its known source-path metadata has not changed.
+
+Those fields are an optimization, not evidence. They do not replace `canonical_sha256`.
+An older index that predates the fields simply cannot take the fast path; the next refresh
+reads the canonical once and stores the derived signature.
+
+## Verified refresh
+
+Filesystems do not make size and modification time cryptographic statements. A file can,
+in principle, be replaced with different same-size bytes while retaining or restoring the
+same modification time.
+
+`--verify` exists for the case where the user wants an exact corpus check:
+
+```bash
+echoflow library refresh --verify
+```
+
+Verified refresh bypasses the metadata fast path, reads every tracked canonical, validates
+its schema, and recomputes its SHA-256. A generation whose bytes are unchanged is still not
+rewritten into DuckDB.
+
+This is also why evidence navigation continues to verify canonical SHA-256 before
+presenting precise source evidence. The refresh fast path is a performance optimization;
+it is not promoted into an integrity guarantee.
+
+## Reconciliation rules
+
+After discovery and validation, refresh computes one typed corpus delta:
+
+```text
+new document            -> upsert
+new canonical generation -> replace/upsert
+moved tracked canonical  -> update canonical path
+missing tracked canonical -> remove from rebuildable library view
+unchanged generation      -> skip
+```
+
+`TranscriptIndex.apply_delta()` applies all lexical removals and upserts in one DuckDB
+transaction. If any write fails, the previous lexical projection remains intact.
+
+Tracked canonical files are strict. If a file that was already part of the library is
+present but cannot be validated, refresh fails closed rather than silently dropping the
+old indexed evidence. Untracked JSON encountered through a directory scan can still be
+skipped as unrelated noise, matching full rebuild behavior.
+
+If a tracked canonical changes availability during the refresh itself, EchoFlow refuses
+the reconciliation and asks for a retry rather than guessing which filesystem state was
+intended.
+
+## Imported and moved transcripts
+
+An explicit import should not require the user to remember the same path forever.
+
+After a canonical transcript has entered the library, its indexed canonical path remains a
+refresh discovery input while that path exists. A later normal refresh therefore keeps an
+external import tracked even when its original `PATH` argument is not repeated.
+
+If the old path no longer exists and a newly discovered canonical with the same document
+identity appears elsewhere, refresh treats it as a move/update. If both the old and new
+canonical paths still exist with the same document ID, refresh fails closed on duplicate
+identity instead of choosing one arbitrarily.
+
+## Semantic projection behavior
+
+The current semantic index has a whole-corpus fingerprint and does not expose an atomic
+per-document mutation contract.
+
+When refresh changes semantic-relevant corpus identity, EchoFlow clears the semantic
+projection before applying the lexical delta. Semantic or hybrid search then remains
+unavailable until embeddings are rebuilt. This is preferable to retaining vectors whose
+stored corpus fingerprint describes evidence that is no longer in the lexical corpus.
+
+Semantic state is invalidated for:
+
+- an added transcript;
+- a removed transcript;
+- changed canonical bytes;
+- a moved canonical path; or
+- changed source-path metadata carried by search chunks.
+
+A filesystem timestamp-only change whose canonical SHA and semantic-relevant metadata are
+unchanged updates the cheap lexical change detector without throwing away valid vectors.
+
+Incremental vector mutation is intentionally not smuggled into this tranche. It can be
+added later by extending the semantic index contract while preserving the same custody and
+generation rules.
+
+## Complexity and scale contract
+
+For an unchanged tracked corpus, normal refresh may enumerate file metadata but must not
+open canonical JSON merely to discover that nothing changed.
+
+The regression suite exercises a 100-transcript corpus and requires:
+
+```text
+100 unchanged transcripts -> 0 canonical reads
+1 changed transcript       -> 1 canonical read
+```
+
+This is a deterministic I/O contract rather than a wall-clock benchmark, so it remains
+stable across CI hardware. Separate representative-corpus qualification should measure
+cold/warm latency, database size, semantic rebuild cost, and interactive search behavior.
+
+## Full rebuild remains the repair lever
+
+Incremental refresh is the normal maintenance path. It does not make full rebuild obsolete.
+
+Use `library rebuild` when the derived lexical database is absent, damaged, incompatible,
+or deliberately being regenerated under a new projection/tokenization contract. Rebuild
+re-reads the discoverable canonical corpus and replaces the disposable index atomically.
+
+The custody hierarchy does not change:
+
+- canonical JSON remains authoritative transcript evidence;
+- notes/tags/collections/saved searches remain authoritative human state;
+- lexical/semantic/research DuckDB state remains rebuildable;
+- refresh never turns a projection into a second source of truth.

--- a/src/echoflow/cli_custody.py
+++ b/src/echoflow/cli_custody.py
@@ -1,4 +1,4 @@
-"""CLI for custody-aware deletion and private execution-state retention."""
+"""CLI for custody-aware deletion, retention, and library maintenance registration."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 from echoflow.app.app_container import AppContainer
+from echoflow.cli_refresh import register_refresh_command
 from echoflow.core.errors import EchoFlowError
 from echoflow.library.custody import (
     DeletionAction,
@@ -278,7 +279,7 @@ def register_custody_commands(
     library_app: typer.Typer,
     container_factory: ContainerFactory,
 ) -> None:
-    """Register deletion planning/execution and private retention controls."""
+    """Register custody controls and adjacent library maintenance commands."""
 
     @library_app.command("delete")
     def delete_transcript(
@@ -352,3 +353,5 @@ def register_custody_commands(
             confirm=confirm,
             json_output=json_output,
         )
+
+    register_refresh_command(library_app, container_factory)

--- a/src/echoflow/cli_refresh.py
+++ b/src/echoflow/cli_refresh.py
@@ -1,0 +1,137 @@
+"""CLI for incremental transcript-library reconciliation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, cast
+
+import typer
+
+from echoflow.app.app_container import AppContainer
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.service import LibraryRefreshReport
+
+ContainerFactory = Callable[[typer.Context], AppContainer]
+
+
+def _root_context(context: typer.Context) -> typer.Context:
+    return cast("typer.Context", context.find_root())
+
+
+def _report_dict(report: LibraryRefreshReport) -> dict[str, object]:
+    return {
+        "backend_id": report.backend_id,
+        "indexed_documents": report.indexed_documents,
+        "added_document_ids": list(report.added_document_ids),
+        "updated_document_ids": list(report.updated_document_ids),
+        "removed_document_ids": list(report.removed_document_ids),
+        "unchanged_document_ids": list(report.unchanged_document_ids),
+        "added_documents": len(report.added_document_ids),
+        "updated_documents": len(report.updated_document_ids),
+        "removed_documents": len(report.removed_document_ids),
+        "unchanged_documents": len(report.unchanged_document_ids),
+        "skipped_files": report.skipped_files,
+        "semantic_invalidated": report.semantic_invalidated,
+        "verified_all_tracked": report.verified_all_tracked,
+        "changed": report.changed,
+    }
+
+
+def _handle_error(exc: Exception) -> None:
+    if isinstance(exc, EchoFlowError):
+        typer.echo(exc.public_message, err=True)
+        raise typer.Exit(code=exc.exit_code) from None
+    if isinstance(exc, ValueError):
+        raise typer.BadParameter(str(exc)) from exc
+    typer.echo(
+        f"EchoFlow library refresh failed internally ({type(exc).__name__})",
+        err=True,
+    )
+    raise typer.Exit(code=3) from None
+
+
+def _render_report(report: LibraryRefreshReport) -> None:
+    typer.echo(
+        f"Library current with {report.indexed_documents} transcript(s): "
+        f"{len(report.added_document_ids)} added, "
+        f"{len(report.updated_document_ids)} updated, "
+        f"{len(report.removed_document_ids)} removed, "
+        f"{len(report.unchanged_document_ids)} unchanged."
+    )
+    if report.skipped_files:
+        typer.echo(
+            f"Skipped {report.skipped_files} unrelated or invalid untracked JSON file(s)."
+        )
+    if report.semantic_invalidated:
+        typer.echo(
+            "Semantic embeddings were invalidated because indexed evidence changed; "
+            "rebuild embeddings before semantic or hybrid search."
+        )
+    if report.verified_all_tracked:
+        typer.echo(
+            "Re-hashed and validated every tracked canonical transcript during this refresh."
+        )
+
+
+def _refresh(
+    context: typer.Context,
+    container_factory: ContainerFactory,
+    paths: tuple[Path, ...],
+    *,
+    verify: bool,
+    json_output: bool,
+) -> None:
+    try:
+        report = (
+            container_factory(_root_context(context))
+            .transcript_library()
+            .refresh(paths, verify=verify)
+        )
+    except Exception as exc:
+        _handle_error(exc)
+        return
+    if json_output:
+        typer.echo(json.dumps(_report_dict(report), sort_keys=True))
+        return
+    _render_report(report)
+
+
+def register_refresh_command(
+    library_app: typer.Typer,
+    container_factory: ContainerFactory,
+) -> None:
+    """Register fast incremental library reconciliation."""
+
+    @library_app.command("refresh")
+    def refresh_library(
+        context: typer.Context,
+        paths: Annotated[
+            list[Path] | None,
+            typer.Argument(
+                metavar="[PATH]...",
+                help=(
+                    "Optional canonical transcript file(s) or directories to discover "
+                    "in addition to tracked and configured library paths."
+                ),
+            ),
+        ] = None,
+        verify: bool = typer.Option(
+            False,
+            "--verify",
+            help=(
+                "Re-hash and validate every tracked canonical transcript instead of "
+                "using the stored size/mtime fast path; unchanged generations are "
+                "still not rewritten."
+            ),
+        ),
+        json_output: bool = typer.Option(False, "--json"),
+    ) -> None:
+        _refresh(
+            context,
+            container_factory,
+            tuple(paths or ()),
+            verify=verify,
+            json_output=json_output,
+        )

--- a/src/echoflow/library/duckdb_index.py
+++ b/src/echoflow/library/duckdb_index.py
@@ -181,11 +181,15 @@ class DuckDbTranscriptIndex:
         self._require_open()
         upsert_ids = tuple(item.document_id for item in upserts)
         if len(upsert_ids) != len(set(upsert_ids)):
-            raise ValueError("incremental upserts cannot contain duplicate document IDs")
+            raise ValueError(
+                "incremental upserts cannot contain duplicate document IDs"
+            )
         if any(not document_id.strip() for document_id in removals):
             raise ValueError("incremental removals cannot contain empty document IDs")
         if len(removals) != len(set(removals)):
-            raise ValueError("incremental removals cannot contain duplicate document IDs")
+            raise ValueError(
+                "incremental removals cannot contain duplicate document IDs"
+            )
         if set(upsert_ids).intersection(removals):
             raise ValueError("a document cannot be both upserted and removed")
 

--- a/src/echoflow/library/duckdb_index.py
+++ b/src/echoflow/library/duckdb_index.py
@@ -120,6 +120,8 @@ class DuckDbTranscriptIndex:
                 document_id VARCHAR PRIMARY KEY,
                 source_sha256 VARCHAR NOT NULL,
                 canonical_sha256 VARCHAR,
+                canonical_size_bytes BIGINT,
+                canonical_modified_ns BIGINT,
                 transcript_schema_version INTEGER NOT NULL,
                 detected_language VARCHAR,
                 canonical_path VARCHAR NOT NULL,
@@ -151,6 +153,12 @@ class DuckDbTranscriptIndex:
         self._connection.execute(
             "ALTER TABLE documents ADD COLUMN IF NOT EXISTS canonical_sha256 VARCHAR"
         )
+        self._connection.execute(
+            "ALTER TABLE documents ADD COLUMN IF NOT EXISTS canonical_size_bytes BIGINT"
+        )
+        self._connection.execute(
+            "ALTER TABLE documents ADD COLUMN IF NOT EXISTS canonical_modified_ns BIGINT"
+        )
 
     def rebuild(self, transcripts: tuple[IndexedTranscript, ...]) -> None:
         self._require_open()
@@ -164,16 +172,37 @@ class DuckDbTranscriptIndex:
             self._connection.execute("ROLLBACK")
             raise
 
-    def upsert(self, transcript: IndexedTranscript) -> None:
+    def apply_delta(
+        self,
+        *,
+        upserts: tuple[IndexedTranscript, ...],
+        removals: tuple[str, ...],
+    ) -> None:
         self._require_open()
+        upsert_ids = tuple(item.document_id for item in upserts)
+        if len(upsert_ids) != len(set(upsert_ids)):
+            raise ValueError("incremental upserts cannot contain duplicate document IDs")
+        if any(not document_id.strip() for document_id in removals):
+            raise ValueError("incremental removals cannot contain empty document IDs")
+        if len(removals) != len(set(removals)):
+            raise ValueError("incremental removals cannot contain duplicate document IDs")
+        if set(upsert_ids).intersection(removals):
+            raise ValueError("a document cannot be both upserted and removed")
+
         self._connection.execute("BEGIN TRANSACTION")
         try:
-            self._delete_document(transcript.document_id)
-            self._insert_transcript(transcript)
+            for document_id in removals:
+                self._delete_document(document_id)
+            for transcript in upserts:
+                self._delete_document(transcript.document_id)
+                self._insert_transcript(transcript)
             self._connection.execute("COMMIT")
         except Exception:
             self._connection.execute("ROLLBACK")
             raise
+
+    def upsert(self, transcript: IndexedTranscript) -> None:
+        self.apply_delta(upserts=(transcript,), removals=())
 
     def _insert_transcript(self, transcript: IndexedTranscript) -> None:
         self._connection.execute(
@@ -182,18 +211,22 @@ class DuckDbTranscriptIndex:
                 document_id,
                 source_sha256,
                 canonical_sha256,
+                canonical_size_bytes,
+                canonical_modified_ns,
                 transcript_schema_version,
                 detected_language,
                 canonical_path,
                 source_path,
                 source_size_bytes,
                 source_modified_ns
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 transcript.document_id,
                 transcript.source_sha256,
                 transcript.canonical_sha256,
+                transcript.canonical_size_bytes,
+                transcript.canonical_modified_ns,
                 transcript.transcript_schema_version,
                 transcript.detected_language,
                 transcript.canonical_path,
@@ -230,16 +263,9 @@ class DuckDbTranscriptIndex:
                 )
 
     def remove(self, document_id: str) -> None:
-        self._require_open()
         if not document_id.strip():
             raise ValueError("document_id cannot be empty")
-        self._connection.execute("BEGIN TRANSACTION")
-        try:
-            self._delete_document(document_id)
-            self._connection.execute("COMMIT")
-        except Exception:
-            self._connection.execute("ROLLBACK")
-            raise
+        self.apply_delta(upserts=(), removals=(document_id,))
 
     def _delete_document(self, document_id: str) -> None:
         self._connection.execute(
@@ -264,11 +290,13 @@ class DuckDbTranscriptIndex:
         rows = self._connection.execute(
             """
             SELECT d.document_id, d.source_sha256, d.canonical_sha256,
+                   d.canonical_size_bytes, d.canonical_modified_ns,
                    d.detected_language, d.canonical_path, d.source_path,
                    COUNT(s.segment_id)
             FROM documents d
             LEFT JOIN segments s USING (document_id)
             GROUP BY d.document_id, d.source_sha256, d.canonical_sha256,
+                     d.canonical_size_bytes, d.canonical_modified_ns,
                      d.detected_language, d.canonical_path, d.source_path
             ORDER BY d.document_id
             """
@@ -278,10 +306,12 @@ class DuckDbTranscriptIndex:
                 document_id=str(row[0]),
                 source_sha256=str(row[1]),
                 canonical_sha256=None if row[2] is None else str(row[2]),
-                detected_language=None if row[3] is None else str(row[3]),
-                canonical_path=str(row[4]),
-                source_path=None if row[5] is None else str(row[5]),
-                segment_count=int(row[6]),
+                canonical_size_bytes=None if row[3] is None else int(row[3]),
+                canonical_modified_ns=None if row[4] is None else int(row[4]),
+                detected_language=None if row[5] is None else str(row[5]),
+                canonical_path=str(row[6]),
+                source_path=None if row[7] is None else str(row[7]),
+                segment_count=int(row[8]),
             )
             for row in rows
         )

--- a/src/echoflow/library/index.py
+++ b/src/echoflow/library/index.py
@@ -85,18 +85,13 @@ class IndexedTranscript:
             raise ValueError("segment IDs must be unique within a document")
 
     def _validate_canonical_signature(self) -> None:
-        if (self.canonical_size_bytes is None) != (
-            self.canonical_modified_ns is None
-        ):
+        if (self.canonical_size_bytes is None) != (self.canonical_modified_ns is None):
             raise ValueError(
                 "canonical size and modified time must either both be set or both be absent"
             )
         if self.canonical_size_bytes is not None and self.canonical_size_bytes < 1:
             raise ValueError("canonical_size_bytes must be positive")
-        if (
-            self.canonical_modified_ns is not None
-            and self.canonical_modified_ns < 0
-        ):
+        if self.canonical_modified_ns is not None and self.canonical_modified_ns < 0:
             raise ValueError("canonical_modified_ns cannot be negative")
 
 

--- a/src/echoflow/library/index.py
+++ b/src/echoflow/library/index.py
@@ -58,6 +58,8 @@ class IndexedTranscript:
     source_modified_ns: int
     segments: tuple[IndexedSegment, ...]
     canonical_sha256: str | None = None
+    canonical_size_bytes: int | None = None
+    canonical_modified_ns: int | None = None
 
     def __post_init__(self) -> None:
         if not self.document_id.strip():
@@ -77,9 +79,25 @@ class IndexedTranscript:
             raise ValueError("source_size_bytes must be positive")
         if self.source_modified_ns < 0:
             raise ValueError("source_modified_ns cannot be negative")
+        self._validate_canonical_signature()
         segment_ids = tuple(segment.segment_id for segment in self.segments)
         if len(segment_ids) != len(set(segment_ids)):
             raise ValueError("segment IDs must be unique within a document")
+
+    def _validate_canonical_signature(self) -> None:
+        if (self.canonical_size_bytes is None) != (
+            self.canonical_modified_ns is None
+        ):
+            raise ValueError(
+                "canonical size and modified time must either both be set or both be absent"
+            )
+        if self.canonical_size_bytes is not None and self.canonical_size_bytes < 1:
+            raise ValueError("canonical_size_bytes must be positive")
+        if (
+            self.canonical_modified_ns is not None
+            and self.canonical_modified_ns < 0
+        ):
+            raise ValueError("canonical_modified_ns cannot be negative")
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,6 +109,8 @@ class IndexedDocument:
     source_path: str | None
     segment_count: int
     canonical_sha256: str | None = None
+    canonical_size_bytes: int | None = None
+    canonical_modified_ns: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -170,6 +190,15 @@ class TranscriptIndex(Protocol):
 
     def rebuild(self, transcripts: tuple[IndexedTranscript, ...]) -> None:
         """Replace the complete derived index atomically."""
+        ...
+
+    def apply_delta(
+        self,
+        *,
+        upserts: tuple[IndexedTranscript, ...],
+        removals: tuple[str, ...],
+    ) -> None:
+        """Apply one incremental corpus delta atomically."""
         ...
 
     def upsert(self, transcript: IndexedTranscript) -> None: ...

--- a/src/echoflow/library/projection.py
+++ b/src/echoflow/library/projection.py
@@ -49,17 +49,30 @@ def load_indexed_transcript(
 ) -> IndexedTranscript:
     """Validate the searchable projection of one authoritative canonical artifact."""
     try:
-        payload = file_manager.read_file(canonical_path)
+        canonical = canonical_path.expanduser().resolve(strict=False)
+        before = canonical.stat()
+        payload = file_manager.read_file(canonical)
+        after = canonical.stat()
+        if (before.st_size, before.st_mtime_ns) != (
+            after.st_size,
+            after.st_mtime_ns,
+        ):
+            raise TranscriptProjectionError(
+                "Canonical transcript changed while it was being indexed"
+            )
         if len(payload) > _MAX_CANONICAL_BYTES:
             raise TranscriptProjectionError(
                 "Canonical transcript is too large to index safely"
+            )
+        if len(payload) != after.st_size:
+            raise TranscriptProjectionError(
+                "Canonical transcript size changed while it was being indexed"
             )
         document = _TranscriptProjection.model_validate(json.loads(payload))
         if document.schema_version != 1:
             raise TranscriptProjectionError(
                 "Canonical transcript schema is unsupported by this EchoFlow build"
             )
-        canonical = canonical_path.expanduser().resolve(strict=False)
         source = (
             None
             if source_path is None
@@ -84,6 +97,8 @@ def load_indexed_transcript(
             document_id=document.job_id,
             source_sha256=document.source.sha256,
             canonical_sha256=hashlib.sha256(payload).hexdigest(),
+            canonical_size_bytes=after.st_size,
+            canonical_modified_ns=after.st_mtime_ns,
             transcript_schema_version=document.schema_version,
             detected_language=document.detected_language,
             canonical_path=str(canonical),

--- a/src/echoflow/library/service.py
+++ b/src/echoflow/library/service.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
 
@@ -51,6 +51,27 @@ class LibraryRebuildReport:
 
 
 @dataclass(frozen=True, slots=True)
+class LibraryRefreshReport:
+    backend_id: str
+    indexed_documents: int
+    added_document_ids: tuple[str, ...]
+    updated_document_ids: tuple[str, ...]
+    removed_document_ids: tuple[str, ...]
+    unchanged_document_ids: tuple[str, ...]
+    skipped_files: int
+    semantic_invalidated: bool
+    verified_all_tracked: bool
+
+    @property
+    def changed(self) -> bool:
+        return bool(
+            self.added_document_ids
+            or self.updated_document_ids
+            or self.removed_document_ids
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class SemanticRebuildReport:
     lexical_backend_id: str
     semantic_backend_id: str
@@ -79,6 +100,23 @@ class _Candidate:
     strict: bool
 
 
+@dataclass(frozen=True, slots=True)
+class _RefreshCandidateResult:
+    transcript: IndexedTranscript | None = None
+    unchanged_document_id: str | None = None
+    skipped: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _RefreshDelta:
+    upserts: tuple[IndexedTranscript, ...]
+    added: tuple[str, ...]
+    updated: tuple[str, ...]
+    removed: tuple[str, ...]
+    unchanged: tuple[str, ...]
+    semantic_dirty: bool
+
+
 class TranscriptLibraryService:
     """Coordinate canonical transcript discovery, indexing, search, and evidence."""
 
@@ -105,6 +143,41 @@ class TranscriptLibraryService:
             backend_id=self.index.backend_id,
             indexed_documents=len(ordered),
             skipped_files=skipped,
+        )
+
+    def refresh(
+        self,
+        additional_paths: tuple[Path, ...] = (),
+        *,
+        verify: bool = False,
+    ) -> LibraryRefreshReport:
+        """Reconcile changed canonical generations without rebuilding unchanged documents."""
+        existing = {
+            document.document_id: document for document in self.index.documents()
+        }
+        existing_by_path = {
+            self._resolved_path(document.canonical_path): document
+            for document in existing.values()
+        }
+        candidates = self._refresh_candidates(existing, additional_paths)
+        loaded, unchanged, skipped = self._load_refresh_candidates(
+            candidates,
+            existing,
+            existing_by_path,
+            verify=verify,
+        )
+        delta = self._plan_refresh_delta(existing, loaded, unchanged)
+        semantic_invalidated = self._apply_refresh_delta(delta)
+        return LibraryRefreshReport(
+            backend_id=self.index.backend_id,
+            indexed_documents=len(self.index.documents()),
+            added_document_ids=delta.added,
+            updated_document_ids=delta.updated,
+            removed_document_ids=delta.removed,
+            unchanged_document_ids=delta.unchanged,
+            skipped_files=skipped,
+            semantic_invalidated=semantic_invalidated,
+            verified_all_tracked=verify,
         )
 
     def rebuild_semantic(
@@ -267,6 +340,318 @@ class TranscriptLibraryService:
         ordered = tuple(transcripts[key] for key in sorted(transcripts))
         return ordered, skipped
 
+    def _load_refresh_candidates(
+        self,
+        candidates: tuple[_Candidate, ...],
+        existing: dict[str, IndexedDocument],
+        existing_by_path: dict[Path, IndexedDocument],
+        *,
+        verify: bool,
+    ) -> tuple[dict[str, IndexedTranscript], set[str], int]:
+        loaded: dict[str, IndexedTranscript] = {}
+        unchanged: set[str] = set()
+        skipped = 0
+        for candidate in candidates:
+            result = self._load_refresh_candidate(
+                candidate,
+                existing_by_path.get(candidate.canonical_path),
+                existing,
+                verify=verify,
+            )
+            if result.skipped:
+                skipped += 1
+                continue
+            if result.unchanged_document_id is not None:
+                unchanged.add(result.unchanged_document_id)
+                continue
+            transcript = result.transcript
+            if transcript is None:
+                raise RuntimeError("refresh candidate produced no disposition")
+            self._reject_duplicate_refresh_identity(
+                transcript,
+                candidate.canonical_path,
+                existing,
+                loaded,
+            )
+            loaded[transcript.document_id] = transcript
+        return loaded, unchanged, skipped
+
+    def _load_refresh_candidate(
+        self,
+        candidate: _Candidate,
+        existing_at_path: IndexedDocument | None,
+        existing: dict[str, IndexedDocument],
+        *,
+        verify: bool,
+    ) -> _RefreshCandidateResult:
+        source_path = self._effective_source_path(candidate, existing_at_path)
+        if self._can_fast_skip(
+            candidate,
+            existing_at_path,
+            source_path,
+            verify=verify,
+        ):
+            if existing_at_path is None:
+                raise RuntimeError("fast refresh skip requires an indexed document")
+            return _RefreshCandidateResult(
+                unchanged_document_id=existing_at_path.document_id
+            )
+        try:
+            transcript = load_indexed_transcript(
+                candidate.canonical_path,
+                source_path=source_path,
+                file_manager=self.file_manager,
+            )
+        except TranscriptProjectionError as exc:
+            if candidate.strict or existing_at_path is not None:
+                raise TranscriptLibraryBuildError(
+                    "A tracked canonical transcript could not be refreshed safely",
+                    cause=exc,
+                ) from exc
+            return _RefreshCandidateResult(skipped=True)
+        previous = existing.get(transcript.document_id)
+        if (
+            transcript.source_path is None
+            and previous is not None
+            and previous.source_path is not None
+        ):
+            transcript = replace(transcript, source_path=previous.source_path)
+        return _RefreshCandidateResult(transcript=transcript)
+
+    def _can_fast_skip(
+        self,
+        candidate: _Candidate,
+        existing_at_path: IndexedDocument | None,
+        source_path: Path | None,
+        *,
+        verify: bool,
+    ) -> bool:
+        if verify or existing_at_path is None:
+            return False
+        return self._signature_matches(
+            existing_at_path, candidate.canonical_path
+        ) and self._same_source_path(existing_at_path.source_path, source_path)
+
+    def _plan_refresh_delta(
+        self,
+        existing: dict[str, IndexedDocument],
+        loaded: dict[str, IndexedTranscript],
+        unchanged: set[str],
+    ) -> _RefreshDelta:
+        upserts: list[IndexedTranscript] = []
+        added: list[str] = []
+        updated: list[str] = []
+        semantic_dirty = False
+        for document_id in sorted(loaded):
+            transcript = loaded[document_id]
+            previous = existing.get(document_id)
+            if previous is None:
+                added.append(document_id)
+                upserts.append(transcript)
+                semantic_dirty = True
+            elif self._same_indexed_projection(previous, transcript):
+                unchanged.add(document_id)
+            else:
+                updated.append(document_id)
+                upserts.append(transcript)
+                semantic_dirty = (
+                    semantic_dirty
+                    or self._semantic_projection_changed(previous, transcript)
+                )
+        removed = self._removed_documents(existing, loaded, unchanged)
+        return _RefreshDelta(
+            upserts=tuple(upserts),
+            added=tuple(added),
+            updated=tuple(updated),
+            removed=removed,
+            unchanged=tuple(sorted(unchanged)),
+            semantic_dirty=semantic_dirty or bool(removed),
+        )
+
+    def _removed_documents(
+        self,
+        existing: dict[str, IndexedDocument],
+        loaded: dict[str, IndexedTranscript],
+        unchanged: set[str],
+    ) -> tuple[str, ...]:
+        removed: list[str] = []
+        for document_id, document in sorted(existing.items()):
+            if document_id in loaded or document_id in unchanged:
+                continue
+            canonical = self._resolved_path(document.canonical_path)
+            if canonical.is_file():
+                raise TranscriptLibraryBuildError(
+                    "A tracked canonical transcript changed availability during refresh; "
+                    "retry the refresh"
+                )
+            removed.append(document_id)
+        return tuple(removed)
+
+    def _apply_refresh_delta(self, delta: _RefreshDelta) -> bool:
+        semantic_invalidated = self._invalidate_semantic_if_needed(
+            delta.semantic_dirty
+        )
+        try:
+            self.index.apply_delta(
+                upserts=delta.upserts,
+                removals=delta.removed,
+            )
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as exc:
+            detail = (
+                " Semantic embeddings were already invalidated."
+                if semantic_invalidated
+                else ""
+            )
+            raise TranscriptLibraryBuildError(
+                "The incremental transcript index refresh could not be applied atomically."
+                + detail,
+                cause=exc,
+            ) from exc
+        return semantic_invalidated
+
+    def _refresh_candidates(
+        self,
+        existing: dict[str, IndexedDocument],
+        additional_paths: tuple[Path, ...],
+    ) -> tuple[_Candidate, ...]:
+        candidates = {
+            candidate.canonical_path: candidate
+            for candidate in self._discover(additional_paths)
+        }
+        for document in existing.values():
+            canonical = self._resolved_path(document.canonical_path)
+            if not canonical.is_file():
+                continue
+            source = (
+                None
+                if document.source_path is None
+                else self._resolved_path(document.source_path)
+            )
+            discovered = candidates.get(canonical)
+            if discovered is None:
+                candidates[canonical] = _Candidate(canonical, source, True)
+                continue
+            candidates[canonical] = _Candidate(
+                canonical,
+                discovered.source_path or source,
+                True,
+            )
+        return tuple(candidates[path] for path in sorted(candidates))
+
+    @staticmethod
+    def _effective_source_path(
+        candidate: _Candidate,
+        existing: IndexedDocument | None,
+    ) -> Path | None:
+        if candidate.source_path is not None:
+            return candidate.source_path
+        if existing is None or existing.source_path is None:
+            return None
+        return Path(existing.source_path).expanduser().resolve(strict=False)
+
+    @staticmethod
+    def _signature_matches(document: IndexedDocument, canonical_path: Path) -> bool:
+        if (
+            document.canonical_size_bytes is None
+            or document.canonical_modified_ns is None
+        ):
+            return False
+        try:
+            stat = canonical_path.stat()
+        except OSError as exc:
+            raise TranscriptLibraryBuildError(
+                "A tracked canonical transcript could not be inspected for refresh",
+                cause=exc,
+            ) from exc
+        return (
+            stat.st_size == document.canonical_size_bytes
+            and stat.st_mtime_ns == document.canonical_modified_ns
+        )
+
+    @staticmethod
+    def _same_source_path(stored: str | None, candidate: Path | None) -> bool:
+        stored_path = (
+            None
+            if stored is None
+            else Path(stored).expanduser().resolve(strict=False)
+        )
+        return stored_path == candidate
+
+    @staticmethod
+    def _same_indexed_projection(
+        previous: IndexedDocument,
+        current: IndexedTranscript,
+    ) -> bool:
+        return (
+            previous.canonical_sha256 == current.canonical_sha256
+            and TranscriptLibraryService._resolved_path(previous.canonical_path)
+            == TranscriptLibraryService._resolved_path(current.canonical_path)
+            and TranscriptLibraryService._same_source_path(
+                previous.source_path,
+                None if current.source_path is None else Path(current.source_path),
+            )
+            and previous.canonical_size_bytes == current.canonical_size_bytes
+            and previous.canonical_modified_ns == current.canonical_modified_ns
+        )
+
+    @staticmethod
+    def _semantic_projection_changed(
+        previous: IndexedDocument,
+        current: IndexedTranscript,
+    ) -> bool:
+        return (
+            previous.canonical_sha256 != current.canonical_sha256
+            or TranscriptLibraryService._resolved_path(previous.canonical_path)
+            != TranscriptLibraryService._resolved_path(current.canonical_path)
+            or not TranscriptLibraryService._same_source_path(
+                previous.source_path,
+                None if current.source_path is None else Path(current.source_path),
+            )
+        )
+
+    def _reject_duplicate_refresh_identity(
+        self,
+        transcript: IndexedTranscript,
+        candidate_path: Path,
+        existing: dict[str, IndexedDocument],
+        loaded: dict[str, IndexedTranscript],
+    ) -> None:
+        loaded_match = loaded.get(transcript.document_id)
+        if (
+            loaded_match is not None
+            and self._resolved_path(loaded_match.canonical_path) != candidate_path
+        ):
+            raise TranscriptLibraryBuildError(
+                "Duplicate canonical transcript job ID found while refreshing library"
+            )
+        previous = existing.get(transcript.document_id)
+        if previous is None:
+            return
+        previous_path = self._resolved_path(previous.canonical_path)
+        if previous_path != candidate_path and previous_path.is_file():
+            raise TranscriptLibraryBuildError(
+                "Duplicate canonical transcript job ID found while refreshing library"
+            )
+
+    def _invalidate_semantic_if_needed(self, semantic_dirty: bool) -> bool:
+        if not semantic_dirty or self.semantic_index is None:
+            return False
+        try:
+            state = self.semantic_index.state()
+            if state is None:
+                return False
+            self.semantic_index.clear()
+            return True
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as exc:
+            raise TranscriptLibraryBuildError(
+                "Stale semantic state could not be invalidated before library refresh",
+                cause=exc,
+            ) from exc
+
     def _current_index_fingerprint(self) -> str:
         documents = self.index.documents()
         digest = hashlib.sha256()
@@ -365,3 +750,7 @@ class TranscriptLibraryService:
             while block := source.read(_HASH_BLOCK_SIZE):
                 digest.update(block)
         return digest.hexdigest()
+
+    @staticmethod
+    def _resolved_path(path: str | Path) -> Path:
+        return Path(path).expanduser().resolve(strict=False)

--- a/src/echoflow/library/service.py
+++ b/src/echoflow/library/service.py
@@ -454,9 +454,8 @@ class TranscriptLibraryService:
             else:
                 updated.append(document_id)
                 upserts.append(transcript)
-                semantic_dirty = (
-                    semantic_dirty
-                    or self._semantic_projection_changed(previous, transcript)
+                semantic_dirty = semantic_dirty or self._semantic_projection_changed(
+                    previous, transcript
                 )
         removed = self._removed_documents(existing, loaded, unchanged)
         return _RefreshDelta(
@@ -488,9 +487,7 @@ class TranscriptLibraryService:
         return tuple(removed)
 
     def _apply_refresh_delta(self, delta: _RefreshDelta) -> bool:
-        semantic_invalidated = self._invalidate_semantic_if_needed(
-            delta.semantic_dirty
-        )
+        semantic_invalidated = self._invalidate_semantic_if_needed(delta.semantic_dirty)
         try:
             self.index.apply_delta(
                 upserts=delta.upserts,
@@ -573,9 +570,7 @@ class TranscriptLibraryService:
     @staticmethod
     def _same_source_path(stored: str | None, candidate: Path | None) -> bool:
         stored_path = (
-            None
-            if stored is None
-            else Path(stored).expanduser().resolve(strict=False)
+            None if stored is None else Path(stored).expanduser().resolve(strict=False)
         )
         return stored_path == candidate
 

--- a/src/echoflow/library/tests/test_duckdb_refresh.py
+++ b/src/echoflow/library/tests/test_duckdb_refresh.py
@@ -70,7 +70,9 @@ def test_apply_delta_rolls_back_entire_refresh_when_one_upsert_fails(
     tmp_path: Path,
 ) -> None:
     index = _index(tmp_path)
-    original = _transcript(tmp_path, "original", "original evidence", canonical_char="1")
+    original = _transcript(
+        tmp_path, "original", "original evidence", canonical_char="1"
+    )
     index.rebuild((original,))
     valid = _transcript(tmp_path, "valid", "valid evidence", canonical_char="2")
     duplicate_segment = IndexedTranscript(

--- a/src/echoflow/library/tests/test_duckdb_refresh.py
+++ b/src/echoflow/library/tests/test_duckdb_refresh.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from echoflow.library.duckdb_index import DuckDbTranscriptIndex
+from echoflow.library.index import IndexedSegment, IndexedTranscript, SearchQuery
+
+
+class DirectoryManager:
+    def ensure_directory_exists(
+        self, directory_path: str | Path, *, private: bool = False
+    ) -> None:
+        assert private
+        Path(directory_path).mkdir(parents=True, exist_ok=True)
+
+
+def _transcript(
+    tmp_path: Path,
+    document_id: str,
+    text: str,
+    *,
+    canonical_char: str,
+) -> IndexedTranscript:
+    return IndexedTranscript(
+        document_id=document_id,
+        source_sha256="a" * 64,
+        canonical_sha256=canonical_char * 64,
+        canonical_size_bytes=100,
+        canonical_modified_ns=10,
+        transcript_schema_version=1,
+        detected_language="en",
+        canonical_path=str(tmp_path / f"{document_id}.json"),
+        source_path=str(tmp_path / f"{document_id}.wav"),
+        source_size_bytes=10,
+        source_modified_ns=5,
+        segments=(IndexedSegment("segment-000000", 0, 1, text),),
+    )
+
+
+def _index(tmp_path: Path) -> DuckDbTranscriptIndex:
+    return DuckDbTranscriptIndex(
+        tmp_path / "library.duckdb",
+        DirectoryManager(),  # type: ignore[arg-type]
+    )
+
+
+def test_apply_delta_commits_upserts_and_removals_together(tmp_path: Path) -> None:
+    index = _index(tmp_path)
+    first = _transcript(tmp_path, "first", "old first", canonical_char="1")
+    second = _transcript(tmp_path, "second", "old second", canonical_char="2")
+    index.rebuild((first, second))
+
+    replacement = _transcript(
+        tmp_path,
+        "second",
+        "replacement second",
+        canonical_char="3",
+    )
+    third = _transcript(tmp_path, "third", "new third", canonical_char="4")
+    index.apply_delta(upserts=(replacement, third), removals=("first",))
+
+    assert [item.document_id for item in index.documents()] == ["second", "third"]
+    assert index.search(SearchQuery("old")) == ()
+    assert index.search(SearchQuery("replacement"))[0].document_id == "second"
+    assert index.search(SearchQuery("new"))[0].document_id == "third"
+
+
+def test_apply_delta_rolls_back_entire_refresh_when_one_upsert_fails(
+    tmp_path: Path,
+) -> None:
+    index = _index(tmp_path)
+    original = _transcript(tmp_path, "original", "original evidence", canonical_char="1")
+    index.rebuild((original,))
+    valid = _transcript(tmp_path, "valid", "valid evidence", canonical_char="2")
+    duplicate_segment = IndexedTranscript(
+        document_id="broken",
+        source_sha256="a" * 64,
+        canonical_sha256="3" * 64,
+        canonical_size_bytes=100,
+        canonical_modified_ns=10,
+        transcript_schema_version=1,
+        detected_language="en",
+        canonical_path=str(tmp_path / "broken.json"),
+        source_path=None,
+        source_size_bytes=10,
+        source_modified_ns=5,
+        segments=(
+            IndexedSegment("segment-000000", 0, 1, "first"),
+            IndexedSegment("segment-000001", 1, 2, "second"),
+        ),
+    )
+    # Force the second insert to fail inside DuckDB after earlier delta work has run.
+    index._connection.execute(
+        """
+        CREATE UNIQUE INDEX force_text_collision
+        ON segments(text)
+        """
+    )
+    broken = IndexedTranscript(
+        document_id=duplicate_segment.document_id,
+        source_sha256=duplicate_segment.source_sha256,
+        canonical_sha256=duplicate_segment.canonical_sha256,
+        canonical_size_bytes=duplicate_segment.canonical_size_bytes,
+        canonical_modified_ns=duplicate_segment.canonical_modified_ns,
+        transcript_schema_version=duplicate_segment.transcript_schema_version,
+        detected_language=duplicate_segment.detected_language,
+        canonical_path=duplicate_segment.canonical_path,
+        source_path=duplicate_segment.source_path,
+        source_size_bytes=duplicate_segment.source_size_bytes,
+        source_modified_ns=duplicate_segment.source_modified_ns,
+        segments=(
+            IndexedSegment("segment-000000", 0, 1, "collision"),
+            IndexedSegment("segment-000001", 1, 2, "collision"),
+        ),
+    )
+
+    with pytest.raises(duckdb.ConstraintException):
+        index.apply_delta(
+            upserts=(valid, broken),
+            removals=("original",),
+        )
+
+    assert [item.document_id for item in index.documents()] == ["original"]
+    assert index.search(SearchQuery("original"))[0].document_id == "original"
+    assert index.contains("valid") is False
+    assert index.contains("broken") is False
+
+
+@pytest.mark.parametrize(
+    ("upserts", "removals", "message"),
+    [
+        (("duplicate", "duplicate"), (), "duplicate document IDs"),
+        ((), ("",), "empty document IDs"),
+        ((), ("same", "same"), "duplicate document IDs"),
+        (("same",), ("same",), "both upserted and removed"),
+    ],
+)
+def test_apply_delta_rejects_ambiguous_delta_contract(
+    tmp_path: Path,
+    upserts: tuple[str, ...],
+    removals: tuple[str, ...],
+    message: str,
+) -> None:
+    index = _index(tmp_path)
+    transcripts = tuple(
+        _transcript(tmp_path, item, item, canonical_char=str(position + 1))
+        for position, item in enumerate(upserts)
+    )
+    with pytest.raises(ValueError, match=message):
+        index.apply_delta(upserts=transcripts, removals=removals)

--- a/src/echoflow/library/tests/test_projection.py
+++ b/src/echoflow/library/tests/test_projection.py
@@ -159,7 +159,9 @@ def test_projection_rejects_oversized_artifact_before_json_parse(
         )
 
 
-def test_projection_fails_closed_if_canonical_changes_during_read(tmp_path: Path) -> None:
+def test_projection_fails_closed_if_canonical_changes_during_read(
+    tmp_path: Path,
+) -> None:
     payload = json.dumps(_document()).encode()
     canonical = _canonical(tmp_path, payload)
 

--- a/src/echoflow/library/tests/test_projection.py
+++ b/src/echoflow/library/tests/test_projection.py
@@ -16,6 +16,14 @@ class ReadStore:
         return self.payload
 
 
+class MutatingReadStore:
+    def read_file(self, file_path: str | Path) -> bytes:
+        path = Path(file_path)
+        payload = path.read_bytes()
+        path.write_bytes(payload + b" ")
+        return payload
+
+
 def _document() -> dict[str, object]:
     return {
         "schema_version": 1,
@@ -59,9 +67,15 @@ def _document() -> dict[str, object]:
     }
 
 
+def _canonical(tmp_path: Path, payload: bytes) -> Path:
+    path = tmp_path / "transcript.json"
+    path.write_bytes(payload)
+    return path
+
+
 def test_projection_extracts_only_searchable_canonical_evidence(tmp_path: Path) -> None:
     payload = json.dumps(_document()).encode()
-    canonical = tmp_path / "transcript.json"
+    canonical = _canonical(tmp_path, payload)
     source = tmp_path / "audio.wav"
 
     indexed = load_indexed_transcript(
@@ -74,16 +88,20 @@ def test_projection_extracts_only_searchable_canonical_evidence(tmp_path: Path) 
     assert indexed.source_sha256 == "0" * 64
     assert indexed.canonical_path == str(canonical.resolve())
     assert indexed.source_path == str(source.resolve())
+    assert indexed.canonical_size_bytes == len(payload)
+    assert indexed.canonical_modified_ns == canonical.stat().st_mtime_ns
     assert [segment.language for segment in indexed.segments] == ["fr", "de", "en"]
     assert indexed.segments[0].speaker_ref == "speaker-01"
     assert indexed.segments[0].text == "hello"
 
 
 def test_projection_accepts_unknown_source_path(tmp_path: Path) -> None:
+    payload = json.dumps(_document()).encode()
+    canonical = _canonical(tmp_path, payload)
     indexed = load_indexed_transcript(
-        tmp_path / "transcript.json",
+        canonical,
         source_path=None,
-        file_manager=ReadStore(json.dumps(_document()).encode()),  # type: ignore[arg-type]
+        file_manager=ReadStore(payload),  # type: ignore[arg-type]
     )
     assert indexed.source_path is None
 
@@ -118,9 +136,10 @@ def test_projection_accepts_unknown_source_path(tmp_path: Path) -> None:
 def test_projection_fails_closed_on_malformed_canonical_data(
     tmp_path: Path, payload: bytes, message: str
 ) -> None:
+    canonical = _canonical(tmp_path, payload)
     with pytest.raises(TranscriptProjectionError, match=message):
         load_indexed_transcript(
-            tmp_path / "transcript.json",
+            canonical,
             source_path=None,
             file_manager=ReadStore(payload),  # type: ignore[arg-type]
         )
@@ -130,9 +149,23 @@ def test_projection_rejects_oversized_artifact_before_json_parse(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(projection, "_MAX_CANONICAL_BYTES", 4)
+    payload = b"12345"
+    canonical = _canonical(tmp_path, payload)
     with pytest.raises(TranscriptProjectionError, match="too large"):
         load_indexed_transcript(
-            tmp_path / "transcript.json",
+            canonical,
             source_path=None,
-            file_manager=ReadStore(b"12345"),  # type: ignore[arg-type]
+            file_manager=ReadStore(payload),  # type: ignore[arg-type]
+        )
+
+
+def test_projection_fails_closed_if_canonical_changes_during_read(tmp_path: Path) -> None:
+    payload = json.dumps(_document()).encode()
+    canonical = _canonical(tmp_path, payload)
+
+    with pytest.raises(TranscriptProjectionError, match="changed while"):
+        load_indexed_transcript(
+            canonical,
+            source_path=None,
+            file_manager=MutatingReadStore(),  # type: ignore[arg-type]
         )

--- a/src/echoflow/library/tests/test_refresh.py
+++ b/src/echoflow/library/tests/test_refresh.py
@@ -176,7 +176,9 @@ def test_noop_refresh_skips_canonical_reads_for_unchanged_tracked_files(
     assert report.changed is False
 
 
-def test_refresh_cost_is_proportional_to_changed_canonical_files(tmp_path: Path) -> None:
+def test_refresh_cost_is_proportional_to_changed_canonical_files(
+    tmp_path: Path,
+) -> None:
     source = tmp_path / "audio.wav"
     source.write_bytes(b"audio")
     store = CountingStore()

--- a/src/echoflow/library/tests/test_refresh.py
+++ b/src/echoflow/library/tests/test_refresh.py
@@ -1,0 +1,430 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from echoflow.library.duckdb_index import DuckDbTranscriptIndex
+from echoflow.library.errors import TranscriptLibraryBuildError
+from echoflow.library.index import SearchQuery
+from echoflow.library.service import TranscriptLibraryService
+from echoflow.workspace.lifecycle import JobLifecycleRecord, JobStatus
+from echoflow.workspace.models import JobId, WorkspacePaths
+
+
+class CountingStore:
+    def __init__(self) -> None:
+        self.reads: list[Path] = []
+
+    def ensure_directory_exists(
+        self, directory_path: str | Path, *, private: bool = False
+    ) -> None:
+        path = Path(directory_path)
+        path.mkdir(parents=True, exist_ok=True)
+
+    def read_file(self, file_path: str | Path) -> bytes:
+        path = Path(file_path)
+        self.reads.append(path.resolve(strict=False))
+        return path.read_bytes()
+
+    def list_files(
+        self,
+        directory_path: str | Path,
+        extensions: tuple[str, ...] | None = None,
+    ) -> list[Path]:
+        directory = Path(directory_path)
+        if not directory.is_dir():
+            return []
+        paths = [path for path in directory.iterdir() if path.is_file()]
+        if extensions is not None:
+            paths = [path for path in paths if path.suffix.lower() in extensions]
+        return sorted(paths)
+
+
+class LifecycleStore:
+    def __init__(self, records: tuple[JobLifecycleRecord, ...]) -> None:
+        self.records = records
+
+    def list_records(self) -> tuple[JobLifecycleRecord, ...]:
+        return self.records
+
+
+class SemanticStub:
+    backend_id = "semantic-stub"
+
+    def __init__(self) -> None:
+        self.ready = True
+        self.clear_calls = 0
+
+    def state(self) -> object | None:
+        return object() if self.ready else None
+
+    def clear(self) -> None:
+        self.clear_calls += 1
+        self.ready = False
+
+
+def _paths(tmp_path: Path) -> WorkspacePaths:
+    return WorkspacePaths(
+        state_dir=tmp_path / "state",
+        cache_dir=tmp_path / "cache",
+        model_dir=tmp_path / "cache" / "models",
+        output_dir=tmp_path / "output",
+    )
+
+
+def _write_canonical(
+    path: Path,
+    *,
+    job_id: str,
+    source: Path,
+    text: str,
+) -> None:
+    source_bytes = source.read_bytes()
+    digest = hashlib.sha256(source_bytes).hexdigest()
+    stat = source.stat()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "job_id": job_id,
+                "source": {
+                    "sha256": digest,
+                    "size_bytes": len(source_bytes),
+                    "modified_ns": stat.st_mtime_ns,
+                },
+                "detected_language": "en",
+                "segments": [
+                    {
+                        "segment_id": "segment-000000",
+                        "start_seconds": 0.0,
+                        "end_seconds": 1.0,
+                        "text": text,
+                        "language": "en",
+                    }
+                ],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def _record(source: Path, canonical: Path, job_id: str) -> JobLifecycleRecord:
+    return JobLifecycleRecord(
+        job_id=JobId(job_id),
+        input_path=source,
+        output_dir=canonical.parent,
+        status=JobStatus.COMPLETED,
+        started_at="2026-08-19T00:00:00+00:00",
+        updated_at="2026-08-19T00:01:00+00:00",
+        process_id=None,
+        process_started_at=None,
+        artifact_path=canonical,
+    )
+
+
+def _service(
+    tmp_path: Path,
+    store: CountingStore,
+    records: tuple[JobLifecycleRecord, ...] = (),
+    *,
+    semantic: SemanticStub | None = None,
+) -> TranscriptLibraryService:
+    paths = _paths(tmp_path)
+    paths.output_dir.mkdir(parents=True, exist_ok=True)
+    index = DuckDbTranscriptIndex(
+        paths.state_dir / "library" / "transcripts.duckdb",
+        store,  # type: ignore[arg-type]
+    )
+    return TranscriptLibraryService(
+        index=index,
+        lifecycle_store=LifecycleStore(records),  # type: ignore[arg-type]
+        paths=paths,
+        file_manager=store,  # type: ignore[arg-type]
+        semantic_index=semantic,  # type: ignore[arg-type]
+    )
+
+
+def test_noop_refresh_skips_canonical_reads_for_unchanged_tracked_files(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    first = _paths(tmp_path).output_dir / "first.json"
+    second = _paths(tmp_path).output_dir / "second.json"
+    _write_canonical(first, job_id="job-1", source=source, text="alpha evidence")
+    _write_canonical(second, job_id="job-2", source=source, text="beta evidence")
+    store = CountingStore()
+    service = _service(
+        tmp_path,
+        store,
+        (_record(source, first, "job-1"), _record(source, second, "job-2")),
+    )
+    service.rebuild()
+    store.reads.clear()
+
+    report = service.refresh()
+
+    assert store.reads == []
+    assert report.added_document_ids == ()
+    assert report.updated_document_ids == ()
+    assert report.removed_document_ids == ()
+    assert report.unchanged_document_ids == ("job-1", "job-2")
+    assert report.indexed_documents == 2
+    assert report.changed is False
+
+
+def test_refresh_cost_is_proportional_to_changed_canonical_files(tmp_path: Path) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    store = CountingStore()
+    service = _service(tmp_path, store)
+    output = _paths(tmp_path).output_dir
+    for index in range(100):
+        _write_canonical(
+            output / f"transcript-{index:03d}.json",
+            job_id=f"job-{index:03d}",
+            source=source,
+            text=f"evidence {index}",
+        )
+    service.rebuild()
+    store.reads.clear()
+
+    unchanged = service.refresh()
+
+    assert unchanged.indexed_documents == 100
+    assert len(unchanged.unchanged_document_ids) == 100
+    assert store.reads == []
+
+    changed_path = output / "transcript-042.json"
+    _write_canonical(
+        changed_path,
+        job_id="job-042",
+        source=source,
+        text="replacement evidence with changed length for forty two",
+    )
+    store.reads.clear()
+
+    changed = service.refresh()
+
+    assert changed.updated_document_ids == ("job-042",)
+    assert len(changed.unchanged_document_ids) == 99
+    assert store.reads == [changed_path.resolve()]
+
+
+def test_refresh_reads_and_reindexes_only_changed_generation(tmp_path: Path) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    first = _paths(tmp_path).output_dir / "first.json"
+    second = _paths(tmp_path).output_dir / "second.json"
+    _write_canonical(first, job_id="job-1", source=source, text="alpha evidence")
+    _write_canonical(second, job_id="job-2", source=source, text="beta evidence")
+    store = CountingStore()
+    service = _service(tmp_path, store)
+    service.rebuild()
+    store.reads.clear()
+
+    _write_canonical(
+        second,
+        job_id="job-2",
+        source=source,
+        text="gamma replacement evidence with a changed size",
+    )
+    report = service.refresh()
+
+    assert store.reads == [second.resolve()]
+    assert report.updated_document_ids == ("job-2",)
+    assert report.unchanged_document_ids == ("job-1",)
+    assert [match.document_id for match in service.search(SearchQuery("gamma"))] == [
+        "job-2"
+    ]
+    assert service.search(SearchQuery("beta")) == ()
+
+
+def test_refresh_adds_new_and_removes_missing_in_one_reconciliation(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    old = _paths(tmp_path).output_dir / "old.json"
+    _write_canonical(old, job_id="old", source=source, text="old evidence")
+    store = CountingStore()
+    service = _service(tmp_path, store)
+    service.rebuild()
+    old.unlink()
+
+    new = _paths(tmp_path).output_dir / "new.json"
+    _write_canonical(new, job_id="new", source=source, text="new evidence")
+    report = service.refresh()
+
+    assert report.added_document_ids == ("new",)
+    assert report.removed_document_ids == ("old",)
+    assert [item.document_id for item in service.documents()] == ["new"]
+
+
+def test_refresh_keeps_explicit_import_tracked_without_repeating_import_path(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    external = tmp_path / "external" / "interview.json"
+    _write_canonical(external, job_id="external", source=source, text="outside")
+    store = CountingStore()
+    service = _service(tmp_path, store)
+    service.rebuild((external,))
+    store.reads.clear()
+
+    report = service.refresh()
+
+    assert report.unchanged_document_ids == ("external",)
+    assert store.reads == []
+    assert service.documents()[0].canonical_path == str(external.resolve())
+
+
+def test_refresh_updates_moved_tracked_canonical_without_losing_known_source_path(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    canonical = _paths(tmp_path).output_dir / "interview.json"
+    _write_canonical(canonical, job_id="job-1", source=source, text="moving evidence")
+    store = CountingStore()
+    service = _service(
+        tmp_path,
+        store,
+        (_record(source, canonical, "job-1"),),
+    )
+    service.rebuild()
+
+    moved = tmp_path / "archive" / "interview.json"
+    moved.parent.mkdir()
+    canonical.rename(moved)
+    report = service.refresh((moved,))
+
+    assert report.updated_document_ids == ("job-1",)
+    document = service.documents()[0]
+    assert document.canonical_path == str(moved.resolve())
+    assert document.source_path == str(source.resolve())
+
+
+def test_refresh_rejects_duplicate_document_identity_when_original_still_exists(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    canonical = _paths(tmp_path).output_dir / "interview.json"
+    _write_canonical(canonical, job_id="job-1", source=source, text="evidence")
+    duplicate = tmp_path / "copy.json"
+    duplicate.write_bytes(canonical.read_bytes())
+    store = CountingStore()
+    service = _service(tmp_path, store)
+    service.rebuild()
+
+    with pytest.raises(TranscriptLibraryBuildError, match="Duplicate"):
+        service.refresh((duplicate,))
+
+    assert [item.document_id for item in service.documents()] == ["job-1"]
+
+
+def test_refresh_fails_closed_for_corrupt_tracked_canonical_and_keeps_old_index(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    canonical = _paths(tmp_path).output_dir / "interview.json"
+    _write_canonical(canonical, job_id="job-1", source=source, text="old evidence")
+    store = CountingStore()
+    service = _service(tmp_path, store)
+    service.rebuild()
+    canonical.write_text("not json and definitely a different size")
+
+    with pytest.raises(TranscriptLibraryBuildError, match="tracked canonical"):
+        service.refresh()
+
+    assert service.search(SearchQuery("old"))[0].document_id == "job-1"
+
+
+def test_verify_bypasses_metadata_fast_path_and_catches_same_signature_tamper(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    canonical = _paths(tmp_path).output_dir / "interview.json"
+    _write_canonical(canonical, job_id="job-1", source=source, text="alpha evidence")
+    store = CountingStore()
+    service = _service(tmp_path, store)
+    service.rebuild()
+    original_stat = canonical.stat()
+    original_bytes = canonical.read_bytes()
+    tampered = original_bytes.replace(b"alpha", b"omega")
+    assert len(tampered) == len(original_bytes)
+    canonical.write_bytes(tampered)
+    os.utime(
+        canonical,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+    store.reads.clear()
+
+    fast = service.refresh()
+    assert fast.unchanged_document_ids == ("job-1",)
+    assert store.reads == []
+    assert service.search(SearchQuery("alpha"))
+
+    verified = service.refresh(verify=True)
+    assert verified.updated_document_ids == ("job-1",)
+    assert verified.verified_all_tracked is True
+    assert service.search(SearchQuery("alpha")) == ()
+    assert service.search(SearchQuery("omega"))
+
+
+def test_semantic_state_is_preserved_for_stat_only_touch_but_invalidated_for_content(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    canonical = _paths(tmp_path).output_dir / "interview.json"
+    _write_canonical(canonical, job_id="job-1", source=source, text="alpha evidence")
+    store = CountingStore()
+    semantic = SemanticStub()
+    service = _service(tmp_path, store, semantic=semantic)
+    service.rebuild()
+
+    stat = canonical.stat()
+    os.utime(canonical, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+    touched = service.refresh()
+    assert touched.updated_document_ids == ("job-1",)
+    assert touched.semantic_invalidated is False
+    assert semantic.clear_calls == 0
+
+    _write_canonical(
+        canonical,
+        job_id="job-1",
+        source=source,
+        text="replacement evidence with new content",
+    )
+    changed = service.refresh()
+    assert changed.semantic_invalidated is True
+    assert semantic.clear_calls == 1
+
+
+def test_refresh_skips_untracked_invalid_json_but_tracked_invalid_json_is_strict(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "audio.wav"
+    source.write_bytes(b"audio")
+    canonical = _paths(tmp_path).output_dir / "interview.json"
+    _write_canonical(canonical, job_id="job-1", source=source, text="evidence")
+    unrelated = _paths(tmp_path).output_dir / "preferences.json"
+    unrelated.write_text('{"not": "a transcript"}')
+    store = CountingStore()
+    service = _service(tmp_path, store)
+
+    first = service.refresh()
+    assert first.added_document_ids == ("job-1",)
+    assert first.skipped_files == 1
+
+    canonical.write_text('{"broken": true}')
+    with pytest.raises(TranscriptLibraryBuildError, match="tracked canonical"):
+        service.refresh()

--- a/src/echoflow/tests/test_cli_refresh.py
+++ b/src/echoflow/tests/test_cli_refresh.py
@@ -68,7 +68,7 @@ def test_refresh_human_output_explains_delta_skip_and_semantic_invalidation() ->
     assert "1 updated" in result.output
     assert "1 removed" in result.output
     assert "1 unchanged" in result.output
-    assert "skipped 2" in result.output
+    assert "Skipped 2" in result.output
     assert "Semantic embeddings were invalidated" in result.output
     assert "re-hashed and validated" in result.output
 
@@ -108,7 +108,7 @@ def test_refresh_cli_reports_public_errors_and_masks_internal_details() -> None:
     internal.refresh.side_effect = RuntimeError("secret /private/library.duckdb")
     internal_result = runner.invoke(_app(internal), ["library", "refresh"])
 
-    assert public_result.exit_code == 3
+    assert public_result.exit_code == 2
     assert "tracked canonical transcript" in public_result.output
     assert internal_result.exit_code == 3
     assert "failed internally (RuntimeError)" in internal_result.output

--- a/src/echoflow/tests/test_cli_refresh.py
+++ b/src/echoflow/tests/test_cli_refresh.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import typer
+from typer.testing import CliRunner
+
+from echoflow.cli_library import register_library_commands
+from echoflow.library.errors import TranscriptLibraryBuildError
+from echoflow.library.service import LibraryRefreshReport
+
+
+def _app(service: Mock) -> typer.Typer:
+    app = typer.Typer()
+    container = Mock()
+    container.transcript_library.return_value = service
+    register_library_commands(app, lambda context: container)
+    return app
+
+
+def _report(*, semantic_invalidated: bool = False) -> LibraryRefreshReport:
+    return LibraryRefreshReport(
+        backend_id="duckdb-bm25-v1",
+        indexed_documents=4,
+        added_document_ids=("new",),
+        updated_document_ids=("changed",),
+        removed_document_ids=("gone",),
+        unchanged_document_ids=("same",),
+        skipped_files=2,
+        semantic_invalidated=semantic_invalidated,
+        verified_all_tracked=True,
+    )
+
+
+def test_refresh_cli_passes_paths_and_verify_and_emits_json() -> None:
+    service = Mock()
+    service.refresh.return_value = _report(semantic_invalidated=True)
+
+    result = CliRunner().invoke(
+        _app(service),
+        ["library", "refresh", "./imports", "--verify", "--json"],
+    )
+
+    assert result.exit_code == 0
+    service.refresh.assert_called_once()
+    (paths,) = service.refresh.call_args.args
+    assert paths == (Path("imports"),)
+    assert service.refresh.call_args.kwargs == {"verify": True}
+    payload = json.loads(result.stdout)
+    assert payload["changed"] is True
+    assert payload["added_document_ids"] == ["new"]
+    assert payload["updated_document_ids"] == ["changed"]
+    assert payload["removed_document_ids"] == ["gone"]
+    assert payload["unchanged_document_ids"] == ["same"]
+    assert payload["semantic_invalidated"] is True
+    assert payload["verified_all_tracked"] is True
+
+
+def test_refresh_human_output_explains_delta_skip_and_semantic_invalidation() -> None:
+    service = Mock()
+    service.refresh.return_value = _report(semantic_invalidated=True)
+
+    result = CliRunner().invoke(_app(service), ["library", "refresh", "--verify"])
+
+    assert result.exit_code == 0
+    assert "4 transcript(s)" in result.output
+    assert "1 added" in result.output
+    assert "1 updated" in result.output
+    assert "1 removed" in result.output
+    assert "1 unchanged" in result.output
+    assert "skipped 2" in result.output
+    assert "Semantic embeddings were invalidated" in result.output
+    assert "re-hashed and validated" in result.output
+
+
+def test_refresh_noop_human_output_does_not_claim_semantic_invalidation() -> None:
+    service = Mock()
+    service.refresh.return_value = LibraryRefreshReport(
+        backend_id="duckdb-bm25-v1",
+        indexed_documents=2,
+        added_document_ids=(),
+        updated_document_ids=(),
+        removed_document_ids=(),
+        unchanged_document_ids=("one", "two"),
+        skipped_files=0,
+        semantic_invalidated=False,
+        verified_all_tracked=False,
+    )
+
+    result = CliRunner().invoke(_app(service), ["library", "refresh"])
+
+    assert result.exit_code == 0
+    assert "2 unchanged" in result.output
+    assert "Semantic embeddings were invalidated" not in result.output
+    service.refresh.assert_called_once_with((), verify=False)
+
+
+def test_refresh_cli_reports_public_errors_and_masks_internal_details() -> None:
+    runner = CliRunner()
+
+    public = Mock()
+    public.refresh.side_effect = TranscriptLibraryBuildError(
+        "A tracked canonical transcript could not be refreshed safely"
+    )
+    public_result = runner.invoke(_app(public), ["library", "refresh"])
+
+    internal = Mock()
+    internal.refresh.side_effect = RuntimeError("secret /private/library.duckdb")
+    internal_result = runner.invoke(_app(internal), ["library", "refresh"])
+
+    assert public_result.exit_code == 3
+    assert "tracked canonical transcript" in public_result.output
+    assert internal_result.exit_code == 3
+    assert "failed internally (RuntimeError)" in internal_result.output
+    assert "/private/library.duckdb" not in internal_result.output

--- a/src/echoflow/tests/test_cli_refresh.py
+++ b/src/echoflow/tests/test_cli_refresh.py
@@ -70,7 +70,7 @@ def test_refresh_human_output_explains_delta_skip_and_semantic_invalidation() ->
     assert "1 unchanged" in result.output
     assert "Skipped 2" in result.output
     assert "Semantic embeddings were invalidated" in result.output
-    assert "re-hashed and validated" in result.output
+    assert "Re-hashed and validated" in result.output
 
 
 def test_refresh_noop_human_output_does_not_claim_semantic_invalidation() -> None:


### PR DESCRIPTION
## Summary

Make ordinary transcript-library maintenance incremental instead of re-reading and rewriting the whole canonical corpus.

`echoflow library refresh` reconciles added, changed, moved, removed, and unchanged canonical transcript generations against the rebuildable lexical index. Full `library rebuild` remains the explicit repair/recovery lever.

## Refresh contract

- canonical generation identity remains `(document_id, canonical_sha256)`
- normal refresh stores and uses derived canonical `size_bytes` + `modified_ns` only as a cheap change detector
- unchanged tracked transcripts are not opened or rewritten
- `--verify` bypasses the metadata fast path and re-hashes/schema-validates every tracked canonical transcript
- old indexes migrate the derived signature columns in place; their first refresh reads once, then becomes eligible for the fast path
- tracked external imports remain discoverable without repeating the original path while their indexed path exists
- a newly discovered same-ID canonical can move a transcript when the old path is gone
- duplicate same-ID canonical paths that both still exist fail closed
- invalid/corrupt tracked canonical JSON fails closed before lexical mutation
- a tracked canonical that changes availability during reconciliation causes refresh to refuse and ask for a retry

Size/mtime never replaces cryptographic evidence identity. Precise evidence navigation continues to verify canonical SHA-256 before presenting exact evidence.

## Atomic lexical delta

Adds `TranscriptIndex.apply_delta(upserts=..., removals=...)` and a DuckDB implementation that applies the complete lexical reconciliation in one transaction. New/changed generations are upserted; missing generations are removed; unchanged generations are skipped.

## Semantic behavior

The current semantic index remains whole-corpus/fingerprint bound. If refresh changes semantic-relevant corpus identity, EchoFlow invalidates the semantic projection rather than retaining stale vectors. Timestamp-only metadata changes with identical canonical bytes/path/source metadata do not discard valid vectors.

Incremental vector mutation is intentionally outside this tranche.

## Performance contract

The regression suite makes the I/O property deterministic rather than timing-dependent:

```text
100 unchanged tracked transcripts -> 0 canonical reads
1 changed transcript               -> 1 canonical read
```

## CLI

```bash
echoflow library refresh
echoflow library refresh /path/to/imported/transcripts
echoflow library refresh --verify
echoflow library refresh --json
```

Human and JSON output report added/updated/removed/unchanged IDs/counts, skipped untracked JSON, whether semantic state was invalidated, and whether every tracked canonical was cryptographically verified.

## Tests

Coverage includes zero-read no-op refresh, a 100-document unchanged corpus and one-document change, changed-generation replacement, add/remove reconciliation, durable explicit imports, moved canonicals, duplicate identity refusal, corrupt tracked evidence, same-signature tamper plus `--verify`, semantic invalidation boundaries, atomic DuckDB rollback, projection mutation during read, and CLI rendering/error masking.

The first CI laps found only Ruff formatting drift and three incorrect case/exit-code expectations in the new CLI tests. Those tests were aligned to the existing public CLI contract; production refresh semantics were not weakened to satisfy CI.

## Documentation / roadmap

Adds `docs/architecture/incremental-library-refresh.md` and advances `ROADMAP.md` so incremental refresh is foundation.

The next product sequence is now:

1. thin GUI over existing application services
2. desktop packaging, first-run setup, updates, and safe uninstall
3. backup/restore, research portability, and selected-result export
4. packaged semantic dependency/model-custody qualification
5. representative-device release qualification

The packaging milestone explicitly covers Windows installer/application delivery, signed/notarized macOS application delivery, a deliberate Linux desktop package, Python/FFmpeg/native dependency custody, explicit model acquisition, and the invariant that uninstalling EchoFlow must not silently delete user-owned evidence or research state.

## Quality

Current head: `9a5c90cb0dca812390fa4b4900d40ebd083c7b0e`

Quality #626 completed successfully on this exact head:

- locked dependency audit: passed
- Ruff lint/security rules: passed
- Ruff formatting: passed
- strict mypy: passed
- Vulture dead-code check: passed
- Radon complexity reporting: passed
- pytest branch-coverage gate: passed without lowering the repository-wide 90% threshold
- distribution build: passed
- clean-wheel install verification: passed
- macOS platform smoke: passed, including all 1,060 tests, package build, and clean-wheel verification
- Windows platform smoke: passed, including all 1,060 tests, package build, and clean-wheel verification

The PR remains draft and mergeable for review; it has not been merged automatically.