### PR TITLE
feat(desktop): review and deliberately re-anchor research evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,10 +60,11 @@ flowchart LR
 Text fallback: EchoFlow already spans local media, reliable transcription, canonical
 evidence, retrieval, verified navigation, durable research, lifecycle controls, incremental
 refresh, remembered locations, native import, Library discovery, the verified evidence
-reader, exact-generation research return, note mutation, and saved-search lifecycle.
-Remaining work is primarily productization: finish advanced Research/search controls, expose
-processing/model/job controls, add playback and lifecycle UI, package the application, make
-durable work portable, and qualify real devices.
+reader, exact-generation research return, note mutation, label navigation, saved-search
+lifecycle, and explicit research-anchor maintenance. Remaining work is primarily
+productization: finish advanced Research/search controls, expose processing/model/job
+controls, add playback and lifecycle UI, package the application, make durable work
+portable, and qualify real devices.
 
 # What is foundation now
 
@@ -101,28 +102,37 @@ evidence only after EchoFlow reopens the canonical transcript, verifies generati
 identity, resolves exact segment/word coordinates, and returns a source-relative seek
 coordinate.
 
-Durable research anchors now use the same verifier as search navigation. A note can reopen
-its exact stored canonical generation, even when that generation is older than the current
+Durable research anchors use the same verifier as search navigation. A note can reopen its
+exact stored canonical generation, even when that generation is older than the current
 library document. Missing, changed, or incompatible anchored evidence fails closed rather
 than being silently rebound.
 
 ## Durable research workspace
 
-Authoritative SQLite owns notes, tags, collections, evidence anchors, and saved-search
-intent. A monotonic journal drives a rebuildable DuckDB research projection.
-`ResearchWorkspaceService` composes those stores with verified transcript retrieval.
+Authoritative SQLite owns notes, tags, collections, current evidence anchors, superseded
+anchor history, and saved-search intent. A monotonic journal drives a rebuildable DuckDB
+research projection. `ResearchWorkspaceService` composes those stores with verified
+transcript retrieval.
 
 The desktop can browse current and older-generation notes, create a note from verified
-evidence, edit/delete notes, replace tag/collection assignments, and reopen the exact
-canonical evidence a note cites. Desktop note edits are optimistic-concurrency checked
-against authoritative `updated_at`; body plus labels commit atomically with one
-research-journal event. Editing research never silently rebinds its evidence anchor.
+evidence, edit/delete notes, replace tag/collection assignments, navigate by labels, and
+reopen the exact canonical evidence a note cites. Desktop note edits are
+optimistic-concurrency checked against authoritative `updated_at`; body plus labels commit
+atomically with one research-journal event. Editing research never silently rebinds its
+evidence anchor.
 
-Saved searches are durable questions, not result snapshots. The desktop can now create,
-run, rename, and delete them. Rename/delete operations are version-checked in the
-authoritative SQLite transaction, while rename preserves the existing typed query intent
-server-side. Running a saved search resolves current evidence and current research
-relationships again.
+The Research evidence-maintenance surface can now classify a note anchor as current
+verified, older verified, or unavailable. For a non-current note it may preview a verified
+current-generation candidate only when document and recorded-source identity match. A
+re-anchor requires separate confirmation bound to note version and candidate canonical
+SHA-256. The old anchor is preserved durably before the current pointer changes, and the
+normal projection journal advances once. There is no automatic or cross-recording
+re-anchoring.
+
+Saved searches are durable questions, not result snapshots. The desktop can create, run,
+rename, and delete them. Rename/delete operations are version-checked in the authoritative
+SQLite transaction, while rename preserves the existing typed query intent server-side.
+Running a saved search resolves current evidence and current research relationships again.
 
 Research operations emit privacy-safe structured events through the normal application
 logger. Logs carry operation identity, generation identity, modes, counts, and outcomes,
@@ -158,11 +168,13 @@ The shell provides Archive/Midnight themes, keyboard-visible navigation, native 
 selection, one-time versus remembered import choices, recording discovery, transcript
 refresh, grouped Library discovery, verified evidence reading/cursor movement, Research
 browse, provenance-bound note creation, version-checked note mutation, exact-generation
-research return, and saved-search lifecycle/replay.
+research return, first-class label navigation, saved-search lifecycle/replay, and explicit
+research-anchor review/re-anchor.
 
 React does not receive arbitrary shell, SQL/database, or raw evidence-path capability. It
-also does not decide whether a research anchor is valid, which generation should satisfy
-it, how saved-search intent is represented, or whether a stale durable mutation may win.
+also does not decide whether a research anchor is valid, derive a re-anchor candidate,
+choose canonical paths/generations, represent saved-search intent, or decide whether a stale
+durable mutation may win.
 
 # Capability → desktop productization audit
 
@@ -188,12 +200,12 @@ or CLI contract worth productizing, not that the desktop should simply expose a 
 | Lexical BM25 retrieval | private corpus ranking | **implemented** through Library discovery | advanced phrase/ANY/ALL and sort controls | Research/search completion |
 | Semantic retrieval | optional local chunks/embeddings | backend ready, not normal packaged path | desktop mode control after model/dependency custody qualification | Search + semantic qualification |
 | Hybrid RRF retrieval | lexical + semantic rank fusion | backend ready | retrieval-mode control and explainable result state | Search + semantic qualification |
-| Verified evidence navigation | generation verification, context, exact word timing and seek coordinate | search results and note anchors **implemented** | tag/collection return path and media playback | Research completion + playback |
-| Unified discovery | typed transcript/note/tag/collection groups without fabricated cross-type score | **implemented** | richer filters and object-specific actions | Research/search completion |
-| Research notes | exact generation-bound anchors in authoritative SQLite | browse/create/edit/delete/exact-evidence return **implemented** | explicit unavailable/stale-anchor review and intentional re-anchor UX | Research completion |
-| Tags and collections | durable names/relationships + rebuildable projection | browse + note assignment **implemented** | dedicated navigation/filter/manage flows | Research completion |
+| Verified evidence navigation | generation verification, context, exact word timing and seek coordinate | search results and note anchors **implemented** | media playback | Playback |
+| Unified discovery | typed transcript/note/tag/collection groups without fabricated cross-type score | **implemented** | richer typed filters and object-specific actions | Research/search completion |
+| Research notes | exact generation-bound anchors + superseded anchor history in authoritative SQLite | browse/create/edit/delete/exact-evidence return/review/re-anchor **implemented** | richer typed search integration | Research/search completion |
+| Tags and collections | durable names/relationships + rebuildable projection | browse + assignment + first-class navigation/filter **implemented** | optional dedicated label management polish | Settings / research polish |
 | Saved searches | typed durable intent with current-corpus re-resolution and version-safe rename/delete | create/run/rename/delete + result handoff **implemented** | advanced typed intent editing alongside search controls | Research/search completion |
-| Research-aware filtering | tags/collections/note text constrain evidence before ranking | backend ready | desktop filters with inspectable active state | Research/search completion |
+| Research-aware filtering | tags/collections/note text constrain evidence before ranking | backend ready; label-note filtering visible | expose full transcript search filters with inspectable active state | Research/search completion |
 | Safe deletion | typed dry-run plans, exact confirmation binding, source double-guard | none | custody center with plan review and explicit confirmation | Lifecycle UI |
 | Retention | execution-state-only age policies preserving evidence/research | none | retention settings, preview, cleanup result | Lifecycle UI |
 | Local source playback | verified source-relative seek coordinate exists | no playback | Tauri-owned media capability, playback state, source mismatch/unavailable handling | Native playback |
@@ -212,7 +224,7 @@ processing/control plane in Python, but a normal desktop user cannot yet launch 
 that work. Productization should expose that capability before packaging freezes the native
 runtime shape.
 
-## 1. Finish Research search, navigation, and stale-anchor polish
+## 1. Finish advanced Research/search controls
 
 Current foundation after this tranche:
 
@@ -223,21 +235,24 @@ Current foundation after this tranche:
 - guarded note deletion;
 - optimistic concurrency using authoritative `updated_at`;
 - exact-generation note → verified-evidence return with no automatic rebinding;
+- first-class tag/collection navigation with backend AND semantics;
 - saved-search create/run/rename/delete and result-to-evidence handoff;
-- saved-search mutation concurrency in authoritative SQLite; and
-- no frontend SQL, SQLite, raw evidence paths, or generation-selection logic.
+- saved-search mutation concurrency in authoritative SQLite;
+- explicit stale/unavailable anchor review;
+- deliberate same-source re-anchor with reviewed-generation confirmation and durable prior-anchor history; and
+- no frontend SQL, SQLite, raw evidence paths, repair-candidate derivation, or generation-selection logic.
 
-Remaining work:
+Remaining first-release Research work:
 
-- make tags and collections first-class navigation/filter affordances instead of labels only;
-- provide an explicit stale/unavailable-anchor review workflow and, if added, a deliberate
-  re-anchor operation that never masquerades as the original evidence generation; and
 - expose typed search controls for phrase/ANY/ALL, speaker, language, transcript, research
-  filters, retrieval mode, and sort.
+  filters, retrieval mode, and sort; and
+- let saved-search intent creation/editing use those same inspectable typed controls rather
+  than a hidden interpretation layer.
 
 The primary research circuit is now real: **find evidence → verify → annotate → organize →
-ask a durable question → replay it → return to exact evidence.** The remaining work makes
-that circuit richer rather than inventing its authority.
+ask a durable question → replay it → return to exact evidence → deliberately maintain the
+evidence pointer when needed.** The remaining work makes search intent richer rather than
+inventing new authority.
 
 ## 2. Build the desktop Processing center
 

--- a/docs/architecture/research-state.md
+++ b/docs/architecture/research-state.md
@@ -1,19 +1,19 @@
 # Durable research state architecture
 
 Status: authoritative notes/tags/collections, saved searches, projection sync/rebuild,
-research-aware retrieval, unified discovery, desktop note CRUD/labels, exact-generation
-note → evidence return, and saved-search create/run/rename/delete are implemented. Advanced
-Research filtering/navigation and explicit stale-anchor review/re-anchor remain work.  
-Last updated: August 19, 2026
+research-aware retrieval, unified discovery, desktop note CRUD/labels, first-class label
+navigation, exact-generation note → evidence return, saved-search lifecycle, and explicit
+stale/unavailable-anchor review plus provenance-preserving re-anchoring are implemented.  
+Last updated: August 20, 2026
 
 EchoFlow keeps **user-authored research knowledge durable** while still making that
 knowledge fast enough to use as part of corpus search.
 
 The design deliberately uses two stores with different authority:
 
-- **SQLite is authoritative user state.** Notes, tags, collections, evidence anchors, and
-  saved-search intent live there because they are unique work the user cannot reconstruct
-  from the transcript.
+- **SQLite is authoritative user state.** Notes, tags, collections, evidence anchors,
+  superseded anchor history, and saved-search intent live there because they are unique
+  work the user cannot reconstruct from the transcript.
 - **DuckDB is a rebuildable research projection.** It carries only relationships and
   lexical terms needed to query that user state efficiently alongside transcript search.
 
@@ -63,7 +63,7 @@ worse.
 
 | Store | Authority | Contains | Rebuildable? |
 |---|---|---|---|
-| SQLite research state | authoritative | notes, evidence anchors, tags, collections, saved searches, relationships, outbox sequence | **No** |
+| SQLite research state | authoritative | notes, current + superseded evidence anchors, tags, collections, saved searches, relationships, outbox sequence | **No** |
 | DuckDB research projection | derived | evidence keys, note IDs, tag/collection IDs, lexical note terms, projection watermark | Yes |
 | DuckDB lexical index | derived | transcript terms and segment metadata | Yes |
 | DuckDB semantic index | derived | semantic chunks, segment map, numeric vectors | Yes |
@@ -100,8 +100,8 @@ The load-bearing projected evidence key is:
 
 The full durable anchor also carries source identity, canonical path custody, optional
 source path custody, and source-relative time coordinates. Including canonical SHA-256
-prevents a stale annotation from silently attaching to a new transcript generation that
-reuses `segment-000042`.
+prevents an annotation from silently attaching to a new transcript generation that reuses
+`segment-000042`.
 
 ## Verified anchors, creation, and exact-generation return
 
@@ -116,15 +116,61 @@ create-note bridge carries the expected canonical SHA-256 and refuses the write 
 library has moved to a newer generation before Save. React never invents an annotation
 identity or receives a raw canonical/source path.
 
-Existing anchors can now be reopened through `EvidenceLocator.locate_anchor()` and
+Existing anchors reopen through `EvidenceLocator.locate_anchor()` and
 `ResearchWorkspaceService.open_note_evidence()`. That read path verifies the **stored**
 canonical bytes and source/document identities, validates stored segments and timing,
 expands canonical context, and resolves speaker display labels against the stored
 canonical generation.
 
 The current transcript index is not used to substitute a newer generation. An older anchor
-either opens against its exact valid stored evidence or fails closed. This is a read path,
-not a migration path.
+either opens against its exact valid stored evidence or fails closed. Exact-generation
+return remains a read path, not an implicit migration path.
+
+## Explicit anchor review and deliberate re-anchoring
+
+`ResearchAnchorReviewService` adds a separate maintenance path without weakening exact
+return. Review first attempts to reopen the stored anchor and classifies it as:
+
+- `current_verified`;
+- `older_verified`; or
+- `unavailable`.
+
+`older_verified` is not an error state. The user may keep that historical anchor forever.
+
+For a non-current note the service may prepare a **candidate** from the current canonical
+generation, but only when current evidence has the same `document_id` and the same
+`source_sha256`. Candidate segments are derived from the old anchor's source-relative time
+span, loaded from the current canonical transcript, then passed back through the existing
+`EvidenceLocator` verifier. Similar-looking text in another recording is never considered a
+repair candidate.
+
+Candidate review does not mutate research state. Confirmation sends the authoritative
+note `updated_at` plus the reviewed candidate canonical SHA-256. The service recomputes the
+candidate server-side. If either the note or current generation changed, confirmation
+fails and the user must review again.
+
+The actual write is owned by `SqliteResearchAnchorStateStore`, a narrow adapter over the
+**same** `research.sqlite3` authority. It uses one `BEGIN IMMEDIATE` transaction to:
+
+1. copy the previous anchor and ordered segment IDs into `note_anchor_history` and
+   `note_anchor_history_segments`;
+2. replace the note's current anchor columns and segment relationships;
+3. advance the existing monotonic research journal exactly once; and
+4. commit all state together.
+
+The history extension has its own schema-version metadata so additive anchor-history
+storage can evolve without pretending the entire research schema was recreated. A note
+deletion cascades through its superseded anchor history because that history exists only to
+preserve the provenance of the durable note.
+
+Re-anchoring cannot change `document_id` or `source_sha256`. This operation repairs a
+note's current pointer within one recorded evidence lineage. It is not a general relinking
+or cross-recording migration facility.
+
+DuckDB never stores superseded anchor history as authority. Once the current note anchor
+changes, the normal research journal causes the disposable projection to replace that
+note's current evidence relationships. Historical anchors remain SQLite-only durable
+provenance.
 
 ## Mutation, concurrency, and the journal
 
@@ -134,15 +180,14 @@ its change-journal record.
 
 Desktop note editing replaces body, tag relationships, and collection relationships in one
 SQLite transaction and advances the journal once. The `EvidenceAnchor` columns and segment
-relationships are not part of that update.
+relationships are not part of a normal prose/label update.
 
-Desktop note edit/delete carries the `updated_at` value it read. The store checks that
-version after `BEGIN IMMEDIATE` has acquired the writer boundary. A mismatch fails closed,
-so a CLI edit or another local surface cannot be silently overwritten by stale React state.
-CLI commands that intentionally operate directly remain compatible and do not require a UI
-version token.
+Desktop note edit/delete and deliberate re-anchor carry the `updated_at` value they read.
+The stores check that version after `BEGIN IMMEDIATE` has acquired the writer boundary. A
+mismatch fails closed, so a CLI edit or another local surface cannot be silently
+overwritten by stale React state.
 
-Saved-search rename/delete now uses the same local concurrency principle. The workspace
+Saved-search rename/delete uses the same local concurrency principle. The workspace
 metadata store checks optional `expected_updated_at` after its `BEGIN IMMEDIATE` boundary.
 Desktop callers always provide that version. Existing CLI/application callers may omit it
 where they deliberately operate as the immediate local authority.
@@ -178,6 +223,10 @@ semantic retrieval then ranks **inside that scope**.
 `evidence_scope = None` means unrestricted by research state. `evidence_scope = ()` means
 the research restriction matched no evidence and search must return nothing.
 
+Tags and collections are also first-class desktop navigation affordances. Multiple selected
+labels preserve the backend's existing AND semantics; React does not reimplement filtering
+over a capped overview snapshot.
+
 ## Saved searches are authored intent
 
 Saved searches live in authoritative SQLite because a named reusable question is
@@ -198,12 +247,17 @@ convenience views and remain disposable.
 `ResearchWorkspaceService` composes verified anchors, authoritative SQLite research state,
 deterministic projection convergence, DuckDB research filtering/summaries, transcript
 retrieval, grouped discovery, exact-generation research return, and saved-search behavior.
+`ResearchAnchorReviewService` is a deliberately narrow companion for evidence maintenance.
 
-The CLI and desktop bridge delegate to this service. Desktop methods are narrow DTO
-operations: overview, verified note creation, atomic note replacement, guarded note
-deletion, exact note-evidence opening, and saved-search create/update/delete/run. React does
-not issue SQL, open SQLite/DuckDB, choose canonical generations, or receive canonical/source
-filesystem paths.
+The CLI and desktop bridge delegate to application services. Desktop methods are narrow DTO
+operations: overview, filtered notes, verified note creation, atomic note replacement,
+guarded note deletion, exact note-evidence opening, saved-search lifecycle, anchor review,
+and confirmed re-anchor. React does not issue SQL, open SQLite/DuckDB, choose canonical
+paths, derive repair candidates, or receive raw canonical/source filesystem paths.
+
+Anchor-review DTOs expose evidence text, canonical SHA, segment IDs, and numeric coordinates
+needed for inspection. They deliberately omit raw source/canonical paths and source SHA.
+The backend retains those custody details and uses them during verification.
 
 Research application operations emit structured events through the existing `ILogger`
 boundary. Operational logs carry stable event names plus IDs, canonical SHA where evidence
@@ -211,24 +265,18 @@ identity matters, retrieval mode, counts, current/older state, and exception typ
 failure. They deliberately omit note bodies, query text, saved-search names/descriptions,
 and raw filesystem paths. Logging must not become a shadow research archive.
 
-Older-generation anchors remain visible as older evidence. Editing their human-authored
-prose or labels is permitted because the evidence anchor does not move. Automatic
-re-anchoring is not permitted merely because a newer transcript reuses the same friendly
-segment ID.
-
 ## Current deliberate limits
 
 Research state currently does not provide:
 
-- dedicated desktop tag/collection navigation and filter management yet;
 - advanced typed desktop search controls for phrase/ANY/ALL, speaker, language, transcript,
-  research filters, retrieval mode, and sort yet;
-- explicit stale/unavailable-anchor review/re-anchor UX yet;
+  research filters, retrieval mode, and sort;
 - rich-text/WYSIWYG note bodies;
 - semantic embeddings over note prose;
 - automatic cross-generation re-anchoring;
+- cross-recording re-anchoring;
 - collaborative synchronization; or
-- selected/citable result-set objects yet.
+- selected/citable result-set objects.
 
 ## Invariants for maintainers
 
@@ -238,16 +286,20 @@ Research state currently does not provide:
 4. **Desktop stale writes must fail rather than silently overwrite newer user state.**
 5. **Editing note prose/labels must not rebind its evidence anchor.**
 6. **Opening a research anchor must verify its stored generation or fail closed; it must not substitute current evidence.**
-7. **The DuckDB watermark advances atomically with projected rows.**
-8. **Projection replay is idempotent.**
-9. **Research joins include canonical generation identity, not segment ID alone.**
-10. **Empty research scope means no matches, not unrestricted search.**
-11. **Research constraints are applied before ranking/scoring when they are filters.**
-12. **Presentation hydrates authoritative note content from SQLite.**
-13. **Saved searches persist typed intent, not derived result scope.**
-14. **Saved-search rename must preserve typed intent unless an explicit intent-edit operation exists.**
-15. **Desktop presentation receives narrow DTOs, not raw database/filesystem authority.**
-16. **Operational logging must not copy human research prose or query content into a second archive.**
-17. **Deleting any DuckDB file must never delete unique user-authored knowledge.**
+7. **Reviewing a re-anchor candidate must not mutate authoritative research state.**
+8. **A confirmed re-anchor must preserve the superseded anchor before replacing the current pointer.**
+9. **Re-anchor confirmation is bound to both note version and reviewed canonical generation.**
+10. **Re-anchoring cannot cross document or recorded-source identity.**
+11. **The DuckDB watermark advances atomically with projected rows.**
+12. **Projection replay is idempotent.**
+13. **Research joins include canonical generation identity, not segment ID alone.**
+14. **Empty research scope means no matches, not unrestricted search.**
+15. **Research constraints are applied before ranking/scoring when they are filters.**
+16. **Presentation hydrates authoritative note content from SQLite.**
+17. **Saved searches persist typed intent, not derived result scope.**
+18. **Saved-search rename must preserve typed intent unless an explicit intent-edit operation exists.**
+19. **Desktop presentation receives narrow DTOs, not raw database/filesystem authority.**
+20. **Operational logging must not copy human research prose or query content into a second archive.**
+21. **Deleting any DuckDB file must never delete unique user-authored knowledge.**
 
 If a refactor makes one of those statements false, it changes EchoFlow's custody model.

--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -82,7 +82,7 @@ Desktop edit/delete carries the note’s authoritative `updated_at` version. If 
 another local surface changed that note after it was displayed, EchoFlow refuses the stale
 write and asks the user to refresh. Local-first does not mean lost-update-safe by accident.
 
-A note can now reopen the exact canonical generation it cites. The backend reuses the same
+A note can reopen the exact canonical generation it cites. The backend reuses the same
 canonical verifier as search navigation: it hashes the stored canonical bytes, checks the
 stored source and document identities, validates the stored segments and timing, expands
 context, and resolves speaker display labels for that exact generation. React does not
@@ -160,17 +160,54 @@ canonical SHA-256, EchoFlow does **not** silently move the old note.
 The old note remains durable historical user state. The projected evidence key includes
 canonical generation identity so stale annotations cannot accidentally attach to new
 evidence. Editing the prose or labels on that old note still leaves its original anchor
-unchanged. The desktop can now inspect the older generation when those exact canonical
-bytes remain available and valid.
+unchanged. The desktop can inspect the older generation when those exact canonical bytes
+remain available and valid.
 
-A later re-anchor workflow must be an explicit user decision that shows both generations;
-it must never be an incidental side effect of opening or editing a note.
+### Review and deliberately re-anchor an older note
+
+The desktop now has an **Evidence maintenance** surface for notes whose anchor is not the
+current canonical generation. Review is read-only. EchoFlow classifies the stored anchor as:
+
+- **current verified**: it already points to the current verified generation;
+- **older verified**: the exact stored generation still verifies and remains legitimate
+  historical evidence; or
+- **unavailable**: the stored generation cannot currently be verified on this machine.
+
+Older does not mean broken. An older verified anchor can remain exactly where it is for as
+long as the user wants.
+
+For a non-current anchor, EchoFlow may also prepare a **current-generation candidate**. It
+will only do so when the current library document has the same durable document identity
+and the same recorded-source SHA-256. Candidate coordinates are derived from the note's
+source-relative time span, resolved to current canonical segments, and verified through the
+normal evidence locator. EchoFlow does not search another recording for something that
+looks similar, and React never chooses a canonical path or generation.
+
+Reviewing the candidate still changes nothing. Re-anchoring requires a second explicit
+confirmation. That confirmation carries both the note's `updated_at` version and the
+candidate canonical SHA-256 the user reviewed. If the note or current transcript changes
+before confirmation, EchoFlow refuses the mutation and requires another review.
+
+A successful re-anchor is one authoritative SQLite transaction:
+
+1. copy the old evidence anchor and its segment identities into durable anchor history;
+2. replace the note's current anchor with the reviewed same-source candidate;
+3. advance the research projection journal once; and
+4. commit all three together or roll all three back.
+
+The old anchor therefore does not vanish. It becomes a durable provenance record attached
+to that note. Re-anchoring changes **which evidence the note currently points to**; it does
+not rewrite the fact that the note used to point somewhere else.
+
+If EchoFlow cannot derive a safe same-source candidate, the Research surface shows the
+problem and offers no re-anchor action. There is intentionally no automatic or
+cross-recording fallback.
 
 ## Why two databases?
 
 | Store | Job | Rebuildable? |
 |---|---|---|
-| SQLite research state | authoritative notes/tags/collections/saved searches and evidence anchors | **No** |
+| SQLite research state | authoritative notes/tags/collections/saved searches, current evidence anchors, and superseded anchor history | **No** |
 | DuckDB research projection | fast derived relationships and lexical note terms | Yes |
 | DuckDB transcript index | transcript terms/segments for lexical ranking | Yes |
 | DuckDB semantic index | chunks/vectors for semantic retrieval | Yes |
@@ -224,13 +261,12 @@ second notebook.
 
 The storage, evidence-address, unified-discovery, Research overview, verified note
 creation, note edit/delete/label mutation, first-class tag/collection navigation,
-exact-generation note return, and saved-search create/run/rename/delete contracts are
-built.
+exact-generation note return, saved-search lifecycle, and explicit stale/unavailable anchor
+review plus provenance-preserving re-anchor contracts are built.
 
-The remaining first-release Research tranche is narrower:
-
-- expose advanced typed search/research controls without hidden interpretation; and
-- stale/unavailable-anchor review and any explicit re-anchor UX with user confirmation.
+The remaining first-release Research tranche is now the richer typed search surface:
+phrase/ANY/ALL behavior, speaker/language/transcript constraints, inspectable research
+filters, retrieval mode, and sort without hidden interpretation.
 
 Selected evidence packets, REFI-QDA interoperability, saved-question snapshots/diffs,
 comparison workspaces, evidence-linked writing/script boards, portable research bundles,
@@ -238,7 +274,7 @@ and live provisional capture are deliberately post-MVP work. See
 **[Post-MVP research roadmap](post-mvp-roadmap.md)**.
 
 The product does not currently provide rich-text/WYSIWYG editing, semantic embeddings over
-note prose, automatic cross-generation re-anchoring, or collaborative sync.
+note prose, **automatic** cross-generation re-anchoring, or collaborative sync.
 
 > **Your research state is durable. Its fast query representation is disposable. The two
 > can always meet again through exact evidence identities.**

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createDesktopClient } from "./api/desktop";
 import { type Theme } from "./components/WorkspaceHeader";
 import { IntakeWorkspace } from "./IntakeWorkspace";
-import { ResearchWorkspace } from "./ResearchWorkspace";
+import { ResearchWorkspaceWithAnchorReview } from "./ResearchWorkspaceWithAnchorReview";
 import { SearchWorkspace } from "./SearchWorkspace";
 
 const client = createDesktopClient();
@@ -27,7 +27,13 @@ export function App() {
     if (view === "library") {
       return <SearchWorkspace client={client} theme={theme} onThemeChange={setTheme} />;
     }
-    return <ResearchWorkspace client={client} theme={theme} onThemeChange={setTheme} />;
+    return (
+      <ResearchWorkspaceWithAnchorReview
+        client={client}
+        theme={theme}
+        onThemeChange={setTheme}
+      />
+    );
   }, [theme, view]);
 
   return (

--- a/frontend/src/ResearchAnchorReviewPanel.tsx
+++ b/frontend/src/ResearchAnchorReviewPanel.tsx
@@ -82,12 +82,12 @@ export function ResearchAnchorReviewPanel({
     try {
       await reanchorResearchNote(reviewed);
       setConfirmingNoteId(null);
+      setNotes((current) => current.filter((item) => item.note_id !== note.note_id));
       setReviews((current) => {
         const next = { ...current };
         delete next[note.note_id];
         return next;
       });
-      await loadReviewable();
       onReanchored();
       setMessage(
         "Note re-anchored to the reviewed current generation. The prior anchor was preserved in durable history.",
@@ -196,9 +196,7 @@ export function ResearchAnchorReviewPanel({
 
                     {reviewed.history.length > 0 && (
                       <details className="research-anchor-history">
-                        <summary>
-                          Previous anchors ({reviewed.history.length})
-                        </summary>
+                        <summary>Previous anchors ({reviewed.history.length})</summary>
                         <ol>
                           {reviewed.history.map((entry) => (
                             <li key={entry.revision}>
@@ -220,7 +218,11 @@ export function ResearchAnchorReviewPanel({
                             Prepare re-anchor
                           </button>
                         ) : (
-                          <div className="research-anchor-confirm" role="group" aria-label="Confirm re-anchor">
+                          <div
+                            className="research-anchor-confirm"
+                            role="group"
+                            aria-label="Confirm re-anchor"
+                          >
                             <p>
                               This changes the note’s current evidence pointer to the candidate above. The existing anchor will be retained as immutable history.
                             </p>
@@ -229,7 +231,9 @@ export function ResearchAnchorReviewPanel({
                               disabled={busy}
                               onClick={() => void confirmReanchor(note)}
                             >
-                              {busy ? "Re-anchoring…" : "Confirm re-anchor to reviewed candidate"}
+                              {busy
+                                ? "Re-anchoring…"
+                                : "Confirm re-anchor to reviewed candidate"}
                             </button>
                             <button
                               type="button"

--- a/frontend/src/ResearchAnchorReviewPanel.tsx
+++ b/frontend/src/ResearchAnchorReviewPanel.tsx
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { DesktopClient, ResearchNoteResult } from "./api/desktop";
+import { formatEvidenceTime } from "./format";
+import {
+  reanchorResearchNote,
+  reviewResearchAnchor,
+  type ResearchAnchorReviewResult,
+} from "./researchAnchorApi";
+import "./research-anchor-review.css";
+
+interface ResearchAnchorReviewPanelProps {
+  client: DesktopClient;
+  onReanchored: () => void;
+}
+
+function statusCopy(review: ResearchAnchorReviewResult): string {
+  if (review.status === "current_verified") {
+    return "This note now cites the current verified canonical generation.";
+  }
+  if (review.status === "older_verified") {
+    return "The stored evidence still verifies, but it belongs to an older canonical generation.";
+  }
+  return "The stored canonical evidence cannot currently be verified on this machine.";
+}
+
+function shortSha(value: string): string {
+  return `${value.slice(0, 10)}…${value.slice(-6)}`;
+}
+
+export function ResearchAnchorReviewPanel({
+  client,
+  onReanchored,
+}: ResearchAnchorReviewPanelProps) {
+  const [notes, setNotes] = useState<ResearchNoteResult[]>([]);
+  const [reviews, setReviews] = useState<Record<string, ResearchAnchorReviewResult>>({});
+  const [confirmingNoteId, setConfirmingNoteId] = useState<string | null>(null);
+  const [busyNoteId, setBusyNoteId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const loadReviewable = useCallback(async () => {
+    const overview = await client.researchOverview();
+    setNotes(overview.notes.filter((note) => !note.current));
+  }, [client]);
+
+  useEffect(() => {
+    void loadReviewable().catch((caught) => {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "EchoFlow could not inspect research anchors.",
+      );
+    });
+  }, [loadReviewable]);
+
+  async function review(note: ResearchNoteResult) {
+    setBusyNoteId(note.note_id);
+    setConfirmingNoteId(null);
+    setError(null);
+    setMessage(null);
+    try {
+      const result = await reviewResearchAnchor(note);
+      setReviews((current) => ({ ...current, [note.note_id]: result }));
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "EchoFlow could not review that evidence anchor.",
+      );
+    } finally {
+      setBusyNoteId(null);
+    }
+  }
+
+  async function confirmReanchor(note: ResearchNoteResult) {
+    const reviewed = reviews[note.note_id];
+    if (!reviewed?.candidate) return;
+    setBusyNoteId(note.note_id);
+    setError(null);
+    setMessage(null);
+    try {
+      await reanchorResearchNote(reviewed);
+      setConfirmingNoteId(null);
+      setReviews((current) => {
+        const next = { ...current };
+        delete next[note.note_id];
+        return next;
+      });
+      await loadReviewable();
+      onReanchored();
+      setMessage(
+        "Note re-anchored to the reviewed current generation. The prior anchor was preserved in durable history.",
+      );
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "EchoFlow could not re-anchor that note.",
+      );
+    } finally {
+      setBusyNoteId(null);
+    }
+  }
+
+  return (
+    <section className="research-anchor-review" aria-labelledby="anchor-review-title">
+      <div className="research-anchor-review-heading">
+        <div>
+          <p className="mini-label">Evidence maintenance</p>
+          <h2 id="anchor-review-title">Review older or unavailable note anchors</h2>
+          <p>
+            EchoFlow never silently moves research to a newer transcript. Review the stored
+            evidence and any current-generation candidate first, then explicitly confirm a
+            re-anchor if the candidate is correct.
+          </p>
+        </div>
+        <span className="research-count" aria-label={`${notes.length} notes need review`}>
+          {notes.length}
+        </span>
+      </div>
+
+      {message && (
+        <p className="research-mutation-status" aria-live="polite">
+          {message}
+        </p>
+      )}
+      {error && (
+        <p className="error-banner research-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {notes.length === 0 ? (
+        <p className="research-empty">No older or unavailable anchors need review.</p>
+      ) : (
+        <div className="research-anchor-review-list">
+          {notes.map((note) => {
+            const reviewed = reviews[note.note_id];
+            const confirming = confirmingNoteId === note.note_id;
+            const busy = busyNoteId === note.note_id;
+            return (
+              <article key={note.note_id} className="research-anchor-card">
+                <div className="research-anchor-card-header">
+                  <div>
+                    <strong>{note.body}</strong>
+                    <p>
+                      {note.document_id} · {formatEvidenceTime(note.start_seconds)} · stored
+                      generation <code>{shortSha(note.canonical_sha256)}</code>
+                    </p>
+                  </div>
+                  <button type="button" disabled={busy} onClick={() => void review(note)}>
+                    {busy ? "Reviewing…" : reviewed ? "Review again" : "Review evidence status"}
+                  </button>
+                </div>
+
+                {reviewed && (
+                  <div className="research-anchor-comparison" aria-live="polite">
+                    <p className={`research-anchor-status research-anchor-status-${reviewed.status}`}>
+                      {statusCopy(reviewed)}
+                    </p>
+
+                    <div className="research-anchor-columns">
+                      <section aria-label="Stored anchor">
+                        <p className="mini-label">Stored anchor</p>
+                        {reviewed.anchored ? (
+                          <>
+                            <p>{reviewed.anchored.text}</p>
+                            <small>
+                              {formatEvidenceTime(reviewed.anchored.start_seconds)} · {shortSha(reviewed.anchored.canonical_sha256)}
+                            </small>
+                          </>
+                        ) : (
+                          <p className="research-anchor-unavailable">
+                            Stored evidence cannot be verified locally. The durable anchor has not been changed.
+                          </p>
+                        )}
+                      </section>
+
+                      <section aria-label="Current candidate">
+                        <p className="mini-label">Current-generation candidate</p>
+                        {reviewed.candidate ? (
+                          <>
+                            <p>{reviewed.candidate.text}</p>
+                            <small>
+                              {formatEvidenceTime(reviewed.candidate.start_seconds)} · {shortSha(reviewed.candidate.canonical_sha256)}
+                            </small>
+                          </>
+                        ) : (
+                          <p className="research-anchor-unavailable">
+                            EchoFlow could not derive a safe same-source current candidate. No re-anchor action is available.
+                          </p>
+                        )}
+                      </section>
+                    </div>
+
+                    {reviewed.history.length > 0 && (
+                      <details className="research-anchor-history">
+                        <summary>
+                          Previous anchors ({reviewed.history.length})
+                        </summary>
+                        <ol>
+                          {reviewed.history.map((entry) => (
+                            <li key={entry.revision}>
+                              Revision {entry.revision} · {shortSha(entry.canonical_sha256)} · replaced {new Date(entry.replaced_at).toLocaleString()}
+                            </li>
+                          ))}
+                        </ol>
+                      </details>
+                    )}
+
+                    {reviewed.candidate && reviewed.status !== "current_verified" && (
+                      <div className="research-anchor-actions">
+                        {!confirming ? (
+                          <button
+                            type="button"
+                            className="research-anchor-prepare"
+                            onClick={() => setConfirmingNoteId(note.note_id)}
+                          >
+                            Prepare re-anchor
+                          </button>
+                        ) : (
+                          <div className="research-anchor-confirm" role="group" aria-label="Confirm re-anchor">
+                            <p>
+                              This changes the note’s current evidence pointer to the candidate above. The existing anchor will be retained as immutable history.
+                            </p>
+                            <button
+                              type="button"
+                              disabled={busy}
+                              onClick={() => void confirmReanchor(note)}
+                            >
+                              {busy ? "Re-anchoring…" : "Confirm re-anchor to reviewed candidate"}
+                            </button>
+                            <button
+                              type="button"
+                              disabled={busy}
+                              onClick={() => setConfirmingNoteId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/ResearchWorkspaceWithAnchorReview.tsx
+++ b/frontend/src/ResearchWorkspaceWithAnchorReview.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+import type { DesktopClient } from "./api/desktop";
+import type { Theme } from "./components/WorkspaceHeader";
+import { ResearchAnchorReviewPanel } from "./ResearchAnchorReviewPanel";
+import { ResearchWorkspace } from "./ResearchWorkspace";
+
+interface ResearchWorkspaceWithAnchorReviewProps {
+  client: DesktopClient;
+  theme: Theme;
+  onThemeChange: (theme: Theme) => void;
+}
+
+export function ResearchWorkspaceWithAnchorReview({
+  client,
+  theme,
+  onThemeChange,
+}: ResearchWorkspaceWithAnchorReviewProps) {
+  const [workspaceRevision, setWorkspaceRevision] = useState(0);
+
+  return (
+    <>
+      <ResearchWorkspace
+        key={workspaceRevision}
+        client={client}
+        theme={theme}
+        onThemeChange={onThemeChange}
+      />
+      <ResearchAnchorReviewPanel
+        client={client}
+        onReanchored={() => setWorkspaceRevision((current) => current + 1)}
+      />
+    </>
+  );
+}

--- a/frontend/src/research-anchor-review.css
+++ b/frontend/src/research-anchor-review.css
@@ -1,0 +1,180 @@
+.research-anchor-review {
+  max-width: 1180px;
+  margin: 34px auto 0;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--surface);
+}
+
+.research-anchor-review-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.research-anchor-review-heading h2 {
+  margin: 6px 0 8px;
+}
+
+.research-anchor-review-heading p {
+  max-width: 760px;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.research-anchor-review-list {
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.research-anchor-card {
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface-raised);
+}
+
+.research-anchor-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.research-anchor-card-header strong {
+  display: block;
+  max-width: 740px;
+}
+
+.research-anchor-card-header p {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.research-anchor-card button {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 9px 12px;
+  background: var(--surface);
+  cursor: pointer;
+}
+
+.research-anchor-card button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.research-anchor-card button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.research-anchor-comparison {
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
+}
+
+.research-anchor-status {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--surface-soft);
+}
+
+.research-anchor-status-current_verified {
+  border-left: 4px solid var(--accent);
+}
+
+.research-anchor-status-older_verified,
+.research-anchor-status-unavailable {
+  border-left: 4px solid var(--focus);
+}
+
+.research-anchor-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.research-anchor-columns section {
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface);
+}
+
+.research-anchor-columns section > p:not(.mini-label) {
+  line-height: 1.55;
+}
+
+.research-anchor-columns small {
+  color: var(--muted);
+}
+
+.research-anchor-unavailable {
+  color: var(--muted);
+}
+
+.research-anchor-history {
+  margin-top: 14px;
+  color: var(--muted);
+}
+
+.research-anchor-history summary {
+  cursor: pointer;
+  color: var(--ink);
+}
+
+.research-anchor-history ol {
+  margin-bottom: 0;
+}
+
+.research-anchor-actions {
+  margin-top: 16px;
+}
+
+.research-anchor-prepare,
+.research-anchor-confirm button:first-of-type {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.research-anchor-confirm {
+  padding: 14px;
+  border: 1px solid var(--focus);
+  border-radius: 14px;
+  background: var(--surface-soft);
+}
+
+.research-anchor-confirm p {
+  margin-top: 0;
+  line-height: 1.5;
+}
+
+.research-anchor-confirm button + button {
+  margin-left: 8px;
+}
+
+@media (max-width: 760px) {
+  .research-anchor-review-heading,
+  .research-anchor-card-header {
+    flex-direction: column;
+  }
+
+  .research-anchor-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .research-anchor-confirm button {
+    width: 100%;
+  }
+
+  .research-anchor-confirm button + button {
+    margin: 8px 0 0;
+  }
+}

--- a/frontend/src/researchAnchorApi.ts
+++ b/frontend/src/researchAnchorApi.ts
@@ -1,0 +1,157 @@
+import type { ResearchNoteResult } from "./api/desktop";
+
+export type ResearchAnchorStatus = "current_verified" | "older_verified" | "unavailable";
+
+export interface ResearchAnchorEvidencePreview {
+  document_id: string;
+  canonical_sha256: string;
+  segment_ids: string[];
+  start_seconds: number;
+  end_seconds: number;
+  seek_seconds: number;
+  text: string;
+}
+
+export interface ResearchAnchorHistoryEntry {
+  revision: number;
+  canonical_sha256: string;
+  segment_ids: string[];
+  start_seconds: number;
+  end_seconds: number;
+  replaced_at: string;
+}
+
+export interface ResearchAnchorReviewResult {
+  note_id: string;
+  updated_at: string;
+  status: ResearchAnchorStatus;
+  anchored: ResearchAnchorEvidencePreview | null;
+  candidate: ResearchAnchorEvidencePreview | null;
+  history: ResearchAnchorHistoryEntry[];
+}
+
+interface ReanchorResult {
+  note_id: string;
+  updated_at: string;
+  canonical_sha256: string;
+  current: boolean;
+}
+
+interface DesktopError {
+  code: string;
+  message: string;
+}
+
+interface DesktopResponse<T> {
+  protocol_version: 1;
+  request_id: string;
+  ok: boolean;
+  result: T | null;
+  error: DesktopError | null;
+}
+
+let mockReanchored = false;
+
+function isMockMode(): boolean {
+  return new URLSearchParams(window.location.search).get("e2e") === "1";
+}
+
+async function request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  const response = (await invoke<unknown>("desktop_request", {
+    request: {
+      protocol_version: 1,
+      request_id: crypto.randomUUID(),
+      method,
+      params,
+    },
+  })) as DesktopResponse<T>;
+  if (
+    !response ||
+    response.protocol_version !== 1 ||
+    typeof response.request_id !== "string" ||
+    typeof response.ok !== "boolean"
+  ) {
+    throw new Error("EchoFlow desktop bridge returned an incompatible response");
+  }
+  if (!response.ok || response.result === null) {
+    throw new Error(response.error?.message ?? "EchoFlow could not complete that request");
+  }
+  return response.result;
+}
+
+function mockPreview(
+  note: ResearchNoteResult,
+  canonicalSha256: string,
+  text: string,
+): ResearchAnchorEvidencePreview {
+  return {
+    document_id: note.document_id,
+    canonical_sha256: canonicalSha256,
+    segment_ids: [...note.segment_ids],
+    start_seconds: note.start_seconds,
+    end_seconds: note.end_seconds,
+    seek_seconds: note.start_seconds,
+    text,
+  };
+}
+
+export async function reviewResearchAnchor(
+  note: ResearchNoteResult,
+): Promise<ResearchAnchorReviewResult> {
+  if (isMockMode()) {
+    if (mockReanchored) {
+      return {
+        note_id: note.note_id,
+        updated_at: "2026-08-20T08:10:00+00:00",
+        status: "current_verified",
+        anchored: mockPreview(note, "d".repeat(64), "Current reviewed evidence."),
+        candidate: null,
+        history: [
+          {
+            revision: 1,
+            canonical_sha256: note.canonical_sha256,
+            segment_ids: [...note.segment_ids],
+            start_seconds: note.start_seconds,
+            end_seconds: note.end_seconds,
+            replaced_at: "2026-08-20T08:10:00+00:00",
+          },
+        ],
+      };
+    }
+    return {
+      note_id: note.note_id,
+      updated_at: note.updated_at,
+      status: "older_verified",
+      anchored: mockPreview(note, note.canonical_sha256, "Earlier verified evidence."),
+      candidate: mockPreview(note, "d".repeat(64), "Current reviewed evidence."),
+      history: [],
+    };
+  }
+  return request<ResearchAnchorReviewResult>("workspace.research.note.anchor.review", {
+    note_id: note.note_id,
+    context_segments: 1,
+  });
+}
+
+export async function reanchorResearchNote(
+  review: ResearchAnchorReviewResult,
+): Promise<ReanchorResult> {
+  if (!review.candidate) {
+    throw new Error("No reviewed current evidence candidate is available.");
+  }
+  if (isMockMode()) {
+    mockReanchored = true;
+    return {
+      note_id: review.note_id,
+      updated_at: "2026-08-20T08:10:00+00:00",
+      canonical_sha256: review.candidate.canonical_sha256,
+      current: true,
+    };
+  }
+  return request<ReanchorResult>("workspace.research.note.anchor.reanchor", {
+    note_id: review.note_id,
+    expected_updated_at: review.updated_at,
+    expected_candidate_sha256: review.candidate.canonical_sha256,
+  });
+}

--- a/frontend/tests/research-anchor-review.spec.ts
+++ b/frontend/tests/research-anchor-review.spec.ts
@@ -1,0 +1,58 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+async function openResearch(page: import("@playwright/test").Page) {
+  await page.goto("/?e2e=1");
+  await page.getByRole("button", { name: "Research" }).click();
+  await expect(page.getByRole("heading", { name: "Your research layer." })).toBeVisible();
+}
+
+test("Susan can review an older anchor before deliberately re-anchoring it", async ({
+  page,
+}) => {
+  await openResearch(page);
+
+  const maintenance = page.getByRole("region", {
+    name: "Review older or unavailable note anchors",
+  });
+  await expect(maintenance).toBeVisible();
+  await expect(maintenance).toContainText(
+    "EchoFlow never silently moves research to a newer transcript.",
+  );
+
+  const card = maintenance
+    .locator(".research-anchor-card")
+    .filter({ hasText: "Earlier interpretation retained for provenance." });
+  await card.getByRole("button", { name: "Review evidence status" }).click();
+
+  await expect(card).toContainText(
+    "The stored evidence still verifies, but it belongs to an older canonical generation.",
+  );
+  await expect(card.getByRole("region", { name: "Stored anchor" })).toContainText(
+    "Earlier verified evidence.",
+  );
+  await expect(card.getByRole("region", { name: "Current candidate" })).toContainText(
+    "Current reviewed evidence.",
+  );
+  await expect(card).not.toContainText("/Users/");
+  await expect(card).not.toContainText("canonical_path");
+  await expect(card).not.toContainText("source_path");
+
+  await card.getByRole("button", { name: "Prepare re-anchor" }).click();
+  const confirmation = card.getByRole("group", { name: "Confirm re-anchor" });
+  await expect(confirmation).toContainText(
+    "The existing anchor will be retained as immutable history.",
+  );
+  await confirmation
+    .getByRole("button", { name: "Confirm re-anchor to reviewed candidate" })
+    .click();
+
+  await expect(
+    maintenance.getByText(
+      "Note re-anchored to the reviewed current generation. The prior anchor was preserved in durable history.",
+    ),
+  ).toBeVisible();
+
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});

--- a/frontend/tests/research.spec.ts
+++ b/frontend/tests/research.spec.ts
@@ -52,6 +52,7 @@ test("research workspace refresh remains keyboard reachable", async ({ page }) =
 test("Susan can filter by durable labels and return to verified evidence", async ({ page }) => {
   await openResearch(page);
 
+  const notes = page.getByLabel("Notes", { exact: true });
   const tags = page.getByRole("group", { name: "Research tags" });
   await tags.getByRole("button", { name: "#governance" }).click();
 
@@ -59,9 +60,11 @@ test("Susan can filter by durable labels and return to verified evidence", async
   await expect(active).toContainText("Every selected label must match the same note.");
   await expect(active.getByRole("button", { name: "Remove tag governance" })).toBeVisible();
   await expect(
-    page.getByText("Follow up on ABC governance during the next interview."),
+    notes.getByText("Follow up on ABC governance during the next interview."),
   ).toBeVisible();
-  await expect(page.getByText("Earlier interpretation retained for provenance.")).toHaveCount(0);
+  await expect(
+    notes.getByText("Earlier interpretation retained for provenance."),
+  ).toHaveCount(0);
 
   await tags.getByRole("button", { name: "#program" }).click();
   await expect(active.getByRole("button", { name: "Remove tag program" })).toBeVisible();
@@ -84,7 +87,9 @@ test("Susan can filter by durable labels and return to verified evidence", async
   await reader.getByRole("button", { name: "Close" }).click();
 
   await active.getByRole("button", { name: "Clear filters" }).click();
-  await expect(page.getByText("Earlier interpretation retained for provenance.")).toBeVisible();
+  await expect(
+    notes.getByText("Earlier interpretation retained for provenance."),
+  ).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();
   expect(results.violations).toEqual([]);

--- a/src/echoflow/desktop/bridge.py
+++ b/src/echoflow/desktop/bridge.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 
 from echoflow.app.app_container import AppContainer
 from echoflow.core.errors import EchoFlowError
+from echoflow.desktop.research_anchor_bridge import dispatch_research_anchor
 from echoflow.library.errors import ResearchStateError
 from echoflow.library.evidence import EvidenceContextSegment, EvidenceWord
 from echoflow.library.index import SearchQuery
@@ -67,6 +68,8 @@ class _DesktopRequest(BaseModel):
         "workspace.research.note.update",
         "workspace.research.note.delete",
         "workspace.research.note.evidence",
+        "workspace.research.note.anchor.review",
+        "workspace.research.note.anchor.reanchor",
         "workspace.research.saved_search.create",
         "workspace.research.saved_search.update",
         "workspace.research.saved_search.delete",
@@ -619,6 +622,11 @@ def _dispatch_research_note(
     request: _DesktopRequest,
     workspace: ResearchWorkspaceService,
 ) -> object:
+    if request.method in {
+        "workspace.research.note.anchor.review",
+        "workspace.research.note.anchor.reanchor",
+    }:
+        return dispatch_research_anchor(request.method, request.params, workspace)
     if request.method == "workspace.research.note.create":
         create_params = _CreateResearchNoteParams.model_validate(request.params)
         return _create_research_note(create_params, workspace)

--- a/src/echoflow/desktop/research_anchor_bridge.py
+++ b/src/echoflow/desktop/research_anchor_bridge.py
@@ -1,0 +1,112 @@
+"""Narrow desktop DTOs for explicit research-anchor review and re-anchoring."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from echoflow.library.research import LocatedCanonicalEvidence
+from echoflow.library.research_anchor_review import (
+    ResearchAnchorReview,
+    ResearchAnchorReviewService,
+)
+from echoflow.library.research_workspace import ResearchWorkspaceService
+
+
+class _ReviewAnchorParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    note_id: str = Field(min_length=1, max_length=200)
+    context_segments: int = Field(default=1, ge=0, le=10)
+
+    @field_validator("note_id")
+    @classmethod
+    def strip_note_id(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("note_id cannot be blank")
+        return stripped
+
+
+class _ReanchorNoteParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    note_id: str = Field(min_length=1, max_length=200)
+    expected_updated_at: str = Field(min_length=1, max_length=200)
+    expected_candidate_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @field_validator("note_id", "expected_updated_at")
+    @classmethod
+    def strip_required_text(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("value cannot be blank")
+        return stripped
+
+
+def _serialize_evidence(item: LocatedCanonicalEvidence | None) -> object:
+    if item is None:
+        return None
+    evidence = item.evidence
+    result_ids = set(evidence.result_segment_ids)
+    text = " ".join(
+        segment.text
+        for segment in evidence.context_segments
+        if segment.segment_id in result_ids
+    )
+    return {
+        "document_id": evidence.document_id,
+        "canonical_sha256": evidence.canonical_sha256,
+        "segment_ids": list(evidence.result_segment_ids),
+        "start_seconds": evidence.start_seconds,
+        "end_seconds": evidence.end_seconds,
+        "seek_seconds": evidence.seek_seconds,
+        "text": text,
+    }
+
+
+def _serialize_review(review: ResearchAnchorReview) -> dict[str, object]:
+    return {
+        "note_id": review.note.note.note_id,
+        "updated_at": review.note.note.updated_at,
+        "status": review.status.value,
+        "anchored": _serialize_evidence(review.anchored),
+        "candidate": _serialize_evidence(review.candidate),
+        "history": [
+            {
+                "revision": entry.revision,
+                "canonical_sha256": entry.anchor.canonical_sha256,
+                "segment_ids": list(entry.anchor.segment_ids),
+                "start_seconds": entry.anchor.start_seconds,
+                "end_seconds": entry.anchor.end_seconds,
+                "replaced_at": entry.replaced_at,
+            }
+            for entry in review.history
+        ],
+    }
+
+
+def dispatch_research_anchor(
+    method: str,
+    params: dict[str, object],
+    workspace: ResearchWorkspaceService,
+) -> dict[str, object]:
+    service = ResearchAnchorReviewService.for_workspace(workspace)
+    if method == "workspace.research.note.anchor.review":
+        parsed = _ReviewAnchorParams.model_validate(params)
+        return _serialize_review(
+            service.review(parsed.note_id, context_segments=parsed.context_segments)
+        )
+    if method == "workspace.research.note.anchor.reanchor":
+        parsed = _ReanchorNoteParams.model_validate(params)
+        updated = service.reanchor_to_reviewed_current(
+            parsed.note_id,
+            expected_updated_at=parsed.expected_updated_at,
+            expected_candidate_sha256=parsed.expected_candidate_sha256,
+        )
+        return {
+            "note_id": updated.note.note_id,
+            "updated_at": updated.note.updated_at,
+            "canonical_sha256": updated.note.anchor.canonical_sha256,
+            "current": updated.current,
+        }
+    raise ValueError("Unsupported research anchor desktop method")

--- a/src/echoflow/desktop/research_anchor_bridge.py
+++ b/src/echoflow/desktop/research_anchor_bridge.py
@@ -91,18 +91,21 @@ def dispatch_research_anchor(
     workspace: ResearchWorkspaceService,
 ) -> dict[str, object]:
     if method == "workspace.research.note.anchor.review":
-        parsed = _ReviewAnchorParams.model_validate(params)
+        review_params = _ReviewAnchorParams.model_validate(params)
         service = ResearchAnchorReviewService.for_workspace(workspace)
         return _serialize_review(
-            service.review(parsed.note_id, context_segments=parsed.context_segments)
+            service.review(
+                review_params.note_id,
+                context_segments=review_params.context_segments,
+            )
         )
     if method == "workspace.research.note.anchor.reanchor":
-        parsed = _ReanchorNoteParams.model_validate(params)
+        reanchor_params = _ReanchorNoteParams.model_validate(params)
         service = ResearchAnchorReviewService.for_workspace(workspace)
         updated = service.reanchor_to_reviewed_current(
-            parsed.note_id,
-            expected_updated_at=parsed.expected_updated_at,
-            expected_candidate_sha256=parsed.expected_candidate_sha256,
+            reanchor_params.note_id,
+            expected_updated_at=reanchor_params.expected_updated_at,
+            expected_candidate_sha256=reanchor_params.expected_candidate_sha256,
         )
         return {
             "note_id": updated.note.note_id,

--- a/src/echoflow/desktop/research_anchor_bridge.py
+++ b/src/echoflow/desktop/research_anchor_bridge.py
@@ -90,14 +90,15 @@ def dispatch_research_anchor(
     params: dict[str, object],
     workspace: ResearchWorkspaceService,
 ) -> dict[str, object]:
-    service = ResearchAnchorReviewService.for_workspace(workspace)
     if method == "workspace.research.note.anchor.review":
         parsed = _ReviewAnchorParams.model_validate(params)
+        service = ResearchAnchorReviewService.for_workspace(workspace)
         return _serialize_review(
             service.review(parsed.note_id, context_segments=parsed.context_segments)
         )
     if method == "workspace.research.note.anchor.reanchor":
         parsed = _ReanchorNoteParams.model_validate(params)
+        service = ResearchAnchorReviewService.for_workspace(workspace)
         updated = service.reanchor_to_reviewed_current(
             parsed.note_id,
             expected_updated_at=parsed.expected_updated_at,

--- a/src/echoflow/desktop/tests/test_research_anchor_bridge.py
+++ b/src/echoflow/desktop/tests/test_research_anchor_bridge.py
@@ -1,0 +1,190 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+from pydantic import ValidationError
+
+import echoflow.desktop.bridge as desktop_bridge
+import echoflow.desktop.research_anchor_bridge as anchor_bridge
+from echoflow.desktop.bridge import DesktopServices, handle_request
+from echoflow.library.evidence import EvidenceAnchor, EvidenceContextSegment, EvidenceLocation
+from echoflow.library.research import LocatedCanonicalEvidence
+from echoflow.library.research_anchor_review import ResearchAnchorReview, ResearchAnchorStatus
+from echoflow.library.research_state import ResearchAnchorHistoryEntry, ResearchNote
+from echoflow.library.research_workspace import ResearchNoteView
+
+
+def _anchor(*, canonical_digit: str = "b") -> EvidenceAnchor:
+    return EvidenceAnchor(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256=canonical_digit * 64,
+        canonical_path=f"/secret/{canonical_digit}.json",
+        source_path="/secret/source.wav",
+        segment_ids=("segment-1",),
+        start_seconds=4.0,
+        end_seconds=5.0,
+    )
+
+
+def _located(anchor: EvidenceAnchor, text: str) -> LocatedCanonicalEvidence:
+    return LocatedCanonicalEvidence(
+        evidence=EvidenceLocation(
+            document_id=anchor.document_id,
+            source_sha256=anchor.source_sha256,
+            canonical_sha256=anchor.canonical_sha256,
+            canonical_path=anchor.canonical_path,
+            source_path=anchor.source_path,
+            result_segment_ids=anchor.segment_ids,
+            start_seconds=anchor.start_seconds,
+            end_seconds=anchor.end_seconds,
+            seek_seconds=anchor.start_seconds,
+            result_speaker_refs=(),
+            matched_words=(),
+            context_segments=(
+                EvidenceContextSegment(
+                    segment_id="segment-1",
+                    start_seconds=4.0,
+                    end_seconds=5.0,
+                    text=text,
+                    speaker_refs=(),
+                    words=(),
+                    is_result_segment=True,
+                    lexical_match=False,
+                ),
+            ),
+        ),
+        speakers=(),
+    )
+
+
+def _review() -> ResearchAnchorReview:
+    old = _anchor()
+    current = _anchor(canonical_digit="c")
+    note = ResearchNote(
+        note_id="note-1",
+        body="Interpretation",
+        anchor=old,
+        tag_ids=(),
+        collection_ids=(),
+        created_at="2026-08-20T08:00:00+00:00",
+        updated_at="2026-08-20T08:00:00+00:00",
+    )
+    return ResearchAnchorReview(
+        note=ResearchNoteView(note=note, current=False, tags=(), collections=()),
+        status=ResearchAnchorStatus.OLDER_VERIFIED,
+        anchored=_located(old, "Stored evidence"),
+        candidate=_located(current, "Current candidate"),
+        history=(
+            ResearchAnchorHistoryEntry(
+                note_id="note-1",
+                revision=1,
+                anchor=_anchor(canonical_digit="1"),
+                replaced_at="2026-08-19T08:00:00+00:00",
+            ),
+        ),
+    )
+
+
+def _services() -> DesktopServices:
+    return DesktopServices(
+        locations=cast(Any, SimpleNamespace()),
+        workspace=cast(Any, SimpleNamespace()),
+    )
+
+
+def _request(method: str, params: dict[str, object]) -> dict[str, object]:
+    return {
+        "protocol_version": 1,
+        "request_id": "anchor-1",
+        "method": method,
+        "params": params,
+    }
+
+
+def test_anchor_methods_are_explicitly_allowlisted(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def dispatch(method: str, params: dict[str, object], workspace: object) -> object:
+        calls.append((method, params))
+        return {"accepted": True}
+
+    monkeypatch.setattr(desktop_bridge, "dispatch_research_anchor", dispatch)
+
+    review = handle_request(
+        _request("workspace.research.note.anchor.review", {"note_id": "note-1"}),
+        _services(),
+    )
+    reanchor = handle_request(
+        _request(
+            "workspace.research.note.anchor.reanchor",
+            {
+                "note_id": "note-1",
+                "expected_updated_at": "2026-08-20T08:00:00+00:00",
+                "expected_candidate_sha256": "c" * 64,
+            },
+        ),
+        _services(),
+    )
+
+    assert review["ok"] is True
+    assert reanchor["ok"] is True
+    assert [item[0] for item in calls] == [
+        "workspace.research.note.anchor.review",
+        "workspace.research.note.anchor.reanchor",
+    ]
+
+
+def test_anchor_review_serializer_never_exposes_authoritative_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = Mock()
+    service.review.return_value = _review()
+    monkeypatch.setattr(
+        anchor_bridge.ResearchAnchorReviewService,
+        "for_workspace",
+        classmethod(lambda cls, workspace: service),
+    )
+
+    result = anchor_bridge.dispatch_research_anchor(
+        "workspace.research.note.anchor.review",
+        {"note_id": "note-1", "context_segments": 1},
+        cast(Any, SimpleNamespace()),
+    )
+
+    assert result["status"] == "older_verified"
+    assert result["anchored"]["text"] == "Stored evidence"  # type: ignore[index]
+    assert result["candidate"]["text"] == "Current candidate"  # type: ignore[index]
+    assert result["history"][0]["canonical_sha256"] == "1" * 64  # type: ignore[index]
+    assert "/secret" not in str(result)
+    assert "canonical_path" not in str(result)
+    assert "source_path" not in str(result)
+    assert "source_sha256" not in str(result)
+
+
+def test_anchor_bridge_rejects_extra_or_malformed_confirmation_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        anchor_bridge.ResearchAnchorReviewService,
+        "for_workspace",
+        classmethod(lambda cls, workspace: Mock()),
+    )
+
+    with pytest.raises(ValidationError):
+        anchor_bridge.dispatch_research_anchor(
+            "workspace.research.note.anchor.review",
+            {"note_id": "note-1", "sql": "SELECT * FROM notes"},
+            cast(Any, SimpleNamespace()),
+        )
+    with pytest.raises(ValidationError):
+        anchor_bridge.dispatch_research_anchor(
+            "workspace.research.note.anchor.reanchor",
+            {
+                "note_id": "note-1",
+                "expected_updated_at": "v1",
+                "expected_candidate_sha256": "not-a-sha",
+            },
+            cast(Any, SimpleNamespace()),
+        )

--- a/src/echoflow/desktop/tests/test_research_anchor_bridge.py
+++ b/src/echoflow/desktop/tests/test_research_anchor_bridge.py
@@ -110,7 +110,9 @@ def _request(method: str, params: dict[str, object]) -> dict[str, object]:
     }
 
 
-def test_anchor_methods_are_explicitly_allowlisted(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_anchor_methods_are_explicitly_allowlisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls: list[tuple[str, dict[str, object]]] = []
 
     def dispatch(method: str, params: dict[str, object], workspace: object) -> object:

--- a/src/echoflow/desktop/tests/test_research_anchor_bridge.py
+++ b/src/echoflow/desktop/tests/test_research_anchor_bridge.py
@@ -8,9 +8,16 @@ from pydantic import ValidationError
 import echoflow.desktop.bridge as desktop_bridge
 import echoflow.desktop.research_anchor_bridge as anchor_bridge
 from echoflow.desktop.bridge import DesktopServices, handle_request
-from echoflow.library.evidence import EvidenceAnchor, EvidenceContextSegment, EvidenceLocation
+from echoflow.library.evidence import (
+    EvidenceAnchor,
+    EvidenceContextSegment,
+    EvidenceLocation,
+)
 from echoflow.library.research import LocatedCanonicalEvidence
-from echoflow.library.research_anchor_review import ResearchAnchorReview, ResearchAnchorStatus
+from echoflow.library.research_anchor_review import (
+    ResearchAnchorReview,
+    ResearchAnchorStatus,
+)
 from echoflow.library.research_state import ResearchAnchorHistoryEntry, ResearchNote
 from echoflow.library.research_workspace import ResearchNoteView
 

--- a/src/echoflow/desktop/tests/test_research_anchor_bridge_edges.py
+++ b/src/echoflow/desktop/tests/test_research_anchor_bridge_edges.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+from pydantic import ValidationError
+
+import echoflow.desktop.research_anchor_bridge as anchor_bridge
+
+
+def _install_service(monkeypatch: pytest.MonkeyPatch, service: Mock) -> None:
+    monkeypatch.setattr(
+        anchor_bridge.ResearchAnchorReviewService,
+        "for_workspace",
+        classmethod(lambda cls, workspace: service),
+    )
+
+
+def test_reanchor_bridge_serializes_authoritative_updated_note(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = Mock()
+    service.reanchor_to_reviewed_current.return_value = SimpleNamespace(
+        note=SimpleNamespace(
+            note_id="note-1",
+            updated_at="2026-08-20T09:00:00+00:00",
+            anchor=SimpleNamespace(canonical_sha256="c" * 64),
+        ),
+        current=True,
+    )
+    _install_service(monkeypatch, service)
+
+    result = anchor_bridge.dispatch_research_anchor(
+        "workspace.research.note.anchor.reanchor",
+        {
+            "note_id": "note-1",
+            "expected_updated_at": "2026-08-20T08:00:00+00:00",
+            "expected_candidate_sha256": "c" * 64,
+        },
+        cast(Any, SimpleNamespace()),
+    )
+
+    assert result == {
+        "note_id": "note-1",
+        "updated_at": "2026-08-20T09:00:00+00:00",
+        "canonical_sha256": "c" * 64,
+        "current": True,
+    }
+    service.reanchor_to_reviewed_current.assert_called_once_with(
+        "note-1",
+        expected_updated_at="2026-08-20T08:00:00+00:00",
+        expected_candidate_sha256="c" * 64,
+    )
+
+
+def test_anchor_bridge_validates_blank_identity_before_service_construction() -> None:
+    with pytest.raises(ValidationError):
+        anchor_bridge.dispatch_research_anchor(
+            "workspace.research.note.anchor.review",
+            {"note_id": "   "},
+            cast(Any, SimpleNamespace()),
+        )
+
+    with pytest.raises(ValidationError):
+        anchor_bridge.dispatch_research_anchor(
+            "workspace.research.note.anchor.reanchor",
+            {
+                "note_id": "note-1",
+                "expected_updated_at": "   ",
+                "expected_candidate_sha256": "c" * 64,
+            },
+            cast(Any, SimpleNamespace()),
+        )
+
+
+def test_anchor_bridge_handles_empty_evidence_and_rejects_unknown_method() -> None:
+    assert anchor_bridge._serialize_evidence(None) is None
+
+    with pytest.raises(ValueError, match="Unsupported research anchor desktop method"):
+        anchor_bridge.dispatch_research_anchor(
+            "workspace.research.note.anchor.unknown",
+            {},
+            cast(Any, SimpleNamespace()),
+        )

--- a/src/echoflow/library/research_anchor_review.py
+++ b/src/echoflow/library/research_anchor_review.py
@@ -6,8 +6,11 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
-from echoflow.core.errors import EchoFlowError
-from echoflow.library.errors import ResearchStateError, TranscriptProjectionError
+from echoflow.library.errors import (
+    EvidenceNavigationError,
+    ResearchStateError,
+    TranscriptProjectionError,
+)
 from echoflow.library.evidence import EvidenceAnchor
 from echoflow.library.index import IndexedDocument, IndexedSegment
 from echoflow.library.projection import load_indexed_transcript
@@ -68,11 +71,11 @@ class ResearchAnchorReviewService:
 
         anchored: LocatedCanonicalEvidence | None = None
         try:
-            anchored = self.workspace.navigation.locate_anchor(
+            anchored = self._locate_evidence(
                 note.note.anchor,
                 context_segments=context_segments,
             )
-        except EchoFlowError:
+        except EvidenceNavigationError:
             anchored = None
 
         if note.current and anchored is not None:
@@ -153,12 +156,30 @@ class ResearchAnchorReviewService:
             anchor = self._candidate_anchor(note)
             if anchor is None:
                 return None
-            return self.workspace.navigation.locate_anchor(
+            return self._locate_evidence(
                 anchor,
                 context_segments=context_segments,
             )
-        except (EchoFlowError, OSError, ValueError):
+        except (
+            EvidenceNavigationError,
+            TranscriptProjectionError,
+            OSError,
+            ValueError,
+        ):
             return None
+
+    def _locate_evidence(
+        self,
+        anchor: EvidenceAnchor,
+        *,
+        context_segments: int,
+    ) -> LocatedCanonicalEvidence:
+        """Classify canonical evidence without coupling validity to speaker-label state."""
+        evidence = self.workspace.evidence_locator.locate_anchor(
+            anchor,
+            context_segments=context_segments,
+        )
+        return LocatedCanonicalEvidence(evidence=evidence, speakers=())
 
     def _candidate_anchor(self, note: ResearchNote) -> EvidenceAnchor | None:
         document = self._current_document(note.anchor.document_id)

--- a/src/echoflow/library/research_anchor_review.py
+++ b/src/echoflow/library/research_anchor_review.py
@@ -16,7 +16,10 @@ from echoflow.library.index import IndexedDocument, IndexedSegment
 from echoflow.library.projection import load_indexed_transcript
 from echoflow.library.research import LocatedCanonicalEvidence
 from echoflow.library.research_state import ResearchAnchorHistoryEntry, ResearchNote
-from echoflow.library.research_workspace import ResearchNoteView, ResearchWorkspaceService
+from echoflow.library.research_workspace import (
+    ResearchNoteView,
+    ResearchWorkspaceService,
+)
 from echoflow.library.sqlite_research_anchor_state import SqliteResearchAnchorStateStore
 
 

--- a/src/echoflow/library/research_anchor_review.py
+++ b/src/echoflow/library/research_anchor_review.py
@@ -1,0 +1,252 @@
+"""Review stale research anchors and deliberately bind notes to reviewed current evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.errors import ResearchStateError, TranscriptProjectionError
+from echoflow.library.evidence import EvidenceAnchor
+from echoflow.library.index import IndexedDocument, IndexedSegment
+from echoflow.library.projection import load_indexed_transcript
+from echoflow.library.research import LocatedCanonicalEvidence
+from echoflow.library.research_state import ResearchAnchorHistoryEntry, ResearchNote
+from echoflow.library.research_workspace import ResearchNoteView, ResearchWorkspaceService
+from echoflow.library.sqlite_research_anchor_state import SqliteResearchAnchorStateStore
+
+
+class ResearchAnchorStatus(StrEnum):
+    CURRENT_VERIFIED = "current_verified"
+    OLDER_VERIFIED = "older_verified"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchAnchorReview:
+    """Evidence review result; a candidate is preview only until explicitly confirmed."""
+
+    note: ResearchNoteView
+    status: ResearchAnchorStatus
+    anchored: LocatedCanonicalEvidence | None
+    candidate: LocatedCanonicalEvidence | None
+    history: tuple[ResearchAnchorHistoryEntry, ...]
+
+
+class ResearchAnchorReviewService:
+    """Compose current library evidence with durable anchor history without auto-rebinding."""
+
+    def __init__(
+        self,
+        workspace: ResearchWorkspaceService,
+        anchor_state: SqliteResearchAnchorStateStore,
+    ) -> None:
+        self.workspace = workspace
+        self.anchor_state = anchor_state
+
+    @classmethod
+    def for_workspace(
+        cls, workspace: ResearchWorkspaceService
+    ) -> ResearchAnchorReviewService:
+        database_path = getattr(workspace.state, "database_path", None)
+        if not isinstance(database_path, Path):
+            raise ResearchStateError(
+                "Research anchor maintenance is unavailable for this research-state backend"
+            )
+        return cls(workspace, SqliteResearchAnchorStateStore(database_path))
+
+    def review(
+        self,
+        note_id: str,
+        *,
+        context_segments: int = 1,
+    ) -> ResearchAnchorReview:
+        note = self.workspace.note(note_id)
+        if note is None:
+            raise ResearchStateError("Research note does not exist")
+
+        anchored: LocatedCanonicalEvidence | None = None
+        try:
+            anchored = self.workspace.navigation.locate_anchor(
+                note.note.anchor,
+                context_segments=context_segments,
+            )
+        except EchoFlowError:
+            anchored = None
+
+        if note.current and anchored is not None:
+            status = ResearchAnchorStatus.CURRENT_VERIFIED
+            candidate = None
+        else:
+            status = (
+                ResearchAnchorStatus.OLDER_VERIFIED
+                if anchored is not None
+                else ResearchAnchorStatus.UNAVAILABLE
+            )
+            candidate = self._candidate_evidence(
+                note.note,
+                context_segments=context_segments,
+            )
+
+        history = self.anchor_state.note_anchor_history(note.note.note_id)
+        self._log_review(note, status=status, candidate=candidate)
+        return ResearchAnchorReview(
+            note=note,
+            status=status,
+            anchored=anchored,
+            candidate=candidate,
+            history=history,
+        )
+
+    def reanchor_to_reviewed_current(
+        self,
+        note_id: str,
+        *,
+        expected_updated_at: str,
+        expected_candidate_sha256: str,
+    ) -> ResearchNoteView:
+        note = self.workspace.note(note_id)
+        if note is None:
+            raise ResearchStateError("Research note does not exist")
+        if note.current:
+            raise ResearchStateError("Research note already cites current evidence")
+
+        candidate = self._candidate_anchor(note.note)
+        if candidate is None:
+            raise ResearchStateError(
+                "No safe current-generation candidate is available for this note"
+            )
+        if candidate.canonical_sha256 != expected_candidate_sha256:
+            raise ResearchStateError(
+                "Current transcript changed since the candidate was reviewed; review again before re-anchoring"
+            )
+
+        self.anchor_state.reanchor_note(
+            note.note.note_id,
+            candidate,
+            expected_updated_at=expected_updated_at,
+        )
+        updated = self.workspace.note(note.note.note_id)
+        if updated is None:
+            raise ResearchStateError("Re-anchored research note could not be read back")
+        if self.workspace.logger is not None:
+            self.workspace.logger.info(
+                "research_note_reanchored",
+                note_id=updated.note.note_id,
+                document_id=updated.note.anchor.document_id,
+                canonical_sha256=updated.note.anchor.canonical_sha256,
+                prior_canonical_sha256=note.note.anchor.canonical_sha256,
+                history_count=len(
+                    self.anchor_state.note_anchor_history(updated.note.note_id)
+                ),
+            )
+        return updated
+
+    def _candidate_evidence(
+        self,
+        note: ResearchNote,
+        *,
+        context_segments: int,
+    ) -> LocatedCanonicalEvidence | None:
+        try:
+            anchor = self._candidate_anchor(note)
+            if anchor is None:
+                return None
+            return self.workspace.navigation.locate_anchor(
+                anchor,
+                context_segments=context_segments,
+            )
+        except (EchoFlowError, OSError, ValueError):
+            return None
+
+    def _candidate_anchor(self, note: ResearchNote) -> EvidenceAnchor | None:
+        document = self._current_document(note.anchor.document_id)
+        if document is None or document.canonical_sha256 is None:
+            return None
+        if document.canonical_sha256 == note.anchor.canonical_sha256:
+            return None
+        if document.source_sha256 != note.anchor.source_sha256:
+            return None
+
+        indexed = load_indexed_transcript(
+            Path(document.canonical_path),
+            source_path=(
+                None if document.source_path is None else Path(document.source_path)
+            ),
+            file_manager=self.workspace.transcript_library.file_manager,
+        )
+        if (
+            indexed.document_id != document.document_id
+            or indexed.source_sha256 != document.source_sha256
+            or indexed.canonical_sha256 != document.canonical_sha256
+        ):
+            raise TranscriptProjectionError(
+                "Current transcript changed while preparing re-anchor review"
+            )
+
+        selected = self._segments_for_time(
+            indexed.segments,
+            start_seconds=note.anchor.start_seconds,
+            end_seconds=note.anchor.end_seconds,
+        )
+        if not selected:
+            return None
+        candidate_start = max(note.anchor.start_seconds, selected[0].start_seconds)
+        candidate_end = min(note.anchor.end_seconds, selected[-1].end_seconds)
+        if candidate_end < candidate_start:
+            return None
+        return self.workspace.evidence_locator.resolve_anchor(
+            document,
+            tuple(segment.segment_id for segment in selected),
+            start_seconds=candidate_start,
+            end_seconds=candidate_end,
+        )
+
+    def _current_document(self, document_id: str) -> IndexedDocument | None:
+        return next(
+            (
+                document
+                for document in self.workspace.transcript_library.documents()
+                if document.document_id == document_id
+            ),
+            None,
+        )
+
+    @staticmethod
+    def _segments_for_time(
+        segments: tuple[IndexedSegment, ...],
+        *,
+        start_seconds: float,
+        end_seconds: float,
+    ) -> tuple[IndexedSegment, ...]:
+        if end_seconds == start_seconds:
+            return tuple(
+                segment
+                for segment in segments
+                if segment.start_seconds <= start_seconds <= segment.end_seconds
+            )
+        return tuple(
+            segment
+            for segment in segments
+            if segment.end_seconds > start_seconds
+            and segment.start_seconds < end_seconds
+        )
+
+    def _log_review(
+        self,
+        note: ResearchNoteView,
+        *,
+        status: ResearchAnchorStatus,
+        candidate: LocatedCanonicalEvidence | None,
+    ) -> None:
+        if self.workspace.logger is None:
+            return
+        self.workspace.logger.info(
+            "research_note_anchor_reviewed",
+            note_id=note.note.note_id,
+            document_id=note.note.anchor.document_id,
+            canonical_sha256=note.note.anchor.canonical_sha256,
+            status=status.value,
+            candidate_available=candidate is not None,
+        )

--- a/src/echoflow/library/research_state.py
+++ b/src/echoflow/library/research_state.py
@@ -115,6 +115,23 @@ class ResearchProjectionSnapshot:
 
 
 @runtime_checkable
+class ResearchAnchorStateStore(Protocol):
+    """Narrow same-database port for deliberate evidence-anchor maintenance."""
+
+    def reanchor_note(
+        self,
+        note_id: str,
+        anchor: EvidenceAnchor,
+        *,
+        expected_updated_at: str,
+    ) -> None: ...
+
+    def note_anchor_history(
+        self, note_id: str
+    ) -> tuple[ResearchAnchorHistoryEntry, ...]: ...
+
+
+@runtime_checkable
 class ResearchStateStore(Protocol):
     """Authoritative durable store for user-authored research knowledge."""
 
@@ -139,18 +156,6 @@ class ResearchStateStore(Protocol):
         collections: tuple[str, ...],
         expected_updated_at: str | None = None,
     ) -> ResearchNote: ...
-
-    def reanchor_note(
-        self,
-        note_id: str,
-        anchor: EvidenceAnchor,
-        *,
-        expected_updated_at: str | None = None,
-    ) -> ResearchNote: ...
-
-    def note_anchor_history(
-        self, note_id: str
-    ) -> tuple[ResearchAnchorHistoryEntry, ...]: ...
 
     def delete_note(
         self, note_id: str, *, expected_updated_at: str | None = None

--- a/src/echoflow/library/research_state.py
+++ b/src/echoflow/library/research_state.py
@@ -34,6 +34,24 @@ class ResearchNote:
 
 
 @dataclass(frozen=True, slots=True)
+class ResearchAnchorHistoryEntry:
+    """One superseded note anchor retained as authoritative provenance."""
+
+    note_id: str
+    revision: int
+    anchor: EvidenceAnchor
+    replaced_at: str
+
+    def __post_init__(self) -> None:
+        if not self.note_id.strip():
+            raise ValueError("anchor history note_id cannot be empty")
+        if self.revision < 1:
+            raise ValueError("anchor history revision must be positive")
+        if not self.replaced_at.strip():
+            raise ValueError("anchor history replacement time cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
 class ResearchTag:
     tag_id: str
     name: str
@@ -121,6 +139,18 @@ class ResearchStateStore(Protocol):
         collections: tuple[str, ...],
         expected_updated_at: str | None = None,
     ) -> ResearchNote: ...
+
+    def reanchor_note(
+        self,
+        note_id: str,
+        anchor: EvidenceAnchor,
+        *,
+        expected_updated_at: str | None = None,
+    ) -> ResearchNote: ...
+
+    def note_anchor_history(
+        self, note_id: str
+    ) -> tuple[ResearchAnchorHistoryEntry, ...]: ...
 
     def delete_note(
         self, note_id: str, *, expected_updated_at: str | None = None

--- a/src/echoflow/library/sqlite_research_anchor_state.py
+++ b/src/echoflow/library/sqlite_research_anchor_state.py
@@ -37,9 +37,7 @@ class SqliteResearchAnchorStateStore:
         expected_updated_at: str,
     ) -> None:
         resolved_id = self._validate_id(note_id, "note_id")
-        expected_version = self._validate_id(
-            expected_updated_at, "expected_updated_at"
-        )
+        expected_version = self._validate_id(expected_updated_at, "expected_updated_at")
         with self._connection() as connection:
             connection.execute("BEGIN IMMEDIATE")
             row = connection.execute(
@@ -81,7 +79,9 @@ class SqliteResearchAnchorStateStore:
                 (resolved_id,),
             ).fetchone()
             if revision_row is None:
-                raise ResearchStateError("Research anchor history could not be advanced")
+                raise ResearchStateError(
+                    "Research anchor history could not be advanced"
+                )
             revision = int(revision_row[0])
             replaced_at = self._now()
             connection.execute(

--- a/src/echoflow/library/sqlite_research_anchor_state.py
+++ b/src/echoflow/library/sqlite_research_anchor_state.py
@@ -206,12 +206,14 @@ class SqliteResearchAnchorStateStore:
 
     def _initialize_extension(self) -> None:
         with self._connection() as connection:
-            connection.execute("BEGIN IMMEDIATE")
             core = connection.execute(
                 "SELECT schema_version FROM metadata WHERE singleton = 1"
             ).fetchone()
             if core is None:
                 raise ResearchStateError("Research state metadata is missing")
+            # executescript() owns its DDL transaction behavior in sqlite3. Keep the
+            # idempotent table creation separate from the version-row transaction rather
+            # than pretending an earlier BEGIN survives executescript's commit boundary.
             connection.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS anchor_history_metadata (
@@ -246,6 +248,7 @@ class SqliteResearchAnchorStateStore:
                     ON note_anchor_history(note_id, canonical_sha256);
                 """
             )
+            connection.execute("BEGIN IMMEDIATE")
             connection.execute(
                 """
                 INSERT OR IGNORE INTO anchor_history_metadata
@@ -258,7 +261,7 @@ class SqliteResearchAnchorStateStore:
                 """
                 SELECT schema_version FROM anchor_history_metadata
                 WHERE singleton = 1
-                """
+                """,
             ).fetchone()
             if row is None or int(row[0]) != _EXTENSION_SCHEMA_VERSION:
                 raise ResearchStateError(

--- a/src/echoflow/library/sqlite_research_anchor_state.py
+++ b/src/echoflow/library/sqlite_research_anchor_state.py
@@ -1,0 +1,341 @@
+"""Same-database durable history for deliberate research-note re-anchoring."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+from echoflow.library.errors import ResearchStateError
+from echoflow.library.evidence import EvidenceAnchor
+from echoflow.library.research_state import ResearchAnchorHistoryEntry
+
+_EXTENSION_SCHEMA_VERSION = 1
+_MAX_ID_CHARS = 200
+
+
+class SqliteResearchAnchorStateStore:
+    """Maintain note anchors in the authoritative research SQLite transaction boundary.
+
+    This adapter deliberately shares the existing research SQLite file. Re-anchoring one
+    note, preserving its prior anchor, replacing current segment relationships, and
+    advancing the projection journal therefore commit or roll back together.
+    """
+
+    def __init__(self, database_path: Path) -> None:
+        self.database_path = database_path.expanduser().resolve(strict=False)
+        self._initialize_extension()
+
+    def reanchor_note(
+        self,
+        note_id: str,
+        anchor: EvidenceAnchor,
+        *,
+        expected_updated_at: str,
+    ) -> None:
+        resolved_id = self._validate_id(note_id, "note_id")
+        expected_version = self._validate_id(
+            expected_updated_at, "expected_updated_at"
+        )
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """
+                SELECT document_id, canonical_sha256, source_sha256, canonical_path,
+                       source_path, start_seconds, end_seconds, updated_at
+                FROM notes WHERE note_id = ?
+                """,
+                (resolved_id,),
+            ).fetchone()
+            if row is None:
+                raise ResearchStateError("Research note does not exist")
+            if str(row[7]) != expected_version:
+                raise ResearchStateError(
+                    "Research note changed since its evidence was reviewed; refresh before re-anchoring"
+                )
+
+            old_anchor = self._anchor_from_note_row(
+                connection,
+                resolved_id,
+                row,
+            )
+            if anchor.document_id != old_anchor.document_id:
+                raise ResearchStateError(
+                    "Re-anchoring cannot move a note to a different transcript"
+                )
+            if anchor.source_sha256 != old_anchor.source_sha256:
+                raise ResearchStateError(
+                    "Re-anchoring cannot move a note to different source evidence"
+                )
+            if anchor == old_anchor:
+                raise ResearchStateError("Research note already cites that evidence")
+
+            revision_row = connection.execute(
+                """
+                SELECT COALESCE(MAX(revision), 0) + 1
+                FROM note_anchor_history WHERE note_id = ?
+                """,
+                (resolved_id,),
+            ).fetchone()
+            if revision_row is None:
+                raise ResearchStateError("Research anchor history could not be advanced")
+            revision = int(revision_row[0])
+            replaced_at = self._now()
+            connection.execute(
+                """
+                INSERT INTO note_anchor_history (
+                    note_id, revision, document_id, canonical_sha256, source_sha256,
+                    canonical_path, source_path, start_seconds, end_seconds, replaced_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    resolved_id,
+                    revision,
+                    old_anchor.document_id,
+                    old_anchor.canonical_sha256,
+                    old_anchor.source_sha256,
+                    old_anchor.canonical_path,
+                    old_anchor.source_path,
+                    old_anchor.start_seconds,
+                    old_anchor.end_seconds,
+                    replaced_at,
+                ),
+            )
+            connection.executemany(
+                """
+                INSERT INTO note_anchor_history_segments (
+                    note_id, revision, ordinal, segment_id
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (
+                    (resolved_id, revision, ordinal, segment_id)
+                    for ordinal, segment_id in enumerate(old_anchor.segment_ids)
+                ),
+            )
+
+            connection.execute(
+                """
+                UPDATE notes
+                SET document_id = ?, canonical_sha256 = ?, source_sha256 = ?,
+                    canonical_path = ?, source_path = ?, start_seconds = ?,
+                    end_seconds = ?, updated_at = ?
+                WHERE note_id = ?
+                """,
+                (
+                    anchor.document_id,
+                    anchor.canonical_sha256,
+                    anchor.source_sha256,
+                    anchor.canonical_path,
+                    anchor.source_path,
+                    anchor.start_seconds,
+                    anchor.end_seconds,
+                    replaced_at,
+                    resolved_id,
+                ),
+            )
+            connection.execute(
+                "DELETE FROM note_segments WHERE note_id = ?", (resolved_id,)
+            )
+            connection.executemany(
+                """
+                INSERT INTO note_segments (note_id, ordinal, segment_id)
+                VALUES (?, ?, ?)
+                """,
+                (
+                    (resolved_id, ordinal, segment_id)
+                    for ordinal, segment_id in enumerate(anchor.segment_ids)
+                ),
+            )
+            self._journal(connection, resolved_id)
+            connection.commit()
+
+    def note_anchor_history(
+        self, note_id: str
+    ) -> tuple[ResearchAnchorHistoryEntry, ...]:
+        resolved_id = self._validate_id(note_id, "note_id")
+        with self._connection() as connection:
+            exists = connection.execute(
+                "SELECT 1 FROM notes WHERE note_id = ?", (resolved_id,)
+            ).fetchone()
+            if exists is None:
+                raise ResearchStateError("Research note does not exist")
+            rows = connection.execute(
+                """
+                SELECT revision, document_id, canonical_sha256, source_sha256,
+                       canonical_path, source_path, start_seconds, end_seconds,
+                       replaced_at
+                FROM note_anchor_history
+                WHERE note_id = ?
+                ORDER BY revision DESC
+                """,
+                (resolved_id,),
+            ).fetchall()
+            entries: list[ResearchAnchorHistoryEntry] = []
+            for row in rows:
+                revision = int(row[0])
+                segment_rows = connection.execute(
+                    """
+                    SELECT segment_id FROM note_anchor_history_segments
+                    WHERE note_id = ? AND revision = ?
+                    ORDER BY ordinal
+                    """,
+                    (resolved_id, revision),
+                ).fetchall()
+                anchor = EvidenceAnchor(
+                    document_id=str(row[1]),
+                    canonical_sha256=str(row[2]),
+                    source_sha256=str(row[3]),
+                    canonical_path=str(row[4]),
+                    source_path=None if row[5] is None else str(row[5]),
+                    segment_ids=tuple(str(item[0]) for item in segment_rows),
+                    start_seconds=float(cast("float | int", row[6])),
+                    end_seconds=float(cast("float | int", row[7])),
+                )
+                entries.append(
+                    ResearchAnchorHistoryEntry(
+                        note_id=resolved_id,
+                        revision=revision,
+                        anchor=anchor,
+                        replaced_at=str(row[8]),
+                    )
+                )
+            return tuple(entries)
+
+    def _initialize_extension(self) -> None:
+        with self._connection() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            core = connection.execute(
+                "SELECT schema_version FROM metadata WHERE singleton = 1"
+            ).fetchone()
+            if core is None:
+                raise ResearchStateError("Research state metadata is missing")
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS anchor_history_metadata (
+                    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                    schema_version INTEGER NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS note_anchor_history (
+                    note_id TEXT NOT NULL REFERENCES notes(note_id) ON DELETE CASCADE,
+                    revision INTEGER NOT NULL,
+                    document_id TEXT NOT NULL,
+                    canonical_sha256 TEXT NOT NULL,
+                    source_sha256 TEXT NOT NULL,
+                    canonical_path TEXT NOT NULL,
+                    source_path TEXT,
+                    start_seconds REAL NOT NULL,
+                    end_seconds REAL NOT NULL,
+                    replaced_at TEXT NOT NULL,
+                    PRIMARY KEY (note_id, revision)
+                );
+                CREATE TABLE IF NOT EXISTS note_anchor_history_segments (
+                    note_id TEXT NOT NULL,
+                    revision INTEGER NOT NULL,
+                    ordinal INTEGER NOT NULL,
+                    segment_id TEXT NOT NULL,
+                    PRIMARY KEY (note_id, revision, ordinal),
+                    UNIQUE (note_id, revision, segment_id),
+                    FOREIGN KEY (note_id, revision)
+                        REFERENCES note_anchor_history(note_id, revision)
+                        ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS note_anchor_history_generation_idx
+                    ON note_anchor_history(note_id, canonical_sha256);
+                """
+            )
+            connection.execute(
+                """
+                INSERT OR IGNORE INTO anchor_history_metadata
+                    (singleton, schema_version)
+                VALUES (1, ?)
+                """,
+                (_EXTENSION_SCHEMA_VERSION,),
+            )
+            row = connection.execute(
+                """
+                SELECT schema_version FROM anchor_history_metadata
+                WHERE singleton = 1
+                """
+            ).fetchone()
+            if row is None or int(row[0]) != _EXTENSION_SCHEMA_VERSION:
+                raise ResearchStateError(
+                    "Research anchor-history schema is unsupported by this EchoFlow build"
+                )
+            connection.commit()
+
+    @staticmethod
+    def _anchor_from_note_row(
+        connection: sqlite3.Connection,
+        note_id: str,
+        row: tuple[object, ...],
+    ) -> EvidenceAnchor:
+        segment_rows = connection.execute(
+            """
+            SELECT segment_id FROM note_segments
+            WHERE note_id = ? ORDER BY ordinal
+            """,
+            (note_id,),
+        ).fetchall()
+        return EvidenceAnchor(
+            document_id=str(row[0]),
+            canonical_sha256=str(row[1]),
+            source_sha256=str(row[2]),
+            canonical_path=str(row[3]),
+            source_path=None if row[4] is None else str(row[4]),
+            segment_ids=tuple(str(item[0]) for item in segment_rows),
+            start_seconds=float(cast("float | int", row[5])),
+            end_seconds=float(cast("float | int", row[6])),
+        )
+
+    @staticmethod
+    def _journal(connection: sqlite3.Connection, note_id: str) -> int:
+        connection.execute(
+            "UPDATE metadata SET current_sequence = current_sequence + 1 WHERE singleton = 1"
+        )
+        row = connection.execute(
+            "SELECT current_sequence FROM metadata WHERE singleton = 1"
+        ).fetchone()
+        if row is None:
+            raise ResearchStateError("Research state metadata is missing")
+        sequence_id = int(row[0])
+        connection.execute(
+            "INSERT INTO changes (sequence_id, note_id) VALUES (?, ?)",
+            (sequence_id, note_id),
+        )
+        return sequence_id
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        connection: sqlite3.Connection | None = None
+        try:
+            connection = sqlite3.connect(self.database_path, timeout=5.0)
+            connection.execute("PRAGMA foreign_keys = ON")
+            connection.execute("PRAGMA busy_timeout = 5000")
+            connection.execute("PRAGMA synchronous = FULL")
+            yield connection
+        except sqlite3.Error as exc:
+            if connection is not None:
+                connection.rollback()
+            raise ResearchStateError(
+                "Research anchor database operation failed", cause=exc
+            ) from exc
+        finally:
+            if connection is not None:
+                connection.close()
+
+    @staticmethod
+    def _validate_id(value: str, name: str) -> str:
+        if not value.strip():
+            raise ValueError(f"{name} cannot be blank")
+        if len(value) > _MAX_ID_CHARS:
+            raise ValueError(f"{name} is too long")
+        if any(character in value for character in ("\r", "\n", "\x00")):
+            raise ValueError(f"{name} contains unsupported control characters")
+        return value
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(UTC).isoformat(timespec="microseconds")

--- a/src/echoflow/library/tests/test_research_anchor_review.py
+++ b/src/echoflow/library/tests/test_research_anchor_review.py
@@ -1,0 +1,254 @@
+from unittest.mock import Mock
+
+import pytest
+
+from echoflow.library.errors import EvidenceNavigationError, ResearchStateError
+from echoflow.library.evidence import EvidenceAnchor, EvidenceContextSegment, EvidenceLocation
+from echoflow.library.index import IndexedDocument, IndexedSegment, IndexedTranscript
+from echoflow.library.research import LocatedCanonicalEvidence
+from echoflow.library.research_anchor_review import (
+    ResearchAnchorReviewService,
+    ResearchAnchorStatus,
+)
+from echoflow.library.research_state import ResearchAnchorStateStore, ResearchNote
+from echoflow.library.research_workspace import ResearchNoteView
+
+
+def _anchor(*, canonical_digit: str = "b", segment_id: str = "old-1") -> EvidenceAnchor:
+    return EvidenceAnchor(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256=canonical_digit * 64,
+        canonical_path=f"/private/{canonical_digit}.json",
+        source_path="/private/source.wav",
+        segment_ids=(segment_id,),
+        start_seconds=2.1,
+        end_seconds=2.9,
+    )
+
+
+def _note_view(*, current: bool = False, canonical_digit: str = "b") -> ResearchNoteView:
+    return ResearchNoteView(
+        note=ResearchNote(
+            note_id="note-1",
+            body="Interpretation",
+            anchor=_anchor(canonical_digit=canonical_digit),
+            tag_ids=(),
+            collection_ids=(),
+            created_at="2026-08-20T08:00:00+00:00",
+            updated_at="2026-08-20T08:00:00+00:00",
+        ),
+        current=current,
+        tags=(),
+        collections=(),
+    )
+
+
+def _document(*, source_digit: str = "a") -> IndexedDocument:
+    return IndexedDocument(
+        document_id="job-1",
+        source_sha256=source_digit * 64,
+        canonical_sha256="c" * 64,
+        detected_language="en",
+        canonical_path="/private/c.json",
+        source_path="/private/source.wav",
+        segment_count=2,
+    )
+
+
+def _indexed() -> IndexedTranscript:
+    return IndexedTranscript(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256="c" * 64,
+        transcript_schema_version=1,
+        detected_language="en",
+        canonical_path="/private/c.json",
+        source_path="/private/source.wav",
+        source_size_bytes=100,
+        source_modified_ns=1,
+        canonical_size_bytes=100,
+        canonical_modified_ns=1,
+        segments=(
+            IndexedSegment("current-1", 2.0, 2.5, "Current first half"),
+            IndexedSegment("current-2", 2.5, 3.0, "Current second half"),
+        ),
+    )
+
+
+def _located(anchor: EvidenceAnchor, text: str) -> LocatedCanonicalEvidence:
+    return LocatedCanonicalEvidence(
+        evidence=EvidenceLocation(
+            document_id=anchor.document_id,
+            source_sha256=anchor.source_sha256,
+            canonical_sha256=anchor.canonical_sha256,
+            canonical_path=anchor.canonical_path,
+            source_path=anchor.source_path,
+            result_segment_ids=anchor.segment_ids,
+            start_seconds=anchor.start_seconds,
+            end_seconds=anchor.end_seconds,
+            seek_seconds=anchor.start_seconds,
+            result_speaker_refs=(),
+            matched_words=(),
+            context_segments=(
+                EvidenceContextSegment(
+                    segment_id=anchor.segment_ids[0],
+                    start_seconds=anchor.start_seconds,
+                    end_seconds=anchor.end_seconds,
+                    text=text,
+                    speaker_refs=(),
+                    words=(),
+                    is_result_segment=True,
+                    lexical_match=False,
+                ),
+            ),
+        ),
+        speakers=(),
+    )
+
+
+def _service(monkeypatch: pytest.MonkeyPatch) -> tuple[ResearchAnchorReviewService, Mock, Mock]:
+    workspace = Mock()
+    workspace.note.return_value = _note_view()
+    workspace.transcript_library.documents.return_value = (_document(),)
+    workspace.transcript_library.file_manager = Mock()
+    candidate = EvidenceAnchor(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256="c" * 64,
+        canonical_path="/private/c.json",
+        source_path="/private/source.wav",
+        segment_ids=("current-1", "current-2"),
+        start_seconds=2.1,
+        end_seconds=2.9,
+    )
+    workspace.evidence_locator.resolve_anchor.return_value = candidate
+    workspace.navigation.locate_anchor.side_effect = lambda anchor, **_: _located(
+        anchor, "Old evidence" if anchor.canonical_sha256.startswith("b") else "Current evidence"
+    )
+    workspace.logger = Mock()
+    anchor_state = Mock(spec=ResearchAnchorStateStore)
+    anchor_state.note_anchor_history.return_value = ()
+    monkeypatch.setattr(
+        "echoflow.library.research_anchor_review.load_indexed_transcript",
+        lambda *args, **kwargs: _indexed(),
+    )
+    return ResearchAnchorReviewService(workspace, anchor_state), workspace, anchor_state
+
+
+def test_review_distinguishes_verified_older_evidence_and_previews_current_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, workspace, _ = _service(monkeypatch)
+
+    review = service.review("note-1", context_segments=2)
+
+    assert review.status is ResearchAnchorStatus.OLDER_VERIFIED
+    assert review.anchored is not None
+    assert review.anchored.evidence.canonical_sha256 == "b" * 64
+    assert review.candidate is not None
+    assert review.candidate.evidence.canonical_sha256 == "c" * 64
+    workspace.evidence_locator.resolve_anchor.assert_called_once()
+    assert workspace.navigation.locate_anchor.call_count == 2
+
+
+def test_review_can_report_unavailable_stored_anchor_without_hiding_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, workspace, _ = _service(monkeypatch)
+
+    def locate(anchor: EvidenceAnchor, **_: object) -> LocatedCanonicalEvidence:
+        if anchor.canonical_sha256 == "b" * 64:
+            raise EvidenceNavigationError("Stored generation missing")
+        return _located(anchor, "Current evidence")
+
+    workspace.navigation.locate_anchor.side_effect = locate
+
+    review = service.review("note-1")
+
+    assert review.status is ResearchAnchorStatus.UNAVAILABLE
+    assert review.anchored is None
+    assert review.candidate is not None
+
+
+def test_review_current_verified_anchor_never_fabricates_reanchor_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, workspace, _ = _service(monkeypatch)
+    current = _note_view(current=True, canonical_digit="c")
+    workspace.note.return_value = current
+    workspace.navigation.locate_anchor.side_effect = None
+    workspace.navigation.locate_anchor.return_value = _located(current.note.anchor, "Current")
+
+    review = service.review("note-1")
+
+    assert review.status is ResearchAnchorStatus.CURRENT_VERIFIED
+    assert review.candidate is None
+    workspace.evidence_locator.resolve_anchor.assert_not_called()
+
+
+def test_reanchor_binds_confirmation_to_candidate_sha_and_reloads_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, workspace, anchor_state = _service(monkeypatch)
+    original = workspace.note.return_value
+    current = _note_view(current=True, canonical_digit="c")
+
+    def mutate(*_: object, **__: object) -> None:
+        workspace.note.return_value = current
+
+    anchor_state.reanchor_note.side_effect = mutate
+
+    updated = service.reanchor_to_reviewed_current(
+        "note-1",
+        expected_updated_at=original.note.updated_at,
+        expected_candidate_sha256="c" * 64,
+    )
+
+    assert updated == current
+    anchor_state.reanchor_note.assert_called_once()
+    call = anchor_state.reanchor_note.call_args
+    assert call.args[0] == "note-1"
+    assert call.args[1].canonical_sha256 == "c" * 64
+    assert call.kwargs["expected_updated_at"] == original.note.updated_at
+
+
+def test_reanchor_rejects_changed_candidate_and_current_note(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, workspace, anchor_state = _service(monkeypatch)
+
+    with pytest.raises(ResearchStateError, match="changed since the candidate was reviewed"):
+        service.reanchor_to_reviewed_current(
+            "note-1",
+            expected_updated_at="2026-08-20T08:00:00+00:00",
+            expected_candidate_sha256="d" * 64,
+        )
+    anchor_state.reanchor_note.assert_not_called()
+
+    workspace.note.return_value = _note_view(current=True, canonical_digit="c")
+    with pytest.raises(ResearchStateError, match="already cites current"):
+        service.reanchor_to_reviewed_current(
+            "note-1",
+            expected_updated_at="2026-08-20T08:00:00+00:00",
+            expected_candidate_sha256="c" * 64,
+        )
+
+
+def test_candidate_requires_same_source_and_time_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, workspace, _ = _service(monkeypatch)
+    workspace.transcript_library.documents.return_value = (_document(source_digit="f"),)
+    assert service._candidate_anchor(_note_view().note) is None
+
+    segments = _indexed().segments
+    assert [item.segment_id for item in service._segments_for_time(segments, start_seconds=2.1, end_seconds=2.9)] == [
+        "current-1",
+        "current-2",
+    ]
+    assert [item.segment_id for item in service._segments_for_time(segments, start_seconds=2.5, end_seconds=2.5)] == [
+        "current-1",
+        "current-2",
+    ]
+    assert service._segments_for_time(segments, start_seconds=4.0, end_seconds=5.0) == ()

--- a/src/echoflow/library/tests/test_research_anchor_review.py
+++ b/src/echoflow/library/tests/test_research_anchor_review.py
@@ -3,7 +3,11 @@ from unittest.mock import Mock
 import pytest
 
 from echoflow.library.errors import EvidenceNavigationError, ResearchStateError
-from echoflow.library.evidence import EvidenceAnchor, EvidenceContextSegment, EvidenceLocation
+from echoflow.library.evidence import (
+    EvidenceAnchor,
+    EvidenceContextSegment,
+    EvidenceLocation,
+)
 from echoflow.library.index import IndexedDocument, IndexedSegment, IndexedTranscript
 from echoflow.library.research_anchor_review import (
     ResearchAnchorReviewService,

--- a/src/echoflow/library/tests/test_research_anchor_review.py
+++ b/src/echoflow/library/tests/test_research_anchor_review.py
@@ -30,7 +30,9 @@ def _anchor(*, canonical_digit: str = "b", segment_id: str = "old-1") -> Evidenc
     )
 
 
-def _note_view(*, current: bool = False, canonical_digit: str = "b") -> ResearchNoteView:
+def _note_view(
+    *, current: bool = False, canonical_digit: str = "b"
+) -> ResearchNoteView:
     return ResearchNoteView(
         note=ResearchNote(
             note_id="note-1",
@@ -125,11 +127,13 @@ def _service(
         end_seconds=2.9,
     )
     workspace.evidence_locator.resolve_anchor.return_value = candidate
-    workspace.evidence_locator.locate_anchor.side_effect = lambda anchor, **_: _evidence(
-        anchor,
-        "Old evidence"
-        if anchor.canonical_sha256.startswith("b")
-        else "Current evidence",
+    workspace.evidence_locator.locate_anchor.side_effect = lambda anchor, **_: (
+        _evidence(
+            anchor,
+            "Old evidence"
+            if anchor.canonical_sha256.startswith("b")
+            else "Current evidence",
+        )
     )
     workspace.logger = Mock()
     anchor_state = Mock(spec=ResearchAnchorStateStore)

--- a/src/echoflow/library/tests/test_research_anchor_review.py
+++ b/src/echoflow/library/tests/test_research_anchor_review.py
@@ -5,7 +5,6 @@ import pytest
 from echoflow.library.errors import EvidenceNavigationError, ResearchStateError
 from echoflow.library.evidence import EvidenceAnchor, EvidenceContextSegment, EvidenceLocation
 from echoflow.library.index import IndexedDocument, IndexedSegment, IndexedTranscript
-from echoflow.library.research import LocatedCanonicalEvidence
 from echoflow.library.research_anchor_review import (
     ResearchAnchorReviewService,
     ResearchAnchorStatus,
@@ -76,38 +75,37 @@ def _indexed() -> IndexedTranscript:
     )
 
 
-def _located(anchor: EvidenceAnchor, text: str) -> LocatedCanonicalEvidence:
-    return LocatedCanonicalEvidence(
-        evidence=EvidenceLocation(
-            document_id=anchor.document_id,
-            source_sha256=anchor.source_sha256,
-            canonical_sha256=anchor.canonical_sha256,
-            canonical_path=anchor.canonical_path,
-            source_path=anchor.source_path,
-            result_segment_ids=anchor.segment_ids,
-            start_seconds=anchor.start_seconds,
-            end_seconds=anchor.end_seconds,
-            seek_seconds=anchor.start_seconds,
-            result_speaker_refs=(),
-            matched_words=(),
-            context_segments=(
-                EvidenceContextSegment(
-                    segment_id=anchor.segment_ids[0],
-                    start_seconds=anchor.start_seconds,
-                    end_seconds=anchor.end_seconds,
-                    text=text,
-                    speaker_refs=(),
-                    words=(),
-                    is_result_segment=True,
-                    lexical_match=False,
-                ),
+def _evidence(anchor: EvidenceAnchor, text: str) -> EvidenceLocation:
+    return EvidenceLocation(
+        document_id=anchor.document_id,
+        source_sha256=anchor.source_sha256,
+        canonical_sha256=anchor.canonical_sha256,
+        canonical_path=anchor.canonical_path,
+        source_path=anchor.source_path,
+        result_segment_ids=anchor.segment_ids,
+        start_seconds=anchor.start_seconds,
+        end_seconds=anchor.end_seconds,
+        seek_seconds=anchor.start_seconds,
+        result_speaker_refs=(),
+        matched_words=(),
+        context_segments=(
+            EvidenceContextSegment(
+                segment_id=anchor.segment_ids[0],
+                start_seconds=anchor.start_seconds,
+                end_seconds=anchor.end_seconds,
+                text=text,
+                speaker_refs=(),
+                words=(),
+                is_result_segment=True,
+                lexical_match=False,
             ),
         ),
-        speakers=(),
     )
 
 
-def _service(monkeypatch: pytest.MonkeyPatch) -> tuple[ResearchAnchorReviewService, Mock, Mock]:
+def _service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[ResearchAnchorReviewService, Mock, Mock]:
     workspace = Mock()
     workspace.note.return_value = _note_view()
     workspace.transcript_library.documents.return_value = (_document(),)
@@ -123,8 +121,11 @@ def _service(monkeypatch: pytest.MonkeyPatch) -> tuple[ResearchAnchorReviewServi
         end_seconds=2.9,
     )
     workspace.evidence_locator.resolve_anchor.return_value = candidate
-    workspace.navigation.locate_anchor.side_effect = lambda anchor, **_: _located(
-        anchor, "Old evidence" if anchor.canonical_sha256.startswith("b") else "Current evidence"
+    workspace.evidence_locator.locate_anchor.side_effect = lambda anchor, **_: _evidence(
+        anchor,
+        "Old evidence"
+        if anchor.canonical_sha256.startswith("b")
+        else "Current evidence",
     )
     workspace.logger = Mock()
     anchor_state = Mock(spec=ResearchAnchorStateStore)
@@ -149,7 +150,7 @@ def test_review_distinguishes_verified_older_evidence_and_previews_current_candi
     assert review.candidate is not None
     assert review.candidate.evidence.canonical_sha256 == "c" * 64
     workspace.evidence_locator.resolve_anchor.assert_called_once()
-    assert workspace.navigation.locate_anchor.call_count == 2
+    assert workspace.evidence_locator.locate_anchor.call_count == 2
 
 
 def test_review_can_report_unavailable_stored_anchor_without_hiding_candidate(
@@ -157,12 +158,12 @@ def test_review_can_report_unavailable_stored_anchor_without_hiding_candidate(
 ) -> None:
     service, workspace, _ = _service(monkeypatch)
 
-    def locate(anchor: EvidenceAnchor, **_: object) -> LocatedCanonicalEvidence:
+    def locate(anchor: EvidenceAnchor, **_: object) -> EvidenceLocation:
         if anchor.canonical_sha256 == "b" * 64:
             raise EvidenceNavigationError("Stored generation missing")
-        return _located(anchor, "Current evidence")
+        return _evidence(anchor, "Current evidence")
 
-    workspace.navigation.locate_anchor.side_effect = locate
+    workspace.evidence_locator.locate_anchor.side_effect = locate
 
     review = service.review("note-1")
 
@@ -177,8 +178,10 @@ def test_review_current_verified_anchor_never_fabricates_reanchor_candidate(
     service, workspace, _ = _service(monkeypatch)
     current = _note_view(current=True, canonical_digit="c")
     workspace.note.return_value = current
-    workspace.navigation.locate_anchor.side_effect = None
-    workspace.navigation.locate_anchor.return_value = _located(current.note.anchor, "Current")
+    workspace.evidence_locator.locate_anchor.side_effect = None
+    workspace.evidence_locator.locate_anchor.return_value = _evidence(
+        current.note.anchor, "Current"
+    )
 
     review = service.review("note-1")
 
@@ -218,7 +221,10 @@ def test_reanchor_rejects_changed_candidate_and_current_note(
 ) -> None:
     service, workspace, anchor_state = _service(monkeypatch)
 
-    with pytest.raises(ResearchStateError, match="changed since the candidate was reviewed"):
+    with pytest.raises(
+        ResearchStateError,
+        match="changed since the candidate was reviewed",
+    ):
         service.reanchor_to_reviewed_current(
             "note-1",
             expected_updated_at="2026-08-20T08:00:00+00:00",
@@ -243,12 +249,27 @@ def test_candidate_requires_same_source_and_time_overlap(
     assert service._candidate_anchor(_note_view().note) is None
 
     segments = _indexed().segments
-    assert [item.segment_id for item in service._segments_for_time(segments, start_seconds=2.1, end_seconds=2.9)] == [
-        "current-1",
-        "current-2",
-    ]
-    assert [item.segment_id for item in service._segments_for_time(segments, start_seconds=2.5, end_seconds=2.5)] == [
-        "current-1",
-        "current-2",
-    ]
-    assert service._segments_for_time(segments, start_seconds=4.0, end_seconds=5.0) == ()
+    assert [
+        item.segment_id
+        for item in service._segments_for_time(
+            segments,
+            start_seconds=2.1,
+            end_seconds=2.9,
+        )
+    ] == ["current-1", "current-2"]
+    assert [
+        item.segment_id
+        for item in service._segments_for_time(
+            segments,
+            start_seconds=2.5,
+            end_seconds=2.5,
+        )
+    ] == ["current-1", "current-2"]
+    assert (
+        service._segments_for_time(
+            segments,
+            start_seconds=4.0,
+            end_seconds=5.0,
+        )
+        == ()
+    )

--- a/src/echoflow/library/tests/test_research_anchor_safety_edges.py
+++ b/src/echoflow/library/tests/test_research_anchor_safety_edges.py
@@ -118,8 +118,8 @@ def _service() -> tuple[ResearchAnchorReviewService, Mock, Mock]:
     workspace.note.return_value = _note_view()
     workspace.transcript_library.documents.return_value = (_document(),)
     workspace.transcript_library.file_manager = Mock()
-    workspace.evidence_locator.locate_anchor.side_effect = lambda anchor, **_: _evidence(
-        anchor
+    workspace.evidence_locator.locate_anchor.side_effect = lambda anchor, **_: (
+        _evidence(anchor)
     )
     workspace.evidence_locator.resolve_anchor.return_value = EvidenceAnchor(
         document_id="job-1",
@@ -176,7 +176,9 @@ def test_reanchor_rejects_when_no_safe_candidate_exists() -> None:
     service, workspace, anchor_state = _service()
     workspace.transcript_library.documents.return_value = ()
 
-    with pytest.raises(ResearchStateError, match="No safe current-generation candidate"):
+    with pytest.raises(
+        ResearchStateError, match="No safe current-generation candidate"
+    ):
         service.reanchor_to_reviewed_current(
             "note-1",
             expected_updated_at=_note_view().note.updated_at,

--- a/src/echoflow/library/tests/test_research_anchor_safety_edges.py
+++ b/src/echoflow/library/tests/test_research_anchor_safety_edges.py
@@ -1,0 +1,261 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+
+from echoflow.library.errors import ResearchStateError, TranscriptProjectionError
+from echoflow.library.evidence import EvidenceAnchor, EvidenceContextSegment, EvidenceLocation
+from echoflow.library.index import IndexedDocument, IndexedSegment, IndexedTranscript
+from echoflow.library.research_anchor_review import (
+    ResearchAnchorReviewService,
+    ResearchAnchorStatus,
+)
+from echoflow.library.research_state import ResearchAnchorStateStore, ResearchNote
+from echoflow.library.research_workspace import ResearchNoteView
+
+
+def _anchor(*, canonical_digit: str = "b") -> EvidenceAnchor:
+    return EvidenceAnchor(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256=canonical_digit * 64,
+        canonical_path=f"/private/{canonical_digit}.json",
+        source_path="/private/source.wav",
+        segment_ids=("segment-1",),
+        start_seconds=2.1,
+        end_seconds=2.9,
+    )
+
+
+def _note_view(*, current: bool = False, canonical_digit: str = "b") -> ResearchNoteView:
+    note = ResearchNote(
+        note_id="note-1",
+        body="Interpretation",
+        anchor=_anchor(canonical_digit=canonical_digit),
+        tag_ids=(),
+        collection_ids=(),
+        created_at="2026-08-20T08:00:00+00:00",
+        updated_at="2026-08-20T08:00:00+00:00",
+    )
+    return ResearchNoteView(note=note, current=current, tags=(), collections=())
+
+
+def _document() -> IndexedDocument:
+    return IndexedDocument(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256="c" * 64,
+        detected_language="en",
+        canonical_path="/private/c.json",
+        source_path="/private/source.wav",
+        segment_count=1,
+    )
+
+
+def _indexed(
+    *,
+    document_id: str = "job-1",
+    canonical_digit: str = "c",
+    segments: tuple[IndexedSegment, ...] | None = None,
+) -> IndexedTranscript:
+    return IndexedTranscript(
+        document_id=document_id,
+        source_sha256="a" * 64,
+        canonical_sha256=canonical_digit * 64,
+        transcript_schema_version=1,
+        detected_language="en",
+        canonical_path="/private/c.json",
+        source_path="/private/source.wav",
+        source_size_bytes=100,
+        source_modified_ns=1,
+        canonical_size_bytes=100,
+        canonical_modified_ns=1,
+        segments=(
+            (IndexedSegment("current-1", 2.0, 3.0, "Current evidence"),)
+            if segments is None
+            else segments
+        ),
+    )
+
+
+def _evidence(anchor: EvidenceAnchor) -> EvidenceLocation:
+    return EvidenceLocation(
+        document_id=anchor.document_id,
+        source_sha256=anchor.source_sha256,
+        canonical_sha256=anchor.canonical_sha256,
+        canonical_path=anchor.canonical_path,
+        source_path=anchor.source_path,
+        result_segment_ids=anchor.segment_ids,
+        start_seconds=anchor.start_seconds,
+        end_seconds=anchor.end_seconds,
+        seek_seconds=anchor.start_seconds,
+        result_speaker_refs=(),
+        matched_words=(),
+        context_segments=(
+            EvidenceContextSegment(
+                segment_id=anchor.segment_ids[0],
+                start_seconds=anchor.start_seconds,
+                end_seconds=anchor.end_seconds,
+                text="Verified evidence",
+                speaker_refs=(),
+                words=(),
+                is_result_segment=True,
+                lexical_match=False,
+            ),
+        ),
+    )
+
+
+def _service() -> tuple[ResearchAnchorReviewService, Mock, Mock]:
+    workspace = Mock()
+    workspace.note.return_value = _note_view()
+    workspace.transcript_library.documents.return_value = (_document(),)
+    workspace.transcript_library.file_manager = Mock()
+    workspace.evidence_locator.locate_anchor.side_effect = lambda anchor, **_: _evidence(
+        anchor
+    )
+    workspace.evidence_locator.resolve_anchor.return_value = EvidenceAnchor(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        canonical_sha256="c" * 64,
+        canonical_path="/private/c.json",
+        source_path="/private/source.wav",
+        segment_ids=("current-1",),
+        start_seconds=2.1,
+        end_seconds=2.9,
+    )
+    workspace.logger = None
+    anchor_state = Mock(spec=ResearchAnchorStateStore)
+    anchor_state.note_anchor_history.return_value = ()
+    return ResearchAnchorReviewService(workspace, anchor_state), workspace, anchor_state
+
+
+def test_for_workspace_rejects_non_sqlite_research_state() -> None:
+    workspace = SimpleNamespace(state=SimpleNamespace())
+
+    with pytest.raises(ResearchStateError, match="maintenance is unavailable"):
+        ResearchAnchorReviewService.for_workspace(cast(Any, workspace))
+
+
+def test_review_and_reanchor_reject_a_note_that_no_longer_exists() -> None:
+    service, workspace, anchor_state = _service()
+    workspace.note.return_value = None
+
+    with pytest.raises(ResearchStateError, match="does not exist"):
+        service.review("note-missing")
+    with pytest.raises(ResearchStateError, match="does not exist"):
+        service.reanchor_to_reviewed_current(
+            "note-missing",
+            expected_updated_at="v1",
+            expected_candidate_sha256="c" * 64,
+        )
+
+    anchor_state.reanchor_note.assert_not_called()
+
+
+def test_review_keeps_older_anchor_when_no_current_document_exists() -> None:
+    service, workspace, _ = _service()
+    workspace.transcript_library.documents.return_value = ()
+
+    review = service.review("note-1")
+
+    assert review.status is ResearchAnchorStatus.OLDER_VERIFIED
+    assert review.anchored is not None
+    assert review.candidate is None
+    workspace.evidence_locator.resolve_anchor.assert_not_called()
+
+
+def test_reanchor_rejects_when_no_safe_candidate_exists() -> None:
+    service, workspace, anchor_state = _service()
+    workspace.transcript_library.documents.return_value = ()
+
+    with pytest.raises(ResearchStateError, match="No safe current-generation candidate"):
+        service.reanchor_to_reviewed_current(
+            "note-1",
+            expected_updated_at=_note_view().note.updated_at,
+            expected_candidate_sha256="c" * 64,
+        )
+
+    anchor_state.reanchor_note.assert_not_called()
+
+
+def test_reanchor_fails_closed_when_authoritative_write_cannot_be_read_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, workspace, anchor_state = _service()
+    candidate = workspace.evidence_locator.resolve_anchor.return_value
+    workspace.note.side_effect = [_note_view(), None]
+    monkeypatch.setattr(service, "_candidate_anchor", lambda note: candidate)
+
+    with pytest.raises(ResearchStateError, match="could not be read back"):
+        service.reanchor_to_reviewed_current(
+            "note-1",
+            expected_updated_at=_note_view().note.updated_at,
+            expected_candidate_sha256="c" * 64,
+        )
+
+    anchor_state.reanchor_note.assert_called_once()
+
+
+def test_reanchor_succeeds_without_operational_logger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, workspace, anchor_state = _service()
+    original = _note_view()
+    current = _note_view(current=True, canonical_digit="c")
+    candidate = workspace.evidence_locator.resolve_anchor.return_value
+    workspace.note.side_effect = [original, current]
+    workspace.logger = None
+    monkeypatch.setattr(service, "_candidate_anchor", lambda note: candidate)
+
+    assert (
+        service.reanchor_to_reviewed_current(
+            "note-1",
+            expected_updated_at=original.note.updated_at,
+            expected_candidate_sha256="c" * 64,
+        )
+        == current
+    )
+    anchor_state.note_anchor_history.assert_not_called()
+
+
+def test_candidate_rejects_changed_projection_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, _ = _service()
+    monkeypatch.setattr(
+        "echoflow.library.research_anchor_review.load_indexed_transcript",
+        lambda *args, **kwargs: _indexed(document_id="job-2"),
+    )
+
+    with pytest.raises(TranscriptProjectionError, match="changed while preparing"):
+        service._candidate_anchor(_note_view().note)
+
+
+def test_candidate_returns_none_when_current_generation_has_no_time_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, workspace, _ = _service()
+    monkeypatch.setattr(
+        "echoflow.library.research_anchor_review.load_indexed_transcript",
+        lambda *args, **kwargs: _indexed(
+            segments=(IndexedSegment("later", 10.0, 11.0, "Later evidence"),)
+        ),
+    )
+
+    assert service._candidate_anchor(_note_view().note) is None
+    workspace.evidence_locator.resolve_anchor.assert_not_called()
+
+
+def test_candidate_preview_converts_projection_failure_to_no_safe_preview(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, _ = _service()
+
+    def fail(_: ResearchNote) -> EvidenceAnchor | None:
+        raise TranscriptProjectionError("changed")
+
+    monkeypatch.setattr(service, "_candidate_anchor", fail)
+
+    assert service._candidate_evidence(_note_view().note, context_segments=1) is None

--- a/src/echoflow/library/tests/test_research_anchor_safety_edges.py
+++ b/src/echoflow/library/tests/test_research_anchor_safety_edges.py
@@ -5,7 +5,11 @@ from unittest.mock import Mock
 import pytest
 
 from echoflow.library.errors import ResearchStateError, TranscriptProjectionError
-from echoflow.library.evidence import EvidenceAnchor, EvidenceContextSegment, EvidenceLocation
+from echoflow.library.evidence import (
+    EvidenceAnchor,
+    EvidenceContextSegment,
+    EvidenceLocation,
+)
 from echoflow.library.index import IndexedDocument, IndexedSegment, IndexedTranscript
 from echoflow.library.research_anchor_review import (
     ResearchAnchorReviewService,
@@ -28,7 +32,9 @@ def _anchor(*, canonical_digit: str = "b") -> EvidenceAnchor:
     )
 
 
-def _note_view(*, current: bool = False, canonical_digit: str = "b") -> ResearchNoteView:
+def _note_view(
+    *, current: bool = False, canonical_digit: str = "b"
+) -> ResearchNoteView:
     note = ResearchNote(
         note_id="note-1",
         body="Interpretation",

--- a/src/echoflow/library/tests/test_research_anchor_state.py
+++ b/src/echoflow/library/tests/test_research_anchor_state.py
@@ -96,7 +96,9 @@ def test_reanchor_is_optimistic_and_rolls_back_history_on_stale_version(
     newer = state.update_note("note-1", "Changed elsewhere")
     anchor_state = SqliteResearchAnchorStateStore(state.database_path)
 
-    with pytest.raises(ResearchStateError, match="changed since its evidence was reviewed"):
+    with pytest.raises(
+        ResearchStateError, match="changed since its evidence was reviewed"
+    ):
         anchor_state.reanchor_note(
             "note-1",
             _anchor(canonical_digit="c"),
@@ -145,9 +147,7 @@ def test_reanchor_refuses_noop_and_retains_multiple_history_revisions(
         )
 
     first = _anchor(canonical_digit="c", segment_ids=("current-1",))
-    anchor_state.reanchor_note(
-        "note-1", first, expected_updated_at=original.updated_at
-    )
+    anchor_state.reanchor_note("note-1", first, expected_updated_at=original.updated_at)
     after_first = state.note("note-1")
     assert after_first is not None
     second = _anchor(canonical_digit="d", segment_ids=("current-2",))
@@ -181,9 +181,9 @@ def test_anchor_history_cascades_with_note_and_versions_its_extension(
         anchor_state.note_anchor_history("note-1")
 
     with sqlite3.connect(state.database_path) as connection:
-        assert connection.execute("SELECT COUNT(*) FROM note_anchor_history").fetchone() == (
-            0,
-        )
+        assert connection.execute(
+            "SELECT COUNT(*) FROM note_anchor_history"
+        ).fetchone() == (0,)
         connection.execute(
             "UPDATE anchor_history_metadata SET schema_version = 99 WHERE singleton = 1"
         )

--- a/src/echoflow/library/tests/test_research_anchor_state.py
+++ b/src/echoflow/library/tests/test_research_anchor_state.py
@@ -1,0 +1,193 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from echoflow.library.errors import ResearchStateError
+from echoflow.library.evidence import EvidenceAnchor
+from echoflow.library.sqlite_research_anchor_state import SqliteResearchAnchorStateStore
+from echoflow.library.sqlite_research_state import SqliteResearchStateStore
+
+
+class PrivateDirectoryStore:
+    def ensure_directory_exists(
+        self, directory_path: str | Path, *, private: bool = False
+    ) -> None:
+        assert private
+        Path(directory_path).mkdir(parents=True, exist_ok=True)
+
+
+def _anchor(
+    *,
+    document_id: str = "job-1",
+    source_digit: str = "a",
+    canonical_digit: str = "b",
+    segment_ids: tuple[str, ...] = ("segment-1",),
+    start_seconds: float = 2.0,
+    end_seconds: float = 3.0,
+) -> EvidenceAnchor:
+    return EvidenceAnchor(
+        document_id=document_id,
+        source_sha256=source_digit * 64,
+        canonical_sha256=canonical_digit * 64,
+        canonical_path=f"/private/{document_id}-{canonical_digit}.json",
+        source_path=f"/private/{document_id}.wav",
+        segment_ids=segment_ids,
+        start_seconds=start_seconds,
+        end_seconds=end_seconds,
+    )
+
+
+def _state(tmp_path: Path) -> SqliteResearchStateStore:
+    return SqliteResearchStateStore(
+        tmp_path / "state" / "research.sqlite3",
+        PrivateDirectoryStore(),  # type: ignore[arg-type]
+    )
+
+
+def test_reanchor_preserves_prior_anchor_and_advances_projection_once(
+    tmp_path: Path,
+) -> None:
+    state = _state(tmp_path)
+    original = state.create_note(
+        _anchor(),
+        "Interpretation",
+        tags=("review",),
+        collections=("Chapter 1",),
+        note_id="note-1",
+    )
+    anchor_state = SqliteResearchAnchorStateStore(state.database_path)
+    replacement = _anchor(
+        canonical_digit="c",
+        segment_ids=("segment-current-1", "segment-current-2"),
+        start_seconds=2.1,
+        end_seconds=3.2,
+    )
+
+    anchor_state.reanchor_note(
+        "note-1",
+        replacement,
+        expected_updated_at=original.updated_at,
+    )
+
+    updated = state.note("note-1")
+    assert updated is not None
+    assert updated.anchor == replacement
+    assert updated.body == original.body
+    assert updated.tag_ids == original.tag_ids
+    assert updated.collection_ids == original.collection_ids
+    assert updated.updated_at != original.updated_at
+    assert state.current_sequence() == 2
+    assert [change.sequence_id for change in state.changes_after(1, limit=10)] == [2]
+    assert state.projection_records(("note-1",))[0].anchor == replacement
+
+    history = anchor_state.note_anchor_history("note-1")
+    assert len(history) == 1
+    assert history[0].revision == 1
+    assert history[0].anchor == original.anchor
+    assert history[0].replaced_at == updated.updated_at
+
+
+def test_reanchor_is_optimistic_and_rolls_back_history_on_stale_version(
+    tmp_path: Path,
+) -> None:
+    state = _state(tmp_path)
+    original = state.create_note(_anchor(), "Interpretation", note_id="note-1")
+    newer = state.update_note("note-1", "Changed elsewhere")
+    anchor_state = SqliteResearchAnchorStateStore(state.database_path)
+
+    with pytest.raises(ResearchStateError, match="changed since its evidence was reviewed"):
+        anchor_state.reanchor_note(
+            "note-1",
+            _anchor(canonical_digit="c"),
+            expected_updated_at=original.updated_at,
+        )
+
+    assert state.note("note-1") == newer
+    assert state.current_sequence() == 2
+    assert anchor_state.note_anchor_history("note-1") == ()
+
+
+def test_reanchor_refuses_cross_document_or_cross_source_moves(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    original = state.create_note(_anchor(), "Interpretation", note_id="note-1")
+    anchor_state = SqliteResearchAnchorStateStore(state.database_path)
+
+    with pytest.raises(ResearchStateError, match="different transcript"):
+        anchor_state.reanchor_note(
+            "note-1",
+            _anchor(document_id="job-2", canonical_digit="c"),
+            expected_updated_at=original.updated_at,
+        )
+    with pytest.raises(ResearchStateError, match="different source evidence"):
+        anchor_state.reanchor_note(
+            "note-1",
+            _anchor(source_digit="f", canonical_digit="c"),
+            expected_updated_at=original.updated_at,
+        )
+
+    assert state.current_sequence() == 1
+    assert anchor_state.note_anchor_history("note-1") == ()
+
+
+def test_reanchor_refuses_noop_and_retains_multiple_history_revisions(
+    tmp_path: Path,
+) -> None:
+    state = _state(tmp_path)
+    original = state.create_note(_anchor(), "Interpretation", note_id="note-1")
+    anchor_state = SqliteResearchAnchorStateStore(state.database_path)
+
+    with pytest.raises(ResearchStateError, match="already cites"):
+        anchor_state.reanchor_note(
+            "note-1",
+            original.anchor,
+            expected_updated_at=original.updated_at,
+        )
+
+    first = _anchor(canonical_digit="c", segment_ids=("current-1",))
+    anchor_state.reanchor_note(
+        "note-1", first, expected_updated_at=original.updated_at
+    )
+    after_first = state.note("note-1")
+    assert after_first is not None
+    second = _anchor(canonical_digit="d", segment_ids=("current-2",))
+    anchor_state.reanchor_note(
+        "note-1", second, expected_updated_at=after_first.updated_at
+    )
+
+    history = anchor_state.note_anchor_history("note-1")
+    assert [entry.revision for entry in history] == [2, 1]
+    assert history[0].anchor == first
+    assert history[1].anchor == original.anchor
+    assert state.current_sequence() == 3
+
+
+def test_anchor_history_cascades_with_note_and_versions_its_extension(
+    tmp_path: Path,
+) -> None:
+    state = _state(tmp_path)
+    original = state.create_note(_anchor(), "Interpretation", note_id="note-1")
+    anchor_state = SqliteResearchAnchorStateStore(state.database_path)
+    anchor_state.reanchor_note(
+        "note-1",
+        _anchor(canonical_digit="c"),
+        expected_updated_at=original.updated_at,
+    )
+    current = state.note("note-1")
+    assert current is not None
+    state.delete_note("note-1", expected_updated_at=current.updated_at)
+
+    with pytest.raises(ResearchStateError, match="does not exist"):
+        anchor_state.note_anchor_history("note-1")
+
+    with sqlite3.connect(state.database_path) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM note_anchor_history").fetchone() == (
+            0,
+        )
+        connection.execute(
+            "UPDATE anchor_history_metadata SET schema_version = 99 WHERE singleton = 1"
+        )
+        connection.commit()
+
+    with pytest.raises(ResearchStateError, match="schema is unsupported"):
+        SqliteResearchAnchorStateStore(state.database_path)


### PR DESCRIPTION
## Summary

- add an explicit Research evidence-maintenance workflow that distinguishes current verified, older verified, and unavailable note anchors
- preview a current-generation candidate without mutating user research
- derive candidates only from the same document and exact recorded-source SHA using source-relative time plus the normal canonical evidence verifier
- require a second explicit re-anchor confirmation bound to both the note `updated_at` version and the reviewed candidate canonical SHA-256
- preserve every superseded anchor and its ordered segment identities as durable SQLite provenance before changing the note's current evidence pointer
- advance the normal research projection journal exactly once in the same authoritative transaction as the re-anchor
- never offer automatic or cross-recording re-anchoring
- keep raw canonical/source paths and source SHA out of React-facing review DTOs
- add Playwright + axe coverage and update Research/architecture/roadmap truth

## Custody model

Review is read-only. An older verified anchor remains valid historical evidence and may be kept indefinitely.

A successful re-anchor is deliberately narrower than general relinking:

1. same `document_id`
2. same `source_sha256`
3. current candidate regenerated and verified server-side
4. confirmation SHA must still match that candidate
5. note version must still match what the user reviewed
6. previous anchor is copied into durable history
7. current note anchor + segment relationships change
8. one monotonic research-journal event records the projection-invalidating mutation
9. all authoritative writes commit or roll back together in `research.sqlite3`

DuckDB receives only the new current projection through the existing projector. Superseded anchor history remains unique authoritative SQLite state.

## Desktop boundary

The webview receives only reviewable evidence text, canonical generation identity, segment IDs, numeric time coordinates, and safe history metadata. React does not receive raw source/canonical paths, source SHA, SQL/database authority, candidate derivation logic, or generation-selection authority.

## Qualification

This PR remains draft while the full Quality matrix runs. Expected coverage includes SQLite transaction/history behavior, optimistic concurrency, same-source guards, candidate verification, strict bridge DTO validation/path minimization, React two-step confirmation, Playwright accessibility, static analysis, native Tauri locked compile, package verification, and macOS/Windows smoke.