### PR TITLE
feat(desktop): complete note mutations and audit productization

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,60 @@ It can delete only old private job workspaces. Completed jobs are eligible by de
 failed/interrupted jobs require `--include-incomplete` because cleanup removes resume
 capability. Running jobs are never eligible. Canonical transcripts, human research, source
 media, and lightweight lifecycle manifests are preserved.
+
+EchoFlow does not claim that ordinary file deletion proves secure physical erasure on
+SSDs, snapshots, backups, sync history, or copy-on-write storage.
+
+Read **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)** for
+the exact contract.
+
+## What belongs to you? 🦝
+
+| Artifact | Role | Rebuildable? |
+|---|---|---|
+| Original recording | source evidence | **No** |
+| Canonical transcript JSON | authoritative transcript evidence | **No** |
+| Speaker display labels | user-authored knowledge | **No** |
+| Notes, tags, collections, evidence anchors | user-authored knowledge | **No** |
+| Saved searches | user-authored query intent | **No** |
+| Remembered library/recording locations | durable app preference | **No, but machine-local** |
+| TXT/SRT/WebVTT | publication views | Yes |
+| Normalized/enhanced working audio | private processing material | Yes |
+| Lexical/semantic search state | private search projections | Yes |
+| Research query projection | rebuildable view over durable research state | Yes |
+
+A database is allowed to make evidence useful. It is not allowed to become the only place
+unique evidence or human research exists.
+
+## For maintainers
+
+Start with **[docs/architecture/README.md](docs/architecture/README.md)**, especially
+**[Corpus search](docs/architecture/corpus-search.md)**,
+**[Durable research state](docs/architecture/research-state.md)**,
+**[Library lifecycle](docs/architecture/library-lifecycle.md)**,
+**[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and
+**[SECURITY.md](SECURITY.md)**. The documentation visual/voice contract lives in
+**[docs/documentation-style.md](docs/documentation-style.md)**.
+
+Normal qualification includes Ruff lint/format/security rules, strict mypy, Vulture,
+Radon, branch coverage, locked dependency audit, package builds, clean-wheel verification,
+frontend type/build/audit gates, Playwright/axe, and Linux/macOS/Windows CI. Targeted
+mutation testing is reserved for load-bearing logic.
+
+## Where the project goes next
+
+The full capability-to-productization audit now lives in **[ROADMAP.md](ROADMAP.md)**.
+Research browse/create/edit/delete and label assignment are foundation. The immediate
+remaining Research work is saved-search lifecycle, research-object → verified-evidence
+navigation, stale-anchor review, and advanced typed search controls.
+
+After that, the next major product gap is a **desktop Processing center** over existing
+health/resource, managed-model, job-lifecycle, transcription-plan/execution/resume,
+enhancement, diarization, and publication contracts. Then come speaker/control polish,
+Tauri-owned local playback, lifecycle/retention UI, packaging, backup/restore/export,
+packaged semantic qualification, and representative-device release qualification.
+
+---
+
+**Make sensitive local transcription boringly dependable. Make its evidence easy to
+navigate and annotate. Do not give the corpus away.** 💃

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ the local recording-to-evidence lifecycle.
 | Transcript output | canonical JSON plus deterministic TXT, SRT, WebVTT publication views |
 | Search | private BM25 lexical retrieval, optional semantic retrieval, hybrid reciprocal-rank fusion |
 | Evidence navigation | canonical-hash verification, aligned highlights, bounded context, speaker presentation, source seek coordinates |
-| Research workspace | authoritative SQLite notes/tags/collections plus rebuildable DuckDB research projection |
+| Research workspace | authoritative SQLite notes/tags/collections, rebuildable DuckDB projection, desktop browse/create/edit/delete and label assignment |
 | Unified discovery | grouped transcript/note/tag/collection query without fabricated cross-type scores |
 | Saved searches | durable typed query intent that re-resolves current evidence instead of freezing result snapshots |
 | Safe lifecycle | typed plan-bound deletion scopes plus private execution-state retention that preserves evidence/human work by default |
 | Incremental library | cheap refresh/reconciliation plus durable transcript and recording locations |
-| Desktop foundation | Tauri + React shell, native import, Library discovery, verified evidence reader/cursor, Archive/Midnight themes |
+| Desktop foundation | Tauri + React shell, native import, Library discovery, verified evidence reader/cursor, Research workspace, Archive/Midnight themes |
 | Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, Playwright/axe, package verification |
 
 ## From recording to useful evidence
@@ -109,15 +109,25 @@ or accepting a durable note anchor.
 EchoFlow has a thin Tauri + React desktop foundation over the Python application services.
 The current desktop can choose files/folders through native dialogs, remember approved
 locations, discover recordings, search the local library, open verified canonical context,
-and move a source-relative evidence cursor through canonical word coordinates.
+move a source-relative evidence cursor through canonical word coordinates, browse durable
+research, create notes from verified evidence, and edit/delete notes plus their tag and
+collection assignments.
+
+Research edits use the authoritative note `updated_at` as an optimistic-concurrency token.
+The body and label relationships change in one SQLite transaction with one journal event;
+the evidence anchor does not move. If another local surface changed the note first, the
+desktop write fails closed and asks for refresh instead of silently overwriting it.
 
 The browser/webview does **not** receive raw canonical/source filesystem paths for evidence
 navigation. Rust owns native desktop capability; Python owns application rules; React owns
 presentation.
 
-The durable research backend already exists, but the dedicated **Research** desktop
-workspace is the next UI tranche. It will reuse `ResearchWorkspaceService` rather than
-creating browser-owned research state.
+The remaining Research UI work is saved-search lifecycle, research-object → verified
+evidence navigation, explicit stale-anchor review/re-anchor, and advanced typed retrieval
+controls. The broader desktop audit also shows a major processing gap: Python already has
+health/resource/model/job/transcription contracts that still need coherent desktop
+workflows before EchoFlow is a self-contained end-user application. See
+**[ROADMAP.md](ROADMAP.md)** for the complete capability-to-productization map.
 
 There are still no end-user installers or Releases. The supported path remains a source
 build while packaging and first-run behavior are qualified.
@@ -257,68 +267,3 @@ It can delete only old private job workspaces. Completed jobs are eligible by de
 failed/interrupted jobs require `--include-incomplete` because cleanup removes resume
 capability. Running jobs are never eligible. Canonical transcripts, human research, source
 media, and lightweight lifecycle manifests are preserved.
-
-EchoFlow does not claim that ordinary file deletion proves secure physical erasure on
-SSDs, snapshots, backups, sync history, or copy-on-write storage.
-
-Read **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)** for
-the exact contract.
-
-## What belongs to you? 🦝
-
-| Artifact | Role | Rebuildable? |
-|---|---|---|
-| Original recording | source evidence | **No** |
-| Canonical transcript JSON | authoritative transcript evidence | **No** |
-| Speaker display labels | user-authored knowledge | **No** |
-| Notes, tags, collections, evidence anchors | user-authored knowledge | **No** |
-| Saved searches | user-authored query intent | **No** |
-| Remembered library/recording locations | durable app preference | **No, but machine-local** |
-| TXT/SRT/WebVTT | publication views | Yes |
-| Normalized/enhanced working audio | private processing material | Yes |
-| Lexical/semantic search state | private search projections | Yes |
-| Research query projection | rebuildable view over durable research state | Yes |
-
-A database is allowed to make evidence useful. It is not allowed to become the only place
-unique evidence or human research exists.
-
-## For maintainers
-
-Start with **[docs/architecture/README.md](docs/architecture/README.md)**, especially
-**[Corpus search](docs/architecture/corpus-search.md)**,
-**[Durable research state](docs/architecture/research-state.md)**,
-**[Library lifecycle](docs/architecture/library-lifecycle.md)**,
-**[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and
-**[SECURITY.md](SECURITY.md)**. The documentation visual/voice contract lives in
-**[docs/documentation-style.md](docs/documentation-style.md)**.
-
-Normal qualification includes Ruff lint/format/security rules, strict mypy, Vulture,
-Radon, branch coverage, locked dependency audit, package builds, clean-wheel verification,
-frontend type/build/audit gates, Playwright/axe, and Linux/macOS/Windows CI. Targeted
-mutation testing is reserved for load-bearing logic.
-
-## Where the project goes next
-
-Incremental refresh, durable library locations, the desktop shell/import flow, grouped
-Library discovery, and verified evidence reading/cursor are foundation. The next sequence
-is:
-
-1. **Research workspace UI** for browsing/creating/editing notes, assigning
-   tags/collections, and running/managing saved searches through the existing typed backend
-   authority.
-2. **Local media playback** behind a Tauri-owned capability, consuming verified
-   source-relative coordinates without exposing arbitrary raw paths to React.
-3. **Desktop packaging and first run** across Windows, signed/notarized macOS, and a
-   deliberate Linux package, including managed Python/FFmpeg/model custody.
-4. **Backup, restore, and research portability** with evidence-bearing exports and
-   machine-local remembered-path reconciliation.
-5. **Semantic dependency/model qualification** plus representative-device release
-   qualification across ordinary 8/16 GB systems, Apple Silicon, discrete GPUs, and larger
-   workstations.
-
-See **[ROADMAP.md](ROADMAP.md)** for the detailed sequence.
-
----
-
-**Make sensitive local transcription boringly dependable. Make its evidence easy to
-navigate and annotate. Do not give the corpus away.** 💃

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,8 +8,10 @@ portable on ordinary computers while keeping source evidence and human-authored 
 under clear custody.
 
 Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe
-a file?” through a substantial backend foundation and into the first real desktop evidence
-workflows.
+a file?” through a substantial backend foundation and into real desktop evidence and
+research workflows. This roadmap now audits the full product surface so backend capability
+and desktop productization can be planned together rather than rediscovered a few features
+at a time.
 
 ```mermaid
 flowchart LR
@@ -56,14 +58,15 @@ flowchart LR
 
 Text fallback: EchoFlow already spans local media, reliable transcription, canonical
 evidence, retrieval, verified navigation, durable research, lifecycle controls, incremental
-refresh, remembered locations, and the first desktop import/search/evidence-reader
-surfaces. The next work turns the existing research authority into a real desktop
-workspace, then adds local playback, packaging, portability, and release qualification.
+refresh, remembered locations, native import, Library discovery, the verified evidence
+reader, and the first Research interactions. Remaining work is primarily productization:
+finish the research loop, expose processing/model/job controls, add playback and lifecycle
+UI, package the application, make durable work portable, and qualify real devices.
 
 # What is foundation now
 
 The word **foundation** below means the contract exists in code and is protected by tests.
-It does not mean the feature is fully productized for a non-technical end user.
+It does not mean every capability has a non-technical desktop workflow yet.
 
 ## Local execution, media, and model custody
 
@@ -102,49 +105,31 @@ Authoritative SQLite owns notes, tags, collections, evidence anchors, and saved-
 intent. A monotonic journal drives a rebuildable DuckDB research projection.
 `ResearchWorkspaceService` composes those stores with verified transcript retrieval.
 
-Saved searches are durable questions, not result snapshots. Tags/collections and note text
-can constrain eligible evidence before transcript ranking.
+The desktop can browse current and older-generation notes, create a note from verified
+evidence, and edit/delete notes plus replace tag/collection assignments. Desktop edits are
+optimistic-concurrency checked against the authoritative `updated_at` version and body plus
+labels commit atomically with one research-journal event. Editing research never silently
+rebinds its canonical evidence anchor.
 
-The custody hierarchy is:
+Saved searches are durable questions, not result snapshots. Their backend lifecycle is
+implemented; desktop create/run/rename/delete remains work.
 
-| Class | Examples | Rule |
-|---|---|---|
-| Authoritative evidence | original recording, canonical JSON | never treat as cache; destructive deletion must be explicit |
-| Authoritative human knowledge | speaker labels, notes, tags, collections, saved searches | must survive index rebuilds and unrelated deletion |
-| Durable app preference | remembered library/recording locations and processing policy | private user-state; forgetting permission never deletes user files |
-| Rebuildable projection | lexical/semantic/research DuckDB, derived exports | may be regenerated |
-| Private execution state | checkpoints, normalization/enhancement intermediates | lifecycle-managed; not source truth |
-| Lightweight lifecycle metadata | job manifests/discovery pointers | retained when heavyweight execution state is cleaned |
-
-## Safe deletion and retention
+## Safe deletion, refresh, and locations
 
 `LibraryCustodyService` provides dry-run-first typed deletion. Confirmation is bound to the
 exact canonical generation, requested/effective scopes, mutation set, and relevant
 preserved dependencies. Source deletion requires explicit `source-recording`, a second
 `--allow-source` switch, and current provenance verification.
 
-`canonical-transcript` expands only through disposable descendants. It does **not** imply
-notes, saved searches, or source deletion. Age-based retention is narrower still and can
-remove only eligible private execution workspaces.
-
-EchoFlow does not claim secure erasure where SSD wear levelling, snapshots, backups,
-copy-on-write history, or sync/versioning make that guarantee unverifiable.
-
-## Incremental refresh and durable locations
-
 Normal library refresh reconciles changed canonical generations without reopening every
 unchanged transcript. Metadata is a cheap change detector; canonical SHA-256 remains the
-generation authority. `--verify` deliberately reopens and rehashes tracked canonicals.
-
-Remembered locations have one explicit purpose: transcript-library reconciliation or
-recording-source candidate discovery. Missing removable roots stay remembered but are
-reported unavailable. Recording discovery does not itself hash, FFprobe, copy, transcribe,
-or modify media.
+generation authority. Remembered transcript and recording locations persist explicit user
+permission. Missing removable roots stay remembered but unavailable.
 
 The default recording policy is manual. `automatic` is durable permission metadata only;
-no background daemon silently processes recordings today.
+there is no background daemon silently processing recordings today.
 
-## Desktop foundation and import
+## Desktop foundation
 
 The desktop architecture is:
 
@@ -155,77 +140,143 @@ EchoFlow Desktop
 └── Python EchoFlow               application and evidence rules
 ```
 
-The current shell provides Archive/Midnight themes, keyboard-visible navigation, native
-file/folder selection, one-time versus remembered import choices, recording discovery,
-and transcript refresh. React does not receive arbitrary shell, database, or filesystem
-mutation capability.
+The shell provides Archive/Midnight themes, keyboard-visible navigation, native file/folder
+selection, one-time versus remembered import choices, recording discovery, transcript
+refresh, grouped Library discovery, verified evidence reading/cursor movement, Research
+browse, provenance-bound note creation, and version-checked note mutation.
 
-## Library discovery and evidence reader
+React does not receive arbitrary shell, SQL/database, or raw evidence-path capability.
 
-The Library surface now has grouped discovery across transcript evidence, notes, tags, and
-collections. It does not fabricate one relevance score across unlike object types.
+# Capability → desktop productization audit
 
-A search result can open a verified canonical context window. Backend-justified matched
-words retain exact source-relative timing; selecting a canonical word moves an evidence
-cursor, and “Return to match” restores the backend-verified seek coordinate. Raw source
-and canonical filesystem paths stay out of the webview.
+This is the planning inventory. “Backend ready” means there is already a tested application
+or CLI contract worth productizing, not that the desktop should simply expose a CLI flag.
 
-# Current quality contract
+| Capability | Authority available today | Desktop today | Remaining product work | Planned slice |
+|---|---|---|---|---|
+| First-run initialization | private workspace/output allocation and config validation | source-build startup only | first-run wizard, storage choices, failure recovery | Packaging / first run |
+| Health diagnostics | `doctor` checks local state, disk, FFmpeg and system resources | none | human health panel, actionable repair guidance | Processing center |
+| Hardware/resource policy | effective CPU/RAM/accelerator inspection, execution profiles and admission | none | resource summary, safe defaults, explicit overrides | Processing center |
+| Managed model custody | inventory, recommendation, install, immutable revision verification/revalidation/removal | none | model manager, disk-cost visibility, download progress/cancel/retry, offline state | Processing center |
+| Native import and remembered locations | durable transcript/recording roots and discovery permissions | **implemented** | location management/forget/availability polish | Settings / library polish |
+| Recording discovery | candidate media discovery without hashing/probing/transcribing as a side effect | **implemented** | connect selected recordings to an explicit processing flow | Processing center |
+| Job lifecycle | list/show status, progress, failure state, resumability and private-state discard | none | Jobs/Processing view, resume/retry/discard UX | Processing center |
+| Transcription planning | media probe, stream choice, model/engine/resource plan, disk/memory admission, dry run | none | preflight summary before running work | Processing center |
+| Transcription execution | faster-whisper local execution with checkpoints/resume | none | long-running Tauri↔Python execution contract, progress, cancel/resume and crash recovery | Processing center |
+| Difficult-audio enhancement | deterministic FFmpeg suppression with timeline/provenance checks | none | explicit processing option plus explanation/cost preview | Processing controls |
+| Anonymous diarization | recording-scoped speaker turns, word handoffs, overlap-aware presentation | backend only | processing toggle/resource warning and result presentation polish | Processing + speakers |
+| Speaker display labels | durable user-authored names without biometric identity claims | labels can be presented in evidence | rename/manage speakers in desktop | Speaker tools |
+| Canonical JSON authority | reproducible canonical transcript with full provenance | consumed indirectly | transcript/provenance inspector for advanced users | Evidence inspector |
+| TXT/SRT/WebVTT publication | deterministic rebuildable exports | none | export chooser and destination workflow | Evidence/export tools |
+| Lexical BM25 retrieval | private corpus ranking | **implemented** through Library discovery | advanced phrase/ANY/ALL and sort controls | Research/search completion |
+| Semantic retrieval | optional local chunks/embeddings | backend ready, not normal packaged path | desktop mode control after model/dependency custody qualification | Search + semantic qualification |
+| Hybrid RRF retrieval | lexical + semantic rank fusion | backend ready | retrieval-mode control and explainable result state | Search + semantic qualification |
+| Verified evidence navigation | generation verification, context, exact word timing and seek coordinate | **implemented** | research-object return path and media playback | Research completion + playback |
+| Unified discovery | typed transcript/note/tag/collection groups without fabricated cross-type score | **implemented** | richer filters and object-specific actions | Research/search completion |
+| Research notes | exact generation-bound anchors in authoritative SQLite | browse/create/edit/delete **implemented in current tranche** | research-object → evidence navigation, stale-anchor review/re-anchor UX | Research completion |
+| Tags and collections | durable names/relationships + rebuildable projection | browse + note assignment **implemented in current tranche** | dedicated navigation/filter/manage flows | Research completion |
+| Saved searches | create/run/delete typed intent, current-corpus re-resolution | browse only | create/run/rename/delete UI, result handoff | Research completion |
+| Research-aware filtering | tags/collections/note text constrain evidence before ranking | backend ready | desktop filters with inspectable active state | Research/search completion |
+| Safe deletion | typed dry-run plans, exact confirmation binding, source double-guard | none | custody center with plan review and explicit confirmation | Lifecycle UI |
+| Retention | execution-state-only age policies preserving evidence/research | none | retention settings, preview, cleanup result | Lifecycle UI |
+| Local source playback | verified source-relative seek coordinate exists | no playback | Tauri-owned media capability, playback state, source mismatch/unavailable handling | Native playback |
+| Desktop packaging | Python wheel + tested source build | development Tauri shell | managed Python sidecar/runtime, FFmpeg/native deps, Windows/macOS/Linux installers | Packaging |
+| Updates/uninstall | custody semantics exist conceptually | none | signed updates and uninstall that never implies evidence deletion | Packaging |
+| Backup/restore | authority boundaries identify irreplaceable state | none | backup manifest, restore/reconciliation and recovery UX | Portability |
+| Research export | evidence identities and numeric coordinates exist | none | CSV/JSONL/Markdown selected-research export | Portability |
+| Packaged semantic custody | dependency/model rules are designed | not qualified | locked optional stack, immutable embedding model, private cache, offline use | Semantic qualification |
+| Representative hardware | resource-planning contracts exist | CI smoke on major OSes | 8/16 GB, Apple Silicon, dGPU, 32/64 GB real-device qualification | Release qualification |
 
-Current CI is staged so cheap failures stop expensive runners. The repository protects:
+# Product critical path
 
-- locked Python and frontend dependency graphs;
-- Mermaid syntax and the approved EchoFlow diagram palette;
-- Ruff lint/format/security, strict mypy, Vulture, and Radon;
-- compensated dependency-advisory scope checks and dependency audit;
-- repository-wide branch coverage at the unchanged 90% gate;
-- frontend type checking, production build, dependency audit, and raw-HTML guard;
-- Playwright interaction and axe accessibility tests;
-- full macOS and Windows platform smoke;
-- distribution builds and clean-wheel installation.
+The audit changes one important thing about the old roadmap: **media playback is not the
+only major desktop gap after Research.** EchoFlow already has a surprisingly complete local
+processing/control plane in Python, but a normal desktop user cannot yet launch and manage
+that work. Productization should expose that capability before packaging freezes the native
+runtime shape.
 
-Historical PR-specific test counts belong in historical records. The roadmap tracks
-behavioral gates rather than a number that becomes stale with the next test.
+## 1. Finish the Research and Library interaction loop
 
-# Near-term product sequence
+Current foundation after this tranche:
 
-## 1. Research workspace UI
+- Research navigation and authoritative overview;
+- current-versus-older canonical generation presentation;
+- note creation from a verified evidence window;
+- atomic edit of note body + tag/collection assignments;
+- guarded note deletion;
+- optimistic concurrency using authoritative `updated_at`; and
+- no frontend SQL, SQLite, or raw evidence paths.
 
-The research authority already exists in Python. The next tranche should make it usable
-from the desktop without creating a second frontend data model.
+Remaining work:
 
-The first Research slice should:
-
-- enable the Research navigation door;
-- browse authoritative notes, tags, collections, and saved searches;
-- distinguish current evidence anchors from older canonical generations;
-- create a note from a verified evidence window;
-- edit/delete notes and assign/remove tags and collections;
 - create, run, rename, and delete saved searches;
-- navigate a research object back to verified current evidence when possible; and
-- keep every operation inside narrow versioned desktop bridge methods with no frontend SQL
-  or direct SQLite access.
+- navigate a note/tag/collection/saved-search result back to current verified evidence when
+  possible;
+- preserve older-generation anchors visibly and provide explicit review/re-anchor rather
+  than automatic migration; and
+- expose typed search controls for phrase/ANY/ALL, speaker, language, transcript, research
+  filters, retrieval mode, and sort.
 
-Advanced typed search controls for phrase/ANY/ALL, speaker, language, transcript,
-research filters, retrieval mode, and sort belong in this same Library/Research journey.
+This closes the loop: **find evidence → verify → annotate → organize → ask a durable
+question → return to evidence.**
 
-## 2. Local media playback behind Tauri capability
+## 2. Build the desktop Processing center
 
-The evidence reader already has a verified source-relative cursor. The next native media
-step should let that coordinate drive audio/video playback without handing an arbitrary raw
-path to React.
+This is the largest backend-to-product gap.
 
-Rust should own file capability and media lifecycle. Python should continue to own source
-identity/evidence rules. The webview should receive playback state and safe coordinates,
-not general filesystem authority.
+The first Processing center should combine three existing authorities without collapsing
+them into one giant settings screen:
 
-Qualification includes unavailable/moved sources, source-generation mismatch, keyboard
-transport, reduced motion, long media, and seeking around word boundaries.
+1. **Machine + model readiness:** doctor status, runner resources/policy, model inventory,
+   recommendation, install/revalidate/remove and disk cost.
+2. **Job lifecycle:** queued/running/completed/failed work, progress, resumability, failure
+   explanation, resume/retry, and explicit private-state discard.
+3. **Transcription preflight + launch:** selected recording, media/stream summary, profile,
+   model/engine target, disk/memory admission, optional diarization/enhancement/publication,
+   then explicit start.
 
-## 3. Desktop packaging, first run, updates, and uninstall
+Long-running work must not be modeled as a browser request that happens to take an hour.
+Tauri should own native process/capability lifecycle while Python continues to own planning,
+resource admission, transcription correctness, checkpointing, and publication.
 
-A Python wheel proves EchoFlow is distributable to Python. It does not make EchoFlow a
-consumer desktop application.
+## 3. Finish transcript controls and speaker tools
+
+Once desktop processing can create evidence itself, expose the existing user-facing control
+surfaces that make the result understandable:
+
+- selected audio stream where more than one legitimate stream exists;
+- enhancement/diarization choices with resource and provenance implications;
+- publication format selection;
+- speaker display-name editing while retaining anonymous speaker refs as evidence identity;
+- language/speaker transcript presentation controls; and
+- provenance/transcript inspection where it helps troubleshooting or audit.
+
+## 4. Add local media playback behind a Tauri capability
+
+The evidence reader already has a verified source-relative cursor. Let that coordinate drive
+local audio/video without handing an arbitrary path to React.
+
+Rust owns file capability and media lifecycle. Python owns source identity/evidence rules.
+The webview receives playback state and safe coordinates, not general filesystem authority.
+
+Qualification includes unavailable/moved sources, source identity mismatch, keyboard
+transport, reduced motion, long media, and seeking around exact word boundaries.
+
+## 5. Productize safe lifecycle and retention
+
+Before a packaged app invites non-technical users to accumulate large local corpora, give
+them safe cleanup tools:
+
+- dry-run deletion plan review;
+- plan-bound confirmation;
+- visibly separate source, canonical evidence, derived artifacts, execution state, research,
+  and saved-search scopes;
+- the source-recording second guard; and
+- retention preview/cleanup for eligible private execution state.
+
+A friendly Delete button must never flatten EchoFlow’s custody model.
+
+## 6. Desktop packaging, first run, updates, and uninstall
 
 Produce deliberate delivery paths for:
 
@@ -239,7 +290,7 @@ native transcription dependencies, model custody, migrations, updates, and unins
 **Uninstalling EchoFlow must not silently delete canonical transcripts or authoritative
 human research state.** Program removal and user-data destruction are different operations.
 
-## 4. Backup, restore, and research portability
+## 7. Backup, restore, and research portability
 
 Back up what is irreplaceable: canonical evidence, research SQLite state, saved searches,
 speaker labels, and other durable human state. Rebuildable DuckDB projections should be
@@ -251,14 +302,14 @@ and require explicit reconciliation/reapproval on another machine.
 Selected research export should target CSV, JSON/JSONL, and Markdown while retaining
 document/generation identity, segment IDs, and numeric evidence coordinates.
 
-## 5. Semantic dependency and embedding custody qualification
+## 8. Qualify semantic dependencies and embedding custody for packaging
 
 Before semantic retrieval is advertised as a normal packaged capability, qualify one
 locked optional dependency set with managed immutable embedding-model acquisition, private
 cache placement, disk/resource admission, no silent search-time download, offline use after
 installation, and packaged-platform qualification.
 
-## 6. Representative-device release qualification
+## 9. Representative-device release qualification
 
 Exercise real corpora and the packaged app on 8 GB Windows, 16 GB commodity hardware,
 Apple Silicon, a discrete-GPU laptop, and 32/64 GB workstations. Measure real-time factor,
@@ -269,6 +320,26 @@ Also cover Unicode/space-heavy paths, external drives, permission failures, low 
 interrupted downloads, crash/resume, upgrade migrations, uninstall/reinstall, offline
 operation, keyboard/accessibility use, corruption/recovery, location disappearance and
 reappearance, and one-time versus remembered import.
+
+# Cross-cutting rules for every desktop slice
+
+The frontend is not a second application authority. Every new surface should preserve these
+boundaries:
+
+| Concern | Owner |
+|---|---|
+| canonical transcript/evidence rules | Python application services |
+| durable research and custody rules | Python authoritative stores/services |
+| native file/process/media capability | Tauri/Rust |
+| presentation and interaction state | React |
+| raw filesystem authority | never delegated generally to the webview |
+| SQL/database authority | never delegated to React |
+| long-running work | explicit native/application lifecycle, not a giant synchronous UI call |
+
+Destructive operations need typed plans and explicit confirmation. Human-authored state
+needs concurrency-safe mutation. Evidence navigation needs generation verification. Model
+or network acquisition must be explicit. Accessibility and keyboard use remain release
+gates, not cleanup work.
 
 # Conditional later capabilities
 
@@ -298,4 +369,5 @@ The pre-1.0 milestone is not “the tests pass from a checkout.” It is:
 > search and annotate their evidence, recover from common failure, move or back up durable
 > work, update the app safely, and remove the program without losing evidence.
 
-That is the finish line the roadmap is walking toward.
+The capability audit above is the checklist for reaching that state without accidentally
+rebuilding mature backend behavior in the frontend.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ EchoFlow is a **private, local-first workspace for recorded evidence**.
 It can inspect a recording, choose a safe way to run on the computer you actually have,
 transcribe locally, survive interruptions, preserve provenance, search a private corpus,
 navigate results back to verified canonical evidence, keep research notes attached to that
-evidence, save reusable research questions, and expose the first import/search/evidence
+evidence, save reusable research questions, and expose import/search/evidence/research
 workflows through a native desktop shell.
 
 You do **not** need to understand CUDA, DuckDB, SQLite, BM25, vector spaces, immutable
@@ -32,11 +32,12 @@ machinery so the user can concentrate on recordings and evidence.
 | Search a private corpus | supports lexical BM25, optional semantic retrieval, and hybrid RRF |
 | Follow a result to evidence | verifies canonical generation and returns justified segment/word/context/seek coordinates |
 | Keep durable research | stores notes/tags/collections in authoritative private SQLite anchored to exact evidence |
+| Edit research safely | atomically replaces note prose/labels and refuses stale desktop writes |
 | Reuse research questions | stores saved typed query intent and re-resolves current evidence |
 | Remember libraries | persists explicit transcript/recording location permissions without copying user media |
 | Refresh an evolving corpus | incrementally reconciles changed canonical generations and can verify tracked evidence |
 | Remove something safely | plans typed deletion scopes before mutation and binds confirmation to the exact plan |
-| Use a desktop shell | provides Tauri + React import, Library search, verified evidence reading/cursor, and Archive/Midnight themes |
+| Use a desktop shell | provides Tauri + React import, Library search, verified evidence reading/cursor, Research browse/create/edit/delete, and Archive/Midnight themes |
 
 The point is not to make users operate the machinery. The point is to make sensitive local
 transcription and research boringly dependable.
@@ -45,10 +46,9 @@ transcription and research boringly dependable.
 
 - **[Getting started](getting-started.md)** for the source-build path and first transcript.
 - **[Find things across the whole local library](library-discovery.md)** for grouped Library
-  discovery, which now powers the desktop Library surface.
+  discovery, which powers the desktop Library surface.
 - **[Your notes should survive the machinery](research-notes.md)** for authoritative notes,
-  tags, collections, and saved research intent. A dedicated desktop Research workspace is
-  the next UI tranche.
+  tags, collections, saved research intent, and the current desktop Research interactions.
 - **[From search result to the exact evidence](evidence-navigation.md)** for verified
   canonical navigation and the current desktop evidence reader/cursor.
 - **[Transcript time without calculator gymnastics](time-navigation.md)** for timeline and
@@ -82,7 +82,7 @@ flowchart LR
     H --> J[Incremental refresh]
     J --> K[Desktop Library]
     E --> K
-    F --> L[Next Desktop Research]
+    F --> L[Desktop Research]
 
     classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
@@ -109,8 +109,8 @@ flowchart LR
 
 Text fallback: canonical evidence feeds rebuildable search; search resolves back to verified
 evidence; durable notes/tags/collections and saved searches remain authoritative human
-knowledge; lifecycle and refresh reuse those identities; the current desktop Library uses
-the same application contracts, and a dedicated Research surface is next.
+knowledge; lifecycle and refresh reuse those identities; the desktop Library and Research
+surfaces consume the same application contracts.
 
 ## What belongs to you, and what can the raccoon rebuild? 🦝
 
@@ -133,20 +133,18 @@ gone very wrong.
 
 ## What comes next
 
-Incremental refresh, durable locations, the Tauri/React shell, native import, grouped
-Library discovery, and verified evidence reading/cursor are foundation.
+The roadmap now includes a complete backend-capability → desktop-productization audit.
+Research browse/create/edit/delete and label assignment are foundation; the remaining
+Research loop is saved-search lifecycle, research-object → verified-evidence navigation,
+stale-anchor review, and advanced typed search controls.
 
-The next sequence is:
+After that, the major missing user journey is the **desktop Processing center** over already
+implemented health/resource, managed-model, job-lifecycle, transcription-plan, execution,
+resume, enhancement, diarization, and publication contracts. Native playback, safe
+lifecycle UI, packaging, portability, semantic packaging qualification, and representative
+hardware qualification follow on the same critical path.
 
-1. **Research workspace UI** over existing authoritative notes/tags/collections/saved-search
-   services.
-2. **Tauri-owned local media playback** driven by verified source-relative coordinates.
-3. **Desktop packaging and first run** for Windows, signed/notarized macOS, and deliberate
-   Linux delivery.
-4. **Backup, restore, and portable research export** while rebuilding disposable indexes.
-5. **Semantic dependency/model qualification and representative-device release testing**.
-
-See **[ROADMAP.md](../ROADMAP.md)** for detailed sequencing.
+See **[ROADMAP.md](../ROADMAP.md)** for the capability matrix and detailed sequencing.
 
 The editorial and Mermaid visual rules live in
 **[documentation-style.md](documentation-style.md)**.

--- a/docs/architecture/research-state.md
+++ b/docs/architecture/research-state.md
@@ -1,8 +1,9 @@
 # Durable research state architecture
 
 Status: authoritative notes/tags/collections, saved searches, projection sync/rebuild,
-research-aware retrieval, and unified discovery are implemented. A dedicated desktop
-Research workspace is the next UI tranche.  
+research-aware retrieval, unified discovery, desktop Research browse/create, and
+version-checked desktop note mutation are implemented. Saved-search mutation and
+research-object → evidence navigation remain desktop work.  
 Last updated: August 19, 2026
 
 EchoFlow keeps **user-authored research knowledge durable** while still making that
@@ -35,7 +36,7 @@ flowchart LR
     F --> J
     I --> J
     J --> K[CLI and unified discovery]
-    J --> L[Next Desktop Research workspace]
+    J --> L[Desktop Research workspace]
 
     classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
@@ -52,8 +53,8 @@ flowchart LR
 
 Text fallback: canonical evidence creates a verified anchor; user research commits to
 SQLite with a monotonic journal; a deterministic projector builds disposable DuckDB query
-state; saved searches remain SQLite-authored intent; CLI/unified discovery already consume
-the workspace service, and the dedicated desktop Research workspace is next.
+state; saved searches remain SQLite-authored intent; CLI, unified discovery, and the
+desktop Research workspace consume the same application service boundary.
 
 ## Why two stores?
 
@@ -101,7 +102,7 @@ The full durable anchor also carries source identity and source-relative time co
 Including canonical SHA-256 prevents a stale annotation from silently attaching to a new
 transcript generation that reuses `segment-000042`.
 
-## Verified anchors
+## Verified anchors and desktop creation
 
 `EvidenceAnchor` is produced only after canonical evidence validation. Before creating
 durable research anchored to a transcript, the application verifies that the document is
@@ -109,15 +110,26 @@ present, canonical bytes still match the indexed SHA-256, requested segments exi
 canonical order, multi-segment selections are contiguous, and optional sub-segment
 coordinates stay inside the verified span.
 
-The current desktop Evidence reader already exposes the same canonical segment/word/time
-coordinate system. The next Research UI should create notes from those verified coordinates
-rather than inventing a UI-only annotation identity.
+The desktop Evidence reader uses that same canonical segment/word/time system. Its narrow
+create-note bridge carries the expected canonical SHA-256 and refuses the write if the
+library has moved to a newer generation before Save. React never invents an annotation
+identity or receives a raw canonical/source path.
 
-## SQLite transaction boundary and projection
+## Mutation, concurrency, and the journal
 
 The authoritative write path uses foreign keys, WAL mode, `synchronous=FULL`,
 `BEGIN IMMEDIATE` writer serialization, and one transaction for the user mutation **and**
 its change-journal record.
+
+Desktop note editing replaces body, tag relationships, and collection relationships in one
+SQLite transaction and advances the journal once. The `EvidenceAnchor` columns and segment
+relationships are not part of that update.
+
+Desktop edit/delete carries the note `updated_at` value it read. The store checks that
+version after `BEGIN IMMEDIATE` has acquired the writer boundary. A mismatch fails closed,
+so a CLI edit or another local surface cannot be silently overwritten by stale React state.
+CLI commands that intentionally operate directly remain compatible and do not require a UI
+version token.
 
 Every projected mutation advances a monotonic sequence. The projector consumes changes in
 bounded batches and replaces touched notes from current authoritative state. Replay is
@@ -156,26 +168,28 @@ current corpus and research relationships.
 Frequent/recent tag or collection navigation is different. Those rankings are derived
 convenience views and remain disposable.
 
-## Workspace service boundary
+## Workspace and desktop boundaries
 
-`ResearchWorkspaceService` is the application-facing seam. It composes verified anchors,
-authoritative SQLite research state, deterministic projection convergence, DuckDB research
-filtering/summaries, transcript retrieval, grouped discovery, and saved-search/navigation
-behavior.
+`ResearchWorkspaceService` composes verified anchors, authoritative SQLite research state,
+deterministic projection convergence, DuckDB research filtering/summaries, transcript
+retrieval, grouped discovery, and saved-search/navigation behavior.
 
-The CLI uses this service today. The current desktop bridge uses it indirectly for grouped
-Library discovery and evidence presentation. The next desktop tranche should add narrow
-versioned Research operations that delegate back to the same service.
+The CLI and desktop bridge delegate to this service. Desktop methods are narrow DTO
+operations: overview, verified note creation, atomic note replacement, and guarded note
+deletion. React does not issue SQL or open SQLite/DuckDB directly.
 
-React must not issue SQL or open SQLite/DuckDB directly. Older-generation anchors must
-remain visible as older evidence. Automatic re-anchoring is not permitted merely because a
-newer transcript reuses the same friendly segment ID.
+Older-generation anchors remain visible as older evidence. Editing their human-authored
+prose or labels is permitted because the evidence anchor does not move. Automatic
+re-anchoring is not permitted merely because a newer transcript reuses the same friendly
+segment ID.
 
 ## Current deliberate limits
 
 Research state currently does not provide:
 
-- a dedicated desktop Research workspace yet;
+- desktop saved-search create/run/rename/delete yet;
+- desktop research-object → verified-evidence navigation yet;
+- explicit stale-anchor review/re-anchor UX yet;
 - rich-text/WYSIWYG note bodies;
 - semantic embeddings over note prose;
 - automatic cross-generation re-anchoring;
@@ -187,14 +201,16 @@ Research state currently does not provide:
 1. **SQLite research state is authoritative and must never be treated as rebuildable cache.**
 2. **DuckDB research state is a disposable projection and must be reconstructable from SQLite.**
 3. **A user mutation and its journal event commit together.**
-4. **The DuckDB watermark advances atomically with projected rows.**
-5. **Projection replay is idempotent.**
-6. **Research joins include canonical generation identity, not segment ID alone.**
-7. **Empty research scope means no matches, not unrestricted search.**
-8. **Research constraints are applied before ranking/scoring when they are filters.**
-9. **Presentation hydrates authoritative note content from SQLite.**
-10. **Saved searches persist typed intent, not derived result scope.**
-11. **Desktop presentation receives narrow DTOs, not raw database/filesystem authority.**
-12. **Deleting any DuckDB file must never delete unique user-authored knowledge.**
+4. **Desktop stale writes must fail rather than silently overwrite newer user state.**
+5. **Editing note prose/labels must not rebind its evidence anchor.**
+6. **The DuckDB watermark advances atomically with projected rows.**
+7. **Projection replay is idempotent.**
+8. **Research joins include canonical generation identity, not segment ID alone.**
+9. **Empty research scope means no matches, not unrestricted search.**
+10. **Research constraints are applied before ranking/scoring when they are filters.**
+11. **Presentation hydrates authoritative note content from SQLite.**
+12. **Saved searches persist typed intent, not derived result scope.**
+13. **Desktop presentation receives narrow DTOs, not raw database/filesystem authority.**
+14. **Deleting any DuckDB file must never delete unique user-authored knowledge.**
 
 If a refactor makes one of those statements false, it changes EchoFlow's custody model.

--- a/docs/diagrams/docs-family-portrait.svg
+++ b/docs/diagrams/docs-family-portrait.svg
@@ -1,7 +1,7 @@
-<!-- mermaid-sha256: d1838fdc5eab910de57e62a669aac65d1fe147c5252e1822e6a48671fa07fbbd -->
+<!-- mermaid-sha256: 908d4720f1089fd6e19b70f0cf2f6ac98d20d6a09dfd0b20393b47006b047d8e -->
 <svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1600 500">
   <title id="title">EchoFlow family portrait</title>
-  <desc id="desc">A recording becomes canonical transcript evidence, searchable and verifiable, connected to durable research, saved searches, custody planning, incremental refresh, the current desktop Library, and the next Research workspace.</desc>
+  <desc id="desc">A recording becomes canonical transcript evidence, searchable and verifiable, connected to durable research, saved searches, custody planning, incremental refresh, the desktop Library, and the desktop Research workspace.</desc>
   <defs>
     <marker id="arrow" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto"><path d="M0 0L9 4.5L0 9Z" fill="#315E63"/></marker>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="5" stdDeviation="6" flood-color="#1F2930" flood-opacity="0.10"/></filter>
@@ -31,7 +31,7 @@
     <g><rect x="50" y="280" width="150" height="90" rx="18" fill="#FFD6D6" stroke="#9E3434" stroke-width="3"/><text x="125" y="318" text-anchor="middle" fill="#351616">Typed custody</text><text x="125" y="342" text-anchor="middle" fill="#351616">planning</text></g>
 
     <g><rect x="780" y="390" width="220" height="80" rx="18" fill="#D8EEFF" stroke="#2E617B" stroke-width="3"/><text x="890" y="425" text-anchor="middle" fill="#12222A">Current desktop</text><text x="890" y="449" text-anchor="middle" fill="#12222A">Library + reader</text></g>
-    <g><rect x="1040" y="390" width="220" height="80" rx="18" fill="#E8D9FF" stroke="#68469B" stroke-width="3"/><text x="1150" y="425" text-anchor="middle" fill="#1F1630">Next desktop</text><text x="1150" y="449" text-anchor="middle" fill="#1F1630">Research workspace</text></g>
+    <g><rect x="1040" y="390" width="220" height="80" rx="18" fill="#E8D9FF" stroke="#68469B" stroke-width="3"/><text x="1150" y="425" text-anchor="middle" fill="#1F1630">Current desktop</text><text x="1150" y="449" text-anchor="middle" fill="#1F1630">Research workspace</text></g>
     <g><rect x="1330" y="390" width="190" height="80" rx="18" fill="#D8EEFF" stroke="#2E617B" stroke-width="3"/><text x="1425" y="425" text-anchor="middle" fill="#12222A">Same backend</text><text x="1425" y="449" text-anchor="middle" fill="#12222A">contracts</text></g>
   </g>
 </svg>

--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -30,7 +30,7 @@ flowchart LR
     E --> F[DuckDB research projection]
     F --> G[Fast research-aware search]
     G --> A
-    C --> H[Next Desktop Research workspace]
+    C --> H[Desktop Research workspace]
 
     classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
     classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
@@ -45,16 +45,16 @@ flowchart LR
 
 Text fallback: verified canonical evidence anchors durable SQLite research state; a
 transactional journal projects that authority into rebuildable DuckDB query state; the
-next desktop Research workspace will consume the same authority rather than inventing a
+desktop Research workspace consumes the same authority rather than inventing a
 browser-owned notebook.
 
 You do not need to operate either database. `ResearchWorkspaceService` presents one
 research workspace over the two storage roles.
 
-## Add and edit notes today
+## Add, edit, organize, and delete notes
 
-The current CLI anchors to real canonical segment IDs rather than a disposable search row
-or formatted timestamp:
+The CLI anchors to real canonical segment IDs rather than a disposable search row or
+formatted timestamp:
 
 ```bash
 echoflow library notes add TRANSCRIPT_ID segment-000042 \
@@ -69,14 +69,23 @@ canonical transcript bytes and refuses missing, reordered, or non-contiguous sel
 Optional `--start-seconds` and `--end-seconds` may narrow an anchor inside that verified
 span.
 
-List or filter notes:
+The desktop now uses that same rule when a note is created from the verified Evidence
+reader. It sends document/generation identity and canonical coordinates through one narrow
+bridge method. If the library moved to a newer canonical generation before Save, the write
+is refused instead of silently attaching the note to different evidence.
 
-```bash
-echoflow library notes
-echoflow library notes --text "survey methodology" --tag housing
-```
+Existing notes can be edited in the Research workspace. A desktop edit replaces note body,
+tag assignments, and collection assignments **atomically in authoritative SQLite** and
+emits one projection-journal event. The note’s evidence anchor is not rewritten.
 
-Edit authoritative research state explicitly:
+Desktop edit/delete also carries the note’s authoritative `updated_at` version. If a CLI or
+another local surface changed that note after it was displayed, EchoFlow refuses the stale
+write and asks the user to refresh. Local-first does not mean lost-update-safe by accident.
+
+Deletion is explicit and deliberately narrow: deleting a note deletes that human-authored
+note. It does not delete the canonical transcript or original recording.
+
+The equivalent CLI operations remain available:
 
 ```bash
 echoflow library notes edit NOTE_ID --body "Revised note text"
@@ -84,13 +93,6 @@ echoflow library notes set-tags NOTE_ID --tag housing --tag methodology
 echoflow library notes set-collections NOTE_ID --collection "Chapter 3"
 echoflow library notes delete NOTE_ID
 ```
-
-Those commands mutate authoritative SQLite user state. The DuckDB query projection catches
-up from the monotonic journal.
-
-The desktop Evidence reader already works with the same verified segment/word coordinate
-system. The next Research UI tranche should turn verified selections into the exact same
-`EvidenceAnchor` instead of creating a graphical-only annotation model.
 
 ## Use research state to search the transcript corpus
 
@@ -114,9 +116,9 @@ EchoFlow resolves human names to durable IDs, obtains a canonical evidence scope
 research projection, and ranks lexical/semantic candidates **inside that scope**. It does
 not retrieve the whole corpus and throw away results afterward.
 
-Unified workspace discovery is implemented and powers the desktop Library search. Search
-results can show associated note count, tags, and collections alongside original
-evidence/ranking data without inventing one cross-type relevance score.
+Unified workspace discovery powers the desktop Library search. Search results can show
+associated note count, tags, and collections alongside original evidence/ranking data
+without inventing one cross-type relevance score.
 
 ## What if the transcript changes?
 
@@ -126,7 +128,11 @@ canonical SHA-256, EchoFlow does **not** silently move the old note.
 
 The old note remains durable historical user state. The projected evidence key includes
 canonical generation identity so stale annotations cannot accidentally attach to new
-evidence.
+evidence. Editing the prose or labels on that old note still leaves its original anchor
+unchanged.
+
+A later re-anchor workflow must be an explicit user decision that shows both generations;
+it must never be an incidental side effect of editing a note.
 
 ## Why two databases?
 
@@ -161,16 +167,21 @@ current relationships instead of persisted popularity counters.
 
 The tag is durable user state. “Used 147 times” is disposable navigation metadata.
 
+The desktop currently presents saved-search intent but does not yet create/run/rename/delete
+saved searches. That is the next Research interaction slice, together with returning a
+research object to verified evidence.
+
 ## What comes next for the notebook?
 
-The storage, evidence-address, unified-discovery, saved-search, and derived-navigation
-contracts are built. The next tranche is the dedicated desktop Research workspace:
+The storage, evidence-address, unified-discovery, saved-search backend, Research overview,
+verified note creation, and note edit/delete/label mutation contracts are built.
 
-- browse current and older-generation notes;
-- create a note directly from verified desktop evidence;
-- edit/delete notes and assign/remove tags/collections;
-- create, run, rename, and delete saved searches;
-- navigate research objects back to current verified evidence when possible;
+The remaining Research tranche is:
+
+- create, run, rename, and delete saved searches in the desktop;
+- navigate notes/tags/collections/saved searches back to current verified evidence when
+  possible;
+- expose advanced typed search/research filters without hidden interpretation;
 - stale-anchor review/re-anchor UX with explicit user confirmation; and
 - later, selected/citable result sets and portable evidence-bearing research export.
 

--- a/frontend/src/ResearchWorkspace.tsx
+++ b/frontend/src/ResearchWorkspace.tsx
@@ -1,6 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type FormEvent } from "react";
 
-import type { DesktopClient, ResearchOverview } from "./api/desktop";
+import type {
+  DesktopClient,
+  ResearchNoteResult,
+  ResearchOverview,
+} from "./api/desktop";
 import { WorkspaceHeader, type Theme } from "./components/WorkspaceHeader";
 import { formatEvidenceTime } from "./format";
 import "./research.css";
@@ -16,6 +20,15 @@ function formatUpdatedAt(value: string) {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 }
 
+function parseLabels(value: string): string[] {
+  const labels = new Map<string, string>();
+  value.split(",").forEach((raw) => {
+    const label = raw.trim();
+    if (label) labels.set(label.toLocaleLowerCase(), label);
+  });
+  return [...labels.values()];
+}
+
 export function ResearchWorkspace({
   client,
   theme,
@@ -24,6 +37,13 @@ export function ResearchWorkspace({
   const [overview, setOverview] = useState<ResearchOverview | null>(null);
   const [busy, setBusy] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
+  const [deleteNoteId, setDeleteNoteId] = useState<string | null>(null);
+  const [mutatingNoteId, setMutatingNoteId] = useState<string | null>(null);
+  const [draftBody, setDraftBody] = useState("");
+  const [draftTags, setDraftTags] = useState("");
+  const [draftCollections, setDraftCollections] = useState("");
+  const [mutationMessage, setMutationMessage] = useState<string | null>(null);
 
   const loadOverview = useCallback(async () => {
     setBusy(true);
@@ -46,6 +66,65 @@ export function ResearchWorkspace({
     void loadOverview();
   }, [loadOverview]);
 
+  function beginEdit(note: ResearchNoteResult) {
+    setEditingNoteId(note.note_id);
+    setDeleteNoteId(null);
+    setDraftBody(note.body);
+    setDraftTags(note.tags.join(", "));
+    setDraftCollections(note.collections.join(", "));
+    setMutationMessage(null);
+    setError(null);
+  }
+
+  function cancelEdit() {
+    setEditingNoteId(null);
+    setDraftBody("");
+    setDraftTags("");
+    setDraftCollections("");
+  }
+
+  async function saveEdit(event: FormEvent, note: ResearchNoteResult) {
+    event.preventDefault();
+    setMutatingNoteId(note.note_id);
+    setMutationMessage(null);
+    setError(null);
+    try {
+      await client.updateResearchNote(note, {
+        body: draftBody,
+        tags: parseLabels(draftTags),
+        collections: parseLabels(draftCollections),
+      });
+      cancelEdit();
+      await loadOverview();
+      setMutationMessage("Note saved. Its verified evidence anchor is unchanged.");
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "EchoFlow could not update that note.",
+      );
+    } finally {
+      setMutatingNoteId(null);
+    }
+  }
+
+  async function deleteNote(note: ResearchNoteResult) {
+    setMutatingNoteId(note.note_id);
+    setMutationMessage(null);
+    setError(null);
+    try {
+      await client.deleteResearchNote(note);
+      setDeleteNoteId(null);
+      if (editingNoteId === note.note_id) cancelEdit();
+      await loadOverview();
+      setMutationMessage("Note deleted. Transcript evidence was not deleted.");
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "EchoFlow could not delete that note.",
+      );
+    } finally {
+      setMutatingNoteId(null);
+    }
+  }
+
   return (
     <>
       <WorkspaceHeader
@@ -62,14 +141,13 @@ export function ResearchWorkspace({
         </div>
         <div className="research-intro-copy">
           <p>
-            This view reads authoritative notes, tags, collections, and saved-search intent
-            from the local research workspace. Rebuildable search machinery is not the
-            source of truth here.
+            Browse and edit authoritative notes, tags, and collections beside saved-search
+            intent. Rebuildable search machinery is not the source of truth here.
           </p>
           <button
             className="research-refresh"
             type="button"
-            disabled={busy}
+            disabled={busy || mutatingNoteId !== null}
             onClick={() => void loadOverview()}
           >
             {busy ? "Refreshing…" : "Refresh research"}
@@ -84,6 +162,12 @@ export function ResearchWorkspace({
             ? `${overview.notes.length} notes · ${overview.tags.length} tags · ${overview.collections.length} collections · ${overview.saved_searches.length} saved searches`
             : "Research state is unavailable."}
       </p>
+
+      {mutationMessage && (
+        <p className="research-mutation-status" aria-live="polite">
+          {mutationMessage}
+        </p>
+      )}
 
       {error && (
         <p className="error-banner research-error" role="alert">
@@ -106,45 +190,152 @@ export function ResearchWorkspace({
               <p className="research-empty">No research notes yet.</p>
             ) : (
               <div className="research-note-list">
-                {overview.notes.map((note) => (
-                  <article className="research-note-card" key={note.note_id}>
-                    <div className="research-note-meta">
-                      <span>{note.document_id}</span>
-                      <time dateTime={`PT${note.start_seconds}S`}>
-                        {formatEvidenceTime(note.start_seconds)}
-                      </time>
-                      <span
-                        className={
-                          note.current
-                            ? "evidence-state evidence-state-current"
-                            : "evidence-state evidence-state-older"
-                        }
-                      >
-                        {note.current ? "Current evidence" : "Older evidence generation"}
-                      </span>
-                    </div>
-                    <p className="research-note-body">{note.body}</p>
-                    <div className="research-note-footer">
-                      <div
-                        className="research-pills"
-                        role="group"
-                        aria-label="Research labels"
-                      >
-                        {note.tags.map((tag) => (
-                          <span key={`${note.note_id}:tag:${tag}`}>#{tag}</span>
-                        ))}
-                        {note.collections.map((collection) => (
-                          <span key={`${note.note_id}:collection:${collection}`}>
-                            {collection}
-                          </span>
-                        ))}
+                {overview.notes.map((note) => {
+                  const editing = editingNoteId === note.note_id;
+                  const confirmingDelete = deleteNoteId === note.note_id;
+                  const mutating = mutatingNoteId === note.note_id;
+                  return (
+                    <article className="research-note-card" key={note.note_id}>
+                      <div className="research-note-meta">
+                        <span>{note.document_id}</span>
+                        <time dateTime={`PT${note.start_seconds}S`}>
+                          {formatEvidenceTime(note.start_seconds)}
+                        </time>
+                        <span
+                          className={
+                            note.current
+                              ? "evidence-state evidence-state-current"
+                              : "evidence-state evidence-state-older"
+                          }
+                        >
+                          {note.current ? "Current evidence" : "Older evidence generation"}
+                        </span>
                       </div>
-                      <time dateTime={note.updated_at} className="research-updated">
-                        Updated {formatUpdatedAt(note.updated_at)}
-                      </time>
-                    </div>
-                  </article>
-                ))}
+
+                      {editing ? (
+                        <form
+                          className="research-note-editor"
+                          onSubmit={(event) => void saveEdit(event, note)}
+                        >
+                          <label>
+                            Note
+                            <textarea
+                              aria-label={`Note text for ${note.document_id}`}
+                              value={draftBody}
+                              maxLength={50_000}
+                              rows={5}
+                              disabled={mutating}
+                              onChange={(event) => setDraftBody(event.target.value)}
+                            />
+                          </label>
+                          <div className="research-editor-grid">
+                            <label>
+                              Tags
+                              <input
+                                aria-label={`Tags for ${note.document_id}`}
+                                value={draftTags}
+                                disabled={mutating}
+                                onChange={(event) => setDraftTags(event.target.value)}
+                                placeholder="methodology, follow-up"
+                              />
+                            </label>
+                            <label>
+                              Collections
+                              <input
+                                aria-label={`Collections for ${note.document_id}`}
+                                value={draftCollections}
+                                disabled={mutating}
+                                onChange={(event) => setDraftCollections(event.target.value)}
+                                placeholder="Chapter 3, Oral histories"
+                              />
+                            </label>
+                          </div>
+                          <p className="research-anchor-note">
+                            Editing changes only your note and labels. The exact canonical
+                            evidence generation and coordinates stay unchanged.
+                          </p>
+                          <div className="research-note-actions">
+                            <button type="submit" disabled={mutating || !draftBody.trim()}>
+                              {mutating ? "Saving…" : "Save note"}
+                            </button>
+                            <button type="button" disabled={mutating} onClick={cancelEdit}>
+                              Cancel
+                            </button>
+                          </div>
+                        </form>
+                      ) : (
+                        <>
+                          <p className="research-note-body">{note.body}</p>
+                          <div className="research-note-footer">
+                            <div
+                              className="research-pills"
+                              role="group"
+                              aria-label="Research labels"
+                            >
+                              {note.tags.map((tag) => (
+                                <span key={`${note.note_id}:tag:${tag}`}>#{tag}</span>
+                              ))}
+                              {note.collections.map((collection) => (
+                                <span key={`${note.note_id}:collection:${collection}`}>
+                                  {collection}
+                                </span>
+                              ))}
+                            </div>
+                            <time dateTime={note.updated_at} className="research-updated">
+                              Updated {formatUpdatedAt(note.updated_at)}
+                            </time>
+                          </div>
+                          <div className="research-note-actions">
+                            <button
+                              type="button"
+                              disabled={mutatingNoteId !== null}
+                              onClick={() => beginEdit(note)}
+                            >
+                              Edit note
+                            </button>
+                            <button
+                              className="research-action-danger"
+                              type="button"
+                              disabled={mutatingNoteId !== null}
+                              onClick={() => {
+                                setDeleteNoteId(note.note_id);
+                                setMutationMessage(null);
+                              }}
+                            >
+                              Delete note
+                            </button>
+                          </div>
+                        </>
+                      )}
+
+                      {confirmingDelete && !editing && (
+                        <div className="research-delete-confirm" role="group" aria-label="Delete note confirmation">
+                          <p>
+                            Delete this human-authored note? Its canonical transcript and
+                            original recording are not part of this operation.
+                          </p>
+                          <div className="research-note-actions">
+                            <button
+                              className="research-action-danger"
+                              type="button"
+                              disabled={mutating}
+                              onClick={() => void deleteNote(note)}
+                            >
+                              {mutating ? "Deleting…" : "Delete note permanently"}
+                            </button>
+                            <button
+                              type="button"
+                              disabled={mutating}
+                              onClick={() => setDeleteNoteId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </article>
+                  );
+                })}
               </div>
             )}
           </section>

--- a/frontend/src/api/desktop.ts
+++ b/frontend/src/api/desktop.ts
@@ -85,6 +85,12 @@ export interface ResearchNoteResult extends WorkspaceNoteResult {
   updated_at: string;
 }
 
+export interface ResearchNoteUpdate {
+  body: string;
+  tags: string[];
+  collections: string[];
+}
+
 export interface WorkspaceNamedResult {
   name: string;
 }
@@ -152,6 +158,11 @@ export interface DesktopClient {
     evidence: WorkspaceEvidenceResult,
     body: string,
   ): Promise<ResearchNoteResult>;
+  updateResearchNote(
+    note: ResearchNoteResult,
+    update: ResearchNoteUpdate,
+  ): Promise<ResearchNoteResult>;
+  deleteResearchNote(note: ResearchNoteResult): Promise<void>;
 }
 
 function assertResponse<T>(value: unknown): DesktopResponse<T> {
@@ -167,6 +178,15 @@ function assertResponse<T>(value: unknown): DesktopResponse<T> {
     throw new Error("EchoFlow desktop bridge returned an incompatible response");
   }
   return candidate as DesktopResponse<T>;
+}
+
+function normalizeLabels(values: string[]): string[] {
+  const labels = new Map<string, string>();
+  values.forEach((raw) => {
+    const value = raw.trim();
+    if (value) labels.set(value.toLocaleLowerCase(), value);
+  });
+  return [...labels.values()].sort((left, right) => left.localeCompare(right));
 }
 
 class TauriDesktopClient implements DesktopClient {
@@ -276,11 +296,61 @@ class TauriDesktopClient implements DesktopClient {
       end_seconds: evidence.end_seconds,
     });
   }
+
+  updateResearchNote(
+    note: ResearchNoteResult,
+    update: ResearchNoteUpdate,
+  ): Promise<ResearchNoteResult> {
+    return this.request("workspace.research.note.update", {
+      note_id: note.note_id,
+      expected_updated_at: note.updated_at,
+      body: update.body,
+      tags: update.tags,
+      collections: update.collections,
+    });
+  }
+
+  async deleteResearchNote(note: ResearchNoteResult): Promise<void> {
+    await this.request("workspace.research.note.delete", {
+      note_id: note.note_id,
+      expected_updated_at: note.updated_at,
+    });
+  }
 }
 
 class MockDesktopClient implements DesktopClient {
   private locations: LibraryLocation[] = [];
-  private createdNotes: ResearchNoteResult[] = [];
+  private researchMutationVersion = 0;
+  private researchNotes: ResearchNoteResult[] = [
+    {
+      note_id: "note-7",
+      body: "Follow up on ABC governance during the next interview.",
+      document_id: "interview-42",
+      canonical_sha256: "a".repeat(64),
+      segment_ids: ["segment-17"],
+      start_seconds: 862.1,
+      end_seconds: 870.4,
+      current: true,
+      tags: ["program", "governance"],
+      collections: ["Oral histories"],
+      created_at: "2026-08-19T19:20:00+00:00",
+      updated_at: "2026-08-19T19:25:00+00:00",
+    },
+    {
+      note_id: "note-older",
+      body: "Earlier interpretation retained for provenance.",
+      document_id: "interview-11",
+      canonical_sha256: "c".repeat(64),
+      segment_ids: ["segment-3"],
+      start_seconds: 128.4,
+      end_seconds: 135.2,
+      current: false,
+      tags: ["review"],
+      collections: ["Field notes"],
+      created_at: "2026-08-18T14:10:00+00:00",
+      updated_at: "2026-08-18T14:10:00+00:00",
+    },
+  ];
 
   async chooseFiles(kind: LocationKind): Promise<string[]> {
     return kind === "transcript-library"
@@ -461,47 +531,28 @@ class MockDesktopClient implements DesktopClient {
   }
 
   async researchOverview(): Promise<ResearchOverview> {
+    const tagNames = normalizeLabels([
+      "program",
+      "governance",
+      "review",
+      ...this.researchNotes.flatMap((note) => note.tags),
+    ]);
+    const collectionNames = normalizeLabels([
+      "Oral histories",
+      "Field notes",
+      ...this.researchNotes.flatMap((note) => note.collections),
+    ]);
     return {
-      notes: [
-        ...this.createdNotes,
-        {
-          note_id: "note-7",
-          body: "Follow up on ABC governance during the next interview.",
-          document_id: "interview-42",
-          canonical_sha256: "a".repeat(64),
-          segment_ids: ["segment-17"],
-          start_seconds: 862.1,
-          end_seconds: 870.4,
-          current: true,
-          tags: ["program", "governance"],
-          collections: ["Oral histories"],
-          created_at: "2026-08-19T19:20:00+00:00",
-          updated_at: "2026-08-19T19:25:00+00:00",
-        },
-        {
-          note_id: "note-older",
-          body: "Earlier interpretation retained for provenance.",
-          document_id: "interview-11",
-          canonical_sha256: "c".repeat(64),
-          segment_ids: ["segment-3"],
-          start_seconds: 128.4,
-          end_seconds: 135.2,
-          current: false,
-          tags: ["review"],
-          collections: ["Field notes"],
-          created_at: "2026-08-18T14:10:00+00:00",
-          updated_at: "2026-08-18T14:10:00+00:00",
-        },
-      ],
-      tags: [
-        { tag_id: "tag-3", name: "program" },
-        { tag_id: "tag-4", name: "governance" },
-        { tag_id: "tag-5", name: "review" },
-      ],
-      collections: [
-        { collection_id: "collection-2", name: "Oral histories" },
-        { collection_id: "collection-3", name: "Field notes" },
-      ],
+      notes: this.researchNotes.map((note) => ({
+        ...note,
+        tags: [...note.tags],
+        collections: [...note.collections],
+      })),
+      tags: tagNames.map((name, index) => ({ tag_id: `tag-${index + 1}`, name })),
+      collections: collectionNames.map((name, index) => ({
+        collection_id: `collection-${index + 1}`,
+        name,
+      })),
       saved_searches: [
         {
           saved_search_id: "search-9",
@@ -521,9 +572,9 @@ class MockDesktopClient implements DesktopClient {
   ): Promise<ResearchNoteResult> {
     const trimmed = body.trim();
     if (!trimmed) throw new Error("Research note cannot be empty");
-    const now = "2026-08-19T21:44:00+00:00";
+    const now = this.nextResearchTimestamp();
     const note: ResearchNoteResult = {
-      note_id: `note-created-${this.createdNotes.length + 1}`,
+      note_id: `note-created-${this.researchNotes.length + 1}`,
       body: trimmed,
       document_id: evidence.document_id,
       canonical_sha256: evidence.canonical_sha256,
@@ -536,8 +587,46 @@ class MockDesktopClient implements DesktopClient {
       created_at: now,
       updated_at: now,
     };
-    this.createdNotes.unshift(note);
-    return note;
+    this.researchNotes.unshift(note);
+    return { ...note };
+  }
+
+  async updateResearchNote(
+    note: ResearchNoteResult,
+    update: ResearchNoteUpdate,
+  ): Promise<ResearchNoteResult> {
+    const index = this.researchNotes.findIndex((item) => item.note_id === note.note_id);
+    if (index < 0) throw new Error("Research note does not exist");
+    const current = this.researchNotes[index];
+    if (current.updated_at !== note.updated_at) {
+      throw new Error("Research note changed since it was opened; refresh before saving");
+    }
+    const body = update.body.trim();
+    if (!body) throw new Error("Research note cannot be empty");
+    const updated: ResearchNoteResult = {
+      ...current,
+      body,
+      tags: normalizeLabels(update.tags),
+      collections: normalizeLabels(update.collections),
+      updated_at: this.nextResearchTimestamp(),
+    };
+    this.researchNotes[index] = updated;
+    return { ...updated, tags: [...updated.tags], collections: [...updated.collections] };
+  }
+
+  async deleteResearchNote(note: ResearchNoteResult): Promise<void> {
+    const index = this.researchNotes.findIndex((item) => item.note_id === note.note_id);
+    if (index < 0) throw new Error("Research note does not exist");
+    if (this.researchNotes[index].updated_at !== note.updated_at) {
+      throw new Error("Research note changed since it was opened; refresh before saving");
+    }
+    this.researchNotes.splice(index, 1);
+  }
+
+  private nextResearchTimestamp(): string {
+    this.researchMutationVersion += 1;
+    const minute = String(this.researchMutationVersion).padStart(2, "0");
+    return `2026-08-19T22:${minute}:00+00:00`;
   }
 }
 

--- a/frontend/src/api/desktop.ts
+++ b/frontend/src/api/desktop.ts
@@ -598,6 +598,7 @@ class MockDesktopClient implements DesktopClient {
     const index = this.researchNotes.findIndex((item) => item.note_id === note.note_id);
     if (index < 0) throw new Error("Research note does not exist");
     const current = this.researchNotes[index];
+    if (!current) throw new Error("Research note does not exist");
     if (current.updated_at !== note.updated_at) {
       throw new Error("Research note changed since it was opened; refresh before saving");
     }
@@ -617,7 +618,9 @@ class MockDesktopClient implements DesktopClient {
   async deleteResearchNote(note: ResearchNoteResult): Promise<void> {
     const index = this.researchNotes.findIndex((item) => item.note_id === note.note_id);
     if (index < 0) throw new Error("Research note does not exist");
-    if (this.researchNotes[index].updated_at !== note.updated_at) {
+    const current = this.researchNotes[index];
+    if (!current) throw new Error("Research note does not exist");
+    if (current.updated_at !== note.updated_at) {
       throw new Error("Research note changed since it was opened; refresh before saving");
     }
     this.researchNotes.splice(index, 1);

--- a/frontend/src/research.css
+++ b/frontend/src/research.css
@@ -29,11 +29,10 @@
   line-height: 1.65;
 }
 
-.research-refresh {
-  justify-self: start;
+.research-refresh,
+.research-note-actions button {
   border: 1px solid var(--border);
   border-radius: 999px;
-  padding: 9px 14px;
   background: var(--surface-raised);
   color: var(--ink);
   font: inherit;
@@ -42,22 +41,36 @@
   cursor: pointer;
 }
 
-.research-refresh:hover:not(:disabled) {
+.research-refresh {
+  justify-self: start;
+  padding: 9px 14px;
+}
+
+.research-refresh:hover:not(:disabled),
+.research-note-actions button:hover:not(:disabled) {
   border-color: var(--accent);
   color: var(--accent-strong);
 }
 
-.research-refresh:disabled {
+.research-refresh:disabled,
+.research-note-actions button:disabled {
   cursor: progress;
   opacity: 0.62;
 }
 
-.research-status {
+.research-status,
+.research-mutation-status {
   max-width: 1180px;
   margin: 24px auto 0;
   color: var(--muted);
   font-size: 0.78rem;
   letter-spacing: 0.015em;
+}
+
+.research-mutation-status {
+  margin-top: 10px;
+  color: var(--accent-strong);
+  font-weight: 700;
 }
 
 .research-error {
@@ -203,6 +216,93 @@
   text-align: right;
 }
 
+.research-note-actions {
+  margin-top: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.research-note-actions button {
+  padding: 7px 11px;
+  font-size: 0.74rem;
+}
+
+.research-note-actions .research-action-danger {
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--border));
+  color: var(--danger);
+}
+
+.research-note-actions .research-action-danger:hover:not(:disabled) {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.research-note-editor {
+  margin-top: 16px;
+  display: grid;
+  gap: 14px;
+}
+
+.research-note-editor label {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 720;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.research-note-editor textarea,
+.research-note-editor input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: var(--surface-raised);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.research-note-editor textarea {
+  resize: vertical;
+  min-height: 116px;
+}
+
+.research-note-editor textarea:focus-visible,
+.research-note-editor input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.research-editor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.research-anchor-note,
+.research-delete-confirm p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.55;
+}
+
+.research-delete-confirm {
+  margin-top: 14px;
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, var(--border));
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--danger) 7%, var(--surface-raised));
+}
+
 .saved-search-list {
   display: grid;
 }
@@ -297,5 +397,9 @@
 
   .research-updated {
     text-align: left;
+  }
+
+  .research-editor-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/tests/research.spec.ts
+++ b/frontend/tests/research.spec.ts
@@ -55,7 +55,7 @@ test("Susan can edit labels and explicitly delete a durable research note", asyn
   await openResearch(page);
 
   const noteCard = page.locator(".research-note-card").filter({
-    hasText: "Follow up on ABC governance during the next interview.",
+    hasText: "interview-42",
   });
   await noteCard.getByRole("button", { name: "Edit note" }).click();
   await noteCard
@@ -67,20 +67,24 @@ test("Susan can edit labels and explicitly delete a durable research note", asyn
     .fill("Oral histories, Chapter 3");
   await noteCard.getByRole("button", { name: "Save note" }).click();
 
-  await expect(page.getByText("Note saved. Its verified evidence anchor is unchanged.")).toBeVisible();
-  const updatedCard = page.locator(".research-note-card").filter({
-    hasText: "Compare governance with the follow-up interview.",
-  });
-  await expect(updatedCard.getByText("#follow-up", { exact: true })).toBeVisible();
-  await expect(updatedCard.getByText("Chapter 3", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Note saved. Its verified evidence anchor is unchanged."),
+  ).toBeVisible();
+  await expect(
+    noteCard.getByText("Compare governance with the follow-up interview."),
+  ).toBeVisible();
+  await expect(noteCard.getByText("#follow-up", { exact: true })).toBeVisible();
+  await expect(noteCard.getByText("Chapter 3", { exact: true })).toBeVisible();
 
-  await updatedCard.getByRole("button", { name: "Delete note" }).click();
-  await expect(updatedCard.getByLabel("Delete note confirmation")).toContainText(
+  await noteCard.getByRole("button", { name: "Delete note" }).click();
+  await expect(noteCard.getByLabel("Delete note confirmation")).toContainText(
     "canonical transcript and original recording are not part of this operation",
   );
-  await updatedCard.getByRole("button", { name: "Delete note permanently" }).click();
+  await noteCard.getByRole("button", { name: "Delete note permanently" }).click();
 
-  await expect(page.getByText("Note deleted. Transcript evidence was not deleted.")).toBeVisible();
+  await expect(
+    page.getByText("Note deleted. Transcript evidence was not deleted."),
+  ).toBeVisible();
   await expect(
     page.getByText("Compare governance with the follow-up interview."),
   ).toHaveCount(0);

--- a/frontend/tests/research.spec.ts
+++ b/frontend/tests/research.spec.ts
@@ -48,3 +48,43 @@ test("research workspace refresh remains keyboard reachable", async ({ page }) =
   await page.keyboard.press("Enter");
   await expect(page.getByRole("status")).toContainText("2 notes");
 });
+
+test("Susan can edit labels and explicitly delete a durable research note", async ({
+  page,
+}) => {
+  await openResearch(page);
+
+  const noteCard = page.locator(".research-note-card").filter({
+    hasText: "Follow up on ABC governance during the next interview.",
+  });
+  await noteCard.getByRole("button", { name: "Edit note" }).click();
+  await noteCard
+    .getByLabel("Note text for interview-42")
+    .fill("Compare governance with the follow-up interview.");
+  await noteCard.getByLabel("Tags for interview-42").fill("program, follow-up");
+  await noteCard
+    .getByLabel("Collections for interview-42")
+    .fill("Oral histories, Chapter 3");
+  await noteCard.getByRole("button", { name: "Save note" }).click();
+
+  await expect(page.getByText("Note saved. Its verified evidence anchor is unchanged.")).toBeVisible();
+  const updatedCard = page.locator(".research-note-card").filter({
+    hasText: "Compare governance with the follow-up interview.",
+  });
+  await expect(updatedCard.getByText("#follow-up", { exact: true })).toBeVisible();
+  await expect(updatedCard.getByText("Chapter 3", { exact: true })).toBeVisible();
+
+  await updatedCard.getByRole("button", { name: "Delete note" }).click();
+  await expect(updatedCard.getByLabel("Delete note confirmation")).toContainText(
+    "canonical transcript and original recording are not part of this operation",
+  );
+  await updatedCard.getByRole("button", { name: "Delete note permanently" }).click();
+
+  await expect(page.getByText("Note deleted. Transcript evidence was not deleted.")).toBeVisible();
+  await expect(
+    page.getByText("Compare governance with the follow-up interview."),
+  ).toHaveCount(0);
+
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});

--- a/src/echoflow/desktop/bridge.py
+++ b/src/echoflow/desktop/bridge.py
@@ -404,16 +404,16 @@ def _dispatch(request: _DesktopRequest, services: DesktopServices) -> object:
         return _serialize_research_overview(services.workspace)
 
     if request.method == "workspace.research.note.create":
-        note_params = _CreateResearchNoteParams.model_validate(request.params)
-        return _create_research_note(note_params, services.workspace)
+        create_params = _CreateResearchNoteParams.model_validate(request.params)
+        return _create_research_note(create_params, services.workspace)
 
     if request.method == "workspace.research.note.update":
-        note_params = _UpdateResearchNoteParams.model_validate(request.params)
-        return _update_research_note(note_params, services.workspace)
+        update_params = _UpdateResearchNoteParams.model_validate(request.params)
+        return _update_research_note(update_params, services.workspace)
 
     if request.method == "workspace.research.note.delete":
-        note_params = _DeleteResearchNoteParams.model_validate(request.params)
-        return _delete_research_note(note_params, services.workspace)
+        delete_params = _DeleteResearchNoteParams.model_validate(request.params)
+        return _delete_research_note(delete_params, services.workspace)
 
     refresh_params = _RefreshParams.model_validate(request.params)
     refresh_report = services.locations.refresh_transcript_locations(

--- a/src/echoflow/desktop/bridge.py
+++ b/src/echoflow/desktop/bridge.py
@@ -54,6 +54,8 @@ class _DesktopRequest(BaseModel):
         "workspace.discover",
         "workspace.research.overview",
         "workspace.research.note.create",
+        "workspace.research.note.update",
+        "workspace.research.note.delete",
     ]
     params: dict[str, object] = Field(default_factory=dict)
 
@@ -119,6 +121,54 @@ class _CreateResearchNoteParams(BaseModel):
         if len(normalized) != len(set(normalized)):
             raise ValueError("segment IDs cannot repeat")
         return normalized
+
+
+class _UpdateResearchNoteParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    note_id: str = Field(min_length=1, max_length=200)
+    expected_updated_at: str = Field(min_length=1, max_length=200)
+    body: str = Field(min_length=1, max_length=50_000)
+    tags: tuple[str, ...] = Field(default=(), max_length=100)
+    collections: tuple[str, ...] = Field(default=(), max_length=100)
+
+    @field_validator("note_id", "expected_updated_at", "body")
+    @classmethod
+    def strip_required_text(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("value cannot be blank")
+        return stripped
+
+    @field_validator("tags", "collections")
+    @classmethod
+    def validate_labels(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        normalized: dict[str, str] = {}
+        for raw in values:
+            value = raw.strip()
+            if not value:
+                raise ValueError("research labels cannot be blank")
+            if len(value) > 200:
+                raise ValueError("research labels cannot exceed 200 characters")
+            if any(character in value for character in ("\r", "\n", "\x00")):
+                raise ValueError("research labels contain unsupported control characters")
+            normalized.setdefault(value.casefold(), value)
+        return tuple(normalized[key] for key in sorted(normalized))
+
+
+class _DeleteResearchNoteParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    note_id: str = Field(min_length=1, max_length=200)
+    expected_updated_at: str = Field(min_length=1, max_length=200)
+
+    @field_validator("note_id", "expected_updated_at")
+    @classmethod
+    def strip_required_text(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("value cannot be blank")
+        return stripped
 
 
 def _success(request_id: str, result: object) -> dict[str, object]:
@@ -283,6 +333,31 @@ def _create_research_note(
     return _serialize_note(note)
 
 
+def _update_research_note(
+    params: _UpdateResearchNoteParams,
+    workspace: ResearchWorkspaceService,
+) -> dict[str, object]:
+    note = workspace.replace_note(
+        params.note_id,
+        params.body,
+        tags=params.tags,
+        collections=params.collections,
+        expected_updated_at=params.expected_updated_at,
+    )
+    return _serialize_note(note)
+
+
+def _delete_research_note(
+    params: _DeleteResearchNoteParams,
+    workspace: ResearchWorkspaceService,
+) -> dict[str, object]:
+    workspace.delete_note(
+        params.note_id,
+        expected_updated_at=params.expected_updated_at,
+    )
+    return {"note_id": params.note_id, "deleted": True}
+
+
 def _dispatch(request: _DesktopRequest, services: DesktopServices) -> object:
     if request.method == "locations.list":
         _NoParams.model_validate(request.params)
@@ -329,6 +404,14 @@ def _dispatch(request: _DesktopRequest, services: DesktopServices) -> object:
     if request.method == "workspace.research.note.create":
         note_params = _CreateResearchNoteParams.model_validate(request.params)
         return _create_research_note(note_params, services.workspace)
+
+    if request.method == "workspace.research.note.update":
+        note_params = _UpdateResearchNoteParams.model_validate(request.params)
+        return _update_research_note(note_params, services.workspace)
+
+    if request.method == "workspace.research.note.delete":
+        note_params = _DeleteResearchNoteParams.model_validate(request.params)
+        return _delete_research_note(note_params, services.workspace)
 
     refresh_params = _RefreshParams.model_validate(request.params)
     refresh_report = services.locations.refresh_transcript_locations(

--- a/src/echoflow/desktop/bridge.py
+++ b/src/echoflow/desktop/bridge.py
@@ -151,7 +151,9 @@ class _UpdateResearchNoteParams(BaseModel):
             if len(value) > 200:
                 raise ValueError("research labels cannot exceed 200 characters")
             if any(character in value for character in ("\r", "\n", "\x00")):
-                raise ValueError("research labels contain unsupported control characters")
+                raise ValueError(
+                    "research labels contain unsupported control characters"
+                )
             normalized.setdefault(value.casefold(), value)
         return tuple(normalized[key] for key in sorted(normalized))
 

--- a/src/echoflow/desktop/tests/test_research_bridge_mutations.py
+++ b/src/echoflow/desktop/tests/test_research_bridge_mutations.py
@@ -1,0 +1,173 @@
+from typing import Any, cast
+
+from echoflow.desktop.bridge import DesktopServices, handle_request
+from echoflow.library.evidence import EvidenceAnchor
+from echoflow.library.research_state import ResearchNote
+from echoflow.library.research_workspace import ResearchNoteView
+
+
+class _Workspace:
+    def __init__(self) -> None:
+        self.last_replace: dict[str, object] | None = None
+        self.last_delete: dict[str, object] | None = None
+
+    @staticmethod
+    def _view(*, body: str, updated_at: str) -> ResearchNoteView:
+        anchor = EvidenceAnchor(
+            document_id="interview-42",
+            source_sha256="b" * 64,
+            canonical_sha256="a" * 64,
+            canonical_path="/sensitive/canonical.json",
+            source_path="/sensitive/interview.wav",
+            segment_ids=("segment-17",),
+            start_seconds=862.1,
+            end_seconds=870.4,
+        )
+        note = ResearchNote(
+            note_id="note-7",
+            body=body,
+            anchor=anchor,
+            tag_ids=("tag-1", "tag-2"),
+            collection_ids=("collection-1",),
+            created_at="2026-08-19T19:20:00+00:00",
+            updated_at=updated_at,
+        )
+        return ResearchNoteView(
+            note=note,
+            current=True,
+            tags=("follow-up", "program"),
+            collections=("Oral histories",),
+        )
+
+    def replace_note(
+        self,
+        note_id,
+        body,
+        *,
+        tags,
+        collections,
+        expected_updated_at=None,
+    ):
+        self.last_replace = {
+            "note_id": note_id,
+            "body": body,
+            "tags": tags,
+            "collections": collections,
+            "expected_updated_at": expected_updated_at,
+        }
+        return self._view(body=body, updated_at="2026-08-19T22:01:00+00:00")
+
+    def delete_note(self, note_id, *, expected_updated_at=None):
+        self.last_delete = {
+            "note_id": note_id,
+            "expected_updated_at": expected_updated_at,
+        }
+
+
+class _UnusedLocationService:
+    pass
+
+
+def _services(workspace: _Workspace) -> DesktopServices:
+    return DesktopServices(
+        locations=cast(Any, _UnusedLocationService()),
+        workspace=cast(Any, workspace),
+    )
+
+
+def _request(method: str, params: dict[str, object]) -> dict[str, object]:
+    return {
+        "protocol_version": 1,
+        "request_id": "mutation-1",
+        "method": method,
+        "params": params,
+    }
+
+
+def test_note_update_replaces_human_state_without_exposing_paths() -> None:
+    workspace = _Workspace()
+    response = handle_request(
+        _request(
+            "workspace.research.note.update",
+            {
+                "note_id": "note-7",
+                "expected_updated_at": "2026-08-19T19:25:00+00:00",
+                "body": "Compare this passage with the follow-up interview.",
+                "tags": ["program", "follow-up"],
+                "collections": ["Oral histories"],
+            },
+        ),
+        _services(workspace),
+    )
+
+    assert response["ok"] is True
+    assert workspace.last_replace == {
+        "note_id": "note-7",
+        "body": "Compare this passage with the follow-up interview.",
+        "tags": ("follow-up", "program"),
+        "collections": ("Oral histories",),
+        "expected_updated_at": "2026-08-19T19:25:00+00:00",
+    }
+    result = response["result"]
+    assert result["body"] == "Compare this passage with the follow-up interview."
+    assert result["canonical_sha256"] == "a" * 64
+    assert "/sensitive" not in str(result)
+    assert "source_path" not in str(result)
+    assert "canonical_path" not in str(result)
+
+
+def test_note_delete_is_version_bound_and_returns_only_safe_identity() -> None:
+    workspace = _Workspace()
+    response = handle_request(
+        _request(
+            "workspace.research.note.delete",
+            {
+                "note_id": "note-7",
+                "expected_updated_at": "2026-08-19T19:25:00+00:00",
+            },
+        ),
+        _services(workspace),
+    )
+
+    assert response["ok"] is True
+    assert workspace.last_delete == {
+        "note_id": "note-7",
+        "expected_updated_at": "2026-08-19T19:25:00+00:00",
+    }
+    assert response["result"] == {"note_id": "note-7", "deleted": True}
+
+
+def test_note_mutations_reject_unexpected_sql_shaped_parameters() -> None:
+    workspace = _Workspace()
+    update = handle_request(
+        _request(
+            "workspace.research.note.update",
+            {
+                "note_id": "note-7",
+                "expected_updated_at": "2026-08-19T19:25:00+00:00",
+                "body": "Updated",
+                "tags": [],
+                "collections": [],
+                "sql": "UPDATE notes SET body = 'oops'",
+            },
+        ),
+        _services(workspace),
+    )
+    delete = handle_request(
+        _request(
+            "workspace.research.note.delete",
+            {
+                "note_id": "note-7",
+                "expected_updated_at": "2026-08-19T19:25:00+00:00",
+                "sql": "DELETE FROM notes",
+            },
+        ),
+        _services(workspace),
+    )
+
+    assert update["ok"] is False
+    assert update["error"]["code"] == "invalid_request"
+    assert delete["ok"] is False
+    assert delete["error"]["code"] == "invalid_request"
+    assert workspace.last_replace is None
+    assert workspace.last_delete is None

--- a/src/echoflow/library/research_state.py
+++ b/src/echoflow/library/research_state.py
@@ -112,7 +112,19 @@ class ResearchStateStore(Protocol):
 
     def update_note(self, note_id: str, body: str) -> ResearchNote: ...
 
-    def delete_note(self, note_id: str) -> None: ...
+    def replace_note(
+        self,
+        note_id: str,
+        body: str,
+        *,
+        tags: tuple[str, ...],
+        collections: tuple[str, ...],
+        expected_updated_at: str | None = None,
+    ) -> ResearchNote: ...
+
+    def delete_note(
+        self, note_id: str, *, expected_updated_at: str | None = None
+    ) -> None: ...
 
     def note(self, note_id: str) -> ResearchNote | None: ...
 

--- a/src/echoflow/library/research_workspace.py
+++ b/src/echoflow/library/research_workspace.py
@@ -328,8 +328,29 @@ class ResearchWorkspaceService:
     def update_note(self, note_id: str, body: str) -> ResearchNoteView:
         return self._note_view(self.state.update_note(note_id, body))
 
-    def delete_note(self, note_id: str) -> None:
-        self.state.delete_note(note_id)
+    def replace_note(
+        self,
+        note_id: str,
+        body: str,
+        *,
+        tags: tuple[str, ...],
+        collections: tuple[str, ...],
+        expected_updated_at: str | None = None,
+    ) -> ResearchNoteView:
+        """Atomically change human-authored note state without changing its anchor."""
+        note = self.state.replace_note(
+            note_id,
+            body,
+            tags=tags,
+            collections=collections,
+            expected_updated_at=expected_updated_at,
+        )
+        return self._note_view(note)
+
+    def delete_note(
+        self, note_id: str, *, expected_updated_at: str | None = None
+    ) -> None:
+        self.state.delete_note(note_id, expected_updated_at=expected_updated_at)
 
     def set_note_tags(self, note_id: str, names: tuple[str, ...]) -> ResearchNoteView:
         return self._note_view(self.state.set_note_tags(note_id, names))

--- a/src/echoflow/library/sqlite_research_state.py
+++ b/src/echoflow/library/sqlite_research_state.py
@@ -122,15 +122,73 @@ class SqliteResearchStateStore:
             raise ResearchStateError("Updated research note could not be read back")
         return note
 
-    def delete_note(self, note_id: str) -> None:
+    def replace_note(
+        self,
+        note_id: str,
+        body: str,
+        *,
+        tags: tuple[str, ...],
+        collections: tuple[str, ...],
+        expected_updated_at: str | None = None,
+    ) -> ResearchNote:
+        """Atomically replace editable human state without rebinding evidence."""
         resolved_id = self._validate_id(note_id, "note_id")
+        self._validate_body(body)
+        tag_names = self._normalized_names(tags)
+        collection_names = self._normalized_names(collections)
+        if expected_updated_at is not None:
+            self._validate_id(expected_updated_at, "expected_updated_at")
+
         with self._connection() as connection:
             connection.execute("BEGIN IMMEDIATE")
-            changed = connection.execute(
-                "DELETE FROM notes WHERE note_id = ?", (resolved_id,)
-            ).rowcount
-            if changed != 1:
-                raise ResearchStateError("Research note does not exist")
+            self._require_note_version(
+                connection,
+                resolved_id,
+                expected_updated_at=expected_updated_at,
+            )
+            connection.execute(
+                "UPDATE notes SET body = ?, updated_at = ? WHERE note_id = ?",
+                (body, self._now(), resolved_id),
+            )
+            connection.execute(
+                "DELETE FROM note_tags WHERE note_id = ?", (resolved_id,)
+            )
+            for name in tag_names:
+                tag_id = self._ensure_tag(connection, name)
+                connection.execute(
+                    "INSERT INTO note_tags (note_id, tag_id) VALUES (?, ?)",
+                    (resolved_id, tag_id),
+                )
+            connection.execute(
+                "DELETE FROM collection_notes WHERE note_id = ?", (resolved_id,)
+            )
+            for name in collection_names:
+                collection_id = self._ensure_collection(connection, name)
+                connection.execute(
+                    "INSERT INTO collection_notes (collection_id, note_id) VALUES (?, ?)",
+                    (collection_id, resolved_id),
+                )
+            self._journal(connection, resolved_id)
+            note = self._note(connection, resolved_id)
+            connection.commit()
+        if note is None:
+            raise ResearchStateError("Updated research note could not be read back")
+        return note
+
+    def delete_note(
+        self, note_id: str, *, expected_updated_at: str | None = None
+    ) -> None:
+        resolved_id = self._validate_id(note_id, "note_id")
+        if expected_updated_at is not None:
+            self._validate_id(expected_updated_at, "expected_updated_at")
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_note_version(
+                connection,
+                resolved_id,
+                expected_updated_at=expected_updated_at,
+            )
+            connection.execute("DELETE FROM notes WHERE note_id = ?", (resolved_id,))
             self._journal(connection, resolved_id)
             connection.commit()
 
@@ -605,6 +663,23 @@ class SqliteResearchStateStore:
         ).fetchone()
         if row is None:
             raise ResearchStateError("Research note does not exist")
+
+    @staticmethod
+    def _require_note_version(
+        connection: sqlite3.Connection,
+        note_id: str,
+        *,
+        expected_updated_at: str | None,
+    ) -> None:
+        row = connection.execute(
+            "SELECT updated_at FROM notes WHERE note_id = ?", (note_id,)
+        ).fetchone()
+        if row is None:
+            raise ResearchStateError("Research note does not exist")
+        if expected_updated_at is not None and str(row[0]) != expected_updated_at:
+            raise ResearchStateError(
+                "Research note changed since it was opened; refresh before saving"
+            )
 
     @staticmethod
     def _ensure_tag(connection: sqlite3.Connection, name: str) -> str:

--- a/src/echoflow/library/tests/test_research_mutation_concurrency.py
+++ b/src/echoflow/library/tests/test_research_mutation_concurrency.py
@@ -35,7 +35,9 @@ def _anchor() -> EvidenceAnchor:
     )
 
 
-def test_replace_note_is_one_version_checked_authoritative_mutation(tmp_path: Path) -> None:
+def test_replace_note_is_one_version_checked_authoritative_mutation(
+    tmp_path: Path,
+) -> None:
     state = _state(tmp_path)
     original = state.create_note(
         _anchor(),

--- a/src/echoflow/library/tests/test_research_mutation_concurrency.py
+++ b/src/echoflow/library/tests/test_research_mutation_concurrency.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pytest
+
+from echoflow.library.errors import ResearchStateError
+from echoflow.library.evidence import EvidenceAnchor
+from echoflow.library.sqlite_research_state import SqliteResearchStateStore
+
+
+class PrivateDirectoryStore:
+    def ensure_directory_exists(
+        self, directory_path: str | Path, *, private: bool = False
+    ) -> None:
+        assert private
+        Path(directory_path).mkdir(parents=True, exist_ok=True)
+
+
+def _state(tmp_path: Path) -> SqliteResearchStateStore:
+    return SqliteResearchStateStore(
+        tmp_path / "research.sqlite3",
+        PrivateDirectoryStore(),  # type: ignore[arg-type]
+    )
+
+
+def _anchor() -> EvidenceAnchor:
+    return EvidenceAnchor(
+        document_id="interview-42",
+        source_sha256="b" * 64,
+        canonical_sha256="a" * 64,
+        canonical_path="/private/interview-42.json",
+        source_path="/private/interview-42.wav",
+        segment_ids=("segment-17",),
+        start_seconds=862.1,
+        end_seconds=870.4,
+    )
+
+
+def test_replace_note_is_one_version_checked_authoritative_mutation(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    original = state.create_note(
+        _anchor(),
+        "Initial interpretation",
+        tags=("program",),
+        collections=("Oral histories",),
+        note_id="note-7",
+    )
+
+    updated = state.replace_note(
+        "note-7",
+        "Compare this passage with the follow-up interview.",
+        tags=("program", "follow-up"),
+        collections=("Oral histories", "Chapter 3"),
+        expected_updated_at=original.updated_at,
+    )
+
+    assert updated.anchor == original.anchor
+    assert updated.body == "Compare this passage with the follow-up interview."
+    assert {tag.name for tag in state.tags() if tag.tag_id in updated.tag_ids} == {
+        "program",
+        "follow-up",
+    }
+    assert {
+        collection.name
+        for collection in state.collections()
+        if collection.collection_id in updated.collection_ids
+    } == {"Oral histories", "Chapter 3"}
+    assert state.current_sequence() == 2
+    assert [change.sequence_id for change in state.changes_after(1, limit=10)] == [2]
+
+
+def test_stale_replace_and_delete_fail_closed_without_advancing_state(
+    tmp_path: Path,
+) -> None:
+    state = _state(tmp_path)
+    original = state.create_note(_anchor(), "Version one", note_id="note-7")
+    current = state.replace_note(
+        "note-7",
+        "Version two",
+        tags=(),
+        collections=(),
+        expected_updated_at=original.updated_at,
+    )
+    sequence = state.current_sequence()
+
+    with pytest.raises(ResearchStateError, match="changed since it was opened"):
+        state.replace_note(
+            "note-7",
+            "Stale overwrite",
+            tags=("stale",),
+            collections=(),
+            expected_updated_at=original.updated_at,
+        )
+    with pytest.raises(ResearchStateError, match="changed since it was opened"):
+        state.delete_note("note-7", expected_updated_at=original.updated_at)
+
+    assert state.note("note-7") == current
+    assert state.current_sequence() == sequence
+
+    state.delete_note("note-7", expected_updated_at=current.updated_at)
+    assert state.note("note-7") is None
+    assert state.current_sequence() == sequence + 1


### PR DESCRIPTION
## Summary

Complete the next bounded Research interaction slice and replace the short-horizon roadmap with a capability-to-desktop productization audit.

### Research mutation authority

- add atomic authoritative note replacement for body + tag + collection relationships;
- preserve the existing evidence anchor during edits, including older canonical generations;
- bind desktop edit/delete to the note's `updated_at` version so stale local UI cannot silently overwrite a newer CLI/local mutation;
- emit one monotonic research-journal event for one atomic edit;
- keep existing direct CLI mutation contracts compatible.

### Desktop Research interaction

- add narrow allowlisted `workspace.research.note.update` and `workspace.research.note.delete` bridge methods;
- keep unexpected/SQL-shaped parameters fail-closed;
- expose inline keyboard-accessible note editing, tag/collection replacement, and explicit two-step note deletion;
- make deletion copy explicit that canonical transcript evidence and the original recording are not part of note deletion;
- refresh authoritative Research state after mutations rather than creating a second browser-owned data model;
- add Playwright + axe coverage for the full edit/label/delete journey.

### Roadmap and documentation audit

- audit existing backend/application capabilities against current desktop coverage and remaining product work;
- identify the desktop Processing center as the largest backend-to-product gap after the remaining Research loop;
- map health/resource policy, model custody, job lifecycle, transcription planning/execution/resume, enhancement, diarization, speaker labels, publications, retrieval modes, lifecycle controls, playback, packaging, portability, semantic custody, and representative-device qualification;
- update the root README, documentation lobby, Research guide, research-state architecture, Mermaid source, and synchronized SVG fallback to current product truth.

## Product sequencing

The audited critical path is now:

1. finish saved-search lifecycle, research-object → verified-evidence navigation, stale-anchor review, and advanced typed search controls;
2. build a desktop Processing center over existing health/resource/model/job/transcription contracts;
3. finish processing controls and speaker tools;
4. add Tauri-owned local media playback;
5. productize safe lifecycle/retention;
6. package first run/updates/uninstall;
7. add backup/restore/research export;
8. qualify packaged semantic custody;
9. run representative-device release qualification.

## Safety boundaries

- React receives neither SQL nor raw canonical/source paths.
- Editing human-authored research never implicitly rebinds evidence.
- Stale desktop mutations fail closed.
- Note deletion never implies transcript/source deletion.
- The static documentation fallback remains synchronized with its Mermaid source.

## Validation

CI is expected to run on this draft head. Any failures will be fixed on this branch before it is considered ready for review.