### PR TITLE
feat(desktop): add Tauri ingestion UI foundation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -98,13 +98,33 @@ jobs:
         run: node --version && npm --version
 
       - name: Diagnose lockfile integrity metadata
+        shell: bash
         run: |
+          cp package-lock.json "${RUNNER_TEMP}/package-lock.before.json"
           npm install --package-lock-only --ignore-scripts --no-fund --no-audit
-          git diff -- package-lock.json
-          if git diff --quiet -- package-lock.json; then
-            echo "npm did not produce a lockfile repair diff"
-            exit 2
-          fi
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          before = json.loads(Path(os.environ["RUNNER_TEMP"], "package-lock.before.json").read_text())
+          after = json.loads(Path("package-lock.json").read_text())
+          changes = {}
+          before_packages = before.get("packages", {})
+          after_packages = after.get("packages", {})
+          for package in sorted(set(before_packages) | set(after_packages)):
+              old = before_packages.get(package, {})
+              new = after_packages.get(package, {})
+              changed = {}
+              for key in sorted(set(old) | set(new)):
+                  if old.get(key) != new.get(key):
+                      changed[key] = {"before": old.get(key), "after": new.get(key)}
+              if changed:
+                  changes[package] = changed
+          print(json.dumps(changes, indent=2, sort_keys=True))
+          if not changes:
+              raise SystemExit("npm produced no substantive package metadata changes")
+          PY
           exit 1
 
       - name: Type check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -97,34 +97,12 @@ jobs:
       - name: Verify Node runtime
         run: node --version && npm --version
 
-      - name: Diagnose lockfile integrity metadata
+      - name: Resolve suspect registry integrity metadata
         shell: bash
         run: |
-          cp package-lock.json "${RUNNER_TEMP}/package-lock.before.json"
-          npm install --package-lock-only --ignore-scripts --no-fund --no-audit
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          before = json.loads(Path(os.environ["RUNNER_TEMP"], "package-lock.before.json").read_text())
-          after = json.loads(Path("package-lock.json").read_text())
-          changes = {}
-          before_packages = before.get("packages", {})
-          after_packages = after.get("packages", {})
-          for package in sorted(set(before_packages) | set(after_packages)):
-              old = before_packages.get(package, {})
-              new = after_packages.get(package, {})
-              changed = {}
-              for key in sorted(set(old) | set(new)):
-                  if old.get(key) != new.get(key):
-                      changed[key] = {"before": old.get(key), "after": new.get(key)}
-              if changed:
-                  changes[package] = changed
-          print(json.dumps(changes, indent=2, sort_keys=True))
-          if not changes:
-              raise SystemExit("npm produced no substantive package metadata changes")
-          PY
+          echo "jsesc=$(npm view jsesc@3.1.0 dist.integrity)"
+          echo "babel_core=$(npm view @babel/core@7.29.7 dist.integrity)"
+          echo "babel_traverse=$(npm view @babel/traverse@7.29.8 dist.integrity)"
           exit 1
 
       - name: Type check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -108,10 +108,10 @@ jobs:
           rm -f package-lock.json
           npm install --package-lock-only --ignore-scripts --no-fund --no-audit
           git diff --check -- package-lock.json
-          git diff --quiet -- package-lock.json && {
-            echo "npm produced no lockfile change";
-            exit 2;
-          }
+          if git diff --quiet -- package-lock.json; then
+            echo "npm produced no lockfile change"
+            exit 2
+          fi
 
       - name: Commit regenerated lockfile only
         shell: bash
@@ -119,10 +119,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -- package-lock.json
-          git diff --cached --quiet && {
-            echo "No lockfile change was staged";
-            exit 2;
-          }
+          if git diff --cached --quiet; then
+            echo "No lockfile change was staged"
+            exit 2
+          fi
           git commit -m "build(frontend): regenerate npm lockfile"
           git push origin "HEAD:${GITHUB_HEAD_REF}"
           exit 1

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -134,7 +134,7 @@ jobs:
         run: npm install --no-fund --no-audit
 
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Run Playwright accessibility and ingestion flows
         run: npm run test:e2e

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -118,7 +118,7 @@ jobs:
           echo '===ECHOFLOW_PACKAGE_LOCK_END==='
 
   frontend-playwright:
-    needs: frontend-static
+    needs: [static, frontend-static]
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -97,12 +97,15 @@ jobs:
       - name: Verify Node runtime
         run: node --version && npm --version
 
-      - name: Resolve suspect registry integrity metadata
+      - name: Emit npm-authored lockfile bytes
         shell: bash
         run: |
-          echo "jsesc=$(npm view jsesc@3.1.0 dist.integrity)"
-          echo "babel_core=$(npm view @babel/core@7.29.7 dist.integrity)"
-          echo "babel_traverse=$(npm view @babel/traverse@7.29.8 dist.integrity)"
+          rm package-lock.json
+          npm install --package-lock-only --ignore-scripts --no-fund --no-audit
+          echo '===ECHOFLOW_LOCK_B64_BEGIN==='
+          base64 -w 0 package-lock.json
+          echo
+          echo '===ECHOFLOW_LOCK_B64_END==='
           exit 1
 
       - name: Type check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -83,12 +83,6 @@ jobs:
           --progress-spinner off
 
   frontend-static:
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.head_ref == 'agent/desktop-import-ui' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 8
 
@@ -97,35 +91,23 @@ jobs:
         working-directory: frontend
 
     steps:
-      - name: Check out branch head
+      - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ github.head_ref }}
 
-      - name: Regenerate npm lockfile from pinned manifest
-        shell: bash
-        run: |
-          rm -f package-lock.json
-          npm install --package-lock-only --ignore-scripts --no-fund --no-audit
-          git diff --check -- package-lock.json
-          if git diff --quiet -- package-lock.json; then
-            echo "npm produced no lockfile change"
-            exit 2
-          fi
+      - name: Verify Node runtime
+        run: node --version && npm --version
 
-      - name: Commit regenerated lockfile only
-        shell: bash
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -- package-lock.json
-          if git diff --cached --quiet; then
-            echo "No lockfile change was staged"
-            exit 2
-          fi
-          git commit -m "build(frontend): regenerate npm lockfile"
-          git push origin "HEAD:${GITHUB_HEAD_REF}"
-          exit 1
+      - name: Install locked frontend dependencies
+        run: npm ci --no-fund --no-audit
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Audit production frontend dependencies
+        run: npm audit --omit=dev --audit-level=high
 
   frontend-playwright:
     needs: [static, frontend-static]

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -97,10 +97,8 @@ jobs:
       - name: Verify Node runtime
         run: node --version && npm --version
 
-      # Bootstrap uses exact top-level dependency pins. Before this PR is merged,
-      # the generated package-lock.json is committed and this becomes `npm ci`.
-      - name: Install frontend dependencies
-        run: npm install --no-fund --no-audit
+      - name: Install locked frontend dependencies
+        run: npm ci --no-fund --no-audit
 
       - name: Type check
         run: npm run typecheck
@@ -110,12 +108,6 @@ jobs:
 
       - name: Audit production frontend dependencies
         run: npm audit --omit=dev --audit-level=high
-
-      - name: Emit bootstrap lockfile
-        run: |
-          echo '===ECHOFLOW_PACKAGE_LOCK_BEGIN==='
-          cat package-lock.json
-          echo '===ECHOFLOW_PACKAGE_LOCK_END==='
 
   frontend-playwright:
     needs: [static, frontend-static]
@@ -130,8 +122,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Install frontend dependencies
-        run: npm install --no-fund --no-audit
+      - name: Install locked frontend dependencies
+        run: npm ci --no-fund --no-audit
 
       - name: Install Playwright Chromium
         run: npx playwright install chromium

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -35,15 +35,12 @@ jobs:
       - name: Check lockfile
         run: uv lock --check
 
-      # Static analysis needs EchoFlow's runtime dependencies and developer tools,
-      # but not optional ASR/diarization engines or native ffmpeg binaries.
       - name: Install static analysis dependencies
         run: uv sync --locked --group dev
 
       - name: Lint
         run: uv run ruff check . --output-format=github
 
-      # Ruff's diff mode is non-mutating and prints the exact proposed changes.
       - name: Check formatting
         run: uv run ruff format --diff .
 
@@ -70,10 +67,6 @@ jobs:
           --format requirements-txt
           --output-file ${{ runner.temp }}/echoflow-runtime-requirements.txt
 
-      # Lightning 2.6.5 is currently pulled by pyannote and is affected by
-      # CVE-2026-58659 / PYSEC-2026-3624. EchoFlow's diarization adapter blocks
-      # affected/unproven Lightning releases before importing pyannote or resolving
-      # a model. Keep this one advisory visible here until upstream ships its merged fix.
       - name: Verify compensated Lightning advisory scope
         shell: bash
         run: >-
@@ -89,8 +82,65 @@ jobs:
           --ignore-vuln PYSEC-2026-3624
           --progress-spinner off
 
+  frontend-static:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Verify Node runtime
+        run: node --version && npm --version
+
+      # Bootstrap uses exact top-level dependency pins. Before this PR is merged,
+      # the generated package-lock.json is committed and this becomes `npm ci`.
+      - name: Install frontend dependencies
+        run: npm install --no-fund --no-audit
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Audit production frontend dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Emit bootstrap lockfile
+        run: |
+          echo '===ECHOFLOW_PACKAGE_LOCK_BEGIN==='
+          cat package-lock.json
+          echo '===ECHOFLOW_PACKAGE_LOCK_END==='
+
+  frontend-playwright:
+    needs: frontend-static
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install frontend dependencies
+        run: npm install --no-fund --no-audit
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright accessibility and ingestion flows
+        run: npm run test:e2e
+
   quality:
-    needs: static
+    needs: [static, frontend-static]
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -115,10 +165,6 @@ jobs:
       - name: Import optional CPU engine
         run: uv run python -c "import faster_whisper; print(faster_whisper.__version__)"
 
-      # ubuntu-latest ships Linuxbrew, while the Azure apt mirror has repeatedly
-      # timed out while fetching ffmpeg's dependency set. Use the runner-provided
-      # package manager and keep the install bounded; the next step still verifies
-      # that both required executables are actually available.
       - name: Install native media tools
         shell: bash
         run: |
@@ -147,7 +193,7 @@ jobs:
         run: uv run python scripts/verify_distribution.py dist
 
   platform-smoke:
-    needs: static
+    needs: [static, frontend-static]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -83,6 +83,12 @@ jobs:
           --progress-spinner off
 
   frontend-static:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/desktop-import-ui' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 8
 
@@ -91,31 +97,35 @@ jobs:
         working-directory: frontend
 
     steps:
-      - name: Check out repository
+      - name: Check out branch head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.head_ref }}
 
-      - name: Verify Node runtime
-        run: node --version && npm --version
-
-      - name: Emit npm-authored lockfile bytes
+      - name: Regenerate npm lockfile from pinned manifest
         shell: bash
         run: |
-          rm package-lock.json
+          rm -f package-lock.json
           npm install --package-lock-only --ignore-scripts --no-fund --no-audit
-          echo '===ECHOFLOW_LOCK_B64_BEGIN==='
-          base64 -w 0 package-lock.json
-          echo
-          echo '===ECHOFLOW_LOCK_B64_END==='
+          git diff --check -- package-lock.json
+          git diff --quiet -- package-lock.json && {
+            echo "npm produced no lockfile change";
+            exit 2;
+          }
+
+      - name: Commit regenerated lockfile only
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- package-lock.json
+          git diff --cached --quiet && {
+            echo "No lockfile change was staged";
+            exit 2;
+          }
+          git commit -m "build(frontend): regenerate npm lockfile"
+          git push origin "HEAD:${GITHUB_HEAD_REF}"
           exit 1
-
-      - name: Type check
-        run: npm run typecheck
-
-      - name: Build frontend
-        run: npm run build
-
-      - name: Audit production frontend dependencies
-        run: npm audit --omit=dev --audit-level=high
 
   frontend-playwright:
     needs: [static, frontend-static]

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -97,8 +97,15 @@ jobs:
       - name: Verify Node runtime
         run: node --version && npm --version
 
-      - name: Install locked frontend dependencies
-        run: npm ci --no-fund --no-audit
+      - name: Diagnose lockfile integrity metadata
+        run: |
+          npm install --package-lock-only --ignore-scripts --no-fund --no-audit
+          git diff -- package-lock.json
+          if git diff --quiet -- package-lock.json; then
+            echo "npm did not produce a lockfile repair diff"
+            exit 2
+          fi
+          exit 1
 
       - name: Type check
         run: npm run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,13 @@ coverage.xml
 dist/
 mutants-not-found.txt
 
+# Frontend / desktop artifacts
+frontend/node_modules/
+frontend/dist/
+frontend/playwright-report/
+frontend/test-results/
+frontend/src-tauri/target/
+
 # Editor/IDE files
 .vscode/
 .idea/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="description" content="EchoFlow private local research workspace" />
+    <title>EchoFlow</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -70,7 +70,7 @@
     "node_modules/@babel/core": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2GxSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -294,7 +294,7 @@
     "node_modules/@babel/traverse": {
       "version": "7.29.8",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
-      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkQIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -324,133 +324,1867 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz","integrity":"sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==","cpu":["ppc64"],"dev":true,"license":"MIT","optional":true,"os":["aix"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/android-arm": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz","integrity":"sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["android"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/android-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz","integrity":"sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["android"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/android-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz","integrity":"sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["android"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/darwin-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz","integrity":"sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["darwin"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/darwin-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz","integrity":"sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["darwin"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/freebsd-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz","integrity":"sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["freebsd"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/freebsd-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz","integrity":"sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["freebsd"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/linux-arm": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz","integrity":"sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/linux-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz","integrity":"sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/linux-ia32": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz","integrity":"sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==","cpu":["ia32"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/linux-loong64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz","integrity":"sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==","cpu":["loong64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/linux-mips64el": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz","integrity":"sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==","cpu":["mips64el"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/linux-ppc64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz","integrity":"sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==","cpu":["ppc64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/linux-riscv64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz","integrity":"sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==","cpu":["riscv64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/linux-s390x": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz","integrity":"sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==","cpu":["s390x"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/linux-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz","integrity":"sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/netbsd-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz","integrity":"sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["netbsd"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/netbsd-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz","integrity":"sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["netbsd"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/openbsd-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz","integrity":"sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["openbsd"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/openbsd-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz","integrity":"sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["openbsd"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/openharmony-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz","integrity":"sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["openharmony"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/sunos-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz","integrity":"sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["sunos"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/win32-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz","integrity":"sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["win32"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/win32-ia32": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz","integrity":"sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==","cpu":["ia32"],"dev":true,"license":"MIT","optional":true,"os":["win32"],"engines":{"node":">=18"}},
-    "node_modules/@esbuild/win32-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz","integrity":"sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["win32"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {"@jridgewell/sourcemap-codec":"^1.5.0","@jridgewell/trace-mapping":"^0.3.24"}
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
     },
-    "node_modules/@jridgewell/remapping": {"version":"2.3.5","resolved":"https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz","integrity":"sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==","dev":true,"license":"MIT","dependencies":{"@jridgewell/gen-mapping":"^0.3.5","@jridgewell/trace-mapping":"^0.3.24"}},
-    "node_modules/@jridgewell/resolve-uri": {"version":"3.1.2","resolved":"https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz","integrity":"sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==","dev":true,"license":"MIT","engines":{"node":">=6.0.0"}},
-    "node_modules/@jridgewell/sourcemap-codec": {"version":"1.5.5","resolved":"https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz","integrity":"sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==","dev":true,"license":"MIT"},
-    "node_modules/@jridgewell/trace-mapping": {"version":"0.3.31","resolved":"https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz","integrity":"sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==","dev":true,"license":"MIT","dependencies":{"@jridgewell/resolve-uri":"^3.1.0","@jridgewell/sourcemap-codec":"^1.4.14"}},
-    "node_modules/@napi-rs/lzma-linux-x64-gnu": {"version":"1.5.1","resolved":"https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz","integrity":"sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":"^22.20 || ^24.12 || >=25"}},
-    "node_modules/@playwright/test": {"version":"1.54.2","resolved":"https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz","integrity":"sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==","dev":true,"license":"Apache-2.0","dependencies":{"playwright":"1.54.2"},"bin":{"playwright":"cli.js"},"engines":{"node":">=18"}},
-    "node_modules/@rolldown/pluginutils": {"version":"1.0.0-beta.30","resolved":"https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.30.tgz","integrity":"sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw==","dev":true,"license":"MIT"},
-    "node_modules/@rollup/rollup-android-arm-eabi": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz","integrity":"sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["android"]},
-    "node_modules/@rollup/rollup-android-arm64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz","integrity":"sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["android"]},
-    "node_modules/@rollup/rollup-darwin-arm64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz","integrity":"sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["darwin"]},
-    "node_modules/@rollup/rollup-darwin-x64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz","integrity":"sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["darwin"]},
-    "node_modules/@rollup/rollup-freebsd-arm64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz","integrity":"sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["freebsd"]},
-    "node_modules/@rollup/rollup-freebsd-x64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz","integrity":"sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["freebsd"]},
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz","integrity":"sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz","integrity":"sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz","integrity":"sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-arm64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz","integrity":"sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz","integrity":"sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==","cpu":["loong64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-loong64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz","integrity":"sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==","cpu":["loong64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz","integrity":"sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==","cpu":["ppc64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz","integrity":"sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==","cpu":["ppc64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz","integrity":"sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==","cpu":["riscv64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz","integrity":"sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==","cpu":["riscv64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz","integrity":"sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==","cpu":["s390x"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-x64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz","integrity":"sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-linux-x64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz","integrity":"sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
-    "node_modules/@rollup/rollup-openbsd-x64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz","integrity":"sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["openbsd"]},
-    "node_modules/@rollup/rollup-openharmony-arm64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz","integrity":"sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["openharmony"]},
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz","integrity":"sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["win32"]},
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz","integrity":"sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==","cpu":["ia32"],"dev":true,"license":"MIT","optional":true,"os":["win32"]},
-    "node_modules/@rollup/rollup-win32-x64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz","integrity":"sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["win32"]},
-    "node_modules/@rollup/rollup-win32-x64-msvc": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz","integrity":"sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["win32"]},
-    "node_modules/@tauri-apps/api": {"version":"2.8.0","resolved":"https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz","integrity":"sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==","license":"Apache-2.0 OR MIT","funding":{"type":"opencollective","url":"https://opencollective.com/tauri"}},
-    "node_modules/@tauri-apps/cli": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.4.tgz","integrity":"sha512-ejUZBzuQRcjFV+v/gdj/DcbyX/6T4unZQjMSBZwLzP/CymEjKcc2+Fc8xTORThebHDUvqoXMdsCZt8r+hyN15g==","dev":true,"license":"Apache-2.0 OR MIT","bin":{"tauri":"tauri.js"},"engines":{"node":">= 10"},"funding":{"type":"opencollective","url":"https://opencollective.com/tauri"},"optionalDependencies":{"@tauri-apps/cli-darwin-arm64":"2.8.4","@tauri-apps/cli-darwin-x64":"2.8.4","@tauri-apps/cli-linux-arm-gnueabihf":"2.8.4","@tauri-apps/cli-linux-arm64-gnu":"2.8.4","@tauri-apps/cli-linux-arm64-musl":"2.8.4","@tauri-apps/cli-linux-riscv64-gnu":"2.8.4","@tauri-apps/cli-linux-x64-gnu":"2.8.4","@tauri-apps/cli-linux-x64-musl":"2.8.4","@tauri-apps/cli-win32-arm64-msvc":"2.8.4","@tauri-apps/cli-win32-ia32-msvc":"2.8.4","@tauri-apps/cli-win32-x64-msvc":"2.8.4"}},
-    "node_modules/@tauri-apps/cli-darwin-arm64": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.4.tgz","integrity":"sha512-BKu8HRkYV01SMTa7r4fLx+wjgtRK8Vep7lmBdHDioP6b8XH3q2KgsAyPWfEZaZIkZ2LY4SqqGARaE9oilNe0oA==","cpu":["arm64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["darwin"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-darwin-x64": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.4.tgz","integrity":"sha512-imb9PfSd/7G6VAO7v1bQ2A3ZH4NOCbhGJFLchxzepGcXf9NKkfun157JH9mko29K6sqAwuJ88qtzbKCbWJTH9g==","cpu":["x64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["darwin"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.4.tgz","integrity":"sha512-Ml215UnDdl7/fpOrF1CNovym/KjtUbCuPgrcZ4IhqUCnhZdXuphud/JT3E8X97Y03TZ40Sjz8raXYI2ET0exzw==","cpu":["arm"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.4.tgz","integrity":"sha512-pbcgBpMyI90C83CxE5REZ9ODyIlmmAPkkJXtV398X3SgZEIYy5TACYqlyyv2z5yKgD8F8WH4/2fek7+jH+ZXAw==","cpu":["arm64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-linux-arm64-musl": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.4.tgz","integrity":"sha512-zumFeaU1Ws5Ay872FTyIm7z8kfzEHu8NcIn8M6TxbJs0a7GRV21KBdpW1zNj2qy7HynnpQCqjAYXTUUmm9JAOw==","cpu":["arm64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.4.tgz","integrity":"sha512-qiqbB3Zz6IyO201f+1ojxLj65WYj8mixL5cOMo63nlg8CIzsP23cPYUrx1YaDPsCLszKZo7tVs14pc7BWf+/aQ==","cpu":["riscv64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-linux-x64-gnu": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.4.tgz","integrity":"sha512-TaqaDd9Oy6k45Hotx3pOf+pkbsxLaApv4rGd9mLuRM1k6YS/aw81YrsMryYPThrxrScEIUcmNIHaHsLiU4GMkw==","cpu":["x64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-linux-x64-musl": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.4.tgz","integrity":"sha512-ot9STAwyezN8w+bBHZ+bqSQIJ0qPZFlz/AyscpGqB/JnJQVDFQcRDmUPFEaAtt2UUHSWzN3GoTJ5ypqLBp2WQA==","cpu":["x64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-win32-arm64-msvc": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.4.tgz","integrity":"sha512-+2aJ/g90dhLiOLFSD1PbElXX3SoMdpO7HFPAZB+xot3CWlAZD1tReUFy7xe0L5GAR16ZmrxpIDM9v9gn5xRy/w==","cpu":["arm64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["win32"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-win32-ia32-msvc": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.4.tgz","integrity":"sha512-yj7WDxkL1t9Uzr2gufQ1Hl7hrHuFKTNEOyascbc109EoiAqCp0tgZ2IykQqOZmZOHU884UAWI1pVMqBhS/BfhA==","cpu":["ia32"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["win32"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/cli-win32-x64-msvc": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.4.tgz","integrity":"sha512-XuvGB4ehBdd7QhMZ9qbj/8icGEatDuBNxyYHbLKsTYh90ggUlPa/AtaqcC1Fo69lGkTmq9BOKrs1aWSi7xDonA==","cpu":["x64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["win32"],"engines":{"node":">= 10"}},
-    "node_modules/@tauri-apps/plugin-dialog": {"version":"2.4.0","resolved":"https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.4.0.tgz","integrity":"sha512-OvXkrEBfWwtd8tzVCEXIvRfNEX87qs2jv6SqmVPiHcJjBhSF/GUvjqUNIDmKByb5N8nvDqVUM7+g1sXwdC/S9w==","license":"MIT OR Apache-2.0","dependencies":{"@tauri-apps/api":"^2.8.0"}},
-    "node_modules/@types/babel__core": {"version":"7.20.5","resolved":"https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz","integrity":"sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==","dev":true,"license":"MIT","dependencies":{"@babel/parser":"^7.20.7","@babel/types":"^7.20.7","@types/babel__generator":"*","@types/babel__template":"*","@types/babel__traverse":"*"}},
-    "node_modules/@types/babel__generator": {"version":"7.27.0","resolved":"https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz","integrity":"sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==","dev":true,"license":"MIT","dependencies":{"@babel/types":"^7.0.0"}},
-    "node_modules/@types/babel__template": {"version":"7.4.4","resolved":"https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz","integrity":"sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==","dev":true,"license":"MIT","dependencies":{"@babel/parser":"^7.1.0","@babel/types":"^7.0.0"}},
-    "node_modules/@types/babel__traverse": {"version":"7.28.0","resolved":"https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz","integrity":"sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==","dev":true,"license":"MIT","dependencies":{"@babel/types":"^7.28.2"}},
-    "node_modules/@types/estree": {"version":"1.0.9","resolved":"https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz","integrity":"sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==","dev":true,"license":"MIT"},
-    "node_modules/@types/node": {"version":"22.15.32","resolved":"https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz","integrity":"sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==","dev":true,"license":"MIT","dependencies":{"undici-types":"~6.21.0"}},
-    "node_modules/@types/react": {"version":"19.1.9","resolved":"https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz","integrity":"sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==","dev":true,"license":"MIT","dependencies":{"csstype":"^3.0.2"}},
-    "node_modules/@types/react-dom": {"version":"19.1.7","resolved":"https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz","integrity":"sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==","dev":true,"license":"MIT","peerDependencies":{"@types/react":"^19.0.0"}},
-    "node_modules/@vitejs/plugin-react": {"version":"5.0.0","resolved":"https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.0.tgz","integrity":"sha512-Jx9JfsTa05bYkS9xo0hkofp2dCmp1blrKjw9JONs5BTHOvJCgLbaPSuZLGSVJW6u2qe0tc4eevY0+gSNNi0YCw==","dev":true,"license":"MIT","dependencies":{"@babel/core":"^7.28.0","@babel/plugin-transform-react-jsx-self":"^7.27.1","@babel/plugin-transform-react-jsx-source":"^7.27.1","@rolldown/pluginutils":"1.0.0-beta.30","@types/babel__core":"^7.20.5","react-refresh":"^0.17.0"},"engines":{"node":"^20.19.0 || >=22.12.0"},"peerDependencies":{"vite":"^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"}},
-    "node_modules/axe-core": {"version":"4.10.3","resolved":"https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz","integrity":"sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==","dev":true,"license":"MPL-2.0","engines":{"node":">=4"}},
-    "node_modules/baseline-browser-mapping": {"version":"2.11.15","resolved":"https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz","integrity":"sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==","dev":true,"license":"Apache-2.0","bin":{"baseline-browser-mapping":"dist/cli.cjs"},"engines":{"node":">=6.0.0"}},
-    "node_modules/browserslist": {"version":"4.28.8","resolved":"https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz","integrity":"sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==","dev":true,"license":"MIT","dependencies":{"baseline-browser-mapping":"^2.11.12","caniuse-lite":"^1.0.30001809","electron-to-chromium":"^1.5.402","node-releases":"^2.0.53","update-browserslist-db":"^1.3.0"},"bin":{"browserslist":"cli.js"},"engines":{"node":"^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"}},
-    "node_modules/caniuse-lite": {"version":"1.0.30001809","resolved":"https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz","integrity":"sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==","dev":true,"license":"CC-BY-4.0"},
-    "node_modules/convert-source-map": {"version":"2.0.0","resolved":"https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz","integrity":"sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==","dev":true,"license":"MIT"},
-    "node_modules/csstype": {"version":"3.2.3","resolved":"https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz","integrity":"sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==","dev":true,"license":"MIT"},
-    "node_modules/debug": {"version":"4.4.3","resolved":"https://registry.npmjs.org/debug/-/debug-4.4.3.tgz","integrity":"sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==","dev":true,"license":"MIT","dependencies":{"ms":"^2.1.3"},"engines":{"node":">=6.0"},"peerDependenciesMeta":{"supports-color":{"optional":true}}},
-    "node_modules/electron-to-chromium": {"version":"1.5.411","resolved":"https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz","integrity":"sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==","dev":true,"license":"ISC"},
-    "node_modules/esbuild": {"version":"0.25.12","resolved":"https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz","integrity":"sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==","dev":true,"hasInstallScript":true,"license":"MIT","bin":{"esbuild":"bin/esbuild"},"engines":{"node":">=18"},"optionalDependencies":{"@esbuild/aix-ppc64":"0.25.12","@esbuild/android-arm":"0.25.12","@esbuild/android-arm64":"0.25.12","@esbuild/android-x64":"0.25.12","@esbuild/darwin-arm64":"0.25.12","@esbuild/darwin-x64":"0.25.12","@esbuild/freebsd-arm64":"0.25.12","@esbuild/freebsd-x64":"0.25.12","@esbuild/linux-arm":"0.25.12","@esbuild/linux-arm64":"0.25.12","@esbuild/linux-ia32":"0.25.12","@esbuild/linux-loong64":"0.25.12","@esbuild/linux-mips64el":"0.25.12","@esbuild/linux-ppc64":"0.25.12","@esbuild/linux-riscv64":"0.25.12","@esbuild/linux-s390x":"0.25.12","@esbuild/linux-x64":"0.25.12","@esbuild/netbsd-arm64":"0.25.12","@esbuild/netbsd-x64":"0.25.12","@esbuild/openbsd-arm64":"0.25.12","@esbuild/openbsd-x64":"0.25.12","@esbuild/openharmony-arm64":"0.25.12","@esbuild/sunos-x64":"0.25.12","@esbuild/win32-arm64":"0.25.12","@esbuild/win32-ia32":"0.25.12","@esbuild/win32-x64":"0.25.12"}},
-    "node_modules/escalade": {"version":"3.2.0","resolved":"https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz","integrity":"sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==","dev":true,"license":"MIT","engines":{"node":">=6"}},
-    "node_modules/fdir": {"version":"6.5.0","resolved":"https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz","integrity":"sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==","dev":true,"license":"MIT","engines":{"node":">=12.0.0"},"peerDependencies":{"picomatch":"^3 || ^4"},"peerDependenciesMeta":{"picomatch":{"optional":true}}},
-    "node_modules/fsevents": {"version":"2.3.2","resolved":"https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz","integrity":"sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==","dev":true,"hasInstallScript":true,"license":"MIT","optional":true,"os":["darwin"],"engines":{"node":"^8.16.0 || ^10.6.0 || >=11.0.0"}},
-    "node_modules/gensync": {"version":"1.0.0-beta.2","resolved":"https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz","integrity":"sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==","dev":true,"license":"MIT","engines":{"node":">=6.9.0"}},
-    "node_modules/js-tokens": {"version":"4.0.0","resolved":"https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz","integrity":"sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==","dev":true,"license":"MIT"},
-    "node_modules/jsesc": {"version":"3.1.0","resolved":"https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz","integrity":"sha512-/sM3dO2FOzXKqHuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==","dev":true,"license":"MIT","bin":{"jsesc":"bin/jsesc"},"engines":{"node":">=6"}},
-    "node_modules/json5": {"version":"2.2.3","resolved":"https://registry.npmjs.org/json5/-/json5-2.2.3.tgz","integrity":"sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==","dev":true,"license":"MIT","bin":{"json5":"lib/cli.js"},"engines":{"node":">=6"}},
-    "node_modules/lru-cache": {"version":"5.1.1","resolved":"https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz","integrity":"sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==","dev":true,"license":"ISC","dependencies":{"yallist":"^3.0.2"}},
-    "node_modules/ms": {"version":"2.1.3","resolved":"https://registry.npmjs.org/ms/-/ms-2.1.3.tgz","integrity":"sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==","dev":true,"license":"MIT"},
-    "node_modules/nanoid": {"version":"3.3.18","resolved":"https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz","integrity":"sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==","dev":true,"license":"MIT","bin":{"nanoid":"bin/nanoid.cjs"},"engines":{"node":"^10 || ^12 || ^13.7 || ^14 || >=15.0.1"}},
-    "node_modules/node-releases": {"version":"2.0.53","resolved":"https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz","integrity":"sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==","dev":true,"license":"MIT","engines":{"node":">=18"}},
-    "node_modules/picocolors": {"version":"1.1.1","resolved":"https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz","integrity":"sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==","dev":true,"license":"ISC"},
-    "node_modules/picomatch": {"version":"4.0.5","resolved":"https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz","integrity":"sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==","dev":true,"license":"MIT","engines":{"node":">=12"},"funding":{"url":"https://github.com/sponsors/jonschlinkert"}},
-    "node_modules/playwright": {"version":"1.54.2","resolved":"https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz","integrity":"sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==","dev":true,"license":"Apache-2.0","dependencies":{"playwright-core":"1.54.2"},"bin":{"playwright":"cli.js"},"engines":{"node":">=18"},"optionalDependencies":{"fsevents":"2.3.2"}},
-    "node_modules/playwright-core": {"version":"1.54.2","resolved":"https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz","integrity":"sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==","dev":true,"license":"Apache-2.0","bin":{"playwright-core":"cli.js"},"engines":{"node":">=18"}},
-    "node_modules/postcss": {"version":"8.5.26","resolved":"https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz","integrity":"sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==","dev":true,"license":"MIT","dependencies":{"nanoid":"^3.3.17","picocolors":"^1.1.1","source-map-js":"^1.2.1"},"engines":{"node":"^10 || ^12 || >=14"}},
-    "node_modules/react": {"version":"19.1.1","resolved":"https://registry.npmjs.org/react/-/react-19.1.1.tgz","integrity":"sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==","license":"MIT","engines":{"node":">=0.10.0"}},
-    "node_modules/react-dom": {"version":"19.1.1","resolved":"https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz","integrity":"sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==","license":"MIT","dependencies":{"scheduler":"^0.26.0"},"peerDependencies":{"react":"^19.1.1"}},
-    "node_modules/react-refresh": {"version":"0.17.0","resolved":"https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz","integrity":"sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==","dev":true,"license":"MIT","engines":{"node":">=0.10.0"}},
-    "node_modules/rollup": {"version":"4.62.4","resolved":"https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz","integrity":"sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==","dev":true,"license":"MIT","dependencies":{"@types/estree":"1.0.9"},"bin":{"rollup":"dist/bin/rollup"},"engines":{"node":">=18.0.0","npm":">=8.0.0"},"optionalDependencies":{"@napi-rs/lzma-linux-x64-gnu":"1.5.1","@rollup/rollup-android-arm-eabi":"4.62.4","@rollup/rollup-android-arm64":"4.62.4","@rollup/rollup-darwin-arm64":"4.62.4","@rollup/rollup-darwin-x64":"4.62.4","@rollup/rollup-freebsd-arm64":"4.62.4","@rollup/rollup-freebsd-x64":"4.62.4","@rollup/rollup-linux-arm-gnueabihf":"4.62.4","@rollup/rollup-linux-arm-musleabihf":"4.62.4","@rollup/rollup-linux-arm64-gnu":"4.62.4","@rollup/rollup-linux-arm64-musl":"4.62.4","@rollup/rollup-linux-loong64-gnu":"4.62.4","@rollup/rollup-linux-loong64-musl":"4.62.4","@rollup/rollup-linux-ppc64-gnu":"4.62.4","@rollup/rollup-linux-ppc64-musl":"4.62.4","@rollup/rollup-linux-riscv64-gnu":"4.62.4","@rollup/rollup-linux-riscv64-musl":"4.62.4","@rollup/rollup-linux-s390x-gnu":"4.62.4","@rollup/rollup-linux-x64-gnu":"4.62.4","@rollup/rollup-linux-x64-musl":"4.62.4","@rollup/rollup-openbsd-x64":"4.62.4","@rollup/rollup-openharmony-arm64":"4.62.4","@rollup/rollup-win32-arm64-msvc":"4.62.4","@rollup/rollup-win32-ia32-msvc":"4.62.4","@rollup/rollup-win32-x64-gnu":"4.62.4","@rollup/rollup-win32-x64-msvc":"4.62.4","fsevents":"~2.3.2"}},
-    "node_modules/scheduler": {"version":"0.26.0","resolved":"https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz","integrity":"sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==","license":"MIT"},
-    "node_modules/semver": {"version":"6.3.1","resolved":"https://registry.npmjs.org/semver/-/semver-6.3.1.tgz","integrity":"sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==","dev":true,"license":"ISC","bin":{"semver":"bin/semver.js"}},
-    "node_modules/source-map-js": {"version":"1.2.1","resolved":"https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz","integrity":"sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==","dev":true,"license":"BSD-3-Clause","engines":{"node":">=0.10.0"}},
-    "node_modules/tinyglobby": {"version":"0.2.17","resolved":"https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz","integrity":"sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==","dev":true,"license":"MIT","dependencies":{"fdir":"^6.5.0","picomatch":"^4.0.4"},"engines":{"node":">=12.0.0"},"funding":{"url":"https://github.com/sponsors/SuperchupuDev"}},
-    "node_modules/typescript": {"version":"5.9.2","resolved":"https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz","integrity":"sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==","dev":true,"license":"Apache-2.0","bin":{"tsc":"bin/tsc","tsserver":"bin/tsserver"},"engines":{"node":">=14.17"}},
-    "node_modules/undici-types": {"version":"6.21.0","resolved":"https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz","integrity":"sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==","dev":true,"license":"MIT"},
-    "node_modules/update-browserslist-db": {"version":"1.3.1","resolved":"https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz","integrity":"sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==","dev":true,"license":"MIT","dependencies":{"escalade":"^3.2.0","picocolors":"^1.1.1"},"bin":{"update-browserslist-db":"cli.js"},"peerDependencies":{"browserslist":">= 4.21.0"}},
-    "node_modules/vite": {"version":"7.1.2","resolved":"https://registry.npmjs.org/vite/-/vite-7.1.2.tgz","integrity":"sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==","dev":true,"license":"MIT","dependencies":{"esbuild":"^0.25.0","fdir":"^6.4.6","picomatch":"^4.0.3","postcss":"^8.5.6","rollup":"^4.43.0","tinyglobby":"^0.2.14"},"bin":{"vite":"bin/vite.js"},"engines":{"node":"^20.19.0 || >=22.12.0"},"funding":{"url":"https://github.com/vitejs/vite?sponsor=1"},"optionalDependencies":{"fsevents":"~2.3.3"},"peerDependencies":{"@types/node":"^20.19.0 || >=22.12.0","jiti":">=1.21.0","less":"^4.0.0","lightningcss":"^1.21.0","sass":"^1.70.0","sass-embedded":"^1.70.0","stylus":">=0.54.8","sugarss":"^5.0.0","terser":"^5.16.0","tsx":"^4.8.1","yaml":"^2.4.2"},"peerDependenciesMeta":{"@types/node":{"optional":true},"jiti":{"optional":true},"less":{"optional":true},"lightningcss":{"optional":true},"sass":{"optional":true},"sass-embedded":{"optional":true},"stylus":{"optional":true},"sugarss":{"optional":true},"terser":{"optional":true},"tsx":{"optional":true},"yaml":{"optional":true}}},
-    "node_modules/vite/node_modules/fsevents": {"version":"2.3.3","resolved":"https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz","integrity":"sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==","dev":true,"hasInstallScript":true,"license":"MIT","optional":true,"os":["darwin"],"engines":{"node":"^8.16.0 || ^10.6.0 || >=11.0.0"}},
-    "node_modules/yallist": {"version":"3.1.1","resolved":"https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz","integrity":"sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==","dev":true,"license":"ISC"}
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.30.tgz",
+      "integrity": "sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz",
+      "integrity": "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
+    },
+    "node_modules/@tauri-apps/cli": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.4.tgz",
+      "integrity": "sha512-ejUZBzuQRcjFV+v/gdj/DcbyX/6T4unZQjMSBZwLzP/CymEjKcc2+Fc8xTORThebHDUvqoXMdsCZt8r+hyN15g==",
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "bin": {
+        "tauri": "tauri.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      },
+      "optionalDependencies": {
+        "@tauri-apps/cli-darwin-arm64": "2.8.4",
+        "@tauri-apps/cli-darwin-x64": "2.8.4",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.8.4",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.8.4",
+        "@tauri-apps/cli-linux-arm64-musl": "2.8.4",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.8.4",
+        "@tauri-apps/cli-linux-x64-gnu": "2.8.4",
+        "@tauri-apps/cli-linux-x64-musl": "2.8.4",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.8.4",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.8.4",
+        "@tauri-apps/cli-win32-x64-msvc": "2.8.4"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-arm64": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.4.tgz",
+      "integrity": "sha512-BKu8HRkYV01SMTa7r4fLx+wjgtRK8Vep7lmBdHDioP6b8XH3q2KgsAyPWfEZaZIkZ2LY4SqqGARaE9oilNe0oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-x64": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.4.tgz",
+      "integrity": "sha512-imb9PfSd/7G6VAO7v1bQ2A3ZH4NOCbhGJFLchxzepGcXf9NKkfun157JH9mko29K6sqAwuJ88qtzbKCbWJTH9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.4.tgz",
+      "integrity": "sha512-Ml215UnDdl7/fpOrF1CNovym/KjtUbCuPgrcZ4IhqUCnhZdXuphud/JT3E8X97Y03TZ40Sjz8raXYI2ET0exzw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.4.tgz",
+      "integrity": "sha512-pbcgBpMyI90C83CxE5REZ9ODyIlmmAPkkJXtV398X3SgZEIYy5TACYqlyyv2z5yKgD8F8WH4/2fek7+jH+ZXAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-musl": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.4.tgz",
+      "integrity": "sha512-zumFeaU1Ws5Ay872FTyIm7z8kfzEHu8NcIn8M6TxbJs0a7GRV21KBdpW1zNj2qy7HynnpQCqjAYXTUUmm9JAOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.4.tgz",
+      "integrity": "sha512-qiqbB3Zz6IyO201f+1ojxLj65WYj8mixL5cOMo63nlg8CIzsP23cPYUrx1YaDPsCLszKZo7tVs14pc7BWf+/aQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-gnu": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.4.tgz",
+      "integrity": "sha512-TaqaDd9Oy6k45Hotx3pOf+pkbsxLaApv4rGd9mLuRM1k6YS/aw81YrsMryYPThrxrScEIUcmNIHaHsLiU4GMkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-musl": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.4.tgz",
+      "integrity": "sha512-ot9STAwyezN8w+bBHZ+bqSQIJ0qPZFlz/AyscpGqB/JnJQVDFQcRDmUPFEaAtt2UUHSWzN3GoTJ5ypqLBp2WQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.4.tgz",
+      "integrity": "sha512-+2aJ/g90dhLiOLFSD1PbElXX3SoMdpO7HFPAZB+xot3CWlAZD1tReUFy7xe0L5GAR16ZmrxpIDM9v9gn5xRy/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.4.tgz",
+      "integrity": "sha512-yj7WDxkL1t9Uzr2gufQ1Hl7hrHuFKTNEOyascbc109EoiAqCp0tgZ2IykQqOZmZOHU884UAWI1pVMqBhS/BfhA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.4.tgz",
+      "integrity": "sha512-XuvGB4ehBdd7QhMZ9qbj/8icGEatDuBNxyYHbLKsTYh90ggUlPa/AtaqcC1Fo69lGkTmq9BOKrs1aWSi7xDonA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.4.0.tgz",
+      "integrity": "sha512-OvXkrEBfWwtd8tzVCEXIvRfNEX87qs2jv6SqmVPiHcJjBhSF/GUvjqUNIDmKByb5N8nvDqVUM7+g1sXwdC/S9w==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
+      "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
+      "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
+      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.0.tgz",
+      "integrity": "sha512-Jx9JfsTa05bYkS9xo0hkofp2dCmp1blrKjw9JONs5BTHOvJCgLbaPSuZLGSVJW6u2qe0tc4eevY0+gSNNi0YCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.30",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz",
+      "integrity": "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.411",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz",
+      "integrity": "sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.2.tgz",
+      "integrity": "sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.6",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.14"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,456 @@
+{
+  "name": "echoflow-desktop",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "echoflow-desktop",
+      "version": "0.1.0",
+      "dependencies": {
+        "@tauri-apps/api": "2.8.0",
+        "@tauri-apps/plugin-dialog": "2.4.0",
+        "react": "19.1.1",
+        "react-dom": "19.1.1"
+      },
+      "devDependencies": {
+        "@axe-core/playwright": "4.10.2",
+        "@playwright/test": "1.54.2",
+        "@tauri-apps/cli": "2.8.4",
+        "@types/node": "22.15.32",
+        "@types/react": "19.1.9",
+        "@types/react-dom": "19.1.7",
+        "@vitejs/plugin-react": "5.0.0",
+        "playwright-core": "1.54.2",
+        "typescript": "5.9.2",
+        "vite": "7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+      "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2GxSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkQIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz","integrity":"sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==","cpu":["ppc64"],"dev":true,"license":"MIT","optional":true,"os":["aix"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/android-arm": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz","integrity":"sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["android"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/android-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz","integrity":"sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["android"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/android-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz","integrity":"sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["android"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/darwin-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz","integrity":"sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["darwin"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/darwin-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz","integrity":"sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["darwin"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/freebsd-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz","integrity":"sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["freebsd"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/freebsd-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz","integrity":"sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["freebsd"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/linux-arm": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz","integrity":"sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/linux-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz","integrity":"sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/linux-ia32": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz","integrity":"sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==","cpu":["ia32"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/linux-loong64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz","integrity":"sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==","cpu":["loong64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/linux-mips64el": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz","integrity":"sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==","cpu":["mips64el"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/linux-ppc64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz","integrity":"sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==","cpu":["ppc64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/linux-riscv64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz","integrity":"sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==","cpu":["riscv64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/linux-s390x": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz","integrity":"sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==","cpu":["s390x"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/linux-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz","integrity":"sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/netbsd-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz","integrity":"sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["netbsd"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/netbsd-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz","integrity":"sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["netbsd"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/openbsd-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz","integrity":"sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["openbsd"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/openbsd-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz","integrity":"sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["openbsd"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/openharmony-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz","integrity":"sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["openharmony"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/sunos-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz","integrity":"sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["sunos"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/win32-arm64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz","integrity":"sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["win32"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/win32-ia32": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz","integrity":"sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==","cpu":["ia32"],"dev":true,"license":"MIT","optional":true,"os":["win32"],"engines":{"node":">=18"}},
+    "node_modules/@esbuild/win32-x64": {"version":"0.25.12","resolved":"https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz","integrity":"sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["win32"],"engines":{"node":">=18"}},
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {"@jridgewell/sourcemap-codec":"^1.5.0","@jridgewell/trace-mapping":"^0.3.24"}
+    },
+    "node_modules/@jridgewell/remapping": {"version":"2.3.5","resolved":"https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz","integrity":"sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==","dev":true,"license":"MIT","dependencies":{"@jridgewell/gen-mapping":"^0.3.5","@jridgewell/trace-mapping":"^0.3.24"}},
+    "node_modules/@jridgewell/resolve-uri": {"version":"3.1.2","resolved":"https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz","integrity":"sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==","dev":true,"license":"MIT","engines":{"node":">=6.0.0"}},
+    "node_modules/@jridgewell/sourcemap-codec": {"version":"1.5.5","resolved":"https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz","integrity":"sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==","dev":true,"license":"MIT"},
+    "node_modules/@jridgewell/trace-mapping": {"version":"0.3.31","resolved":"https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz","integrity":"sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==","dev":true,"license":"MIT","dependencies":{"@jridgewell/resolve-uri":"^3.1.0","@jridgewell/sourcemap-codec":"^1.4.14"}},
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {"version":"1.5.1","resolved":"https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz","integrity":"sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["linux"],"engines":{"node":"^22.20 || ^24.12 || >=25"}},
+    "node_modules/@playwright/test": {"version":"1.54.2","resolved":"https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz","integrity":"sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==","dev":true,"license":"Apache-2.0","dependencies":{"playwright":"1.54.2"},"bin":{"playwright":"cli.js"},"engines":{"node":">=18"}},
+    "node_modules/@rolldown/pluginutils": {"version":"1.0.0-beta.30","resolved":"https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.30.tgz","integrity":"sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw==","dev":true,"license":"MIT"},
+    "node_modules/@rollup/rollup-android-arm-eabi": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz","integrity":"sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["android"]},
+    "node_modules/@rollup/rollup-android-arm64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz","integrity":"sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["android"]},
+    "node_modules/@rollup/rollup-darwin-arm64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz","integrity":"sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["darwin"]},
+    "node_modules/@rollup/rollup-darwin-x64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz","integrity":"sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["darwin"]},
+    "node_modules/@rollup/rollup-freebsd-arm64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz","integrity":"sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["freebsd"]},
+    "node_modules/@rollup/rollup-freebsd-x64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz","integrity":"sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["freebsd"]},
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz","integrity":"sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz","integrity":"sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==","cpu":["arm"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz","integrity":"sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-arm64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz","integrity":"sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz","integrity":"sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==","cpu":["loong64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-loong64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz","integrity":"sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==","cpu":["loong64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz","integrity":"sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==","cpu":["ppc64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz","integrity":"sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==","cpu":["ppc64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz","integrity":"sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==","cpu":["riscv64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz","integrity":"sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==","cpu":["riscv64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz","integrity":"sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==","cpu":["s390x"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-x64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz","integrity":"sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-linux-x64-musl": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz","integrity":"sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["linux"]},
+    "node_modules/@rollup/rollup-openbsd-x64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz","integrity":"sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["openbsd"]},
+    "node_modules/@rollup/rollup-openharmony-arm64": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz","integrity":"sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["openharmony"]},
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz","integrity":"sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==","cpu":["arm64"],"dev":true,"license":"MIT","optional":true,"os":["win32"]},
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz","integrity":"sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==","cpu":["ia32"],"dev":true,"license":"MIT","optional":true,"os":["win32"]},
+    "node_modules/@rollup/rollup-win32-x64-gnu": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz","integrity":"sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["win32"]},
+    "node_modules/@rollup/rollup-win32-x64-msvc": {"version":"4.62.4","resolved":"https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz","integrity":"sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==","cpu":["x64"],"dev":true,"license":"MIT","optional":true,"os":["win32"]},
+    "node_modules/@tauri-apps/api": {"version":"2.8.0","resolved":"https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz","integrity":"sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==","license":"Apache-2.0 OR MIT","funding":{"type":"opencollective","url":"https://opencollective.com/tauri"}},
+    "node_modules/@tauri-apps/cli": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.8.4.tgz","integrity":"sha512-ejUZBzuQRcjFV+v/gdj/DcbyX/6T4unZQjMSBZwLzP/CymEjKcc2+Fc8xTORThebHDUvqoXMdsCZt8r+hyN15g==","dev":true,"license":"Apache-2.0 OR MIT","bin":{"tauri":"tauri.js"},"engines":{"node":">= 10"},"funding":{"type":"opencollective","url":"https://opencollective.com/tauri"},"optionalDependencies":{"@tauri-apps/cli-darwin-arm64":"2.8.4","@tauri-apps/cli-darwin-x64":"2.8.4","@tauri-apps/cli-linux-arm-gnueabihf":"2.8.4","@tauri-apps/cli-linux-arm64-gnu":"2.8.4","@tauri-apps/cli-linux-arm64-musl":"2.8.4","@tauri-apps/cli-linux-riscv64-gnu":"2.8.4","@tauri-apps/cli-linux-x64-gnu":"2.8.4","@tauri-apps/cli-linux-x64-musl":"2.8.4","@tauri-apps/cli-win32-arm64-msvc":"2.8.4","@tauri-apps/cli-win32-ia32-msvc":"2.8.4","@tauri-apps/cli-win32-x64-msvc":"2.8.4"}},
+    "node_modules/@tauri-apps/cli-darwin-arm64": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.8.4.tgz","integrity":"sha512-BKu8HRkYV01SMTa7r4fLx+wjgtRK8Vep7lmBdHDioP6b8XH3q2KgsAyPWfEZaZIkZ2LY4SqqGARaE9oilNe0oA==","cpu":["arm64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["darwin"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-darwin-x64": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.8.4.tgz","integrity":"sha512-imb9PfSd/7G6VAO7v1bQ2A3ZH4NOCbhGJFLchxzepGcXf9NKkfun157JH9mko29K6sqAwuJ88qtzbKCbWJTH9g==","cpu":["x64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["darwin"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.8.4.tgz","integrity":"sha512-Ml215UnDdl7/fpOrF1CNovym/KjtUbCuPgrcZ4IhqUCnhZdXuphud/JT3E8X97Y03TZ40Sjz8raXYI2ET0exzw==","cpu":["arm"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.8.4.tgz","integrity":"sha512-pbcgBpMyI90C83CxE5REZ9ODyIlmmAPkkJXtV398X3SgZEIYy5TACYqlyyv2z5yKgD8F8WH4/2fek7+jH+ZXAw==","cpu":["arm64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-linux-arm64-musl": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.8.4.tgz","integrity":"sha512-zumFeaU1Ws5Ay872FTyIm7z8kfzEHu8NcIn8M6TxbJs0a7GRV21KBdpW1zNj2qy7HynnpQCqjAYXTUUmm9JAOw==","cpu":["arm64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.8.4.tgz","integrity":"sha512-qiqbB3Zz6IyO201f+1ojxLj65WYj8mixL5cOMo63nlg8CIzsP23cPYUrx1YaDPsCLszKZo7tVs14pc7BWf+/aQ==","cpu":["riscv64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-linux-x64-gnu": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.8.4.tgz","integrity":"sha512-TaqaDd9Oy6k45Hotx3pOf+pkbsxLaApv4rGd9mLuRM1k6YS/aw81YrsMryYPThrxrScEIUcmNIHaHsLiU4GMkw==","cpu":["x64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-linux-x64-musl": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.8.4.tgz","integrity":"sha512-ot9STAwyezN8w+bBHZ+bqSQIJ0qPZFlz/AyscpGqB/JnJQVDFQcRDmUPFEaAtt2UUHSWzN3GoTJ5ypqLBp2WQA==","cpu":["x64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["linux"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-win32-arm64-msvc": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.8.4.tgz","integrity":"sha512-+2aJ/g90dhLiOLFSD1PbElXX3SoMdpO7HFPAZB+xot3CWlAZD1tReUFy7xe0L5GAR16ZmrxpIDM9v9gn5xRy/w==","cpu":["arm64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["win32"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-win32-ia32-msvc": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.8.4.tgz","integrity":"sha512-yj7WDxkL1t9Uzr2gufQ1Hl7hrHuFKTNEOyascbc109EoiAqCp0tgZ2IykQqOZmZOHU884UAWI1pVMqBhS/BfhA==","cpu":["ia32"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["win32"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {"version":"2.8.4","resolved":"https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.8.4.tgz","integrity":"sha512-XuvGB4ehBdd7QhMZ9qbj/8icGEatDuBNxyYHbLKsTYh90ggUlPa/AtaqcC1Fo69lGkTmq9BOKrs1aWSi7xDonA==","cpu":["x64"],"dev":true,"license":"Apache-2.0 OR MIT","optional":true,"os":["win32"],"engines":{"node":">= 10"}},
+    "node_modules/@tauri-apps/plugin-dialog": {"version":"2.4.0","resolved":"https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.4.0.tgz","integrity":"sha512-OvXkrEBfWwtd8tzVCEXIvRfNEX87qs2jv6SqmVPiHcJjBhSF/GUvjqUNIDmKByb5N8nvDqVUM7+g1sXwdC/S9w==","license":"MIT OR Apache-2.0","dependencies":{"@tauri-apps/api":"^2.8.0"}},
+    "node_modules/@types/babel__core": {"version":"7.20.5","resolved":"https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz","integrity":"sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==","dev":true,"license":"MIT","dependencies":{"@babel/parser":"^7.20.7","@babel/types":"^7.20.7","@types/babel__generator":"*","@types/babel__template":"*","@types/babel__traverse":"*"}},
+    "node_modules/@types/babel__generator": {"version":"7.27.0","resolved":"https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz","integrity":"sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==","dev":true,"license":"MIT","dependencies":{"@babel/types":"^7.0.0"}},
+    "node_modules/@types/babel__template": {"version":"7.4.4","resolved":"https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz","integrity":"sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==","dev":true,"license":"MIT","dependencies":{"@babel/parser":"^7.1.0","@babel/types":"^7.0.0"}},
+    "node_modules/@types/babel__traverse": {"version":"7.28.0","resolved":"https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz","integrity":"sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==","dev":true,"license":"MIT","dependencies":{"@babel/types":"^7.28.2"}},
+    "node_modules/@types/estree": {"version":"1.0.9","resolved":"https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz","integrity":"sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==","dev":true,"license":"MIT"},
+    "node_modules/@types/node": {"version":"22.15.32","resolved":"https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz","integrity":"sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==","dev":true,"license":"MIT","dependencies":{"undici-types":"~6.21.0"}},
+    "node_modules/@types/react": {"version":"19.1.9","resolved":"https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz","integrity":"sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==","dev":true,"license":"MIT","dependencies":{"csstype":"^3.0.2"}},
+    "node_modules/@types/react-dom": {"version":"19.1.7","resolved":"https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz","integrity":"sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==","dev":true,"license":"MIT","peerDependencies":{"@types/react":"^19.0.0"}},
+    "node_modules/@vitejs/plugin-react": {"version":"5.0.0","resolved":"https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.0.tgz","integrity":"sha512-Jx9JfsTa05bYkS9xo0hkofp2dCmp1blrKjw9JONs5BTHOvJCgLbaPSuZLGSVJW6u2qe0tc4eevY0+gSNNi0YCw==","dev":true,"license":"MIT","dependencies":{"@babel/core":"^7.28.0","@babel/plugin-transform-react-jsx-self":"^7.27.1","@babel/plugin-transform-react-jsx-source":"^7.27.1","@rolldown/pluginutils":"1.0.0-beta.30","@types/babel__core":"^7.20.5","react-refresh":"^0.17.0"},"engines":{"node":"^20.19.0 || >=22.12.0"},"peerDependencies":{"vite":"^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"}},
+    "node_modules/axe-core": {"version":"4.10.3","resolved":"https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz","integrity":"sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==","dev":true,"license":"MPL-2.0","engines":{"node":">=4"}},
+    "node_modules/baseline-browser-mapping": {"version":"2.11.15","resolved":"https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz","integrity":"sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==","dev":true,"license":"Apache-2.0","bin":{"baseline-browser-mapping":"dist/cli.cjs"},"engines":{"node":">=6.0.0"}},
+    "node_modules/browserslist": {"version":"4.28.8","resolved":"https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz","integrity":"sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==","dev":true,"license":"MIT","dependencies":{"baseline-browser-mapping":"^2.11.12","caniuse-lite":"^1.0.30001809","electron-to-chromium":"^1.5.402","node-releases":"^2.0.53","update-browserslist-db":"^1.3.0"},"bin":{"browserslist":"cli.js"},"engines":{"node":"^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"}},
+    "node_modules/caniuse-lite": {"version":"1.0.30001809","resolved":"https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz","integrity":"sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==","dev":true,"license":"CC-BY-4.0"},
+    "node_modules/convert-source-map": {"version":"2.0.0","resolved":"https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz","integrity":"sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==","dev":true,"license":"MIT"},
+    "node_modules/csstype": {"version":"3.2.3","resolved":"https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz","integrity":"sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==","dev":true,"license":"MIT"},
+    "node_modules/debug": {"version":"4.4.3","resolved":"https://registry.npmjs.org/debug/-/debug-4.4.3.tgz","integrity":"sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==","dev":true,"license":"MIT","dependencies":{"ms":"^2.1.3"},"engines":{"node":">=6.0"},"peerDependenciesMeta":{"supports-color":{"optional":true}}},
+    "node_modules/electron-to-chromium": {"version":"1.5.411","resolved":"https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz","integrity":"sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==","dev":true,"license":"ISC"},
+    "node_modules/esbuild": {"version":"0.25.12","resolved":"https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz","integrity":"sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==","dev":true,"hasInstallScript":true,"license":"MIT","bin":{"esbuild":"bin/esbuild"},"engines":{"node":">=18"},"optionalDependencies":{"@esbuild/aix-ppc64":"0.25.12","@esbuild/android-arm":"0.25.12","@esbuild/android-arm64":"0.25.12","@esbuild/android-x64":"0.25.12","@esbuild/darwin-arm64":"0.25.12","@esbuild/darwin-x64":"0.25.12","@esbuild/freebsd-arm64":"0.25.12","@esbuild/freebsd-x64":"0.25.12","@esbuild/linux-arm":"0.25.12","@esbuild/linux-arm64":"0.25.12","@esbuild/linux-ia32":"0.25.12","@esbuild/linux-loong64":"0.25.12","@esbuild/linux-mips64el":"0.25.12","@esbuild/linux-ppc64":"0.25.12","@esbuild/linux-riscv64":"0.25.12","@esbuild/linux-s390x":"0.25.12","@esbuild/linux-x64":"0.25.12","@esbuild/netbsd-arm64":"0.25.12","@esbuild/netbsd-x64":"0.25.12","@esbuild/openbsd-arm64":"0.25.12","@esbuild/openbsd-x64":"0.25.12","@esbuild/openharmony-arm64":"0.25.12","@esbuild/sunos-x64":"0.25.12","@esbuild/win32-arm64":"0.25.12","@esbuild/win32-ia32":"0.25.12","@esbuild/win32-x64":"0.25.12"}},
+    "node_modules/escalade": {"version":"3.2.0","resolved":"https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz","integrity":"sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==","dev":true,"license":"MIT","engines":{"node":">=6"}},
+    "node_modules/fdir": {"version":"6.5.0","resolved":"https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz","integrity":"sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==","dev":true,"license":"MIT","engines":{"node":">=12.0.0"},"peerDependencies":{"picomatch":"^3 || ^4"},"peerDependenciesMeta":{"picomatch":{"optional":true}}},
+    "node_modules/fsevents": {"version":"2.3.2","resolved":"https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz","integrity":"sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==","dev":true,"hasInstallScript":true,"license":"MIT","optional":true,"os":["darwin"],"engines":{"node":"^8.16.0 || ^10.6.0 || >=11.0.0"}},
+    "node_modules/gensync": {"version":"1.0.0-beta.2","resolved":"https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz","integrity":"sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==","dev":true,"license":"MIT","engines":{"node":">=6.9.0"}},
+    "node_modules/js-tokens": {"version":"4.0.0","resolved":"https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz","integrity":"sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==","dev":true,"license":"MIT"},
+    "node_modules/jsesc": {"version":"3.1.0","resolved":"https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz","integrity":"sha512-/sM3dO2FOzXKqHuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==","dev":true,"license":"MIT","bin":{"jsesc":"bin/jsesc"},"engines":{"node":">=6"}},
+    "node_modules/json5": {"version":"2.2.3","resolved":"https://registry.npmjs.org/json5/-/json5-2.2.3.tgz","integrity":"sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==","dev":true,"license":"MIT","bin":{"json5":"lib/cli.js"},"engines":{"node":">=6"}},
+    "node_modules/lru-cache": {"version":"5.1.1","resolved":"https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz","integrity":"sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==","dev":true,"license":"ISC","dependencies":{"yallist":"^3.0.2"}},
+    "node_modules/ms": {"version":"2.1.3","resolved":"https://registry.npmjs.org/ms/-/ms-2.1.3.tgz","integrity":"sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==","dev":true,"license":"MIT"},
+    "node_modules/nanoid": {"version":"3.3.18","resolved":"https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz","integrity":"sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==","dev":true,"license":"MIT","bin":{"nanoid":"bin/nanoid.cjs"},"engines":{"node":"^10 || ^12 || ^13.7 || ^14 || >=15.0.1"}},
+    "node_modules/node-releases": {"version":"2.0.53","resolved":"https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz","integrity":"sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==","dev":true,"license":"MIT","engines":{"node":">=18"}},
+    "node_modules/picocolors": {"version":"1.1.1","resolved":"https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz","integrity":"sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==","dev":true,"license":"ISC"},
+    "node_modules/picomatch": {"version":"4.0.5","resolved":"https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz","integrity":"sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==","dev":true,"license":"MIT","engines":{"node":">=12"},"funding":{"url":"https://github.com/sponsors/jonschlinkert"}},
+    "node_modules/playwright": {"version":"1.54.2","resolved":"https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz","integrity":"sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==","dev":true,"license":"Apache-2.0","dependencies":{"playwright-core":"1.54.2"},"bin":{"playwright":"cli.js"},"engines":{"node":">=18"},"optionalDependencies":{"fsevents":"2.3.2"}},
+    "node_modules/playwright-core": {"version":"1.54.2","resolved":"https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz","integrity":"sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==","dev":true,"license":"Apache-2.0","bin":{"playwright-core":"cli.js"},"engines":{"node":">=18"}},
+    "node_modules/postcss": {"version":"8.5.26","resolved":"https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz","integrity":"sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==","dev":true,"license":"MIT","dependencies":{"nanoid":"^3.3.17","picocolors":"^1.1.1","source-map-js":"^1.2.1"},"engines":{"node":"^10 || ^12 || >=14"}},
+    "node_modules/react": {"version":"19.1.1","resolved":"https://registry.npmjs.org/react/-/react-19.1.1.tgz","integrity":"sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==","license":"MIT","engines":{"node":">=0.10.0"}},
+    "node_modules/react-dom": {"version":"19.1.1","resolved":"https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz","integrity":"sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==","license":"MIT","dependencies":{"scheduler":"^0.26.0"},"peerDependencies":{"react":"^19.1.1"}},
+    "node_modules/react-refresh": {"version":"0.17.0","resolved":"https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz","integrity":"sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==","dev":true,"license":"MIT","engines":{"node":">=0.10.0"}},
+    "node_modules/rollup": {"version":"4.62.4","resolved":"https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz","integrity":"sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==","dev":true,"license":"MIT","dependencies":{"@types/estree":"1.0.9"},"bin":{"rollup":"dist/bin/rollup"},"engines":{"node":">=18.0.0","npm":">=8.0.0"},"optionalDependencies":{"@napi-rs/lzma-linux-x64-gnu":"1.5.1","@rollup/rollup-android-arm-eabi":"4.62.4","@rollup/rollup-android-arm64":"4.62.4","@rollup/rollup-darwin-arm64":"4.62.4","@rollup/rollup-darwin-x64":"4.62.4","@rollup/rollup-freebsd-arm64":"4.62.4","@rollup/rollup-freebsd-x64":"4.62.4","@rollup/rollup-linux-arm-gnueabihf":"4.62.4","@rollup/rollup-linux-arm-musleabihf":"4.62.4","@rollup/rollup-linux-arm64-gnu":"4.62.4","@rollup/rollup-linux-arm64-musl":"4.62.4","@rollup/rollup-linux-loong64-gnu":"4.62.4","@rollup/rollup-linux-loong64-musl":"4.62.4","@rollup/rollup-linux-ppc64-gnu":"4.62.4","@rollup/rollup-linux-ppc64-musl":"4.62.4","@rollup/rollup-linux-riscv64-gnu":"4.62.4","@rollup/rollup-linux-riscv64-musl":"4.62.4","@rollup/rollup-linux-s390x-gnu":"4.62.4","@rollup/rollup-linux-x64-gnu":"4.62.4","@rollup/rollup-linux-x64-musl":"4.62.4","@rollup/rollup-openbsd-x64":"4.62.4","@rollup/rollup-openharmony-arm64":"4.62.4","@rollup/rollup-win32-arm64-msvc":"4.62.4","@rollup/rollup-win32-ia32-msvc":"4.62.4","@rollup/rollup-win32-x64-gnu":"4.62.4","@rollup/rollup-win32-x64-msvc":"4.62.4","fsevents":"~2.3.2"}},
+    "node_modules/scheduler": {"version":"0.26.0","resolved":"https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz","integrity":"sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==","license":"MIT"},
+    "node_modules/semver": {"version":"6.3.1","resolved":"https://registry.npmjs.org/semver/-/semver-6.3.1.tgz","integrity":"sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==","dev":true,"license":"ISC","bin":{"semver":"bin/semver.js"}},
+    "node_modules/source-map-js": {"version":"1.2.1","resolved":"https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz","integrity":"sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==","dev":true,"license":"BSD-3-Clause","engines":{"node":">=0.10.0"}},
+    "node_modules/tinyglobby": {"version":"0.2.17","resolved":"https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz","integrity":"sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==","dev":true,"license":"MIT","dependencies":{"fdir":"^6.5.0","picomatch":"^4.0.4"},"engines":{"node":">=12.0.0"},"funding":{"url":"https://github.com/sponsors/SuperchupuDev"}},
+    "node_modules/typescript": {"version":"5.9.2","resolved":"https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz","integrity":"sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==","dev":true,"license":"Apache-2.0","bin":{"tsc":"bin/tsc","tsserver":"bin/tsserver"},"engines":{"node":">=14.17"}},
+    "node_modules/undici-types": {"version":"6.21.0","resolved":"https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz","integrity":"sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==","dev":true,"license":"MIT"},
+    "node_modules/update-browserslist-db": {"version":"1.3.1","resolved":"https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz","integrity":"sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==","dev":true,"license":"MIT","dependencies":{"escalade":"^3.2.0","picocolors":"^1.1.1"},"bin":{"update-browserslist-db":"cli.js"},"peerDependencies":{"browserslist":">= 4.21.0"}},
+    "node_modules/vite": {"version":"7.1.2","resolved":"https://registry.npmjs.org/vite/-/vite-7.1.2.tgz","integrity":"sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==","dev":true,"license":"MIT","dependencies":{"esbuild":"^0.25.0","fdir":"^6.4.6","picomatch":"^4.0.3","postcss":"^8.5.6","rollup":"^4.43.0","tinyglobby":"^0.2.14"},"bin":{"vite":"bin/vite.js"},"engines":{"node":"^20.19.0 || >=22.12.0"},"funding":{"url":"https://github.com/vitejs/vite?sponsor=1"},"optionalDependencies":{"fsevents":"~2.3.3"},"peerDependencies":{"@types/node":"^20.19.0 || >=22.12.0","jiti":">=1.21.0","less":"^4.0.0","lightningcss":"^1.21.0","sass":"^1.70.0","sass-embedded":"^1.70.0","stylus":">=0.54.8","sugarss":"^5.0.0","terser":"^5.16.0","tsx":"^4.8.1","yaml":"^2.4.2"},"peerDependenciesMeta":{"@types/node":{"optional":true},"jiti":{"optional":true},"less":{"optional":true},"lightningcss":{"optional":true},"sass":{"optional":true},"sass-embedded":{"optional":true},"stylus":{"optional":true},"sugarss":{"optional":true},"terser":{"optional":true},"tsx":{"optional":true},"yaml":{"optional":true}}},
+    "node_modules/vite/node_modules/fsevents": {"version":"2.3.3","resolved":"https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz","integrity":"sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==","dev":true,"hasInstallScript":true,"license":"MIT","optional":true,"os":["darwin"],"engines":{"node":"^8.16.0 || ^10.6.0 || >=11.0.0"}},
+    "node_modules/yallist": {"version":"3.1.1","resolved":"https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz","integrity":"sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==","dev":true,"license":"ISC"}
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,9 +23,11 @@
     "@axe-core/playwright": "4.10.2",
     "@playwright/test": "1.54.2",
     "@tauri-apps/cli": "2.8.4",
+    "@types/node": "22.15.32",
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
     "@vitejs/plugin-react": "5.0.0",
+    "playwright-core": "1.54.2",
     "typescript": "5.9.2",
     "vite": "7.1.2"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "echoflow-desktop",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test",
+    "tauri": "tauri"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "2.8.0",
+    "@tauri-apps/plugin-dialog": "2.4.0",
+    "react": "19.1.1",
+    "react-dom": "19.1.1"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "4.10.2",
+    "@playwright/test": "1.54.2",
+    "@tauri-apps/cli": "2.8.4",
+    "@types/react": "19.1.9",
+    "@types/react-dom": "19.1.7",
+    "@vitejs/plugin-react": "5.0.0",
+    "typescript": "5.9.2",
+    "vite": "7.1.2"
+  }
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? "line" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173/?e2e=1",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173/?e2e=1",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 2 : 4,
   reporter: process.env.CI ? "line" : "list",
   use: {
     baseURL: "http://127.0.0.1:4173/?e2e=1",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "echoflow-desktop"
+version = "0.1.0"
+description = "EchoFlow local desktop host"
+edition = "2021"
+license = "AGPL-3.0-only"
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"

--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-capability",
+  "description": "Minimum capability surface for the EchoFlow main window",
+  "windows": ["main"],
+  "permissions": ["core:default", "dialog:allow-open"]
+}

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -1,0 +1,48 @@
+use serde_json::Value;
+use std::env;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+const MAX_REQUEST_BYTES: usize = 128 * 1024;
+
+fn run_backend_request(request: Value) -> Result<Value, String> {
+    let encoded = serde_json::to_vec(&request).map_err(|_| "Could not encode desktop request".to_string())?;
+    if encoded.len() > MAX_REQUEST_BYTES {
+        return Err("Desktop request exceeded the safe size limit".to_string());
+    }
+
+    let python = env::var("ECHOFLOW_PYTHON").unwrap_or_else(|_| "python".to_string());
+    let mut child = Command::new(python)
+        .args(["-m", "echoflow.desktop.bridge"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|_| "EchoFlow's local Python service is unavailable".to_string())?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "Could not open the EchoFlow desktop bridge".to_string())?;
+    stdin
+        .write_all(&encoded)
+        .map_err(|_| "Could not send the request to EchoFlow".to_string())?;
+    drop(stdin);
+
+    let output = child
+        .wait_with_output()
+        .map_err(|_| "EchoFlow's local Python service did not finish cleanly".to_string())?;
+    if !output.status.success() {
+        return Err("EchoFlow's local Python service exited unexpectedly".to_string());
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .map_err(|_| "EchoFlow's local Python service returned an invalid response".to_string())
+}
+
+#[tauri::command]
+pub async fn desktop_request(request: Value) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || run_backend_request(request))
+        .await
+        .map_err(|_| "EchoFlow's local service task could not be completed".to_string())?
+}

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -1,0 +1,11 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+mod backend;
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+        .invoke_handler(tauri::generate_handler![backend::desktop_request])
+        .run(tauri::generate_context!())
+        .expect("EchoFlow desktop host could not start");
+}

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "EchoFlow",
+  "version": "0.1.0",
+  "identifier": "org.echoflow.desktop",
+  "build": {
+    "beforeDevCommand": "npm run dev",
+    "devUrl": "http://localhost:5173",
+    "beforeBuildCommand": "npm run build",
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "EchoFlow",
+        "width": 1180,
+        "height": 780,
+        "minWidth": 840,
+        "minHeight": 640,
+        "resizable": true
+      }
+    ],
+    "security": {
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost ws://localhost:5173; img-src 'self' asset: http://asset.localhost data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
+    }
+  },
+  "bundle": {
+    "active": false
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,338 @@
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  createDesktopClient,
+  type LibraryLocation,
+  type LocationKind,
+  type ProcessingPolicy,
+} from "./api/desktop";
+
+const client = createDesktopClient();
+
+type Theme = "archive" | "midnight";
+type SelectionType = "files" | "folder" | null;
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).at(-1) ?? path;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+}
+
+export function App() {
+  const [theme, setTheme] = useState<Theme>("archive");
+  const [purpose, setPurpose] = useState<LocationKind>("recording-source");
+  const [selectionType, setSelectionType] = useState<SelectionType>(null);
+  const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
+  const [remember, setRemember] = useState(false);
+  const [automatic, setAutomatic] = useState(false);
+  const [locations, setLocations] = useState<LibraryLocation[]>([]);
+  const [discovered, setDiscovered] = useState<Array<{ path: string; size: number }>>([]);
+  const [status, setStatus] = useState("Choose recordings or an existing transcript library to begin.");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  useEffect(() => {
+    void client
+      .listLocations()
+      .then(setLocations)
+      .catch(() => setStatus("EchoFlow is ready for a new local import."));
+  }, []);
+
+  const canRemember = selectionType === "folder" && selectedPaths.length === 1;
+  const policy: ProcessingPolicy = automatic ? "automatic" : "manual";
+  const actionLabel = remember ? "Remember this folder" : "Use this selection";
+  const selectedTitle = useMemo(() => {
+    if (selectedPaths.length === 0) return "Nothing selected yet";
+    if (selectedPaths.length === 1) return basename(selectedPaths[0] ?? "");
+    return `${selectedPaths.length} files selected`;
+  }, [selectedPaths]);
+
+  async function chooseFiles() {
+    setError(null);
+    const paths = await client.chooseFiles(purpose);
+    if (paths.length === 0) return;
+    setSelectionType("files");
+    setSelectedPaths(paths);
+    setRemember(false);
+    setAutomatic(false);
+    setStatus("This one-time selection stays local and is not remembered as a watched location.");
+  }
+
+  async function chooseFolder() {
+    setError(null);
+    const path = await client.chooseFolder();
+    if (!path) return;
+    setSelectionType("folder");
+    setSelectedPaths([path]);
+    setRemember(false);
+    setAutomatic(false);
+    setStatus("Choose whether EchoFlow should use this folder once or remember it for future discovery.");
+  }
+
+  async function applySelection() {
+    if (selectedPaths.length === 0) return;
+    setBusy(true);
+    setError(null);
+    try {
+      if (!remember) {
+        setStatus(
+          purpose === "recording-source"
+            ? "Ready for transcription planning. EchoFlow has not saved a folder permission."
+            : "Ready for one-time transcript import. EchoFlow has not saved a folder permission.",
+        );
+        return;
+      }
+
+      const path = selectedPaths[0];
+      if (!path) return;
+      await client.rememberLocation(path, purpose, purpose === "recording-source" ? policy : "manual");
+      setLocations(await client.listLocations());
+      if (purpose === "recording-source") {
+        const report = await client.discoverRecordings();
+        setDiscovered(report.recordings.map((item) => ({ path: item.path, size: item.size_bytes })));
+        setStatus(
+          `Folder remembered. ${report.recordings.length} recording${report.recordings.length === 1 ? "" : "s"} discovered; nothing was transcribed automatically by this action.`,
+        );
+      } else {
+        await client.refreshTranscriptLocations();
+        setStatus("Transcript library remembered and reconciled with EchoFlow's local index.");
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "EchoFlow could not add this location safely.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function switchPurpose(next: LocationKind) {
+    setPurpose(next);
+    setSelectionType(null);
+    setSelectedPaths([]);
+    setRemember(false);
+    setAutomatic(false);
+    setDiscovered([]);
+    setError(null);
+  }
+
+  return (
+    <div className="app-shell">
+      <aside className="sidebar" aria-label="Primary navigation">
+        <div className="brand-block">
+          <div className="brand-mark" aria-hidden="true">E</div>
+          <div>
+            <p className="brand-name">EchoFlow</p>
+            <p className="brand-subtitle">Private evidence workspace</p>
+          </div>
+        </div>
+
+        <nav className="nav-list" aria-label="Workspace">
+          <button className="nav-item nav-item-active" type="button" aria-current="page">
+            <span aria-hidden="true">＋</span> Add evidence
+          </button>
+          <button className="nav-item" type="button" disabled>
+            <span aria-hidden="true">⌕</span> Library
+          </button>
+          <button className="nav-item" type="button" disabled>
+            <span aria-hidden="true">✦</span> Research
+          </button>
+        </nav>
+
+        <div className="privacy-note">
+          <span className="privacy-dot" aria-hidden="true" />
+          <div>
+            <strong>Local by default</strong>
+            <p>Your recordings stay where you put them.</p>
+          </div>
+        </div>
+      </aside>
+
+      <main className="workspace">
+        <header className="topbar">
+          <div>
+            <p className="eyebrow">Evidence intake</p>
+            <h1>Bring your recordings home.</h1>
+          </div>
+          <div className="theme-switch" role="group" aria-label="Appearance">
+            <button
+              type="button"
+              className={theme === "archive" ? "theme-active" : ""}
+              aria-pressed={theme === "archive"}
+              onClick={() => setTheme("archive")}
+            >
+              Archive
+            </button>
+            <button
+              type="button"
+              className={theme === "midnight" ? "theme-active" : ""}
+              aria-pressed={theme === "midnight"}
+              onClick={() => setTheme("midnight")}
+            >
+              Midnight
+            </button>
+          </div>
+        </header>
+
+        <section className="intro-copy" aria-labelledby="intake-title">
+          <div>
+            <p className="section-kicker">01 · Choose what EchoFlow should know about</p>
+            <h2 id="intake-title">Add local evidence without giving up custody.</h2>
+          </div>
+          <p>
+            Select individual files for a one-time job, or remember a research folder so EchoFlow can discover new material when you ask it to refresh.
+          </p>
+        </section>
+
+        <section className="intake-card" aria-label="Import controls">
+          <div className="purpose-tabs" role="tablist" aria-label="Evidence type">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={purpose === "recording-source"}
+              className={purpose === "recording-source" ? "tab-active" : ""}
+              onClick={() => switchPurpose("recording-source")}
+            >
+              Recordings
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={purpose === "transcript-library"}
+              className={purpose === "transcript-library" ? "tab-active" : ""}
+              onClick={() => switchPurpose("transcript-library")}
+            >
+              Existing transcripts
+            </button>
+          </div>
+
+          <div className="picker-grid">
+            <button className="picker-card" type="button" onClick={() => void chooseFiles()}>
+              <span className="picker-icon" aria-hidden="true">↥</span>
+              <span className="picker-title">Choose files</span>
+              <span className="picker-detail">
+                {purpose === "recording-source" ? "Audio or video, one or many" : "Canonical EchoFlow JSON"}
+              </span>
+            </button>
+            <button className="picker-card" type="button" onClick={() => void chooseFolder()}>
+              <span className="picker-icon" aria-hidden="true">⌑</span>
+              <span className="picker-title">Choose folder</span>
+              <span className="picker-detail">Use once or remember for later</span>
+            </button>
+          </div>
+
+          <div className="selection-panel" aria-live="polite">
+            <div className="selection-heading">
+              <div>
+                <p className="mini-label">Current selection</p>
+                <h3>{selectedTitle}</h3>
+              </div>
+              {selectionType && <span className="selection-badge">{selectionType}</span>}
+            </div>
+            {selectedPaths.length > 0 && (
+              <ul className="path-list" aria-label="Selected local paths">
+                {selectedPaths.slice(0, 4).map((path) => (
+                  <li key={path}>{path}</li>
+                ))}
+                {selectedPaths.length > 4 && <li>+ {selectedPaths.length - 4} more</li>}
+              </ul>
+            )}
+          </div>
+
+          {canRemember && (
+            <fieldset className="retention-choice">
+              <legend>How should EchoFlow use this location?</legend>
+              <label className={!remember ? "choice-card choice-active" : "choice-card"}>
+                <input
+                  type="radio"
+                  name="location-retention"
+                  checked={!remember}
+                  onChange={() => {
+                    setRemember(false);
+                    setAutomatic(false);
+                  }}
+                />
+                <span>
+                  <strong>Just this time</strong>
+                  <small>Use the selection now. Do not save the folder as a library permission.</small>
+                </span>
+              </label>
+              <label className={remember ? "choice-card choice-active" : "choice-card"}>
+                <input
+                  type="radio"
+                  name="location-retention"
+                  checked={remember}
+                  onChange={() => setRemember(true)}
+                />
+                <span>
+                  <strong>Remember this folder</strong>
+                  <small>Revisit this location on explicit refresh and normal application lifecycle points.</small>
+                </span>
+              </label>
+            </fieldset>
+          )}
+
+          {remember && purpose === "recording-source" && (
+            <details className="advanced-card">
+              <summary>Advanced processing policy</summary>
+              <label className="checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={automatic}
+                  onChange={(event) => setAutomatic(event.target.checked)}
+                />
+                <span>
+                  <strong>Automatically process newly discovered recordings</strong>
+                  <small>
+                    Explicit opt-in. Discovery itself still does not transcribe, copy, hash, or modify recordings.
+                  </small>
+                </span>
+              </label>
+            </details>
+          )}
+
+          <div className="action-row">
+            <p className="status-copy" role="status">{status}</p>
+            <button
+              className="primary-action"
+              type="button"
+              disabled={selectedPaths.length === 0 || busy}
+              onClick={() => void applySelection()}
+            >
+              {busy ? "Working…" : actionLabel}
+            </button>
+          </div>
+          {error && <p className="error-banner" role="alert">{error}</p>}
+        </section>
+
+        <section className="lower-grid" aria-label="Import overview">
+          <article className="info-card">
+            <p className="mini-label">Remembered locations</p>
+            <strong className="metric">{locations.length}</strong>
+            <p>Private app preferences only. Forgetting one never deletes the files inside it.</p>
+          </article>
+          <article className="info-card">
+            <p className="mini-label">Discovered recordings</p>
+            <strong className="metric">{discovered.length}</strong>
+            <p>
+              {discovered.length === 0
+                ? "Discovery is separate from processing."
+                : `${basename(discovered[0]?.path ?? "")} · ${formatBytes(discovered[0]?.size ?? 0)} and ${Math.max(0, discovered.length - 1)} more`}
+            </p>
+          </article>
+          <article className="info-card provenance-card">
+            <p className="mini-label">Custody rule</p>
+            <strong>Originals stay original.</strong>
+            <p>Selecting media does not move it into a hidden EchoFlow vault.</p>
+          </article>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/api/desktop.ts
+++ b/frontend/src/api/desktop.ts
@@ -1,0 +1,221 @@
+export type LocationKind = "recording-source" | "transcript-library";
+export type ProcessingPolicy = "manual" | "automatic";
+
+export interface LibraryLocation {
+  location_id: string;
+  path: string;
+  kind: LocationKind;
+  enabled: boolean;
+  processing_policy: ProcessingPolicy;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DiscoveredRecording {
+  path: string;
+  size_bytes: number;
+  location_ids: string[];
+  automatic_processing_requested: boolean;
+}
+
+export interface RecordingDiscoveryReport {
+  recordings: DiscoveredRecording[];
+  unavailable_location_ids: string[];
+}
+
+interface DesktopError {
+  code: string;
+  message: string;
+}
+
+interface DesktopResponse<T> {
+  protocol_version: 1;
+  request_id: string;
+  ok: boolean;
+  result: T | null;
+  error: DesktopError | null;
+}
+
+export interface DesktopClient {
+  chooseFiles(kind: LocationKind): Promise<string[]>;
+  chooseFolder(): Promise<string | null>;
+  listLocations(): Promise<LibraryLocation[]>;
+  rememberLocation(
+    path: string,
+    kind: LocationKind,
+    processingPolicy: ProcessingPolicy,
+  ): Promise<LibraryLocation>;
+  discoverRecordings(): Promise<RecordingDiscoveryReport>;
+  refreshTranscriptLocations(): Promise<void>;
+}
+
+function assertResponse<T>(value: unknown): DesktopResponse<T> {
+  if (!value || typeof value !== "object") {
+    throw new Error("EchoFlow desktop bridge returned an invalid response");
+  }
+  const candidate = value as Partial<DesktopResponse<T>>;
+  if (
+    candidate.protocol_version !== 1 ||
+    typeof candidate.request_id !== "string" ||
+    typeof candidate.ok !== "boolean"
+  ) {
+    throw new Error("EchoFlow desktop bridge returned an incompatible response");
+  }
+  return candidate as DesktopResponse<T>;
+}
+
+class TauriDesktopClient implements DesktopClient {
+  private async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const request = {
+      protocol_version: 1,
+      request_id: crypto.randomUUID(),
+      method,
+      params,
+    };
+    const response = assertResponse<T>(
+      await invoke<unknown>("desktop_request", { request }),
+    );
+    if (!response.ok || response.result === null) {
+      throw new Error(response.error?.message ?? "EchoFlow could not complete that request");
+    }
+    return response.result;
+  }
+
+  async chooseFiles(kind: LocationKind): Promise<string[]> {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const filters =
+      kind === "transcript-library"
+        ? [{ name: "EchoFlow transcript", extensions: ["json"] }]
+        : [
+            {
+              name: "Audio and video",
+              extensions: [
+                "aac",
+                "aiff",
+                "avi",
+                "flac",
+                "m4a",
+                "m4v",
+                "mkv",
+                "mov",
+                "mp3",
+                "mp4",
+                "mpeg",
+                "mpg",
+                "ogg",
+                "opus",
+                "wav",
+                "webm",
+                "wma",
+              ],
+            },
+          ];
+    const selected = await open({ multiple: true, directory: false, filters });
+    if (!selected) return [];
+    return Array.isArray(selected) ? selected : [selected];
+  }
+
+  async chooseFolder(): Promise<string | null> {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const selected = await open({ multiple: false, directory: true });
+    return typeof selected === "string" ? selected : null;
+  }
+
+  listLocations(): Promise<LibraryLocation[]> {
+    return this.request("locations.list", {});
+  }
+
+  rememberLocation(
+    path: string,
+    kind: LocationKind,
+    processingPolicy: ProcessingPolicy,
+  ): Promise<LibraryLocation> {
+    return this.request("locations.add", {
+      path,
+      kind,
+      processing_policy: processingPolicy,
+    });
+  }
+
+  discoverRecordings(): Promise<RecordingDiscoveryReport> {
+    return this.request("recordings.discover", {});
+  }
+
+  async refreshTranscriptLocations(): Promise<void> {
+    await this.request("transcripts.refresh", { verify: false });
+  }
+}
+
+class MockDesktopClient implements DesktopClient {
+  private locations: LibraryLocation[] = [];
+
+  async chooseFiles(kind: LocationKind): Promise<string[]> {
+    return kind === "transcript-library"
+      ? ["/Users/susan/Research/interview-01.echoflow.json"]
+      : [
+          "/Users/susan/Research/interview-01.m4a",
+          "/Users/susan/Research/interview-02.mp4",
+        ];
+  }
+
+  async chooseFolder(): Promise<string> {
+    return "/Users/susan/Research/Oral Histories";
+  }
+
+  async listLocations(): Promise<LibraryLocation[]> {
+    return [...this.locations];
+  }
+
+  async rememberLocation(
+    path: string,
+    kind: LocationKind,
+    processingPolicy: ProcessingPolicy,
+  ): Promise<LibraryLocation> {
+    const now = "2026-08-19T19:20:00+00:00";
+    const location: LibraryLocation = {
+      location_id: `location-${this.locations.length + 1}`,
+      path,
+      kind,
+      enabled: true,
+      processing_policy: processingPolicy,
+      created_at: now,
+      updated_at: now,
+    };
+    this.locations.push(location);
+    return location;
+  }
+
+  async discoverRecordings(): Promise<RecordingDiscoveryReport> {
+    return {
+      recordings: [
+        {
+          path: "/Users/susan/Research/Oral Histories/interview-01.m4a",
+          size_bytes: 48_391_232,
+          location_ids: this.locations.map((item) => item.location_id),
+          automatic_processing_requested: this.locations.some(
+            (item) => item.processing_policy === "automatic",
+          ),
+        },
+        {
+          path: "/Users/susan/Research/Oral Histories/interview-02.mp4",
+          size_bytes: 802_160_640,
+          location_ids: this.locations.map((item) => item.location_id),
+          automatic_processing_requested: this.locations.some(
+            (item) => item.processing_policy === "automatic",
+          ),
+        },
+      ],
+      unavailable_location_ids: [],
+    };
+  }
+
+  async refreshTranscriptLocations(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export function createDesktopClient(): DesktopClient {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("e2e") === "1" ? new MockDesktopClient() : new TauriDesktopClient();
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("EchoFlow desktop root is unavailable");
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,161 @@
+:root {
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  --bg: #f3efe7;
+  --surface: #fbf9f4;
+  --surface-raised: #ffffff;
+  --surface-soft: #ece6dc;
+  --ink: #1f2930;
+  --muted: #5f6762;
+  --border: #d9d1c4;
+  --accent: #315e63;
+  --accent-strong: #24494d;
+  --accent-soft: #dce9e6;
+  --focus: #a46d19;
+  --danger: #8a3f43;
+  --shadow: 0 24px 70px rgba(58, 47, 35, 0.08);
+  color: var(--ink);
+  background: var(--bg);
+}
+
+:root[data-theme="midnight"] {
+  --bg: #111519;
+  --surface: #171d22;
+  --surface-raised: #1e252b;
+  --surface-soft: #242d34;
+  --ink: #eef2ef;
+  --muted: #aab6b5;
+  --border: #42515a;
+  --accent: #79b9b0;
+  --accent-strong: #a3d2ca;
+  --accent-soft: #203b3d;
+  --focus: #e4b85d;
+  --danger: #e38c92;
+  --shadow: 0 30px 80px rgba(0, 0, 0, 0.24);
+  color-scheme: dark;
+}
+
+* { box-sizing: border-box; }
+html, body, #root { min-height: 100%; margin: 0; }
+body { min-width: 320px; background: var(--bg); color: var(--ink); }
+button, input { font: inherit; }
+button { color: inherit; }
+button:focus-visible, input:focus-visible, summary:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.app-shell { min-height: 100vh; display: grid; grid-template-columns: 248px minmax(0, 1fr); }
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  padding: 28px 20px;
+  border-right: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 86%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 34px;
+}
+.brand-block { display: flex; align-items: center; gap: 12px; padding: 0 8px; }
+.brand-mark {
+  width: 42px; height: 42px; border-radius: 14px; display: grid; place-items: center;
+  background: var(--ink); color: var(--surface); font-weight: 800; letter-spacing: -0.04em;
+}
+.brand-name, .brand-subtitle, .privacy-note p, .status-copy, .info-card p { margin: 0; }
+.brand-name { font-weight: 760; letter-spacing: -0.03em; }
+.brand-subtitle { margin-top: 2px; font-size: 0.72rem; color: var(--muted); }
+.nav-list { display: grid; gap: 6px; }
+.nav-item {
+  border: 0; background: transparent; border-radius: 12px; padding: 11px 12px;
+  text-align: left; display: flex; gap: 10px; align-items: center; color: var(--muted);
+}
+.nav-item-active { background: var(--surface-soft); color: var(--ink); font-weight: 650; }
+.nav-item:disabled { opacity: 0.54; }
+.privacy-note {
+  margin-top: auto; display: flex; gap: 10px; padding: 14px; border: 1px solid var(--border);
+  border-radius: 14px; background: var(--surface);
+}
+.privacy-note strong { font-size: 0.78rem; }
+.privacy-note p { margin-top: 4px; color: var(--muted); font-size: 0.72rem; line-height: 1.45; }
+.privacy-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); margin-top: 5px; flex: none; }
+
+.workspace { padding: 34px clamp(28px, 5vw, 72px) 64px; overflow: hidden; }
+.topbar { display: flex; justify-content: space-between; gap: 28px; align-items: flex-start; max-width: 1180px; margin: 0 auto; }
+.eyebrow, .section-kicker, .mini-label {
+  margin: 0; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.14em; color: var(--muted); font-weight: 720;
+}
+h1 { margin: 7px 0 0; font-size: clamp(2rem, 4vw, 3.8rem); line-height: 0.98; letter-spacing: -0.055em; font-weight: 690; }
+.theme-switch { border: 1px solid var(--border); background: var(--surface); padding: 4px; border-radius: 999px; display: flex; }
+.theme-switch button { border: 0; background: transparent; border-radius: 999px; padding: 7px 11px; color: var(--muted); font-size: 0.75rem; }
+.theme-switch .theme-active { background: var(--ink); color: var(--surface); }
+
+.intro-copy { max-width: 1180px; margin: 72px auto 24px; display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(260px, 0.75fr); gap: 48px; align-items: end; }
+.intro-copy h2 { margin: 10px 0 0; max-width: 760px; font-size: clamp(1.5rem, 3vw, 2.65rem); line-height: 1.08; letter-spacing: -0.04em; font-weight: 650; }
+.intro-copy > p { margin: 0; color: var(--muted); line-height: 1.65; font-size: 0.92rem; }
+
+.intake-card { max-width: 1180px; margin: 0 auto; border: 1px solid var(--border); border-radius: 24px; background: var(--surface); box-shadow: var(--shadow); overflow: hidden; }
+.purpose-tabs { display: flex; gap: 2px; padding: 8px 8px 0; border-bottom: 1px solid var(--border); }
+.purpose-tabs button { border: 0; border-bottom: 2px solid transparent; background: transparent; padding: 12px 16px 14px; color: var(--muted); }
+.purpose-tabs .tab-active { color: var(--ink); border-bottom-color: var(--accent); font-weight: 680; }
+.picker-grid { padding: 26px; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.picker-card {
+  min-height: 150px; border: 1px solid var(--border); background: var(--surface-raised); border-radius: 18px; padding: 22px;
+  text-align: left; display: grid; align-content: end; justify-items: start; transition: transform 150ms ease, border-color 150ms ease, background 150ms ease;
+}
+.picker-card:hover { transform: translateY(-2px); border-color: var(--accent); background: var(--accent-soft); }
+.picker-icon { width: 38px; height: 38px; border-radius: 12px; display: grid; place-items: center; background: var(--accent-soft); color: var(--accent-strong); margin-bottom: 18px; font-size: 1.15rem; }
+.picker-title { font-weight: 720; letter-spacing: -0.02em; }
+.picker-detail { margin-top: 5px; color: var(--muted); font-size: 0.78rem; }
+.selection-panel { margin: 0 26px 22px; border: 1px solid var(--border); background: var(--surface-soft); border-radius: 16px; padding: 18px; }
+.selection-heading { display: flex; justify-content: space-between; gap: 16px; align-items: center; }
+.selection-heading h3 { margin: 5px 0 0; font-size: 1rem; letter-spacing: -0.015em; }
+.selection-badge { border: 1px solid var(--border); background: var(--surface); border-radius: 999px; padding: 5px 9px; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.path-list { margin: 13px 0 0; padding-left: 18px; color: var(--muted); font-size: 0.74rem; line-height: 1.7; overflow-wrap: anywhere; }
+.retention-choice { border: 0; border-top: 1px solid var(--border); margin: 0; padding: 24px 26px; display: grid; gap: 10px; }
+.retention-choice legend { padding-top: 22px; margin-bottom: 8px; font-weight: 700; letter-spacing: -0.02em; }
+.choice-card { border: 1px solid var(--border); border-radius: 15px; padding: 15px; display: flex; align-items: flex-start; gap: 12px; background: var(--surface-raised); }
+.choice-active { border-color: var(--accent); background: var(--accent-soft); }
+.choice-card input { margin-top: 3px; accent-color: var(--accent); }
+.choice-card span, .checkbox-row span { display: grid; gap: 4px; }
+.choice-card small, .checkbox-row small { color: var(--muted); line-height: 1.45; }
+.advanced-card { margin: 0 26px 24px; border: 1px solid var(--border); border-radius: 15px; background: var(--surface-raised); }
+.advanced-card summary { cursor: pointer; padding: 15px 17px; font-weight: 680; }
+.checkbox-row { display: flex; gap: 12px; padding: 0 17px 17px; align-items: flex-start; }
+.checkbox-row input { margin-top: 4px; accent-color: var(--accent); }
+.action-row { border-top: 1px solid var(--border); padding: 20px 26px; display: flex; justify-content: space-between; gap: 24px; align-items: center; }
+.status-copy { color: var(--muted); line-height: 1.5; font-size: 0.8rem; max-width: 680px; }
+.primary-action { border: 0; border-radius: 12px; background: var(--accent); color: #fff; padding: 11px 16px; font-weight: 720; white-space: nowrap; }
+.primary-action:hover:not(:disabled) { background: var(--accent-strong); }
+.primary-action:disabled { opacity: 0.45; cursor: not-allowed; }
+.error-banner { margin: 0 26px 22px; color: var(--danger); font-weight: 650; }
+
+.lower-grid { max-width: 1180px; margin: 18px auto 0; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
+.info-card { min-height: 150px; padding: 20px; border: 1px solid var(--border); border-radius: 18px; background: color-mix(in srgb, var(--surface) 82%, transparent); }
+.info-card .metric { display: block; margin: 14px 0 8px; font-size: 2.2rem; letter-spacing: -0.05em; }
+.info-card p:last-child { color: var(--muted); line-height: 1.5; font-size: 0.78rem; }
+.provenance-card strong { display: block; margin: 16px 0 9px; font-size: 1.05rem; }
+
+@media (max-width: 900px) {
+  .app-shell { grid-template-columns: 1fr; }
+  .sidebar { position: static; height: auto; border-right: 0; border-bottom: 1px solid var(--border); flex-direction: row; align-items: center; padding: 16px 20px; }
+  .nav-list { display: none; }
+  .privacy-note { margin: 0 0 0 auto; max-width: 240px; }
+  .workspace { padding: 28px 20px 52px; }
+  .intro-copy { margin-top: 48px; grid-template-columns: 1fr; gap: 18px; }
+}
+
+@media (max-width: 680px) {
+  .topbar { display: grid; }
+  .picker-grid, .lower-grid { grid-template-columns: 1fr; }
+  .picker-card { min-height: 128px; }
+  .action-row { align-items: stretch; flex-direction: column; }
+  .primary-action { width: 100%; }
+  .privacy-note { display: none; }
+  .brand-subtitle { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.001ms !important; animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; }
+}

--- a/frontend/tests/import.spec.ts
+++ b/frontend/tests/import.spec.ts
@@ -1,0 +1,60 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test("import surface is keyboard reachable and has no accessibility violations", async ({ page }) => {
+  await page.goto("/?e2e=1");
+
+  await expect(page.getByRole("heading", { name: "Bring your recordings home." })).toBeVisible();
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("button", { name: "Add evidence" })).toBeFocused();
+
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});
+
+test("Susan can stage multiple recordings without remembering their folder", async ({ page }) => {
+  await page.goto("/?e2e=1");
+
+  await page.getByRole("button", { name: "Choose files" }).click();
+  await expect(page.getByRole("heading", { name: "2 files selected" })).toBeVisible();
+  await page.getByRole("button", { name: "Use this selection" }).click();
+
+  await expect(page.getByRole("status")).toContainText("has not saved a folder permission");
+  await expect(page.getByText("Remembered locations").locator("..")).toContainText("0");
+});
+
+test("remembered recording folder keeps discovery separate from processing", async ({ page }) => {
+  await page.goto("/?e2e=1");
+
+  await page.getByRole("button", { name: "Choose folder" }).click();
+  await page.getByRole("radio", { name: /Remember this folder/ }).check();
+  await page.getByText("Advanced processing policy").click();
+  await page.getByRole("checkbox", { name: /Automatically process newly discovered recordings/ }).check();
+  await page.getByRole("button", { name: "Remember this folder" }).click();
+
+  await expect(page.getByRole("status")).toContainText("2 recordings discovered");
+  await expect(page.getByRole("status")).toContainText("nothing was transcribed automatically");
+});
+
+test("transcript libraries never offer automatic processing", async ({ page }) => {
+  await page.goto("/?e2e=1");
+
+  await page.getByRole("tab", { name: "Existing transcripts" }).click();
+  await page.getByRole("button", { name: "Choose folder" }).click();
+  await page.getByRole("radio", { name: /Remember this folder/ }).check();
+
+  await expect(page.getByText("Advanced processing policy")).toHaveCount(0);
+  await page.getByRole("button", { name: "Remember this folder" }).click();
+  await expect(page.getByRole("status")).toContainText("reconciled with EchoFlow's local index");
+});
+
+test("theme switching preserves semantics and accessibility", async ({ page }) => {
+  await page.goto("/?e2e=1");
+
+  await page.getByRole("button", { name: "Midnight" }).click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "midnight");
+  await expect(page.getByRole("heading", { name: "Add local evidence without giving up custody." })).toBeVisible();
+
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "allowJs": false,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
@@ -16,7 +16,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "types": ["node"]
   },
   "include": ["src", "vite.config.ts", "playwright.config.ts", "tests"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["src", "vite.config.ts", "playwright.config.ts", "tests"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  clearScreen: false,
+  server: {
+    strictPort: true,
+  },
+});

--- a/src/echoflow/desktop/__init__.py
+++ b/src/echoflow/desktop/__init__.py
@@ -1,0 +1,1 @@
+"""Machine-facing local desktop adapter for the EchoFlow application services."""

--- a/src/echoflow/desktop/bridge.py
+++ b/src/echoflow/desktop/bridge.py
@@ -1,0 +1,180 @@
+"""Versioned stdin/stdout bridge used by the local Tauri desktop host.
+
+The bridge intentionally exposes a small allowlist of application operations. It does not
+provide arbitrary shell, filesystem, SQL, or database access to the frontend.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import redirect_stdout
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from echoflow.app.app_container import AppContainer
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.locations import (
+    LibraryLocationKind,
+    LibraryLocationService,
+    RecordingProcessingPolicy,
+)
+
+_PROTOCOL_VERSION = 1
+_MAX_REQUEST_BYTES = 128 * 1024
+
+
+class _DesktopRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    protocol_version: Literal[1]
+    request_id: str = Field(min_length=1, max_length=128)
+    method: Literal[
+        "locations.list",
+        "locations.add",
+        "recordings.discover",
+        "transcripts.refresh",
+    ]
+    params: dict[str, object] = Field(default_factory=dict)
+
+
+class _NoParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class _AddLocationParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(min_length=1, max_length=32_768)
+    kind: LibraryLocationKind
+    processing_policy: RecordingProcessingPolicy = RecordingProcessingPolicy.MANUAL
+
+
+class _RefreshParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    verify: bool = False
+
+
+def _success(request_id: str, result: object) -> dict[str, object]:
+    return {
+        "protocol_version": _PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": True,
+        "result": result,
+        "error": None,
+    }
+
+
+def _failure(request_id: str, *, code: str, message: str) -> dict[str, object]:
+    return {
+        "protocol_version": _PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": False,
+        "result": None,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _dispatch(request: _DesktopRequest, service: LibraryLocationService) -> object:
+    if request.method == "locations.list":
+        _NoParams.model_validate(request.params)
+        return [item.to_dict() for item in service.locations()]
+
+    if request.method == "locations.add":
+        params = _AddLocationParams.model_validate(request.params)
+        location = service.add(
+            params.path,
+            kind=params.kind,
+            processing_policy=params.processing_policy,
+        )
+        return location.to_dict()
+
+    if request.method == "recordings.discover":
+        _NoParams.model_validate(request.params)
+        report = service.discover_recordings()
+        return {
+            "recordings": [
+                {
+                    "path": item.path,
+                    "size_bytes": item.size_bytes,
+                    "location_ids": list(item.location_ids),
+                    "automatic_processing_requested": item.automatic_processing_requested,
+                }
+                for item in report.recordings
+            ],
+            "unavailable_location_ids": list(report.unavailable_location_ids),
+        }
+
+    params = _RefreshParams.model_validate(request.params)
+    report = service.refresh_transcript_locations(verify=params.verify)
+    return {
+        "backend_id": report.refresh.backend_id,
+        "indexed_documents": report.refresh.indexed_documents,
+        "added_document_ids": list(report.refresh.added_document_ids),
+        "updated_document_ids": list(report.refresh.updated_document_ids),
+        "removed_document_ids": list(report.refresh.removed_document_ids),
+        "unchanged_document_ids": list(report.refresh.unchanged_document_ids),
+        "skipped_files": report.refresh.skipped_files,
+        "semantic_invalidated": report.refresh.semantic_invalidated,
+        "verified_all_tracked": report.refresh.verified_all_tracked,
+        "unavailable_location_ids": list(report.unavailable_location_ids),
+    }
+
+
+def handle_request(payload: object, service: LibraryLocationService) -> dict[str, object]:
+    request_id = "unknown"
+    if isinstance(payload, dict) and isinstance(payload.get("request_id"), str):
+        request_id = payload["request_id"][:128]
+    try:
+        request = _DesktopRequest.model_validate(payload)
+        return _success(request.request_id, _dispatch(request, service))
+    except ValidationError:
+        return _failure(
+            request_id,
+            code="invalid_request",
+            message="The desktop request was invalid or incompatible",
+        )
+    except EchoFlowError as exc:
+        return _failure(
+            request_id,
+            code=exc.code.value,
+            message=exc.public_message,
+        )
+    except Exception:
+        return _failure(
+            request_id,
+            code="internal_error",
+            message="EchoFlow could not complete the local desktop request",
+        )
+
+
+def main() -> int:
+    raw = sys.stdin.buffer.read(_MAX_REQUEST_BYTES + 1)
+    if len(raw) > _MAX_REQUEST_BYTES:
+        response = _failure(
+            "unknown",
+            code="invalid_request",
+            message="The desktop request exceeded the safe size limit",
+        )
+    else:
+        try:
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            response = _failure(
+                "unknown",
+                code="invalid_request",
+                message="The desktop request was not valid JSON",
+            )
+        else:
+            with redirect_stdout(sys.stderr):
+                service = AppContainer().library_locations()
+                response = handle_request(payload, service)
+    sys.stdout.write(json.dumps(response, separators=(",", ":")))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/echoflow/desktop/bridge.py
+++ b/src/echoflow/desktop/bridge.py
@@ -123,7 +123,9 @@ def _dispatch(request: _DesktopRequest, service: LibraryLocationService) -> obje
     }
 
 
-def handle_request(payload: object, service: LibraryLocationService) -> dict[str, object]:
+def handle_request(
+    payload: object, service: LibraryLocationService
+) -> dict[str, object]:
     request_id = "unknown"
     if isinstance(payload, dict) and isinstance(payload.get("request_id"), str):
         request_id = payload["request_id"][:128]

--- a/src/echoflow/desktop/bridge.py
+++ b/src/echoflow/desktop/bridge.py
@@ -83,17 +83,17 @@ def _dispatch(request: _DesktopRequest, service: LibraryLocationService) -> obje
         return [item.to_dict() for item in service.locations()]
 
     if request.method == "locations.add":
-        params = _AddLocationParams.model_validate(request.params)
+        add_params = _AddLocationParams.model_validate(request.params)
         location = service.add(
-            params.path,
-            kind=params.kind,
-            processing_policy=params.processing_policy,
+            add_params.path,
+            kind=add_params.kind,
+            processing_policy=add_params.processing_policy,
         )
         return location.to_dict()
 
     if request.method == "recordings.discover":
         _NoParams.model_validate(request.params)
-        report = service.discover_recordings()
+        discovery_report = service.discover_recordings()
         return {
             "recordings": [
                 {
@@ -102,24 +102,26 @@ def _dispatch(request: _DesktopRequest, service: LibraryLocationService) -> obje
                     "location_ids": list(item.location_ids),
                     "automatic_processing_requested": item.automatic_processing_requested,
                 }
-                for item in report.recordings
+                for item in discovery_report.recordings
             ],
-            "unavailable_location_ids": list(report.unavailable_location_ids),
+            "unavailable_location_ids": list(
+                discovery_report.unavailable_location_ids
+            ),
         }
 
-    params = _RefreshParams.model_validate(request.params)
-    report = service.refresh_transcript_locations(verify=params.verify)
+    refresh_params = _RefreshParams.model_validate(request.params)
+    refresh_report = service.refresh_transcript_locations(verify=refresh_params.verify)
     return {
-        "backend_id": report.refresh.backend_id,
-        "indexed_documents": report.refresh.indexed_documents,
-        "added_document_ids": list(report.refresh.added_document_ids),
-        "updated_document_ids": list(report.refresh.updated_document_ids),
-        "removed_document_ids": list(report.refresh.removed_document_ids),
-        "unchanged_document_ids": list(report.refresh.unchanged_document_ids),
-        "skipped_files": report.refresh.skipped_files,
-        "semantic_invalidated": report.refresh.semantic_invalidated,
-        "verified_all_tracked": report.refresh.verified_all_tracked,
-        "unavailable_location_ids": list(report.unavailable_location_ids),
+        "backend_id": refresh_report.refresh.backend_id,
+        "indexed_documents": refresh_report.refresh.indexed_documents,
+        "added_document_ids": list(refresh_report.refresh.added_document_ids),
+        "updated_document_ids": list(refresh_report.refresh.updated_document_ids),
+        "removed_document_ids": list(refresh_report.refresh.removed_document_ids),
+        "unchanged_document_ids": list(refresh_report.refresh.unchanged_document_ids),
+        "skipped_files": refresh_report.refresh.skipped_files,
+        "semantic_invalidated": refresh_report.refresh.semantic_invalidated,
+        "verified_all_tracked": refresh_report.refresh.verified_all_tracked,
+        "unavailable_location_ids": list(refresh_report.unavailable_location_ids),
     }
 
 

--- a/src/echoflow/desktop/bridge.py
+++ b/src/echoflow/desktop/bridge.py
@@ -104,9 +104,7 @@ def _dispatch(request: _DesktopRequest, service: LibraryLocationService) -> obje
                 }
                 for item in discovery_report.recordings
             ],
-            "unavailable_location_ids": list(
-                discovery_report.unavailable_location_ids
-            ),
+            "unavailable_location_ids": list(discovery_report.unavailable_location_ids),
         }
 
     refresh_params = _RefreshParams.model_validate(request.params)

--- a/src/echoflow/desktop/tests/test_bridge.py
+++ b/src/echoflow/desktop/tests/test_bridge.py
@@ -1,0 +1,173 @@
+from pathlib import Path
+
+from echoflow.desktop.bridge import handle_request
+from echoflow.library.errors import LibraryLocationError
+from echoflow.library.locations import (
+    DiscoveredRecording,
+    LibraryLocation,
+    LibraryLocationKind,
+    ManagedTranscriptRefreshReport,
+    RecordingDiscoveryReport,
+    RecordingProcessingPolicy,
+)
+from echoflow.library.service import LibraryRefreshReport
+
+
+class _LocationService:
+    def __init__(self) -> None:
+        self.location = LibraryLocation(
+            location_id="location-one",
+            path=str(Path("/research").resolve()),
+            kind=LibraryLocationKind.RECORDING_SOURCE,
+            enabled=True,
+            processing_policy=RecordingProcessingPolicy.MANUAL,
+            created_at="2026-08-19T19:20:00+00:00",
+            updated_at="2026-08-19T19:20:00+00:00",
+        )
+        self.add_calls = []
+
+    def locations(self):
+        return (self.location,)
+
+    def add(self, path, *, kind, processing_policy):
+        self.add_calls.append((path, kind, processing_policy))
+        return self.location
+
+    def discover_recordings(self):
+        return RecordingDiscoveryReport(
+            recordings=(
+                DiscoveredRecording(
+                    path=str(Path("/research/interview.mp4").resolve()),
+                    size_bytes=42,
+                    location_ids=("location-one",),
+                    automatic_processing_requested=False,
+                ),
+            ),
+            unavailable_location_ids=(),
+        )
+
+    def refresh_transcript_locations(self, *, verify=False):
+        return ManagedTranscriptRefreshReport(
+            refresh=LibraryRefreshReport(
+                backend_id="test",
+                indexed_documents=1,
+                added_document_ids=(),
+                updated_document_ids=(),
+                removed_document_ids=(),
+                unchanged_document_ids=("doc-1",),
+                skipped_files=0,
+                semantic_invalidated=False,
+                verified_all_tracked=verify,
+            ),
+            unavailable_location_ids=(),
+        )
+
+
+def _request(method, params=None):
+    return {
+        "protocol_version": 1,
+        "request_id": "request-1",
+        "method": method,
+        "params": {} if params is None else params,
+    }
+
+
+def test_list_locations_serializes_only_typed_location_state():
+    response = handle_request(_request("locations.list"), _LocationService())
+
+    assert response["ok"] is True
+    assert response["result"][0]["location_id"] == "location-one"
+    assert response["result"][0]["kind"] == "recording-source"
+
+
+def test_add_location_preserves_explicit_automatic_opt_in():
+    service = _LocationService()
+    response = handle_request(
+        _request(
+            "locations.add",
+            {
+                "path": "/research",
+                "kind": "recording-source",
+                "processing_policy": "automatic",
+            },
+        ),
+        service,
+    )
+
+    assert response["ok"] is True
+    assert service.add_calls == [
+        (
+            "/research",
+            LibraryLocationKind.RECORDING_SOURCE,
+            RecordingProcessingPolicy.AUTOMATIC,
+        )
+    ]
+
+
+def test_unknown_method_fails_closed_without_dispatch():
+    response = handle_request(_request("shell.exec"), _LocationService())
+
+    assert response["ok"] is False
+    assert response["error"] == {
+        "code": "invalid_request",
+        "message": "The desktop request was invalid or incompatible",
+    }
+
+
+def test_extra_params_fail_closed():
+    response = handle_request(
+        _request("locations.list", {"sql": "DROP TABLE transcripts"}),
+        _LocationService(),
+    )
+
+    assert response["ok"] is False
+    assert response["error"]["code"] == "invalid_request"
+
+
+def test_safe_application_error_crosses_bridge_without_cause_details():
+    class _FailingService(_LocationService):
+        def add(self, path, *, kind, processing_policy):
+            raise LibraryLocationError(
+                "That location is not available",
+                cause=RuntimeError("secret internal path detail"),
+            )
+
+    response = handle_request(
+        _request(
+            "locations.add",
+            {
+                "path": "/research",
+                "kind": "recording-source",
+                "processing_policy": "manual",
+            },
+        ),
+        _FailingService(),
+    )
+
+    assert response["ok"] is False
+    assert response["error"]["message"] == "That location is not available"
+    assert "secret internal path detail" not in str(response)
+
+
+def test_recording_discovery_does_not_claim_processing_occurred():
+    response = handle_request(_request("recordings.discover"), _LocationService())
+
+    assert response["ok"] is True
+    assert response["result"]["recordings"] == [
+        {
+            "path": str(Path("/research/interview.mp4").resolve()),
+            "size_bytes": 42,
+            "location_ids": ["location-one"],
+            "automatic_processing_requested": False,
+        }
+    ]
+
+
+def test_transcript_refresh_respects_verify_flag():
+    response = handle_request(
+        _request("transcripts.refresh", {"verify": True}),
+        _LocationService(),
+    )
+
+    assert response["ok"] is True
+    assert response["result"]["verified_all_tracked"] is True

--- a/src/echoflow/library/duckdb_index.py
+++ b/src/echoflow/library/duckdb_index.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import duckdb
 
 from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.duckdb_safety import atomic_duckdb_transaction
 from echoflow.library.index import (
     IndexedDocument,
     IndexedTranscript,
@@ -162,15 +163,10 @@ class DuckDbTranscriptIndex:
 
     def rebuild(self, transcripts: tuple[IndexedTranscript, ...]) -> None:
         self._require_open()
-        self._connection.execute("BEGIN TRANSACTION")
-        try:
+        with atomic_duckdb_transaction(self._connection):
             self._clear_tables()
             for transcript in transcripts:
                 self._insert_transcript(transcript)
-            self._connection.execute("COMMIT")
-        except Exception:
-            self._connection.execute("ROLLBACK")
-            raise
 
     def apply_delta(
         self,
@@ -193,17 +189,12 @@ class DuckDbTranscriptIndex:
         if set(upsert_ids).intersection(removals):
             raise ValueError("a document cannot be both upserted and removed")
 
-        self._connection.execute("BEGIN TRANSACTION")
-        try:
+        with atomic_duckdb_transaction(self._connection):
             for document_id in removals:
                 self._delete_document(document_id)
             for transcript in upserts:
                 self._delete_document(transcript.document_id)
                 self._insert_transcript(transcript)
-            self._connection.execute("COMMIT")
-        except Exception:
-            self._connection.execute("ROLLBACK")
-            raise
 
     def upsert(self, transcript: IndexedTranscript) -> None:
         self.apply_delta(upserts=(transcript,), removals=())
@@ -375,7 +366,8 @@ class DuckDbTranscriptIndex:
 
     def clear(self) -> None:
         self._require_open()
-        self._clear_tables()
+        with atomic_duckdb_transaction(self._connection):
+            self._clear_tables()
 
     def _clear_tables(self) -> None:
         self._connection.execute("DELETE FROM terms")

--- a/src/echoflow/library/duckdb_research_projection.py
+++ b/src/echoflow/library/duckdb_research_projection.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import duckdb
 
 from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.duckdb_safety import atomic_duckdb_transaction
 from echoflow.library.errors import ResearchProjectionError
 from echoflow.library.research_projection import (
     EvidenceScopeKey,
@@ -104,17 +105,15 @@ class DuckDbResearchProjection:
         self._require_open()
         if through_sequence < 0:
             raise ValueError("projection sequence cannot be negative")
-        self._connection.execute("BEGIN TRANSACTION")
         try:
-            self._clear_rows()
-            for record in records:
-                self._insert_record(record)
-            self._set_watermark(through_sequence)
-            self._connection.execute("COMMIT")
+            with atomic_duckdb_transaction(self._connection):
+                self._clear_rows()
+                for record in records:
+                    self._insert_record(record)
+                self._set_watermark(through_sequence)
+        except ValueError:
+            raise
         except Exception as exc:
-            self._connection.execute("ROLLBACK")
-            if isinstance(exc, (KeyboardInterrupt, SystemExit, ValueError)):
-                raise
             raise ResearchProjectionError(
                 "Research query projection could not be rebuilt safely", cause=exc
             ) from exc
@@ -135,18 +134,16 @@ class DuckDbResearchProjection:
         touched = tuple(record.note_id for record in records) + deleted_note_ids
         if len(touched) != len(set(touched)):
             raise ValueError("projection batch contains duplicate note identities")
-        self._connection.execute("BEGIN TRANSACTION")
         try:
-            for note_id in touched:
-                self._delete_note(note_id)
-            for record in records:
-                self._insert_record(record)
-            self._set_watermark(through_sequence)
-            self._connection.execute("COMMIT")
+            with atomic_duckdb_transaction(self._connection):
+                for note_id in touched:
+                    self._delete_note(note_id)
+                for record in records:
+                    self._insert_record(record)
+                self._set_watermark(through_sequence)
+        except ValueError:
+            raise
         except Exception as exc:
-            self._connection.execute("ROLLBACK")
-            if isinstance(exc, (KeyboardInterrupt, SystemExit, ValueError)):
-                raise
             raise ResearchProjectionError(
                 "Research query projection could not apply a change batch safely",
                 cause=exc,
@@ -251,14 +248,9 @@ class DuckDbResearchProjection:
 
     def clear(self) -> None:
         self._require_open()
-        self._connection.execute("BEGIN TRANSACTION")
-        try:
+        with atomic_duckdb_transaction(self._connection):
             self._clear_rows()
             self._set_watermark(0)
-            self._connection.execute("COMMIT")
-        except Exception:
-            self._connection.execute("ROLLBACK")
-            raise
 
     def close(self) -> None:
         if self._closed:

--- a/src/echoflow/library/duckdb_safety.py
+++ b/src/echoflow/library/duckdb_safety.py
@@ -30,8 +30,5 @@ def atomic_duckdb_transaction(
         try:
             connection.execute("ROLLBACK")
         except duckdb.Error as rollback_exc:
-            exc.add_note(
-                "DuckDB rollback also failed: "
-                f"{type(rollback_exc).__name__}"
-            )
+            exc.add_note(f"DuckDB rollback also failed: {type(rollback_exc).__name__}")
         raise

--- a/src/echoflow/library/duckdb_safety.py
+++ b/src/echoflow/library/duckdb_safety.py
@@ -1,0 +1,37 @@
+"""Shared transaction safety for EchoFlow's rebuildable DuckDB projections.
+
+This module centralizes atomic mutation semantics. It does not claim that a DuckDB file
+is immune to disk, filesystem, or hardware corruption; EchoFlow deliberately keeps these
+databases rebuildable from authoritative transcript and research state.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import duckdb
+
+
+@contextmanager
+def atomic_duckdb_transaction(
+    connection: duckdb.DuckDBPyConnection,
+) -> Iterator[duckdb.DuckDBPyConnection]:
+    """Commit a DuckDB mutation atomically or roll the whole transaction back.
+
+    BaseException is intentionally covered so interrupts cannot strand a partially applied
+    application-level mutation. If rollback itself fails, preserve the original exception
+    and annotate it with the rollback failure instead of replacing the root cause.
+    """
+
+    connection.execute("BEGIN TRANSACTION")
+    try:
+        yield connection
+        connection.execute("COMMIT")
+    except BaseException as exc:
+        try:
+            connection.execute("ROLLBACK")
+        except duckdb.Error as rollback_exc:
+            exc.add_note(
+                "DuckDB rollback also failed: "
+                f"{type(rollback_exc).__name__}"
+            )
+        raise

--- a/src/echoflow/library/duckdb_semantic.py
+++ b/src/echoflow/library/duckdb_semantic.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import duckdb
 
 from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.duckdb_safety import atomic_duckdb_transaction
 from echoflow.library.index import SearchOperator, SearchQuery
 from echoflow.library.semantic import (
     EmbeddingProfile,
@@ -108,8 +109,7 @@ class DuckDbSemanticIndex:
         ).fetchall()
         if not rows:
             return
-        self._connection.execute("BEGIN TRANSACTION")
-        try:
+        with atomic_duckdb_transaction(self._connection):
             for row in rows:
                 segment_ids = self._string_tuple(row[3], "segment_ids")
                 self._connection.executemany(
@@ -119,10 +119,6 @@ class DuckDbSemanticIndex:
                         for segment_id in segment_ids
                     ],
                 )
-            self._connection.execute("COMMIT")
-        except Exception:
-            self._connection.execute("ROLLBACK")
-            raise
 
     def rebuild(
         self,
@@ -144,8 +140,7 @@ class DuckDbSemanticIndex:
         for vector in vectors:
             self._validate_vector(vector, state.profile.dimensions)
 
-        self._connection.execute("BEGIN TRANSACTION")
-        try:
+        with atomic_duckdb_transaction(self._connection):
             self._clear_tables()
             self._insert_profile(state.profile)
             self._connection.execute(
@@ -162,10 +157,6 @@ class DuckDbSemanticIndex:
                     "INSERT INTO embeddings VALUES (?, ?, ?)",
                     [chunk.chunk_id, state.profile.profile_id, list(vector)],
                 )
-            self._connection.execute("COMMIT")
-        except Exception:
-            self._connection.execute("ROLLBACK")
-            raise
 
     def _insert_profile(self, profile: EmbeddingProfile) -> None:
         self._connection.execute(
@@ -439,7 +430,8 @@ class DuckDbSemanticIndex:
 
     def clear(self) -> None:
         self._require_open()
-        self._clear_tables()
+        with atomic_duckdb_transaction(self._connection):
+            self._clear_tables()
 
     def _clear_tables(self) -> None:
         self._connection.execute("DELETE FROM embeddings")

--- a/src/echoflow/library/tests/test_duckdb_safety.py
+++ b/src/echoflow/library/tests/test_duckdb_safety.py
@@ -25,10 +25,11 @@ def test_atomic_duckdb_transaction_commits_complete_mutation() -> None:
 def test_atomic_duckdb_transaction_rolls_back_complete_mutation() -> None:
     connection = _connection()
 
-    with pytest.raises(RuntimeError, match="forced failure"):
-        with atomic_duckdb_transaction(connection):
-            connection.execute("INSERT INTO values_for_test VALUES (1)")
-            raise RuntimeError("forced failure")
+    with pytest.raises(
+        RuntimeError, match="forced failure"
+    ), atomic_duckdb_transaction(connection):
+        connection.execute("INSERT INTO values_for_test VALUES (1)")
+        raise RuntimeError("forced failure")
 
     assert connection.execute("SELECT value FROM values_for_test").fetchall() == []
 
@@ -36,9 +37,8 @@ def test_atomic_duckdb_transaction_rolls_back_complete_mutation() -> None:
 def test_atomic_duckdb_transaction_rolls_back_interrupts() -> None:
     connection = _connection()
 
-    with pytest.raises(KeyboardInterrupt):
-        with atomic_duckdb_transaction(connection):
-            connection.execute("INSERT INTO values_for_test VALUES (1)")
-            raise KeyboardInterrupt
+    with pytest.raises(KeyboardInterrupt), atomic_duckdb_transaction(connection):
+        connection.execute("INSERT INTO values_for_test VALUES (1)")
+        raise KeyboardInterrupt
 
     assert connection.execute("SELECT value FROM values_for_test").fetchall() == []

--- a/src/echoflow/library/tests/test_duckdb_safety.py
+++ b/src/echoflow/library/tests/test_duckdb_safety.py
@@ -25,9 +25,10 @@ def test_atomic_duckdb_transaction_commits_complete_mutation() -> None:
 def test_atomic_duckdb_transaction_rolls_back_complete_mutation() -> None:
     connection = _connection()
 
-    with pytest.raises(
-        RuntimeError, match="forced failure"
-    ), atomic_duckdb_transaction(connection):
+    with (
+        pytest.raises(RuntimeError, match="forced failure"),
+        atomic_duckdb_transaction(connection),
+    ):
         connection.execute("INSERT INTO values_for_test VALUES (1)")
         raise RuntimeError("forced failure")
 

--- a/src/echoflow/library/tests/test_duckdb_safety.py
+++ b/src/echoflow/library/tests/test_duckdb_safety.py
@@ -1,0 +1,44 @@
+import duckdb
+import pytest
+
+from echoflow.library.duckdb_safety import atomic_duckdb_transaction
+
+
+def _connection() -> duckdb.DuckDBPyConnection:
+    connection = duckdb.connect(":memory:")
+    connection.execute("CREATE TABLE values_for_test (value INTEGER PRIMARY KEY)")
+    return connection
+
+
+def test_atomic_duckdb_transaction_commits_complete_mutation() -> None:
+    connection = _connection()
+
+    with atomic_duckdb_transaction(connection):
+        connection.execute("INSERT INTO values_for_test VALUES (1)")
+        connection.execute("INSERT INTO values_for_test VALUES (2)")
+
+    assert connection.execute(
+        "SELECT value FROM values_for_test ORDER BY value"
+    ).fetchall() == [(1,), (2,)]
+
+
+def test_atomic_duckdb_transaction_rolls_back_complete_mutation() -> None:
+    connection = _connection()
+
+    with pytest.raises(RuntimeError, match="forced failure"):
+        with atomic_duckdb_transaction(connection):
+            connection.execute("INSERT INTO values_for_test VALUES (1)")
+            raise RuntimeError("forced failure")
+
+    assert connection.execute("SELECT value FROM values_for_test").fetchall() == []
+
+
+def test_atomic_duckdb_transaction_rolls_back_interrupts() -> None:
+    connection = _connection()
+
+    with pytest.raises(KeyboardInterrupt):
+        with atomic_duckdb_transaction(connection):
+            connection.execute("INSERT INTO values_for_test VALUES (1)")
+            raise KeyboardInterrupt
+
+    assert connection.execute("SELECT value FROM values_for_test").fetchall() == []


### PR DESCRIPTION
## Summary

Establish EchoFlow's first desktop human workflow: local evidence intake over the durable location/discovery contracts already owned by Python.

This is intentionally a thin desktop adapter. React presents user intent; Tauri owns the native window/file-dialog/process boundary; Python continues to own durable location policy, transcript refresh, recording discovery, database access, and all future processing semantics.

## Desktop stack

- Tauri v2 host scaffold under `frontend/src-tauri/`;
- React + TypeScript + Vite presentation layer;
- Archive and Midnight semantic-token themes;
- native Tauri open-dialog integration for audio/video, canonical JSON, and folders;
- narrow `desktop_request` Tauri command that forwards a versioned allowlisted JSON request to `python -m echoflow.desktop.bridge`;
- no direct frontend SQL, DuckDB/SQLite access, arbitrary shell access, or arbitrary filesystem mutation.

## First ingestion experience

The first screen supports:

- Recordings vs Existing transcripts;
- Choose files vs Choose folder;
- one-time selections that do not persist folder permission;
- remembered folders backed by `LibraryLocationService`;
- advanced explicit `automatic` opt-in only for remembered recording sources;
- recording discovery after a remembered recording source is added;
- transcript-library reconciliation through the existing incremental refresh path;
- clear custody language that selecting media does not copy it into hidden EchoFlow storage.

The automatic policy remains permission metadata. The UI does not claim that discovery itself performed ASR.

## Desktop bridge

`src/echoflow/desktop/bridge.py` exposes protocol version 1 with an explicit method allowlist:

- `locations.list`
- `locations.add`
- `recordings.discover`
- `transcripts.refresh`

Requests are size-bounded and Pydantic-validated with unknown methods/fields refused. Safe `EchoFlowError` messages may cross the boundary; unexpected internal exception details do not.

The Rust host invokes only the fixed `-m echoflow.desktop.bridge` module through the configured local Python runtime. Packaging a managed Python sidecar remains a later desktop-packaging tranche.

## DuckDB transaction hardening

This PR also consolidates the transaction behavior already used by EchoFlow's rebuildable DuckDB projections:

- add one shared `atomic_duckdb_transaction` context manager;
- route lexical rebuild/delta mutations, semantic rebuild/backfill mutations, and research projection rebuild/apply/clear through that boundary;
- make lexical and semantic multi-table `clear()` operations atomic rather than independently deleting tables;
- roll back on interrupts as well as ordinary exceptions so an application-level mutation cannot be intentionally abandoned half-applied;
- preserve existing research-projection public error semantics;
- add real in-memory DuckDB tests for commit, ordinary-exception rollback, and interrupt rollback.

This does not claim physical corruption is impossible. DuckDB state remains deliberately rebuildable from authoritative transcript and research state, and the desktop frontend never opens DuckDB directly.

## Accessibility and visual system

- semantic CSS tokens rather than hard-coded component skins;
- Archive and Midnight themes;
- keyboard-visible focus;
- reduced-motion handling;
- semantic landmarks, tabs, status, alert, fieldset, radio, checkbox, and button controls;
- responsive desktop/narrow-window layouts;
- no external fonts or remote UI resources.

## CI / testing

The quality workflow now has two cheap prerequisite gates:

1. Python `static`: lockfile, Ruff lint/format, strict mypy, Vulture, Radon, dependency audit;
2. `frontend-static`: locked `npm ci`, TypeScript, Vite production build, production dependency audit.

Only after both static gates pass may the expensive jobs start:

- Linux branch-coverage/build verification;
- macOS and Windows platform smoke;
- Playwright + axe Chromium tests.

That means a Python typing/formatting failure installs neither FFmpeg nor Chromium.

Playwright + axe covers:

- keyboard reachability and automated accessibility;
- one-time multi-file recording intake;
- remembered recording-folder discovery;
- explicit automatic-processing opt-in without claiming transcription occurred;
- transcript-folder behavior with no automatic-processing control;
- Archive/Midnight semantic continuity and accessibility.

Frontend dependencies are pinned by an npm-authored `package-lock.json`, and CI uses `npm ci`. The temporary branch-scoped write permission used only to regenerate the malformed bootstrap lockfile has been removed; the final workflow is back to repository-level `contents: read`.

### Exact-head verification

Final candidate head: `5e02b482a29185878d5d7c92b717f8f01bcdc32c`

Quality #650 (`32299110375`) is fully green on that exact head:

- Python static gate: lockfile, Ruff lint/format, strict mypy, Vulture, Radon, dependency audit;
- frontend static gate: locked `npm ci`, TypeScript, Vite build, production npm audit;
- Playwright + axe ingestion/accessibility flows;
- Linux repository-wide branch coverage at the unchanged 90% gate, distribution build, clean-wheel install;
- macOS full test/platform smoke, distribution build, clean-wheel install;
- Windows full test/platform smoke, distribution build, clean-wheel install.

## Not in this tranche

- transcription execution/progress UI;
- search/evidence/research workspace UI;
- model manager;
- packaged Python runtime/sidecar;
- Tauri installer/signing/notarization;
- always-on filesystem watcher/daemon;
- automatic background ASR execution.

Those remain sequenced behind a stable intake chassis.