### PR TITLE
feat(library): add durable library locations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,10 +23,12 @@ flowchart LR
     G --> H[Saved searches and derived navigation]
     H --> I[Safe deletion and retention]
     I --> J[Incremental refresh]
-    J --> K[Thin graphical shell]
-    K --> L[Desktop packaging and first-run]
-    L --> M[Backup restore and portability]
-    M --> N[Release qualification]
+    J --> K[Durable library locations]
+    K --> L[Tauri React desktop foundation]
+    L --> M[Import search evidence research UI]
+    M --> N[Desktop packaging and first-run]
+    N --> O[Backup restore and portability]
+    O --> P[Release qualification]
 ```
 
 # Current foundation
@@ -111,6 +113,7 @@ The custody hierarchy is:
 |---|---|---|
 | Authoritative evidence | original recording, canonical JSON | never treat as cache; destructive deletion must be explicit |
 | Authoritative human knowledge | speaker labels, notes, tags, collections, saved searches | must survive index rebuilds and unrelated deletion |
+| Durable app preference | remembered library/recording locations and processing policy | private user-state; forgetting permission never deletes user files |
 | Rebuildable projection | lexical/semantic/research DuckDB, derived exports | may be regenerated |
 | Private execution state | checkpoints, normalization/enhancement intermediates | lifecycle-managed; not source truth |
 | Lightweight lifecycle metadata | job manifests/discovery pointers | retained when heavyweight execution state is cleaned |
@@ -219,6 +222,36 @@ need to rebuild a database merely because one new transcript appeared.
 See `docs/architecture/incremental-library-refresh.md` for the exact reconciliation and
 verification contract.
 
+## Durable library locations and recording discovery
+
+This is the current backend foundation immediately before the desktop client.
+
+`LibraryLocationService` owns private, schema-versioned remembered directory preferences
+without making filesystem paths part of the search index or research database. A remembered
+location has one explicit purpose:
+
+- `transcript-library` means that the directory may be revisited for canonical transcript
+  reconciliation through the existing incremental refresh service; or
+- `recording-source` means that the directory may be revisited for cheap local recording
+  candidate discovery.
+
+The default recording policy is `manual`. An `automatic` policy is an explicit opt-in
+permission marker for a future application lifecycle adapter; setting it does not itself
+run ASR. Discovery never hashes, FFprobes, copies, transcribes, or modifies a recording.
+Actual processing must continue through the existing transcription planner, resource
+admission, model custody, checkpoint, and execution contracts.
+
+Temporarily unavailable roots, such as unplugged external drives, are reported as offline
+without deleting their durable permission record. Forgetting a location only removes the
+permission record and never deletes user files. EchoFlow private state/cache/model paths
+cannot be registered, and the configured output directory remains an implicit transcript
+root rather than a redundant remembered location.
+
+This tranche intentionally does not add a background daemon or filesystem watcher. Desktop
+startup, explicit Refresh, and post-transcription lifecycle points are sufficient triggers
+until real usage justifies always-on observation. See
+`docs/architecture/library-locations.md`.
+
 ## Test/quality debt repaired after saved-search merge
 
 The saved-search/navigation PR was merged while its Linux branch-coverage gate was still
@@ -233,25 +266,74 @@ stale-plan, provenance, partial-state, and retention tests.
 
 # Near-term product sequence
 
-## 1. First thin GUI
+## 1. Tauri + React desktop foundation and import experience
 
-The GUI has earned its place because the backend is ahead of the human interface.
+The frontend should be a thin local desktop adapter over the application services already
+built. The target stack is Tauri for the small native host, React + TypeScript + Vite for
+the presentation layer, and Playwright plus accessibility automation from the first UI PR.
 
-The first graphical slice should browse/import/open transcripts, launch transcription and
-show job progress, use unified discovery, show speaker/time evidence, create/edit/delete
-notes, apply tags/collections with derived suggestions, browse saved searches, jump to
-source-relative media coordinates, and expose the same typed deletion/retention plans.
+The first desktop slice should establish:
 
-Library refresh should occur through the existing service after successful transcription or
-import and at appropriate application lifecycle points. An explicit Refresh action remains
-useful. Do not introduce an always-on filesystem watcher until real product evidence shows
-it is needed.
+- the native Tauri application shell on Windows, macOS, and Linux;
+- a React/TypeScript design system with semantic theme tokens;
+- Archive and Midnight baseline skins, with richer optional skins remaining cheap to add;
+- keyboard-first navigation, visible focus, reduced-motion support, accessible names and
+  landmarks, and automated Playwright/axe coverage;
+- a narrow versioned IPC boundary where Rust owns desktop/process capability and Python
+  continues to own EchoFlow business logic; and
+- no direct frontend access to DuckDB, SQLite, arbitrary shell execution, or arbitrary
+  filesystem mutation.
 
-The GUI must consume existing application services. It must not invent a second search
-engine, note schema, speaker policy, custody model, refresh implementation, or evidence
-location rule.
+Import is the first human workflow. The GUI should support both one-time and remembered
+choices:
 
-## 2. Desktop packaging, first-run setup, updates, and uninstall
+```text
+Choose files…
+Choose folder…
+
+Use this location:
+(•) Just this time
+( ) Remember this folder
+
+For remembered recording sources only:
+[ ] Automatically process new recordings
+```
+
+The automatic option is advanced opt-in and defaults off. The UI consumes
+`LibraryLocationService`; it does not persist paths or invent scan policy in TypeScript.
+
+For raw recordings, import flows into the existing media probe/planner and may show file,
+container, duration, audio-stream choices, resource estimates, and model requirements
+before execution. For existing canonical transcripts, import/remembered transcript roots
+flow into incremental library refresh. Neither path copies the user's original source merely
+because it was selected.
+
+No always-on watcher or background daemon is required for the first desktop release.
+Application startup, explicit Refresh, and successful transcription are sufficient bounded
+lifecycle triggers.
+
+## 2. Search, evidence navigation, media, and research workspace UI
+
+Once the desktop/import chassis is stable, expose the existing research engine rather than
+building a second frontend search architecture.
+
+The graphical slice should provide:
+
+- Susan-style global search with no database knowledge required;
+- advanced typed search over phrase/ANY/ALL, speaker, language, transcript, tag,
+  collection, note, retrieval-mode, and sort constraints;
+- grouped unified discovery across transcripts, notes, tags, and collections;
+- verified result navigation back to canonical segment/word coordinates;
+- click-to-seek source-relative audio/video playback with justified word highlighting;
+- notes, tags, collections, speaker display labels, and saved searches;
+- explicit refresh/verification state; and
+- the same typed deletion/retention plans already enforced by the backend.
+
+An expert SQL/data-lab surface, if added later, should be a hardened read-only projection
+feature. Raw SQL is not the ordinary advanced-search contract and must never expose mutable
+research authority directly.
+
+## 3. Desktop packaging, first-run setup, updates, and uninstall
 
 A Python wheel proves EchoFlow is distributable to Python. It does not make EchoFlow a
 consumer desktop application.
@@ -262,9 +344,9 @@ Produce an intentional desktop delivery path for supported platforms:
 - a signed/notarized macOS application bundle and normal installer/disk-image flow; and
 - a deliberate Linux desktop package rather than requiring a repository clone.
 
-The package must account for the Python runtime, FFmpeg/FFprobe, native transcription
-runtime dependencies, application assets, and optional capabilities without requiring the
-user to assemble a developer environment.
+The package must account for the Tauri host, managed Python runtime/sidecar, FFmpeg/FFprobe,
+native transcription runtime dependencies, application assets, and optional capabilities
+without requiring the user to assemble a developer environment.
 
 First run should initialize private/public paths, run health checks, inspect hardware, and
 recommend an explicit model download with honest disk/resource requirements. Do not hide
@@ -272,11 +354,11 @@ network-bearing model acquisition inside transcription or search.
 
 Application update and uninstall semantics are custody-sensitive. Updating EchoFlow must
 preserve durable schemas/state or fail safely. Uninstalling the program must not silently
-delete canonical transcripts, research SQLite state, speaker labels, saved searches, or
-other user-owned evidence/knowledge. Program removal and user-data destruction are separate
-operations.
+delete canonical transcripts, research SQLite state, speaker labels, saved searches,
+remembered-location preferences, or other user-owned evidence/knowledge. Program removal
+and user-data destruction are separate operations.
 
-## 3. Backup, restore, research portability, and selected-result export
+## 4. Backup, restore, research portability, and selected-result export
 
 Portability is part of the ownership thesis. A user should be able to back up or move the
 irreplaceable EchoFlow workspace without treating disposable indexes as authority.
@@ -286,19 +368,24 @@ including research SQLite data, saved searches, and speaker display labels. Rebu
 DuckDB lexical/semantic/research projections should be regenerated rather than becoming
 backup authority.
 
+Remembered absolute library locations are machine-local application preferences and should
+not be blindly replayed on another computer during workspace restore. Portability should
+export them as reviewable metadata, then require explicit path reconciliation/re-approval
+on the destination machine.
+
 For research export, target CSV, JSON/JSONL, and Markdown first, then a whole-workspace or
 user-state export manifest when the durable schema is ready. Exports should retain document
 ID, source/canonical SHA-256, segment IDs, and numeric evidence coordinates where
 applicable.
 
-## 4. Qualify semantic dependency and managed embedding custody
+## 5. Qualify semantic dependency and managed embedding custody
 
 Before semantic search is advertised as a normal packaged capability, qualify one locked
 optional semantic dependency set with managed immutable E5 snapshot acquisition, private
 cache placement, disk/resource admission, no silent search-time download, offline
 execution after installation, and packaged-platform qualification.
 
-## 5. Representative-device release qualification
+## 6. Representative-device release qualification
 
 Exercise real corpora and the packaged application on 8 GB Windows, 16 GB commodity
 hardware, Apple Silicon, a discrete-GPU laptop, and larger 32/64 GB workstations. Measure
@@ -308,8 +395,9 @@ responsiveness.
 
 Release qualification should also cover Unicode/space-heavy paths, external drives,
 permission failures, low-disk conditions, interrupted model downloads, crash/resume,
-upgrade migrations, uninstall/reinstall, offline operation, accessibility/keyboard use, and
-corruption/recovery language.
+upgrade migrations, uninstall/reinstall, offline operation, accessibility/keyboard use,
+corruption/recovery language, remembered-location disappearance/reappearance, and
+one-time-vs-persistent import behavior.
 
 The pre-1.0 milestone is not “the tests pass from a checkout.” It is “a normal person can
 install EchoFlow, understand first run, process sensitive recordings, recover from common

--- a/docs/architecture/library-locations.md
+++ b/docs/architecture/library-locations.md
@@ -1,0 +1,120 @@
+# Durable library locations and recording discovery
+
+EchoFlow lets a user work in two modes without confusing them:
+
+1. **one-time selection** — choose particular recordings or canonical transcripts and do not remember the containing directory; and
+2. **remembered locations** — explicitly grant EchoFlow permission to revisit a directory at later application lifecycle points.
+
+Remembering a location is durable application preference state. It is not transcript evidence, research annotation state, or permission to copy/delete the user's source files.
+
+## Custody and storage
+
+Remembered locations are stored privately at:
+
+```text
+<STATE_DIR>/library/user-state/library-locations.json
+```
+
+The file is schema-versioned, validated fail-closed, written atomically through the shared file-manager boundary, and protected as private application state.
+
+A location stores an absolute normalized path, a stable location ID, its purpose, enabled state, and recording-processing policy. EchoFlow does not copy the selected directory into private state.
+
+The configured EchoFlow output directory is already an implicit transcript discovery root and therefore cannot be redundantly registered. Private state/cache/model directories cannot be registered as library locations.
+
+## Location purposes
+
+### Transcript library
+
+A `transcript-library` location means:
+
+> Revisit this directory when reconciling canonical transcript evidence.
+
+At a refresh lifecycle point, enabled and currently available transcript roots are passed to the existing incremental `TranscriptLibraryService.refresh()` path. Missing roots, such as an unplugged external drive, are reported as unavailable but are not silently forgotten.
+
+The existing custody rules remain unchanged:
+
+- canonical JSON remains evidence authority;
+- normal refresh uses metadata only as a cheap change detector;
+- changed/new canonical bytes are validated and hashed before lexical mutation;
+- semantic state is invalidated when corpus identity changes; and
+- full rebuild remains a repair/recovery operation.
+
+### Recording source
+
+A `recording-source` location means:
+
+> Revisit this directory to discover local recording candidates.
+
+Discovery is intentionally cheap. EchoFlow enumerates ordinary audio/video filename candidates, records their path/size/location provenance, and does **not** open, hash, FFprobe, transcribe, copy, or modify them merely because they were discovered.
+
+Media validation remains the responsibility of the existing transcription planner and FFprobe boundary when the user (or an explicitly authorized application workflow) actually plans processing.
+
+Hidden files and unrelated extensions are ignored during cheap discovery. The first backend contract scans the selected directory itself rather than recursively walking arbitrary directory trees; a user may remember multiple roots. Recursive/watch behavior should be added only with explicit traversal, symlink, performance, and custody policy.
+
+## Discovery is not processing
+
+The central invariant is:
+
+```text
+remember location
+      ↓
+discover candidate
+      ↓
+NO ASR SIDE EFFECT
+```
+
+Recording sources have a durable processing policy:
+
+- `manual` — default; discovery may surface candidates, but processing requires explicit user selection;
+- `automatic` — explicit opt-in metadata indicating that a higher-level application adapter may submit newly discovered recordings for processing.
+
+`automatic` does not itself start ASR. `LibraryLocationService.discover_recordings()` never calls the transcription planner or executor.
+
+A future desktop lifecycle adapter that honors automatic processing must still:
+
+1. define a clear trigger, such as application startup/refresh while EchoFlow is running;
+2. avoid processing partially copied or unstable files;
+3. use the normal transcription planner and resource admission path;
+4. require required models to already be present unless a separate explicit network-bearing acquisition was authorized;
+5. preserve resume/checkpoint semantics;
+6. avoid duplicate jobs for the same source generation; and
+7. expose queued/running work visibly to the user.
+
+There is no background daemon in this tranche.
+
+## One-time imports remain first-class
+
+Remembered locations do not replace explicit paths.
+
+A desktop UI should continue to support:
+
+```text
+Choose files…
+Choose folder…
+```
+
+without forcing persistent registration. A user can therefore process ten recordings from Downloads and never grant EchoFlow ongoing discovery permission for Downloads.
+
+Similarly, `library refresh PATH...` remains a valid one-time/external canonical discovery operation. Once an individual external canonical transcript enters the lexical index, its tracked canonical path remains part of refresh reconciliation while it exists, independent of whether its containing directory was remembered.
+
+## Desktop presentation contract
+
+The GUI should present the backend concepts in user language, for example:
+
+```text
+Use this folder
+
+(•) Just this time
+( ) Remember this folder
+
+If remembered as a recording source:
+[ ] Automatically process new recordings
+```
+
+The automatic checkbox must default off. Transcript-library locations never have a processing policy other than `manual` because transcript discovery never runs ASR.
+
+Temporarily unavailable roots should appear as unavailable/offline, not as deleted configuration. Removing a remembered location must only forget the permission record; it must never delete the directory or its contents.
+
+## Why this exists before the GUI
+
+The desktop client should consume one stable backend contract rather than inventing persistence rules in TypeScript. By landing location identity, persistence, discovery, and policy boundaries first, Tauri/React can remain a thin adapter over application-owned behavior.

--- a/src/echoflow/app/app_container.py
+++ b/src/echoflow/app/app_container.py
@@ -21,6 +21,7 @@ from echoflow.library.duckdb_index import DuckDbTranscriptIndex
 from echoflow.library.duckdb_research_projection import DuckDbResearchProjection
 from echoflow.library.duckdb_semantic import DuckDbSemanticIndex
 from echoflow.library.evidence import EvidenceLocator
+from echoflow.library.locations import JsonLibraryLocationStore, LibraryLocationService
 from echoflow.library.research import ResearchNavigationService
 from echoflow.library.research_projector import ResearchStateProjector
 from echoflow.library.research_workspace import ResearchWorkspaceService
@@ -155,6 +156,15 @@ def _create_speaker_label_store(
     )
 
 
+def _create_library_location_store(
+    config: AppConfig, file_manager: FileManagerFacade
+) -> JsonLibraryLocationStore:
+    return JsonLibraryLocationStore(
+        config.STATE_DIR / "library" / "user-state" / "library-locations.json",
+        file_manager,
+    )
+
+
 def _create_research_state_store(
     config: AppConfig, file_manager: FileManagerFacade
 ) -> SqliteResearchStateStore:
@@ -276,6 +286,11 @@ class AppContainer(containers.DeclarativeContainer):
         config=config,
         file_manager=file_manager,
     )
+    library_location_store = providers.Singleton(
+        _create_library_location_store,
+        config=config,
+        file_manager=file_manager,
+    )
     speaker_labels = providers.Singleton(
         SpeakerLabelService,
         index=transcript_index,
@@ -312,6 +327,13 @@ class AppContainer(containers.DeclarativeContainer):
         file_manager=file_manager,
         semantic_index=semantic_index,
         embedding_provider_factory=embedding_provider_factory,
+    )
+    library_locations = providers.Singleton(
+        LibraryLocationService,
+        store=library_location_store,
+        transcript_library=transcript_library,
+        file_manager=file_manager,
+        paths=workspace_paths,
     )
     library_custody = providers.Singleton(
         LibraryCustodyService,

--- a/src/echoflow/library/errors.py
+++ b/src/echoflow/library/errors.py
@@ -47,3 +47,9 @@ class CustodyOperationError(TranscriptLibraryError):
     """A deletion or retention request cannot be executed safely as planned."""
 
     exit_code = 2
+
+
+class LibraryLocationError(TranscriptLibraryError):
+    """Durable library-location state or discovery policy is invalid or unavailable."""
+
+    exit_code = 2

--- a/src/echoflow/library/locations.py
+++ b/src/echoflow/library/locations.py
@@ -221,8 +221,7 @@ class JsonLibraryLocationStore:
                 {
                     "schema_version": _STATE_SCHEMA_VERSION,
                     "locations": [
-                        item.to_dict()
-                        for item in sorted(locations, key=self._sort_key)
+                        item.to_dict() for item in sorted(locations, key=self._sort_key)
                     ],
                 },
                 indent=2,
@@ -340,7 +339,10 @@ class LibraryLocationService:
         roots: list[Path] = []
         unavailable: list[str] = []
         for location in self.store.locations():
-            if not location.enabled or location.kind is not LibraryLocationKind.TRANSCRIPT_LIBRARY:
+            if (
+                not location.enabled
+                or location.kind is not LibraryLocationKind.TRANSCRIPT_LIBRARY
+            ):
                 continue
             root = self._resolved(location.path)
             if not root.is_dir():
@@ -357,7 +359,10 @@ class LibraryLocationService:
         discovered: dict[Path, tuple[int, set[str], bool]] = {}
         unavailable: list[str] = []
         for location in self.store.locations():
-            if not location.enabled or location.kind is not LibraryLocationKind.RECORDING_SOURCE:
+            if (
+                not location.enabled
+                or location.kind is not LibraryLocationKind.RECORDING_SOURCE
+            ):
                 continue
             root = self._resolved(location.path)
             if not root.is_dir():
@@ -365,7 +370,10 @@ class LibraryLocationService:
                 continue
             for candidate in self.file_manager.list_files(root):
                 resolved = candidate.resolve(strict=False)
-                if resolved.name.startswith(".") or resolved.suffix.lower() not in _RECORDING_EXTENSIONS:
+                if (
+                    resolved.name.startswith(".")
+                    or resolved.suffix.lower() not in _RECORDING_EXTENSIONS
+                ):
                     continue
                 metadata = self.file_manager.get_file_metadata(resolved)
                 size = int(metadata["size"])
@@ -417,7 +425,9 @@ class LibraryLocationService:
             updated_at=self._now(),
         )
         self.store.replace_all(
-            tuple(updated if item.location_id == location_id else item for item in current)
+            tuple(
+                updated if item.location_id == location_id else item for item in current
+            )
         )
         return updated
 

--- a/src/echoflow/library/locations.py
+++ b/src/echoflow/library/locations.py
@@ -1,0 +1,464 @@
+"""Durable user-selected library roots and recording discovery policy.
+
+Location state is application-managed private state. Remembering a directory grants
+EchoFlow permission to discover files there at explicit lifecycle points; it never grants
+implicit permission to run ASR. Automatic processing is a durable opt-in policy consumed
+by a higher-level application adapter, not an action performed by this service.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.errors import LibraryLocationError
+from echoflow.library.service import LibraryRefreshReport, TranscriptLibraryService
+from echoflow.workspace.models import WorkspacePaths
+
+_STATE_SCHEMA_VERSION = 1
+_MAX_LOCATIONS = 1_000
+_MAX_DISCOVERED_RECORDINGS = 10_000
+_RECORDING_EXTENSIONS = frozenset(
+    {
+        ".aac",
+        ".aiff",
+        ".avi",
+        ".flac",
+        ".m4a",
+        ".m4v",
+        ".mkv",
+        ".mov",
+        ".mp3",
+        ".mp4",
+        ".mpeg",
+        ".mpg",
+        ".ogg",
+        ".opus",
+        ".wav",
+        ".webm",
+        ".wma",
+    }
+)
+
+
+class LibraryLocationKind(StrEnum):
+    """Purpose granted to one remembered local directory."""
+
+    TRANSCRIPT_LIBRARY = "transcript-library"
+    RECORDING_SOURCE = "recording-source"
+
+
+class RecordingProcessingPolicy(StrEnum):
+    """What a higher-level adapter may do after discovering a recording."""
+
+    MANUAL = "manual"
+    AUTOMATIC = "automatic"
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryLocation:
+    """One durable directory permission chosen by the user."""
+
+    location_id: str
+    path: str
+    kind: LibraryLocationKind
+    enabled: bool
+    processing_policy: RecordingProcessingPolicy
+    created_at: str
+    updated_at: str
+
+    def __post_init__(self) -> None:
+        if not self.location_id.strip():
+            raise ValueError("location_id cannot be empty")
+        if not self.path.strip() or "\x00" in self.path:
+            raise ValueError("location path cannot be empty or contain NUL")
+        if not Path(self.path).is_absolute():
+            raise ValueError("location path must be absolute")
+        if (
+            self.kind is LibraryLocationKind.TRANSCRIPT_LIBRARY
+            and self.processing_policy is not RecordingProcessingPolicy.MANUAL
+        ):
+            raise ValueError("transcript library locations cannot request processing")
+        if not self.created_at.strip() or not self.updated_at.strip():
+            raise ValueError("location timestamps cannot be empty")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "location_id": self.location_id,
+            "path": self.path,
+            "kind": self.kind.value,
+            "enabled": self.enabled,
+            "processing_policy": self.processing_policy.value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveredRecording:
+    """Cheap recording candidate discovery without opening or hashing media bytes."""
+
+    path: str
+    size_bytes: int
+    location_ids: tuple[str, ...]
+    automatic_processing_requested: bool
+
+    def __post_init__(self) -> None:
+        if not self.path.strip() or not Path(self.path).is_absolute():
+            raise ValueError("discovered recording path must be absolute")
+        if self.size_bytes < 1:
+            raise ValueError("discovered recording size must be positive")
+        if not self.location_ids or any(not item.strip() for item in self.location_ids):
+            raise ValueError("discovered recording requires location provenance")
+
+
+@dataclass(frozen=True, slots=True)
+class RecordingDiscoveryReport:
+    recordings: tuple[DiscoveredRecording, ...]
+    unavailable_location_ids: tuple[str, ...]
+
+    @property
+    def automatic_candidates(self) -> tuple[DiscoveredRecording, ...]:
+        return tuple(
+            item for item in self.recordings if item.automatic_processing_requested
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedTranscriptRefreshReport:
+    refresh: LibraryRefreshReport
+    unavailable_location_ids: tuple[str, ...]
+
+
+@runtime_checkable
+class LibraryLocationStore(Protocol):
+    def locations(self) -> tuple[LibraryLocation, ...]: ...
+
+    def replace_all(self, locations: tuple[LibraryLocation, ...]) -> None: ...
+
+
+class _StoredLocation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    location_id: str
+    path: str
+    kind: LibraryLocationKind
+    enabled: bool
+    processing_policy: RecordingProcessingPolicy
+    created_at: str
+    updated_at: str
+
+
+class _StoredState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int
+    locations: list[_StoredLocation]
+
+
+class JsonLibraryLocationStore:
+    """Private atomic JSON authority for application-managed location preferences."""
+
+    def __init__(self, path: Path, file_manager: FileManagerFacade) -> None:
+        self.path = path.expanduser().resolve(strict=False)
+        self.file_manager = file_manager
+
+    def locations(self) -> tuple[LibraryLocation, ...]:
+        if not self.file_manager.file_exists(self.path):
+            return ()
+        try:
+            state = _StoredState.model_validate(
+                json.loads(self.file_manager.read_file(self.path))
+            )
+            if state.schema_version != _STATE_SCHEMA_VERSION:
+                raise LibraryLocationError(
+                    "Library location state was written by an unsupported EchoFlow schema"
+                )
+            locations = tuple(
+                LibraryLocation(
+                    location_id=item.location_id,
+                    path=item.path,
+                    kind=item.kind,
+                    enabled=item.enabled,
+                    processing_policy=item.processing_policy,
+                    created_at=item.created_at,
+                    updated_at=item.updated_at,
+                )
+                for item in state.locations
+            )
+            self._validate_unique(locations)
+            return tuple(sorted(locations, key=self._sort_key))
+        except LibraryLocationError:
+            raise
+        except (
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValidationError,
+            ValueError,
+        ) as exc:
+            raise LibraryLocationError(
+                "Library location state could not be validated safely",
+                cause=exc,
+            ) from exc
+
+    def replace_all(self, locations: tuple[LibraryLocation, ...]) -> None:
+        if len(locations) > _MAX_LOCATIONS:
+            raise LibraryLocationError(
+                f"EchoFlow cannot remember more than {_MAX_LOCATIONS} library locations"
+            )
+        self._validate_unique(locations)
+        self.file_manager.ensure_directory_exists(self.path.parent, private=True)
+        payload = (
+            json.dumps(
+                {
+                    "schema_version": _STATE_SCHEMA_VERSION,
+                    "locations": [
+                        item.to_dict()
+                        for item in sorted(locations, key=self._sort_key)
+                    ],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode("utf-8")
+        self.file_manager.save_file(payload, self.path, private=True)
+
+    @staticmethod
+    def _validate_unique(locations: tuple[LibraryLocation, ...]) -> None:
+        ids = tuple(item.location_id for item in locations)
+        if len(ids) != len(set(ids)):
+            raise LibraryLocationError("Library location state contains duplicate IDs")
+        keys = tuple((item.kind, item.path.casefold()) for item in locations)
+        if len(keys) != len(set(keys)):
+            raise LibraryLocationError(
+                "Library location state contains duplicate directory permissions"
+            )
+
+    @staticmethod
+    def _sort_key(item: LibraryLocation) -> tuple[str, str, str]:
+        return (item.kind.value, item.path.casefold(), item.location_id)
+
+
+class LibraryLocationService:
+    """Manage remembered roots while keeping discovery separate from processing."""
+
+    def __init__(
+        self,
+        *,
+        store: LibraryLocationStore,
+        transcript_library: TranscriptLibraryService,
+        file_manager: FileManagerFacade,
+        paths: WorkspacePaths,
+    ) -> None:
+        self.store = store
+        self.transcript_library = transcript_library
+        self.file_manager = file_manager
+        self.paths = paths
+
+    def locations(self) -> tuple[LibraryLocation, ...]:
+        return self.store.locations()
+
+    def add(
+        self,
+        path: str | Path,
+        *,
+        kind: LibraryLocationKind,
+        processing_policy: RecordingProcessingPolicy = RecordingProcessingPolicy.MANUAL,
+        enabled: bool = True,
+        location_id: str | None = None,
+    ) -> LibraryLocation:
+        resolved = self._validate_new_root(path)
+        if (
+            kind is LibraryLocationKind.TRANSCRIPT_LIBRARY
+            and processing_policy is not RecordingProcessingPolicy.MANUAL
+        ):
+            raise LibraryLocationError(
+                "Automatic processing applies only to recording-source locations"
+            )
+        existing = self.store.locations()
+        if any(
+            item.kind is kind and self._resolved(item.path) == resolved
+            for item in existing
+        ):
+            raise LibraryLocationError(
+                "That directory is already remembered for this library purpose"
+            )
+        now = self._now()
+        location = LibraryLocation(
+            location_id=(location_id or f"location-{uuid4().hex}").strip(),
+            path=str(resolved),
+            kind=kind,
+            enabled=enabled,
+            processing_policy=processing_policy,
+            created_at=now,
+            updated_at=now,
+        )
+        self.store.replace_all(existing + (location,))
+        return location
+
+    def remove(self, location_id: str) -> None:
+        current = self.store.locations()
+        retained = tuple(item for item in current if item.location_id != location_id)
+        if len(retained) == len(current):
+            raise LibraryLocationError("Library location does not exist")
+        self.store.replace_all(retained)
+
+    def set_enabled(self, location_id: str, *, enabled: bool) -> LibraryLocation:
+        return self._replace_location(location_id, enabled=enabled)
+
+    def set_processing_policy(
+        self,
+        location_id: str,
+        *,
+        processing_policy: RecordingProcessingPolicy,
+    ) -> LibraryLocation:
+        current = self._require_location(location_id)
+        if (
+            current.kind is LibraryLocationKind.TRANSCRIPT_LIBRARY
+            and processing_policy is not RecordingProcessingPolicy.MANUAL
+        ):
+            raise LibraryLocationError(
+                "Transcript library locations cannot request automatic processing"
+            )
+        return self._replace_location(
+            location_id,
+            processing_policy=processing_policy,
+        )
+
+    def refresh_transcript_locations(
+        self, *, verify: bool = False
+    ) -> ManagedTranscriptRefreshReport:
+        roots: list[Path] = []
+        unavailable: list[str] = []
+        for location in self.store.locations():
+            if not location.enabled or location.kind is not LibraryLocationKind.TRANSCRIPT_LIBRARY:
+                continue
+            root = self._resolved(location.path)
+            if not root.is_dir():
+                unavailable.append(location.location_id)
+                continue
+            roots.append(root)
+        report = self.transcript_library.refresh(tuple(roots), verify=verify)
+        return ManagedTranscriptRefreshReport(
+            refresh=report,
+            unavailable_location_ids=tuple(sorted(unavailable)),
+        )
+
+    def discover_recordings(self) -> RecordingDiscoveryReport:
+        discovered: dict[Path, tuple[int, set[str], bool]] = {}
+        unavailable: list[str] = []
+        for location in self.store.locations():
+            if not location.enabled or location.kind is not LibraryLocationKind.RECORDING_SOURCE:
+                continue
+            root = self._resolved(location.path)
+            if not root.is_dir():
+                unavailable.append(location.location_id)
+                continue
+            for candidate in self.file_manager.list_files(root):
+                resolved = candidate.resolve(strict=False)
+                if resolved.name.startswith(".") or resolved.suffix.lower() not in _RECORDING_EXTENSIONS:
+                    continue
+                metadata = self.file_manager.get_file_metadata(resolved)
+                size = int(metadata["size"])
+                if size < 1:
+                    continue
+                previous = discovered.get(resolved)
+                ids = set() if previous is None else set(previous[1])
+                ids.add(location.location_id)
+                automatic = (
+                    location.processing_policy is RecordingProcessingPolicy.AUTOMATIC
+                    or (False if previous is None else previous[2])
+                )
+                discovered[resolved] = (size, ids, automatic)
+                if len(discovered) > _MAX_DISCOVERED_RECORDINGS:
+                    raise LibraryLocationError(
+                        "Recording discovery exceeded the safe candidate limit"
+                    )
+        recordings = tuple(
+            DiscoveredRecording(
+                path=str(path),
+                size_bytes=value[0],
+                location_ids=tuple(sorted(value[1])),
+                automatic_processing_requested=value[2],
+            )
+            for path, value in sorted(discovered.items(), key=lambda item: str(item[0]))
+        )
+        return RecordingDiscoveryReport(
+            recordings=recordings,
+            unavailable_location_ids=tuple(sorted(unavailable)),
+        )
+
+    def _replace_location(
+        self,
+        location_id: str,
+        *,
+        enabled: bool | None = None,
+        processing_policy: RecordingProcessingPolicy | None = None,
+    ) -> LibraryLocation:
+        current = self.store.locations()
+        target = self._require_location(location_id, current=current)
+        updated = replace(
+            target,
+            enabled=target.enabled if enabled is None else enabled,
+            processing_policy=(
+                target.processing_policy
+                if processing_policy is None
+                else processing_policy
+            ),
+            updated_at=self._now(),
+        )
+        self.store.replace_all(
+            tuple(updated if item.location_id == location_id else item for item in current)
+        )
+        return updated
+
+    def _require_location(
+        self,
+        location_id: str,
+        *,
+        current: tuple[LibraryLocation, ...] | None = None,
+    ) -> LibraryLocation:
+        if not location_id.strip():
+            raise ValueError("location_id cannot be empty")
+        for item in current if current is not None else self.store.locations():
+            if item.location_id == location_id:
+                return item
+        raise LibraryLocationError("Library location does not exist")
+
+    def _validate_new_root(self, path: str | Path) -> Path:
+        resolved = self._resolved(path)
+        if not resolved.is_dir():
+            raise LibraryLocationError(
+                "A remembered library location must be an existing local directory"
+            )
+        private_roots = (
+            self.paths.state_dir.resolve(strict=False),
+            self.paths.cache_dir.resolve(strict=False),
+            self.paths.model_dir.resolve(strict=False),
+        )
+        if any(resolved == root or root in resolved.parents for root in private_roots):
+            raise LibraryLocationError(
+                "Private EchoFlow application state cannot be registered as a library location"
+            )
+        if resolved == self.paths.output_dir.resolve(strict=False):
+            raise LibraryLocationError(
+                "EchoFlow's configured output directory is already discovered automatically"
+            )
+        return resolved
+
+    @staticmethod
+    def _resolved(path: str | Path) -> Path:
+        return Path(path).expanduser().resolve(strict=False)
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(UTC).isoformat()

--- a/src/echoflow/library/tests/test_locations.py
+++ b/src/echoflow/library/tests/test_locations.py
@@ -82,17 +82,16 @@ def test_add_location_persists_normalized_private_state(tmp_path):
     assert location.processing_policy is RecordingProcessingPolicy.MANUAL
     assert service.locations() == (location,)
     state_path = (
-        _paths(tmp_path).state_dir
-        / "library"
-        / "user-state"
-        / "library-locations.json"
+        _paths(tmp_path).state_dir / "library" / "user-state" / "library-locations.json"
     )
     state = json.loads(state_path.read_text(encoding="utf-8"))
     assert state["schema_version"] == 1
     assert state["locations"][0]["location_id"] == "location-transcripts"
 
 
-def test_same_directory_can_have_distinct_transcript_and_recording_permissions(tmp_path):
+def test_same_directory_can_have_distinct_transcript_and_recording_permissions(
+    tmp_path,
+):
     root = tmp_path / "research"
     root.mkdir()
     service, _ = _service(tmp_path)
@@ -305,9 +304,7 @@ def test_remove_forgets_permission_without_deleting_directory(tmp_path):
 
 def test_corrupt_location_state_fails_closed(tmp_path):
     paths = _paths(tmp_path)
-    state_path = (
-        paths.state_dir / "library" / "user-state" / "library-locations.json"
-    )
+    state_path = paths.state_dir / "library" / "user-state" / "library-locations.json"
     state_path.parent.mkdir(parents=True)
     state_path.write_text('{"schema_version": 1, "locations": [', encoding="utf-8")
     service, _ = _service(tmp_path)
@@ -318,9 +315,7 @@ def test_corrupt_location_state_fails_closed(tmp_path):
 
 def test_unsupported_location_schema_fails_closed(tmp_path):
     paths = _paths(tmp_path)
-    state_path = (
-        paths.state_dir / "library" / "user-state" / "library-locations.json"
-    )
+    state_path = paths.state_dir / "library" / "user-state" / "library-locations.json"
     state_path.parent.mkdir(parents=True)
     state_path.write_text(
         json.dumps({"schema_version": 999, "locations": []}),

--- a/src/echoflow/library/tests/test_locations.py
+++ b/src/echoflow/library/tests/test_locations.py
@@ -1,0 +1,332 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.library.errors import LibraryLocationError
+from echoflow.library.locations import (
+    JsonLibraryLocationStore,
+    LibraryLocationKind,
+    LibraryLocationService,
+    RecordingProcessingPolicy,
+)
+from echoflow.library.service import LibraryRefreshReport
+from echoflow.workspace.models import WorkspacePaths
+
+
+class _TranscriptLibrary:
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[Path, ...], bool]] = []
+
+    def refresh(
+        self,
+        additional_paths: tuple[Path, ...] = (),
+        *,
+        verify: bool = False,
+    ) -> LibraryRefreshReport:
+        self.calls.append((additional_paths, verify))
+        return LibraryRefreshReport(
+            backend_id="test-index",
+            indexed_documents=3,
+            added_document_ids=(),
+            updated_document_ids=(),
+            removed_document_ids=(),
+            unchanged_document_ids=("doc-a", "doc-b", "doc-c"),
+            skipped_files=0,
+            semantic_invalidated=False,
+            verified_all_tracked=verify,
+        )
+
+
+def _paths(tmp_path: Path) -> WorkspacePaths:
+    return WorkspacePaths(
+        state_dir=tmp_path / "private-state",
+        cache_dir=tmp_path / "private-cache",
+        model_dir=tmp_path / "private-cache" / "models",
+        output_dir=tmp_path / "public-output",
+    )
+
+
+def _service(tmp_path: Path) -> tuple[LibraryLocationService, _TranscriptLibrary]:
+    paths = _paths(tmp_path)
+    manager = LocalFileManager()
+    library = _TranscriptLibrary()
+    store = JsonLibraryLocationStore(
+        paths.state_dir / "library" / "user-state" / "library-locations.json",
+        manager,  # type: ignore[arg-type]
+    )
+    return (
+        LibraryLocationService(
+            store=store,
+            transcript_library=library,  # type: ignore[arg-type]
+            file_manager=manager,  # type: ignore[arg-type]
+            paths=paths,
+        ),
+        library,
+    )
+
+
+def test_add_location_persists_normalized_private_state(tmp_path):
+    root = tmp_path / "research transcripts"
+    root.mkdir()
+    service, _ = _service(tmp_path)
+
+    location = service.add(
+        root,
+        kind=LibraryLocationKind.TRANSCRIPT_LIBRARY,
+        location_id="location-transcripts",
+    )
+
+    assert location.path == str(root.resolve())
+    assert location.processing_policy is RecordingProcessingPolicy.MANUAL
+    assert service.locations() == (location,)
+    state_path = (
+        _paths(tmp_path).state_dir
+        / "library"
+        / "user-state"
+        / "library-locations.json"
+    )
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["schema_version"] == 1
+    assert state["locations"][0]["location_id"] == "location-transcripts"
+
+
+def test_same_directory_can_have_distinct_transcript_and_recording_permissions(tmp_path):
+    root = tmp_path / "research"
+    root.mkdir()
+    service, _ = _service(tmp_path)
+
+    transcript = service.add(
+        root,
+        kind=LibraryLocationKind.TRANSCRIPT_LIBRARY,
+        location_id="transcripts",
+    )
+    recording = service.add(
+        root,
+        kind=LibraryLocationKind.RECORDING_SOURCE,
+        location_id="recordings",
+    )
+
+    assert {item.location_id for item in service.locations()} == {
+        transcript.location_id,
+        recording.location_id,
+    }
+
+
+def test_duplicate_permission_is_refused(tmp_path):
+    root = tmp_path / "research"
+    root.mkdir()
+    service, _ = _service(tmp_path)
+    service.add(root, kind=LibraryLocationKind.RECORDING_SOURCE)
+
+    with pytest.raises(LibraryLocationError, match="already remembered"):
+        service.add(root, kind=LibraryLocationKind.RECORDING_SOURCE)
+
+
+def test_private_state_cache_and_models_cannot_be_registered(tmp_path):
+    service, _ = _service(tmp_path)
+    paths = _paths(tmp_path)
+    paths.state_dir.mkdir(parents=True)
+    paths.model_dir.mkdir(parents=True)
+
+    for forbidden in (
+        paths.state_dir,
+        paths.state_dir / "jobs",
+        paths.cache_dir,
+        paths.model_dir,
+    ):
+        forbidden.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(LibraryLocationError, match="Private EchoFlow"):
+            service.add(forbidden, kind=LibraryLocationKind.RECORDING_SOURCE)
+
+
+def test_configured_output_directory_is_already_implicit(tmp_path):
+    service, _ = _service(tmp_path)
+    output = _paths(tmp_path).output_dir
+    output.mkdir(parents=True)
+
+    with pytest.raises(LibraryLocationError, match="already discovered automatically"):
+        service.add(output, kind=LibraryLocationKind.TRANSCRIPT_LIBRARY)
+
+
+def test_automatic_processing_is_explicit_and_recording_only(tmp_path):
+    transcript_root = tmp_path / "transcripts"
+    recording_root = tmp_path / "recordings"
+    transcript_root.mkdir()
+    recording_root.mkdir()
+    service, _ = _service(tmp_path)
+
+    with pytest.raises(LibraryLocationError, match="only to recording-source"):
+        service.add(
+            transcript_root,
+            kind=LibraryLocationKind.TRANSCRIPT_LIBRARY,
+            processing_policy=RecordingProcessingPolicy.AUTOMATIC,
+        )
+
+    recording = service.add(
+        recording_root,
+        kind=LibraryLocationKind.RECORDING_SOURCE,
+        processing_policy=RecordingProcessingPolicy.AUTOMATIC,
+        location_id="auto-recordings",
+    )
+    assert recording.processing_policy is RecordingProcessingPolicy.AUTOMATIC
+
+
+def test_policy_can_be_changed_without_processing_anything(tmp_path):
+    root = tmp_path / "recordings"
+    root.mkdir()
+    (root / "interview.wav").write_bytes(b"not-real-media")
+    service, _ = _service(tmp_path)
+    location = service.add(
+        root,
+        kind=LibraryLocationKind.RECORDING_SOURCE,
+        location_id="source",
+    )
+
+    updated = service.set_processing_policy(
+        location.location_id,
+        processing_policy=RecordingProcessingPolicy.AUTOMATIC,
+    )
+
+    assert updated.processing_policy is RecordingProcessingPolicy.AUTOMATIC
+    assert (root / "interview.wav").read_bytes() == b"not-real-media"
+
+
+def test_recording_discovery_is_cheap_candidate_enumeration(tmp_path):
+    root = tmp_path / "recordings"
+    root.mkdir()
+    (root / "Interview.MP4").write_bytes(b"video")
+    (root / "audio.wav").write_bytes(b"audio")
+    (root / "notes.txt").write_text("not media", encoding="utf-8")
+    (root / ".hidden.mp3").write_bytes(b"hidden")
+    service, _ = _service(tmp_path)
+    service.add(
+        root,
+        kind=LibraryLocationKind.RECORDING_SOURCE,
+        processing_policy=RecordingProcessingPolicy.AUTOMATIC,
+        location_id="source",
+    )
+
+    report = service.discover_recordings()
+
+    assert tuple(Path(item.path).name for item in report.recordings) == (
+        "Interview.MP4",
+        "audio.wav",
+    )
+    assert all(item.location_ids == ("source",) for item in report.recordings)
+    assert len(report.automatic_candidates) == 2
+    assert report.unavailable_location_ids == ()
+
+
+def test_disabled_recording_location_is_not_discovered(tmp_path):
+    root = tmp_path / "recordings"
+    root.mkdir()
+    (root / "interview.mp3").write_bytes(b"audio")
+    service, _ = _service(tmp_path)
+    location = service.add(
+        root,
+        kind=LibraryLocationKind.RECORDING_SOURCE,
+        location_id="source",
+    )
+    service.set_enabled(location.location_id, enabled=False)
+
+    assert service.discover_recordings().recordings == ()
+
+
+def test_missing_removable_recording_root_is_reported_not_deleted(tmp_path):
+    root = tmp_path / "removable"
+    root.mkdir()
+    service, _ = _service(tmp_path)
+    service.add(
+        root,
+        kind=LibraryLocationKind.RECORDING_SOURCE,
+        location_id="usb",
+    )
+    root.rmdir()
+
+    report = service.discover_recordings()
+
+    assert report.recordings == ()
+    assert report.unavailable_location_ids == ("usb",)
+    assert service.locations()[0].location_id == "usb"
+
+
+def test_transcript_refresh_uses_available_enabled_roots_and_reports_missing(tmp_path):
+    available = tmp_path / "available"
+    missing = tmp_path / "missing"
+    disabled = tmp_path / "disabled"
+    available.mkdir()
+    missing.mkdir()
+    disabled.mkdir()
+    service, library = _service(tmp_path)
+    service.add(
+        available,
+        kind=LibraryLocationKind.TRANSCRIPT_LIBRARY,
+        location_id="available",
+    )
+    service.add(
+        missing,
+        kind=LibraryLocationKind.TRANSCRIPT_LIBRARY,
+        location_id="missing",
+    )
+    disabled_location = service.add(
+        disabled,
+        kind=LibraryLocationKind.TRANSCRIPT_LIBRARY,
+        location_id="disabled",
+    )
+    service.set_enabled(disabled_location.location_id, enabled=False)
+    missing.rmdir()
+
+    result = service.refresh_transcript_locations(verify=True)
+
+    assert library.calls == (((available.resolve(),), True),)
+    assert result.unavailable_location_ids == ("missing",)
+    assert result.refresh.verified_all_tracked is True
+
+
+def test_remove_forgets_permission_without_deleting_directory(tmp_path):
+    root = tmp_path / "research"
+    root.mkdir()
+    marker = root / "keep-me.txt"
+    marker.write_text("user data", encoding="utf-8")
+    service, _ = _service(tmp_path)
+    location = service.add(
+        root,
+        kind=LibraryLocationKind.RECORDING_SOURCE,
+        location_id="source",
+    )
+
+    service.remove(location.location_id)
+
+    assert service.locations() == ()
+    assert marker.read_text(encoding="utf-8") == "user data"
+
+
+def test_corrupt_location_state_fails_closed(tmp_path):
+    paths = _paths(tmp_path)
+    state_path = (
+        paths.state_dir / "library" / "user-state" / "library-locations.json"
+    )
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text('{"schema_version": 1, "locations": [', encoding="utf-8")
+    service, _ = _service(tmp_path)
+
+    with pytest.raises(LibraryLocationError, match="validated safely"):
+        service.locations()
+
+
+def test_unsupported_location_schema_fails_closed(tmp_path):
+    paths = _paths(tmp_path)
+    state_path = (
+        paths.state_dir / "library" / "user-state" / "library-locations.json"
+    )
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps({"schema_version": 999, "locations": []}),
+        encoding="utf-8",
+    )
+    service, _ = _service(tmp_path)
+
+    with pytest.raises(LibraryLocationError, match="unsupported EchoFlow schema"):
+        service.locations()

--- a/src/echoflow/library/tests/test_locations.py
+++ b/src/echoflow/library/tests/test_locations.py
@@ -280,7 +280,7 @@ def test_transcript_refresh_uses_available_enabled_roots_and_reports_missing(tmp
 
     result = service.refresh_transcript_locations(verify=True)
 
-    assert library.calls == (((available.resolve(),), True),)
+    assert library.calls == [((available.resolve(),), True)]
     assert result.unavailable_location_ids == ("missing",)
     assert result.refresh.verified_all_tracked is True
 


### PR DESCRIPTION
## Summary

Add a durable backend contract for user-selected library locations before the Tauri/React UI is built.

This tranche separates **discovery permission** from **processing permission**:

- `transcript-library` roots may be revisited by the existing incremental transcript refresh path;
- `recording-source` roots may be revisited for cheap audio/video candidate discovery;
- recording processing defaults to `manual`;
- `automatic` is an explicit opt-in policy marker for a higher-level application lifecycle adapter and does **not** itself run ASR.

## What changed

- added `LibraryLocation`, `LibraryLocationKind`, and `RecordingProcessingPolicy` typed contracts;
- added private schema-versioned `JsonLibraryLocationStore` under `library/user-state/library-locations.json`;
- added `LibraryLocationService` for add/remove/enable/disable/policy management;
- added transcript-root refresh that reuses `TranscriptLibraryService.refresh()` rather than inventing a second index path;
- added cheap recording discovery that does not hash, FFprobe, copy, transcribe, or modify candidate files;
- reports temporarily unavailable remembered roots without silently forgetting them;
- refuses registration of EchoFlow private state/cache/model paths and redundant configured output roots;
- wired the service into `AppContainer` as `library_locations`;
- added co-located tests for persistence, duplicate permissions, private-path refusal, automatic opt-in boundaries, candidate filtering, disabled locations, removable-drive disappearance, transcript refresh, safe forgetting, corrupt state, and unsupported schema;
- documented the custody/lifecycle contract in `docs/architecture/library-locations.md`;
- updated the roadmap so durable locations precede the Tauri/React desktop/import tranche.

## Security / custody boundaries

Remembering a directory does not copy or adopt custody of the files in it. Removing a remembered location only removes the permission record and never deletes source media or transcripts.

The service intentionally adds no background daemon or filesystem watcher. Startup/refresh/post-transcription triggering belongs to a later desktop lifecycle adapter.

The `automatic` policy is permission metadata only. Any future adapter that honors it must still use the existing transcription planner, resource admission, model custody, checkpoint, and execution contracts.

## Validation

Quality #631 passed on exact head `e69a9c1cdec321e9597e2af73fded5449746147d` across Linux, macOS, and Windows. Ruff/security lint, exact formatting, strict mypy, Vulture, Radon, the repository-wide 90% branch-coverage gate, distribution build/install, and all 1,074 platform tests passed.

## Next

After this backend contract is merged, the roadmap moves to:

1. Tauri + React + TypeScript + Vite desktop foundation;
2. native one-time vs remembered import UX over `LibraryLocationService`;
3. Playwright + accessibility harness from the first UI tranche;
4. search/evidence/media/research workspace UI on top of existing Python application services.