### PR TITLE
feat(desktop): simplify Research UI and qualify themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Start with **[docs/README.md](docs/README.md)** for human-facing documentation o
 
 ## What can it do right now?
 
-EchoFlow is pre-production, but the backend and first desktop slices already cover most of
-the local recording-to-evidence lifecycle.
+EchoFlow is pre-production, but the backend and desktop now cover the first coherent path
+from importing a recording through local processing, evidence search, and durable research.
 
 | Area | Current foundation |
 |---|---|
@@ -43,12 +43,14 @@ the local recording-to-evidence lifecycle.
 | Transcript output | canonical JSON plus deterministic TXT, SRT, WebVTT publication views |
 | Search | private BM25 lexical retrieval, optional semantic retrieval, hybrid reciprocal-rank fusion |
 | Evidence navigation | canonical-hash verification, aligned highlights, bounded context, speaker presentation, source seek coordinates |
-| Research workspace | authoritative SQLite notes/tags/collections, rebuildable DuckDB projection, desktop browse/create/edit/delete and label assignment |
+| Research workspace | authoritative SQLite notes/tags/collections, rebuildable DuckDB projection, desktop browse/create/edit/delete/filter/anchor maintenance |
 | Unified discovery | grouped transcript/note/tag/collection query without fabricated cross-type scores |
 | Saved searches | durable typed query intent that re-resolves current evidence instead of freezing result snapshots |
 | Safe lifecycle | typed plan-bound deletion scopes plus private execution-state retention that preserves evidence/human work by default |
 | Incremental library | cheap refresh/reconciliation plus durable transcript and recording locations |
-| Desktop foundation | Tauri + React shell, native import, Library discovery, verified evidence reader/cursor, Research workspace, Archive/Midnight themes |
+| Processing Center | desktop readiness, machine/model state, preflight, start/cancel, resume versus retry, job-state discard, diarization/enhancement/publication intent |
+| Desktop presentation | Tauri + React import, Library, verified evidence reader, Research, Processing, six semantic-token themes with a compact persisted picker |
+| Accessibility | keyboard/semantic-role tests, axe, explicit light/dark browser schemes, and a six-skin contrast matrix |
 | Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, Playwright/axe, package verification |
 
 ## From recording to useful evidence
@@ -106,31 +108,44 @@ or accepting a durable note anchor.
 
 ## Desktop status
 
-EchoFlow has a thin Tauri + React desktop foundation over the Python application services.
-The current desktop can choose files/folders through native dialogs, remember approved
-locations, discover recordings, search the local library, open verified canonical context,
-move a source-relative evidence cursor through canonical word coordinates, browse durable
-research, create notes from verified evidence, and edit/delete notes plus their tag and
-collection assignments.
+The Tauri + React desktop is no longer only an import/search shell. It currently provides:
 
-Research edits use the authoritative note `updated_at` as an optimistic-concurrency token.
-The body and label relationships change in one SQLite transaction with one journal event;
-the evidence anchor does not move. If another local surface changed the note first, the
-desktop write fails closed and asks for refresh instead of silently overwriting it.
+- native file/folder selection and remembered-location permissions;
+- recording discovery without automatic processing side effects;
+- a Processing Center for readiness, model state, job state, preflight, launch, cancel,
+  resume/retry distinction, and private-state discard;
+- Library search across transcripts, notes, tags, and collections;
+- verified evidence context and source-relative cursor coordinates;
+- Research note create/edit/delete, tag/collection navigation, saved-search lifecycle,
+  typed retrieval controls, exact-generation evidence return, and explicit anchor review;
+- six accessible presentation skins through one compact theme picker; and
+- persisted presentation preference without mixing theme state into evidence or research.
 
 The browser/webview does **not** receive raw canonical/source filesystem paths for evidence
 navigation. Rust owns native desktop capability; Python owns application rules; React owns
 presentation.
 
-The remaining Research UI work is saved-search lifecycle, research-object → verified
-evidence navigation, explicit stale-anchor review/re-anchor, and advanced typed retrieval
-controls. The broader desktop audit also shows a major processing gap: Python already has
-health/resource/model/job/transcription contracts that still need coherent desktop
-workflows before EchoFlow is a self-contained end-user application. See
-**[ROADMAP.md](ROADMAP.md)** for the complete capability-to-productization map.
+The current Research UI deliberately translates backend vocabulary into ordinary choices.
+For example, the user chooses **Any of these words**, **All of these words**, or **Exact
+phrase** instead of separately operating phrase and term-operator plumbing. Retrieval,
+ordering, filters, result count, and context live under **Search options**; backend retrieval
+provenance remains available under **Technical details**.
 
 There are still no end-user installers or Releases. The supported path remains a source
 build while packaging and first-run behavior are qualified.
+
+## Themes and accessibility
+
+EchoFlow currently ships **Archive, Midnight, Paper, Moss, Plum, and Ember**. They are not
+six independent CSS systems. Every skin supplies the same semantic roles for background,
+surfaces, text, borders, accent/on-accent, form controls, focus, errors, and selection.
+Components consume those roles rather than inventing per-screen colors.
+
+Every theme explicitly declares its browser `color-scheme`. Playwright checks the same
+contrast pairs across all six skins, including form-control boundaries and focus state, and
+runs axe against representative Research controls. Read
+**[Desktop themes and accessibility](docs/development/desktop-accessibility.md)** for the
+contract.
 
 ## Install the current source build
 
@@ -144,7 +159,11 @@ uv run echoflow init
 uv run echoflow doctor
 ```
 
-## Plan, transcribe, and resume
+For the native desktop, follow **[Desktop development prerequisites](docs/development/desktop-development.md)**.
+
+## Plan, transcribe, and resume from the CLI
+
+The CLI remains useful for automation and source-build qualification:
 
 ```bash
 uv run echoflow models recommend
@@ -169,21 +188,7 @@ Model acquisition is explicit and network-bearing. Transcription does not silent
 download faster-whisper weights. Resume rechecks source identity and current resource
 admission rather than silently changing the execution contract.
 
-## Optional anonymous speakers
-
-```bash
-uv run echoflow transcribe interview.wav --diarize
-uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
-uv run echoflow library speakers transcript JOB_ID
-```
-
-A display name is user-authored presentation state. Anonymous speaker refs remain the
-evidence identity. EchoFlow does not perform biometric identity inference or silent
-cross-recording speaker linking.
-
-## Search, navigate, annotate, and save useful questions
-
-Build or refresh the private lexical library and search it:
+## Search, annotate, and save useful questions
 
 ```bash
 uv run echoflow library rebuild
@@ -205,7 +210,6 @@ uv run echoflow library search \
 The notebook itself is durable user state:
 
 ```bash
-uv run echoflow library notes
 uv run echoflow library notes add JOB_ID segment-000042 \
   --body "Compare this with the 2024 survey." \
   --tag methodology \
@@ -217,9 +221,7 @@ Saved searches persist the question, not today's answer:
 ```bash
 uv run echoflow library saved save "Housing chapter" "rent burden" \
   --tag housing --mode hybrid
-uv run echoflow library saved
 uv run echoflow library saved run "Housing chapter"
-uv run echoflow library navigation
 ```
 
 ## Delete exactly what you mean
@@ -233,25 +235,7 @@ uv run echoflow library delete JOB_ID --scope library-view
 
 The plan prints every action, preserved attached notes, affected document-scoped saved
 searches, and a confirmation token. Nothing changes until the same request is repeated
-with that token:
-
-```bash
-uv run echoflow library delete JOB_ID \
-  --scope library-view \
-  --confirm 'delete:...'
-```
-
-Available transcript-scoped custody operations include:
-
-```text
-library-view          remove rebuildable retrieval membership
-derived-artifacts     delete regenerable TXT/SRT/VTT
-execution-state       delete private checkpoints/intermediates
-canonical-transcript  delete canonical JSON plus disposable descendants
-research-notes        delete notes anchored to this exact canonical generation
-saved-searches        delete saved searches explicitly constrained to this transcript
-source-recording      delete original recording only with --allow-source + provenance match
-```
+with that token.
 
 `canonical-transcript` does **not** imply `research-notes`, `saved-searches`, or
 `source-recording`. Shared tags/collections are never cascade-deleted merely because one
@@ -263,13 +247,8 @@ Age-based retention is narrower still:
 uv run echoflow library retention --execution-days 30
 ```
 
-It can delete only old private job workspaces. Completed jobs are eligible by default;
-failed/interrupted jobs require `--include-incomplete` because cleanup removes resume
-capability. Running jobs are never eligible. Canonical transcripts, human research, source
-media, and lightweight lifecycle manifests are preserved.
-
-EchoFlow does not claim that ordinary file deletion proves secure physical erasure on
-SSDs, snapshots, backups, sync history, or copy-on-write storage.
+It can delete only old private job workspaces. Canonical transcripts, human research,
+source media, and lightweight lifecycle manifests are preserved.
 
 Read **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)** for
 the exact contract.
@@ -284,6 +263,7 @@ the exact contract.
 | Notes, tags, collections, evidence anchors | user-authored knowledge | **No** |
 | Saved searches | user-authored query intent | **No** |
 | Remembered library/recording locations | durable app preference | **No, but machine-local** |
+| Theme preference | machine-local presentation preference | Yes / non-evidence |
 | TXT/SRT/WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
 | Lexical/semantic search state | private search projections | Yes |
@@ -295,32 +275,31 @@ unique evidence or human research exists.
 ## For maintainers
 
 Start with **[docs/architecture/README.md](docs/architecture/README.md)**, especially
+**[Processing Center](docs/architecture/processing-center.md)**,
 **[Corpus search](docs/architecture/corpus-search.md)**,
 **[Durable research state](docs/architecture/research-state.md)**,
 **[Library lifecycle](docs/architecture/library-lifecycle.md)**,
 **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and
-**[SECURITY.md](SECURITY.md)**. The documentation visual/voice contract lives in
-**[docs/documentation-style.md](docs/documentation-style.md)**.
+**[SECURITY.md](SECURITY.md)**.
 
 Normal qualification includes Ruff lint/format/security rules, strict mypy, Vulture,
 Radon, branch coverage, locked dependency audit, package builds, clean-wheel verification,
-frontend type/build/audit gates, Playwright/axe, and Linux/macOS/Windows CI. Targeted
-mutation testing is reserved for load-bearing logic.
+frontend type/build/audit gates, Playwright/axe, the theme contrast matrix, and
+Linux/macOS/Windows CI.
 
 ## Where the project goes next
 
-The full capability-to-productization audit now lives in **[ROADMAP.md](ROADMAP.md)**.
-Research browse/create/edit/delete and label assignment are foundation. The immediate
-remaining Research work is saved-search lifecycle, research-object → verified-evidence
-navigation, stale-anchor review, and advanced typed search controls.
+Research/search and the first Processing Center workflow are built. The next first-release
+sequence is:
 
-After that, the next major product gap is a **desktop Processing center** over existing
-health/resource, managed-model, job-lifecycle, transcription-plan/execution/resume,
-enhancement, diarization, and publication contracts. Then come speaker/control polish,
-Tauri-owned local playback, lifecycle/retention UI, packaging, backup/restore/export,
-packaged semantic qualification, and representative-device release qualification.
+1. transcript and speaker tools plus provenance/details polish;
+2. Tauri-owned local audio/video playback from verified source-relative coordinates;
+3. lifecycle and retention UI over the existing plan-bound custody backend;
+4. architecture/redundancy audit before packaging freezes seams;
+5. packaging, first-run storage setup, signed updates, and evidence-safe uninstall;
+6. backup/restore plus selected research portability;
+7. packaged semantic-model/dependency custody; and
+8. representative-device qualification across ordinary consumer hardware and hostile path,
+   disk, interruption, upgrade, and accessibility cases.
 
----
-
-**Make sensitive local transcription boringly dependable. Make its evidence easy to
-navigate and annotate. Do not give the corpus away.** 💃
+See **[ROADMAP.md](ROADMAP.md)** for the capability matrix and exact sequencing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,10 +8,9 @@ portable on ordinary computers while keeping source evidence and human-authored 
 under clear custody.
 
 Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe
-a file?” through a substantial backend foundation and into real desktop evidence and
-research workflows. This roadmap audits the full product surface so backend capability and
-desktop productization can be planned together rather than rediscovered a few features at
-a time.
+a file?” through a substantial backend foundation into a native desktop that can import,
+process, search, verify, and annotate local evidence. This roadmap is a productization map,
+not a list of every class or CLI command.
 
 ```mermaid
 flowchart LR
@@ -58,20 +57,19 @@ flowchart LR
 </details>
 
 Text fallback: EchoFlow already spans local media, reliable transcription, canonical
-evidence, retrieval, verified navigation, durable research, lifecycle controls, incremental
-refresh, remembered locations, native import, Library discovery, the verified evidence
-reader, exact-generation research return, note mutation, label navigation, saved-search
-lifecycle, explicit research-anchor maintenance, and backend-authoritative typed Research
-search controls. Remaining work is primarily productization: expose processing/model/job
-controls, add playback and lifecycle UI, package the application, make durable work
-portable, and qualify real devices.
+evidence, retrieval, verified navigation, durable research, lifecycle contracts,
+incremental refresh, remembered locations, native import, Library discovery, the verified
+evidence reader, the Research evidence loop, and the desktop Processing Center. Remaining
+first-release work is primarily transcript/speaker polish, playback, lifecycle UI,
+architecture cleanup, packaging, portability, semantic packaging, and real-device
+qualification.
 
 # What is foundation now
 
 The word **foundation** below means the contract exists in code and is protected by tests.
-It does not mean every capability has a non-technical desktop workflow yet.
+It does not mean every capability has finished UX polish or packaged-product qualification.
 
-## Local execution, media, and model custody
+## Local execution, media, model custody, and Processing Center
 
 EchoFlow inspects process-visible CPU/memory, physical accelerator topology, and engine
 capabilities before admitting a concrete local strategy. FFprobe provides deterministic
@@ -81,6 +79,15 @@ source-relative and provenance-bound.
 
 Model acquisition is explicit and network-bearing. Managed model revisions are verified
 and pinned before transcription; EchoFlow does not hide model download inside ASR.
+
+The desktop Processing Center now productizes those authorities. A user can inspect machine
+and model readiness, preflight a selected recording, choose outcome-oriented processing
+intent, start supervised local work, follow durable job state, cancel a native child,
+distinguish resume from fresh retry, and discard private execution state without deleting
+published evidence or research. Python remains authoritative for planning, admission,
+checkpoint compatibility, transcript correctness, model custody, and durable lifecycle;
+Tauri owns allowlisted long-running child-process lifetime; React owns presentation and
+explicit user intent.
 
 ## Canonical evidence and publication
 
@@ -102,11 +109,6 @@ evidence only after EchoFlow reopens the canonical transcript, verifies generati
 identity, resolves exact segment/word coordinates, and returns a source-relative seek
 coordinate.
 
-Durable research anchors use the same verifier as search navigation. A note can reopen its
-exact stored canonical generation, even when that generation is older than the current
-library document. Missing, changed, or incompatible anchored evidence fails closed rather
-than being silently rebound.
-
 ## Durable research workspace
 
 Authoritative SQLite owns notes, tags, collections, current evidence anchors, superseded
@@ -114,29 +116,15 @@ anchor history, and saved-search intent. A monotonic journal drives a rebuildabl
 research projection. `ResearchWorkspaceService` composes those stores with verified
 transcript retrieval.
 
-The desktop can browse current and older-generation notes, create a note from verified
-evidence, edit/delete notes, replace tag/collection assignments, navigate by labels, and
-reopen the exact canonical evidence a note cites. Desktop note edits are
-optimistic-concurrency checked against authoritative `updated_at`; body plus labels commit
-atomically with one research-journal event. Editing research never silently rebinds its
-evidence anchor.
+The desktop supports note create/edit/delete, tag/collection navigation, exact-generation
+note return, saved-search create/run/update/delete, stale/unavailable anchor review,
+provenance-preserving same-source re-anchor, and the full typed Research search contract.
+Saved questions persist intent, not result snapshots.
 
-The Research evidence-maintenance surface can now classify a note anchor as current
-verified, older verified, or unavailable. For a non-current note it may preview a verified
-current-generation candidate only when document and recorded-source identity match. A
-re-anchor requires separate confirmation bound to note version and candidate canonical
-SHA-256. The old anchor is preserved durably before the current pointer changes, and the
-normal projection journal advances once. There is no automatic or cross-recording
-re-anchoring.
-
-Saved searches are durable questions, not result snapshots. The desktop can create, run,
-rename, and delete them. Rename/delete operations are version-checked in the authoritative
-SQLite transaction, while rename preserves the existing typed query intent server-side.
-Running a saved search resolves current evidence and current research relationships again.
-
-Research operations emit privacy-safe structured events through the normal application
-logger. Logs carry operation identity, generation identity, modes, counts, and outcomes,
-not note bodies, query text, saved-search names/descriptions, or raw filesystem paths.
+The UI no longer asks ordinary users to operate backend vocabulary directly. One **Match**
+choice compiles Any words / All words / Exact phrase into the same typed search intent;
+retrieval, ordering, filters, result count, and context are grouped under **Search options**.
+Technical provenance remains inspectable without being the default interface.
 
 ## Safe deletion, refresh, and locations
 
@@ -146,16 +134,15 @@ preserved dependencies. Source deletion requires explicit `source-recording`, a 
 `--allow-source` switch, and current provenance verification.
 
 Normal library refresh reconciles changed canonical generations without reopening every
-unchanged transcript. Metadata is a cheap change detector; canonical SHA-256 remains the
-generation authority. Remembered transcript and recording locations persist explicit user
+unchanged transcript. Remembered transcript and recording locations persist explicit user
 permission. Missing removable roots stay remembered but unavailable.
 
-The default recording policy is manual. `automatic` is durable permission metadata only;
-there is no background daemon silently processing recordings today.
+The default recording policy is manual. Discovery does not itself open, hash, probe, copy,
+or transcribe candidate media.
 
-## Desktop foundation
+## Desktop presentation and accessibility
 
-The desktop architecture is:
+The desktop architecture remains:
 
 ```text
 EchoFlow Desktop
@@ -164,242 +151,160 @@ EchoFlow Desktop
 └── Python EchoFlow               application and evidence rules
 ```
 
-The shell provides Archive/Midnight themes, keyboard-visible navigation, native file/folder
-selection, one-time versus remembered import choices, recording discovery, transcript
-refresh, grouped Library discovery, verified evidence reading/cursor movement, Research
-browse, provenance-bound note creation, version-checked note mutation, exact-generation
-research return, first-class label navigation, saved-search lifecycle/replay, explicit
-research-anchor review/re-anchor, and advanced typed Research search with whole-intent
-saved-search editing.
+The shell now has six skins: Archive, Midnight, Paper, Moss, Plum, and Ember. They share one
+semantic token contract for surfaces, text, controls, focus, errors, selection, and accent
+foregrounds. Theme selection is a compact persisted dropdown and remains presentation-only
+state.
 
-React does not receive arbitrary shell, SQL/database, or raw evidence-path capability. It
-also does not decide whether a research anchor is valid, derive a re-anchor candidate,
-choose canonical paths/generations, represent saved-search intent, or decide whether a stale
-durable mutation may win.
+Every skin declares its browser light/dark `color-scheme`. Playwright checks the same
+WCAG-oriented text and control contrast pairs across all themes and runs axe against real
+Research controls. Components should not add theme-specific colors or assume that accent
+buttons always use white text.
+
+React still does not receive arbitrary shell, SQL/database, model-provider, or raw
+evidence-path capability. Presentation convenience is not permission to move application
+or custody policy into the webview.
 
 # Capability → desktop productization audit
 
-This is the planning inventory. “Backend ready” means there is already a tested application
-or CLI contract worth productizing, not that the desktop should simply expose a CLI flag.
+“Backend ready” means a tested application/CLI contract already exists. “Implemented” means
+the first-release desktop workflow exists; it may still have polish or packaging work.
 
 | Capability | Authority available today | Desktop today | Remaining product work | Planned slice |
 |---|---|---|---|---|
-| First-run initialization | private workspace/output allocation and config validation | source-build startup only | first-run wizard, storage choices, failure recovery | Packaging / first run |
-| Health diagnostics | `doctor` checks local state, disk, FFmpeg and system resources | none | human health panel, actionable repair guidance | Processing center |
-| Hardware/resource policy | effective CPU/RAM/accelerator inspection, execution profiles and admission | none | resource summary, safe defaults, explicit overrides | Processing center |
-| Managed model custody | inventory, recommendation, install, immutable revision verification/revalidation/removal | none | model manager, disk-cost visibility, download progress/cancel/retry, offline state | Processing center |
-| Native import and remembered locations | durable transcript/recording roots and discovery permissions | **implemented** | location management/forget/availability polish | Settings / library polish |
-| Recording discovery | candidate media discovery without hashing/probing/transcribing as a side effect | **implemented** | connect selected recordings to an explicit processing flow | Processing center |
-| Job lifecycle | list/show status, progress, failure state, resumability and private-state discard | none | Jobs/Processing view, resume/retry/discard UX | Processing center |
-| Transcription planning | media probe, stream choice, model/engine/resource plan, disk/memory admission, dry run | none | preflight summary before running work | Processing center |
-| Transcription execution | faster-whisper local execution with checkpoints/resume | none | long-running Tauri↔Python execution contract, progress, cancel/resume and crash recovery | Processing center |
-| Difficult-audio enhancement | deterministic FFmpeg suppression with timeline/provenance checks | none | explicit processing option plus explanation/cost preview | Processing controls |
-| Anonymous diarization | recording-scoped speaker turns, word handoffs, overlap-aware presentation | backend only | processing toggle/resource warning and result presentation polish | Processing + speakers |
-| Speaker display labels | durable user-authored names without biometric identity claims | labels can be presented in evidence | rename/manage speakers in desktop | Speaker tools |
-| Canonical JSON authority | reproducible canonical transcript with full provenance | consumed indirectly | transcript/provenance inspector for advanced users | Evidence inspector |
-| TXT/SRT/WebVTT publication | deterministic rebuildable exports | none | export chooser and destination workflow | Evidence/export tools |
-| Lexical BM25 retrieval | private corpus ranking | **implemented** through Library discovery and typed Research controls | optional search-surface polish | Research/search complete |
-| Semantic retrieval | optional local chunks/embeddings | backend ready, not normal packaged path | desktop mode control after model/dependency custody qualification | Search + semantic qualification |
-| Hybrid RRF retrieval | lexical + semantic rank fusion | backend ready | retrieval-mode control and explainable result state | Search + semantic qualification |
-| Verified evidence navigation | generation verification, context, exact word timing and seek coordinate | search results and note anchors **implemented** | media playback | Playback |
-| Unified discovery | typed transcript/note/tag/collection groups without fabricated cross-type score | **implemented** alongside advanced typed evidence search | optional object-specific action polish | Research/search complete |
-| Research notes | exact generation-bound anchors + superseded anchor history in authoritative SQLite | browse/create/edit/delete/exact-evidence return/review/re-anchor + typed search integration **implemented** | optional research-surface polish | Research/search complete |
-| Tags and collections | durable names/relationships + rebuildable projection | browse + assignment + first-class navigation/filter **implemented** | optional dedicated label management polish | Settings / research polish |
-| Saved searches | typed durable intent with current-corpus re-resolution and version-safe mutation | create/run/delete + inspectable whole-intent editing **implemented** | optional saved-question polish | Research/search complete |
-| Research-aware filtering | tags/collections/note text constrain evidence before ranking | full typed transcript/research filters with inspectable applied intent **implemented** | optional authoritative facet/catalog convenience pickers | Research/search complete |
-| Safe deletion | typed dry-run plans, exact confirmation binding, source double-guard | none | custody center with plan review and explicit confirmation | Lifecycle UI |
-| Retention | execution-state-only age policies preserving evidence/research | none | retention settings, preview, cleanup result | Lifecycle UI |
-| Local source playback | verified source-relative seek coordinate exists | no playback | Tauri-owned media capability, playback state, source mismatch/unavailable handling | Native playback |
-| Desktop packaging | Python wheel + tested source build | development Tauri shell | managed Python sidecar/runtime, FFmpeg/native deps, Windows/macOS/Linux installers | Packaging |
-| Updates/uninstall | custody semantics exist conceptually | none | signed updates and uninstall that never implies evidence deletion | Packaging |
-| Backup/restore | authority boundaries identify irreplaceable state | none | backup manifest, restore/reconciliation and recovery UX | Portability |
-| Research export | evidence identities and numeric coordinates exist | none | CSV/JSONL/Markdown selected-research export | Portability |
-| Packaged semantic custody | dependency/model rules are designed | not qualified | locked optional stack, immutable embedding model, private cache, offline use | Semantic qualification |
-| Representative hardware | resource-planning contracts exist | CI smoke on major OSes | 8/16 GB, Apple Silicon, dGPU, 32/64 GB real-device qualification | Release qualification |
+| First-run initialization | private workspace/output allocation and config validation | source-build startup | storage-location onboarding, repair UX | Packaging / first run |
+| Health diagnostics | doctor/system/resource checks | **implemented** in Processing readiness | richer repair guidance | Processing polish |
+| Hardware/resource policy | effective CPU/RAM/accelerator inspection, profiles, admission | **implemented** in readiness + preflight | representative-device calibration | Device qualification |
+| Managed model custody | inventory, recommendation, install, verification/revalidation/removal | **implemented** through Processing/native tasks | download-progress and offline polish | Processing polish |
+| Native import and remembered locations | durable transcript/recording roots and discovery permissions | **implemented** | location management/forget polish | Settings / library polish |
+| Recording discovery | side-effect-free candidate discovery | **implemented** | source availability polish | Library polish |
+| Job lifecycle | durable status/progress/failure/resumability/discard | **implemented** in Processing | history/detail polish | Processing polish |
+| Transcription planning | probe, stream, strategy, resource and disk admission | **implemented** preflight | presentation refinement | Processing complete |
+| Transcription execution | local execution with checkpoints/resume | **implemented** through Tauri-supervised worker | packaged-runtime qualification | Packaging |
+| Difficult-audio enhancement | deterministic FFmpeg suppression with provenance checks | **implemented** as explicit processing intent | explanation/result presentation | Transcript tools |
+| Anonymous diarization | recording-scoped speaker evidence | **implemented** as explicit processing intent | speaker result presentation/management | Speaker tools |
+| Speaker display labels | durable human names without biometric claims | labels appear in evidence | rename/manage speakers | Speaker tools |
+| Canonical JSON authority | reproducible transcript + provenance | consumed by evidence views | provenance/details inspector | Transcript tools |
+| TXT/SRT/WebVTT publication | deterministic derived exports | publication intent available in processing | destination/export management polish | Transcript tools |
+| Lexical BM25 retrieval | private corpus ranking | **implemented** | ordinary-language polish complete in current tranche | Research/search complete |
+| Semantic + hybrid retrieval | local semantic index + RRF | **implemented** in typed desktop controls when qualified | packaged dependency/model custody | Semantic qualification |
+| Verified evidence navigation | generation verification, context, exact timing, seek | **implemented** | media playback | Playback |
+| Unified discovery | transcript/note/tag/collection groups | **implemented** | optional object actions | Research/search complete |
+| Research notes | exact-generation durable anchors/history | **implemented** | optional editing polish | Research/search complete |
+| Tags and collections | durable relationships + rebuildable projection | **implemented** navigation/filter/assignment | dedicated management optional | Research polish |
+| Saved searches | durable typed intent + current re-resolution | **implemented** whole-intent lifecycle | optional organization polish | Research/search complete |
+| Safe deletion | typed dry-run plans + exact confirmation binding | none | custody review UI | Lifecycle UI |
+| Retention | execution-state-only age policies | none | preview/settings/results | Lifecycle UI |
+| Local source playback | verified source-relative coordinate exists | none | Tauri media capability and transport | Native playback |
+| Themes/accessibility | semantic palette + browser presentation | **implemented** six-skin picker + contrast/axe matrix | representative OS native-control qualification | Desktop comprehension complete |
+| Desktop packaging | Python wheel + source build | development Tauri shell | managed runtime, FFmpeg/native deps, installers | Packaging |
+| Updates/uninstall | custody semantics defined | none | signed updates; uninstall never implies evidence deletion | Packaging |
+| Backup/restore | authority boundaries identify irreplaceable state | none | manifest, restore/reconcile UX | Portability |
+| Research export | stable evidence identities/coordinates exist | none | CSV/JSONL/Markdown selected export | Portability |
+| Packaged semantic custody | dependency/model rules designed | advanced source-build capability | locked stack, immutable model, offline behavior | Semantic qualification |
+| Representative hardware | resource-planning contracts exist | CI smoke | 8/16 GB, Apple Silicon, dGPU, 32/64 GB real-device qualification | Release qualification |
 
 # Product critical path
 
-The audit changes one important thing about the old roadmap: **media playback is not the
-only major desktop gap after Research.** EchoFlow already has a surprisingly complete local
-processing/control plane in Python, but a normal desktop user cannot yet launch and manage
-that work. Productization should expose that capability before packaging freezes the native
-runtime shape.
+## 1. Research/search complete
 
-## 1. Advanced Research/search controls complete
+The first-release Research circuit is coherent: **find evidence → verify → annotate →
+organize → save/replay a question → return to exact evidence → deliberately maintain an
+anchor when necessary**. Phrase/ANY/ALL semantics, speaker/language/transcript constraints,
+research filters, retrieval mode, sort, limits, context, saved whole-intent replacement,
+and retrieval provenance all exist.
 
-Current first-release Research foundation after this tranche:
+The current comprehension tranche changes presentation, not authority. Human choices are
+compiled to the same typed request and Python continues to canonicalize, validate, derive
+research scopes, execute retrieval, and select evidence generations.
 
-- Research navigation and authoritative overview;
-- current-versus-older canonical generation presentation;
-- note creation from a verified evidence window;
-- atomic edit of note body + tag/collection assignments;
-- guarded note deletion;
-- optimistic concurrency using authoritative `updated_at`;
-- exact-generation note → verified-evidence return with no automatic rebinding;
-- first-class tag/collection navigation with backend AND semantics;
-- saved-search create/run/delete plus version-safe whole-intent inspection/editing;
-- explicit stale/unavailable anchor review;
-- deliberate same-source re-anchor with reviewed-generation confirmation and durable prior-anchor history;
-- typed phrase/ANY/ALL, speaker, language, transcript, research-filter, retrieval-mode,
-  sort, result-limit, and context controls;
-- backend-returned applied intent and retrieval provenance; and
-- no frontend SQL, SQLite, raw evidence paths, derived evidence-scope construction,
-  repair-candidate derivation, ranking policy, or generation-selection logic.
+## 2. Processing Center complete
 
-The primary research circuit is now coherent: **find evidence → verify → annotate →
-organize → ask a durable typed question → replay/edit it → return to exact evidence →
-deliberately maintain the evidence pointer when needed.** Further Research additions
-are polish or second-horizon work rather than blockers for the next first-release
-tranche.
+The first Processing workflow now exists over readiness, model state, durable jobs,
+preflight, explicit launch, native supervision, cancel, resume versus retry, and private
+execution-state discard. See **[Processing Center](docs/architecture/processing-center.md)**.
 
-## 2. Build the desktop Processing center
+“Complete” here means the first-release control loop exists. Packaging, representative
+hardware, richer model-download presentation, and transcript/result tooling still remain.
 
-This is the largest backend-to-product gap.
+## 3. Desktop comprehension + theme system complete
 
-The first Processing center should combine three existing authorities without collapsing
-them into one giant settings screen:
+The desktop now uses ordinary search language, hides architecture-only labels from default
+Research interactions, keeps advanced controls behind a clear disclosure, and places
+retrieval provenance under Technical details.
 
-1. **Machine + model readiness:** doctor status, runner resources/policy, model inventory,
-   recommendation, install/revalidate/remove and disk cost.
-2. **Job lifecycle:** queued/running/completed/failed work, progress, resumability, failure
-   explanation, resume/retry, and explicit private-state discard.
-3. **Transcription preflight + launch:** selected recording, media/stream summary, profile,
-   model/engine target, disk/memory admission, optional diarization/enhancement/publication,
-   then explicit start.
+The theme system has one registry, one semantic token contract, a compact six-skin picker,
+local persistence, explicit browser light/dark schemes, centralized native form-control
+theming, and automated contrast/accessibility qualification. See
+**[Desktop themes and accessibility](docs/development/desktop-accessibility.md)**.
 
-Long-running work must not be modeled as a browser request that happens to take an hour.
-Tauri should own native process/capability lifecycle while Python continues to own planning,
-resource admission, transcription correctness, checkpointing, and publication.
+## 4. Transcript and speaker tools
 
-## 3. Finish transcript controls and speaker tools
+Next, make produced evidence easier to inspect and manage without duplicating Processing
+controls:
 
-Once desktop processing can create evidence itself, expose the existing user-facing control
-surfaces that make the result understandable:
+- speaker display-name editing while anonymous refs remain evidence identity;
+- clearer language/speaker transcript presentation;
+- selected audio-stream detail where multiple legitimate streams exist;
+- publication/export destination workflow; and
+- provenance/transcript details for troubleshooting and audit.
 
-- selected audio stream where more than one legitimate stream exists;
-- enhancement/diarization choices with resource and provenance implications;
-- publication format selection;
-- speaker display-name editing while retaining anonymous speaker refs as evidence identity;
-- language/speaker transcript presentation controls; and
-- provenance/transcript inspection where it helps troubleshooting or audit.
+## 5. Native playback
 
-## 4. Add local media playback behind a Tauri capability
+Let the existing verified source-relative coordinate drive local audio/video without giving
+React arbitrary path authority. Rust owns file/media capability; Python owns source identity
+and evidence rules; the webview receives playback state and safe coordinates.
 
-The evidence reader already has a verified source-relative cursor. Let that coordinate drive
-local audio/video without handing an arbitrary path to React.
+Qualification includes moved/unavailable sources, source mismatch, keyboard transport,
+reduced motion, long media, and seeking around exact word boundaries.
 
-Rust owns file capability and media lifecycle. Python owns source identity/evidence rules.
-The webview receives playback state and safe coordinates, not general filesystem authority.
+## 6. Lifecycle + retention UI
 
-Qualification includes unavailable/moved sources, source identity mismatch, keyboard
-transport, reduced motion, long media, and seeking around exact word boundaries.
-
-## 5. Productize safe lifecycle and retention
-
-Before a packaged app invites non-technical users to accumulate large local corpora, give
-them safe cleanup tools:
+Productize existing custody contracts before a packaged app invites large local corpora:
 
 - dry-run deletion plan review;
 - plan-bound confirmation;
-- visibly separate source, canonical evidence, derived artifacts, execution state, research,
-  and saved-search scopes;
-- the source-recording second guard; and
-- retention preview/cleanup for eligible private execution state.
+- explicit source/canonical/research/export/execution scopes;
+- source-recording second guard; and
+- retention preview/result state.
 
-A friendly Delete button must never flatten EchoFlow’s custody model.
+## 7. Architecture/redundancy audit
 
-## 6. Desktop packaging, first run, updates, and uninstall
+Do this **before packaging freezes seams**. Audit bridge DTOs, Pydantic request models,
+React client glue, serializers, service composition, fixtures, Tauri supervisor patterns,
+stale compatibility paths, and duplicated documentation. Refactor where policy is repeated
+or ownership is unclear, not merely where two files look similar.
 
-Produce deliberate delivery paths for:
+## 8. Packaging + first run + update/uninstall
 
-- a normal Windows installer/application entry point;
-- a signed/notarized macOS application bundle and installer/disk-image flow; and
-- an intentional Linux desktop package.
+Ship a managed Python runtime/sidecar, FFmpeg/native dependencies, Windows/macOS/Linux
+delivery, storage-location onboarding, signed updates, and evidence-safe uninstall
+semantics.
 
-Packaging must account for the Tauri host, managed Python runtime/sidecar, FFmpeg/FFprobe,
-native transcription dependencies, model custody, migrations, updates, and uninstall.
+## 9. Backup/restore + research portability
 
-**Uninstalling EchoFlow must not silently delete canonical transcripts or authoritative
-human research state.** Program removal and user-data destruction are different operations.
+Back up canonical evidence and authoritative research, rebuild projections on restore,
+reconcile machine-local paths, and export selected research with stable evidence identities.
 
-## 7. Backup, restore, and research portability
+## 10. Packaged semantic custody
 
-Back up what is irreplaceable: canonical evidence, research SQLite state, saved searches,
-speaker labels, and other durable human state. Rebuildable DuckDB projections should be
-regenerated rather than promoted to backup authority.
+Lock and qualify embedding dependencies, immutable model acquisition, private cache/offline
+behavior, corpus compatibility, and upgrade semantics as an ordinary product feature.
 
-Remembered absolute paths are machine-local preferences. Export them as reviewable metadata
-and require explicit reconciliation/reapproval on another machine.
+## 11. Representative-device qualification
 
-Selected research export should target CSV, JSON/JSONL, and Markdown while retaining
-document/generation identity, segment IDs, and numeric evidence coordinates.
+Qualify 8 GB Windows, 16 GB commodity systems, Apple Silicon, dGPU laptops, 32/64 GB
+systems, Unicode/long paths, external disks, low disk, crashes, interrupted downloads,
+offline use, upgrades/reinstall, display scaling, native controls, keyboard use, and
+accessibility.
 
-## 8. Qualify semantic dependencies and embedding custody for packaging
+# Later research-native work
 
-Before semantic retrieval is advertised as a normal packaged capability, qualify one
-locked optional dependency set with managed immutable embedding-model acquisition, private
-cache placement, disk/resource admission, no silent search-time download, offline use after
-installation, and packaged-platform qualification.
+Snapshots/diffs, REFI-QDA interoperability, evidence packets, comparison workspaces,
+evidence-linked writing/script boards, portable research bundles, and live provisional
+capture remain intentionally separate from the first-release critical path. See
+**[Post-MVP research roadmap](docs/post-mvp-roadmap.md)**.
 
-## 9. Representative-device release qualification
-
-Exercise real corpora and the packaged app on 8 GB Windows, 16 GB commodity hardware,
-Apple Silicon, a discrete-GPU laptop, and 32/64 GB workstations. Measure real-time factor,
-cold/warm model behavior, thermal/memory pressure, private disk cost, enhancement benefit,
-embedding build cost, refresh cost, query latency, and GUI responsiveness.
-
-Also cover Unicode/space-heavy paths, external drives, permission failures, low disk,
-interrupted downloads, crash/resume, upgrade migrations, uninstall/reinstall, offline
-operation, keyboard/accessibility use, corruption/recovery, location disappearance and
-reappearance, and one-time versus remembered import.
-
-# Cross-cutting rules for every desktop slice
-
-The frontend is not a second application authority. Every new surface should preserve these
-boundaries:
-
-| Concern | Owner |
-|---|---|
-| canonical transcript/evidence rules | Python application services |
-| durable research and custody rules | Python authoritative stores/services |
-| native file/process/media capability | Tauri/Rust |
-| presentation and interaction state | React |
-| raw filesystem authority | never delegated generally to the webview |
-| SQL/database authority | never delegated to React |
-| long-running work | explicit native/application lifecycle, not a giant synchronous UI call |
-
-Destructive operations need typed plans and explicit confirmation. Human-authored state
-needs concurrency-safe mutation. Evidence navigation needs generation verification. Model
-or network acquisition must be explicit. Accessibility and keyboard use remain release
-gates, not cleanup work.
-
-# Conditional later capabilities
-
-## Deeper original-media clock qualification
-
-Only add production/media-clock mapping when real recordings require it: non-zero stream
-origins, rational frame/timecode rates, drop-frame semantics, PTS/DTS mapping, and explicit
-synchronization across independent sources.
-
-## Speech/source separation for overlapping speakers
-
-Source separation remains later than honest overlap representation. It adds substantial
-compute/model custody, uncertainty, derived-audio provenance, and failure modes. It should
-demonstrate measurable recognition benefit before entering the normal path.
-
-## Typed query evolution
-
-Natural-language query assistance may eventually compile into the stable typed
-`SearchQuery`/research-filter contract, but it must remain inspectable and must not turn an
-LLM interpretation into hidden retrieval authority.
-
-# Pre-1.0 meaning
-
-The pre-1.0 milestone is not “the tests pass from a checkout.” It is:
-
-> A normal person can install EchoFlow, understand first run, process sensitive recordings,
-> search and annotate their evidence, recover from common failure, move or back up durable
-> work, update the app safely, and remove the program without losing evidence.
-
-The capability audit above is the checklist for reaching that state without accidentally
-rebuilding mature backend behavior in the frontend.
+The sequencing rule remains simple: do not add a larger research superstructure while the
+ordinary desktop still lacks playback, lifecycle UI, packaging, portability, and real-device
+qualification.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,12 @@ EchoFlow is a **private, local-first workspace for recorded evidence**.
 It can inspect a recording, choose a safe way to run on the computer you actually have,
 transcribe locally, survive interruptions, preserve provenance, search a private corpus,
 navigate results back to verified canonical evidence, keep research notes attached to that
-evidence, save reusable research questions, and expose import/search/evidence/research
-workflows through a native desktop shell.
+evidence, save reusable research questions, and expose the main workflow through a native
+desktop shell.
 
-You do **not** need to understand CUDA, DuckDB, SQLite, BM25, vector spaces, immutable
-model revisions, or why a raccoon has been granted library privileges. EchoFlow owns that
-machinery so the user can concentrate on recordings and evidence.
+You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, or desktop
+IPC to use the product. Those are implementation details. The desktop should speak in
+recordings, transcripts, searches, notes, processing, and evidence.
 
 > **The short version:** your recording stays yours, canonical JSON remains inspectable
 > evidence, your notes and saved searches remain your knowledge, and most machinery built
@@ -22,6 +22,7 @@ machinery so the user can concentrate on recordings and evidence.
 |---|---|
 | Transcribe privately | runs faster-whisper locally from a verified managed model |
 | Avoid melting a smaller laptop | inspects process-visible CPU, RAM, and compatible acceleration before choosing a strategy |
+| Use the desktop to process a recording | provides readiness, model state, preflight, start/cancel, job progress, resume versus retry, and private-state discard in Processing |
 | Survive interruption | checkpoints completed work and validates the original contract on resume |
 | Keep the original recording intact | treats source media as read-only during normal processing and writes artifacts separately |
 | Handle audio/video | selects one audio stream deterministically and canonicalizes locally |
@@ -29,45 +30,34 @@ machinery so the user can concentrate on recordings and evidence.
 | Work across languages | supports multilingual decoding plus conservative local language attribution |
 | Distinguish speakers | preserves optional anonymous recording-scoped speaker evidence without claiming identity |
 | Publish useful formats | produces canonical JSON plus rebuildable TXT/SRT/WebVTT |
-| Search a private corpus | supports lexical BM25, optional semantic retrieval, hybrid RRF, and inspectable typed Research search controls |
+| Search a private corpus | supports lexical BM25, optional semantic retrieval, hybrid RRF, and inspectable Research search options |
 | Follow a result to evidence | verifies canonical generation and returns justified segment/word/context/seek coordinates |
 | Keep durable research | stores notes/tags/collections in authoritative private SQLite anchored to exact evidence |
 | Edit research safely | atomically replaces note prose/labels and refuses stale desktop writes |
 | Navigate research labels | filters notes through authoritative tag/collection semantics and keeps selected filters inspectable |
-| Reuse research questions | stores and edits full typed saved-search intent with optimistic concurrency, then re-resolves current evidence |
+| Reuse research questions | stores and edits full typed saved-search intent, then re-resolves current evidence |
 | Remember libraries | persists explicit transcript/recording location permissions without copying user media |
 | Refresh an evolving corpus | incrementally reconciles changed canonical generations and can verify tracked evidence |
 | Remove something safely | plans typed deletion scopes before mutation and binds confirmation to the exact plan |
-| Use a desktop shell | provides Tauri + React import, Library search, verified evidence reading/cursor, Research browse/create/edit/delete/filter, typed Research search, and Archive/Midnight themes |
-
-The point is not to make users operate the machinery. The point is to make sensitive local
-transcription and research boringly dependable.
+| Change appearance | offers Archive, Midnight, Paper, Moss, Plum, and Ember through one persisted, accessible Theme picker |
 
 ## Pick your doorway
 
-- **[Getting started](getting-started.md)** for the source-build path and first transcript.
-- **[Find things across the whole local library](library-discovery.md)** for grouped Library
-  discovery, which powers the desktop Library surface.
-- **[Make the research question inspectable](research-search.md)** for phrase/ANY/ALL,
-  transcript/speaker/language constraints, research filters, retrieval mode, sort, and full
-  typed saved-search intent editing.
-- **[Your notes should survive the machinery](research-notes.md)** for authoritative notes,
-  tags, collections, saved research intent, and the current desktop Research interactions.
-- **[From search result to the exact evidence](evidence-navigation.md)** for verified
-  canonical navigation and the current desktop evidence reader/cursor.
-- **[Transcript time without calculator gymnastics](time-navigation.md)** for timeline and
-  source-relative coordinate semantics.
+- **[Getting started](getting-started.md)** for the source-build path, desktop path, and first transcript.
+- **[Processing Center](architecture/processing-center.md)** for what the desktop processing workflow owns and what remains authoritative in Python/Tauri.
+- **[Find things across the whole local library](library-discovery.md)** for grouped Library discovery.
+- **[Research search](research-search.md)** for Match, Search options, saved searches, and the typed backend contract beneath the ordinary UI.
+- **[Your notes should survive the machinery](research-notes.md)** for notes, tags, collections, saved research intent, and evidence-anchor maintenance.
+- **[From search result to the exact evidence](evidence-navigation.md)** for verified canonical navigation and the evidence reader/cursor.
+- **[Transcript time without calculator gymnastics](time-navigation.md)** for timeline and source-relative coordinate semantics.
 - **[Give the anonymous speakers names](speaker-names.md)** for user-authored speaker labels.
-- **[Semantic search, without the mystery box](semantic-search.md)** for local semantic/hybrid
-  retrieval.
-- **[Safe deletion and retention](architecture/safe-deletion-retention.md)** for custody-aware
-  deletion.
-- **[Post-MVP research roadmap](post-mvp-roadmap.md)** for second-horizon research-native
-  workflows after the first desktop product is coherent.
+- **[Semantic search, without the mystery box](semantic-search.md)** for local semantic/hybrid retrieval.
+- **[Desktop themes and accessibility](development/desktop-accessibility.md)** for the semantic token system and contrast qualification.
+- **[Safe deletion and retention](architecture/safe-deletion-retention.md)** for custody-aware deletion.
+- **[Post-MVP research roadmap](post-mvp-roadmap.md)** for later research-native workflows.
 - **[SECURITY.md](../SECURITY.md)** for the security boundary.
 - **[Architecture](architecture/README.md)** for maintainers.
-- **[Development docs](development/)** for desktop prerequisites, testing, benchmarking,
-  mutation qualification, frontend accessibility, and quality gates.
+- **[Development docs](development/)** for prerequisites, testing, accessibility, benchmarking, and quality gates.
 
 ## The EchoFlow family portrait
 
@@ -116,7 +106,8 @@ flowchart LR
 Text fallback: canonical evidence feeds rebuildable search; search resolves back to verified
 evidence; durable notes/tags/collections and saved searches remain authoritative human
 knowledge; lifecycle and refresh reuse those identities; the desktop Library and Research
-surfaces consume the same application contracts.
+surfaces consume the same application contracts. Processing sits alongside those surfaces
+as the desktop doorway into the existing local execution authorities.
 
 ## What belongs to you, and what can the raccoon rebuild? 🦝
 
@@ -128,6 +119,7 @@ surfaces consume the same application contracts.
 | Research notes, tags, collections, anchors | user-authored knowledge | **No** |
 | Saved searches | user-authored query intent | **No** |
 | Remembered library/recording locations | machine-local app preference | **No, but reconcile on another machine** |
+| Theme preference | machine-local presentation preference | Yes / non-evidence |
 | TXT / SRT / WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
 | Checkpoint workspace after publication | execution/recovery state | Usually disposable |
@@ -137,30 +129,39 @@ surfaces consume the same application contracts.
 If deleting a search projection destroys unique human-authored information, something has
 gone very wrong.
 
+## The desktop today
+
+The first-release Research circuit and Processing Center are both built. Research search
+uses ordinary product language by default: **Any of these words**, **All of these words**,
+or **Exact phrase**; advanced retrieval, ordering, filters, result count, and context are
+under **Search options**. Technical retrieval provenance remains available under
+**Technical details**.
+
+Processing exposes machine/model readiness, durable jobs, preflight, explicit launch,
+native cancellation, resume versus retry, and safe private-state discard without moving
+planning or evidence authority into React.
+
+Appearance is now one compact Theme dropdown rather than one button per skin. All six
+skins share the same semantic control/text/focus tokens and the same contrast/a11y test
+matrix.
+
 ## What comes next
 
-The first-release Research circuit is now coherent across verified evidence navigation,
-authoritative note mutation, first-class label navigation, saved-search lifecycle,
-provenance-preserving anchor maintenance, and inspectable typed search intent. Python owns
-search semantics and durable saved-search replacement; the desktop edits and renders that
-contract without constructing derived evidence scopes or reimplementing retrieval rules.
+The next critical path is:
 
-The next major user journey is the **desktop Processing center** over already implemented
-health/resource, managed-model, job-lifecycle, transcription-plan, execution, resume,
-enhancement, diarization, and publication contracts. Adaptive zero-knob execution belongs
-in that first Processing experience: EchoFlow should inspect the machine, choose a safe
-plan, estimate resource cost, degrade gracefully, and explain its choice without making a
-normal user tune ASR internals.
+1. transcript and speaker tools plus provenance/details polish;
+2. Tauri-owned local media playback from verified source-relative coordinates;
+3. lifecycle and retention UI over the existing custody backend;
+4. architecture/redundancy audit before packaging;
+5. packaging, first run, signed updates, and evidence-safe uninstall;
+6. backup/restore and selected research portability;
+7. packaged semantic custody; and
+8. representative-device qualification.
 
-Native playback, safe lifecycle UI, packaging, portability, semantic packaging
-qualification, and representative hardware qualification follow on the same critical path.
-Only after that first desktop product is coherent do the deliberately separate
+Only after the first desktop product is coherent do the deliberately separate
 **[post-MVP research features](post-mvp-roadmap.md)** become normal roadmap work.
 
-See **[ROADMAP.md](../ROADMAP.md)** for the capability matrix and detailed first-release
-sequencing.
+See **[ROADMAP.md](../ROADMAP.md)** for the capability matrix and detailed sequencing.
 
 The editorial and Mermaid visual rules live in
 **[documentation-style.md](documentation-style.md)**.
-
-💃 **You are now allowed to leave the documentation lobby.**

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -3,8 +3,8 @@
 Welcome to the maintenance hatch.
 
 The user-facing docs explain what EchoFlow does. These pages explain **why the boundaries
-exist, what each capability owns, what it refuses to own, and which invariants must
-survive refactors**.
+exist, what each capability owns, what it refuses to own, and which invariants must survive
+refactors**.
 
 If you are trying to transcribe a file rather than maintain the system, use
 **[Getting started](../getting-started.md)**.
@@ -13,8 +13,9 @@ If you are trying to transcribe a file rather than maintain the system, use
 
 EchoFlow is composed from narrow local capabilities in
 `src/echoflow/app/app_container.py`. The through-line is custody: source evidence,
-canonical transcript truth, private execution state, rebuildable projections, durable
-human knowledge, and desktop presentation deliberately do not share authority semantics.
+canonical transcript truth, private execution state, rebuildable projections, durable human
+knowledge, native process lifetime, and desktop presentation deliberately do not share
+authority semantics.
 
 ```mermaid
 flowchart LR
@@ -43,8 +44,11 @@ flowchart LR
     P --> Q[Plan-bound deletion]
     O --> R[Versioned desktop bridge]
     I --> R
-    R --> S[React Library and evidence reader]
-    N --> T[Next Research workspace UI]
+    N --> R
+    C --> U[ProcessingCenterService]
+    D --> U
+    U --> R
+    R --> S[React Library Research Processing]
 
     classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
@@ -54,11 +58,10 @@ flowchart LR
     classDef stop fill:#FFD6D6,stroke:#9E3434,stroke-width:2px,color:#351616
 
     class A source
-    class B,C,D process
+    class B,C,D,U process
     class E,I,J evidence
     class F,G,H,K,L,M,O view
     class N,R,S inspect
-    class T process
     class P,Q stop
 ```
 
@@ -71,15 +74,16 @@ flowchart LR
 
 Text fallback: canonical JSON is evidence; DuckDB ranks rebuildable views; canonical
 navigation verifies evidence; SQLite owns human research; `ResearchWorkspaceService`
-composes research interactions; the current desktop bridge feeds Library/evidence
-presentation; a dedicated Research UI is the next consumer of that same authority;
-`LibraryCustodyService` keeps destructive policy separate.
+composes research interactions; `ProcessingCenterService` composes machine/model/job and
+preflight authority; the versioned desktop bridge feeds current Library, Research, and
+Processing presentation; `LibraryCustodyService` keeps destructive policy separate.
 
 ## Where to look
 
 | Page | What question it answers |
 |---|---|
 | [Processing capabilities](processing-capabilities.md) | How does the local transcription/research system fit together? |
+| [Processing Center](processing-center.md) | How does the desktop expose readiness, preflight, jobs, and long-running native work without becoming the scheduler? |
 | [Adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) | How does EchoFlow decide what this machine can safely run? |
 | [Media and timeline](media-and-timeline.md) | Which source/stream did we use, and what do timestamps mean? |
 | [Word-level timestamp alignment](word-alignment.md) | How do engine timings become source-relative evidence? |
@@ -92,14 +96,15 @@ presentation; a dedicated Research UI is the next consumer of that same authorit
 | [Library locations](library-locations.md) | What does “remember this folder” persist, and what does discovery refuse to do? |
 | [Incremental library refresh](incremental-library-refresh.md) | How does the corpus reconcile without a full rebuild? |
 | [Safe deletion and retention](safe-deletion-retention.md) | What exactly can be deleted, what is preserved, and how is destructive intent confirmed? |
-| [ROADMAP](../../ROADMAP.md) | What is implemented, what is next, and what remains research? |
+| [Desktop themes/accessibility](../development/desktop-accessibility.md) | How do all skins share one semantic token and contrast contract? |
+| [ROADMAP](../../ROADMAP.md) | What is implemented, what is next, and what remains later? |
 | [SECURITY](../../SECURITY.md) | What does the security boundary actually claim? |
 
 ## Package map
 
 | Package / surface | Responsibility |
 |---|---|
-| `app` | Dependency-injection composition root |
+| `app` | Dependency-injection composition root and application-facing processing composition |
 | `core` | Configuration, errors, observability, health, measurements |
 | `interfaces` | Local filesystem/storage adapters and private-storage policy |
 | `media` | Read-only source inspection and deterministic audio-stream selection |
@@ -108,37 +113,31 @@ presentation; a dedicated Research UI is the next consumer of that same authorit
 | `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language, alignment, diarization, assembly, exports |
 | `workspace` | Private job paths and public artifact allocation |
 | `benchmarking` | Privacy-minimized local execution measurement |
-| `library` | Retrieval, evidence navigation, research authority/projections, saved searches, discovery, refresh, locations, and typed custody policy |
-| `desktop` | Versioned allowlisted Python bridge for native presentation adapters |
+| `library` | Retrieval, evidence navigation, research authority/projections, saved searches, discovery, refresh, locations, typed custody policy |
+| `desktop` | Versioned allowlisted Python bridge for Library/Research/Processing presentation adapters |
 | `frontend` | React/TypeScript presentation over typed desktop operations; no direct DB/filesystem authority |
-| `src-tauri` | Thin native host/capability boundary for dialogs, process lifecycle, and later local media capability |
+| `src-tauri` | Thin native host/capability boundary for dialogs, allowlisted long-running child processes, and later local media capability |
 
 ## Capability boundaries
 
 EchoFlow prefers a small object with one clear job over a universal manager.
 
-The search/research/custody/desktop area deliberately separates responsibilities:
+The search/research/custody/processing/desktop area deliberately separates responsibilities:
 
 1. `TranscriptLibraryService` discovers and ranks rebuildable transcript passages.
 2. `EvidenceLocator` verifies ranked passages against canonical evidence.
-3. `SpeakerLabelService` owns durable recording-scoped human display names without
-   rewriting diarization evidence.
+3. `SpeakerLabelService` owns durable recording-scoped human display names without rewriting diarization evidence.
 4. `ResearchStateStore` owns durable notes, tags, collections, and exact evidence anchors.
-5. `ResearchStateProjector` converges authoritative SQLite state into a disposable DuckDB
-   research projection.
+5. `ResearchStateProjector` converges authoritative SQLite state into a disposable DuckDB research projection.
 6. `ResearchProjectionIndex` owns fast derived research constraints and summaries.
-7. `WorkspaceMetadataStore` owns durable saved-search intent and computes disposable
-   navigation views.
+7. `WorkspaceMetadataStore` owns durable saved-search intent and computes disposable navigation views.
 8. `ResearchWorkspaceService` composes those capabilities for CLI and presentation adapters.
-9. `LibraryLocationService` owns remembered directory permissions and cheap recording
-   discovery without becoming a media processor.
-10. `LibraryCustodyService` owns typed deletion planning/execution and age-based private
-    execution-state retention.
-11. `echoflow.desktop.bridge` exposes an allowlisted versioned IPC surface. Current
-    Library/evidence DTOs retain stable evidence identity without leaking canonical/source
-    filesystem paths to React.
-12. React owns interaction and presentation only. It does not issue SQL, mutate DuckDB or
-    SQLite directly, or receive arbitrary shell authority.
+9. `LibraryLocationService` owns remembered directory permissions and cheap recording discovery without becoming a media processor.
+10. `LibraryCustodyService` owns typed deletion planning/execution and age-based private execution-state retention.
+11. `ProcessingCenterService` composes health/resource/model/job/preflight authority for the desktop without reimplementing those policies.
+12. `echoflow.desktop.bridge` exposes an allowlisted versioned IPC surface. Current Library/Research/Processing DTOs retain necessary identity without leaking general filesystem authority to React.
+13. Tauri supervises allowlisted long-running native child processes. It owns process lifetime, not strategy selection, model validity, or transcript correctness.
+14. React owns interaction and presentation only. It does not issue SQL, mutate DuckDB/SQLite directly, select canonical generations, or decide resource/custody policy.
 
 That split must survive future UI convenience work. Presentation convenience is not
 permission to merge custody boundaries.
@@ -146,8 +145,7 @@ permission to merge custody boundaries.
 ## Why SQLite and DuckDB both exist
 
 SQLite is authoritative for irreplaceable, frequently mutated user research. DuckDB is
-used for rebuildable analytical/query projections. There is one authority, not two
-masters.
+used for rebuildable analytical/query projections. There is one authority, not two masters.
 
 ```text
 SQLite authority
@@ -163,46 +161,58 @@ DuckDB research projection
 If a research projection disappears, rebuild it. If SQLite user state disappears, unique
 human work is lost. That asymmetry is intentional.
 
-Saved searches live in authoritative SQLite because they are authored intent. Their
-runtime evidence scope does not. Replaying a saved search re-resolves the current corpus
-and current research relationships.
+Saved searches live in authoritative SQLite because they are authored intent. Their runtime
+evidence scope does not. Replaying a saved search re-resolves the current corpus and current
+research relationships.
+
+## Desktop presentation does not rename authority
+
+The desktop now intentionally translates internal vocabulary into ordinary product
+language. For example, Research presents one **Match** choice while the backend keeps
+separate phrase/operator properties, and it calls lexical/semantic/hybrid **Wording / Meaning
+/ Wording + meaning**.
+
+That translation is presentation only. Python still validates/canonicalizes the typed
+request, derives research evidence scope, chooses retrieval behavior, and verifies evidence.
+Similarly, the six UI skins share semantic CSS tokens; theme selection cannot alter backend
+requests, evidence identity, or research state.
 
 ## The custody rules 🦝
 
-1. **Original media is source evidence and read-only during normal processing.** Explicit
-   source deletion is a separate provenance-checked operation.
+1. **Original media is source evidence and read-only during normal processing.** Explicit source deletion is separate and provenance-checked.
 2. **Canonical transcript JSON is authoritative transcript evidence.**
 3. **Managed model manifests describe verified local execution dependencies.**
 4. **Lexical, semantic, and research DuckDB databases are rebuildable projections.**
-5. **Speaker labels, notes, tags, collections, and saved searches are human-authored
-   authority and do not inherit index deletion semantics.**
+5. **Speaker labels, notes, tags, collections, and saved searches are human-authored authority and do not inherit index deletion semantics.**
 6. **Research joins include canonical generation identity, not a friendly segment ID alone.**
-7. **Precise navigation resolves to verified canonical evidence rather than trusting a
-   stale search projection.**
+7. **Precise navigation resolves to verified canonical evidence rather than trusting a stale search projection.**
 8. **Research filters apply before ranking/scoring when they define eligible evidence.**
 9. **Saved searches persist typed query intent, not a frozen derived evidence scope.**
-10. **Canonical deletion preserves attached notes and document-scoped saved searches unless
-    their own destructive scopes are explicitly selected.**
+10. **Canonical deletion preserves attached notes and document-scoped saved searches unless their own destructive scopes are explicitly selected.**
 11. **Age-based retention can delete only private job workspaces.**
 12. **Remembered locations are permissions/pointers, not copies of user media.**
-13. **The desktop webview receives typed presentation DTOs, not arbitrary filesystem paths
-    or database handles.**
-14. **EchoFlow does not claim secure erasure it cannot prove.**
+13. **The desktop webview receives typed presentation DTOs, not arbitrary filesystem paths or database handles.**
+14. **Long-running native process supervision does not create a second job or checkpoint authority.**
+15. **Theme/presentation state is machine-local preference, not evidence or research state.**
+16. **EchoFlow does not claim secure erasure it cannot prove.**
 
-Search infrastructure may disappear. User-authored knowledge may not disappear by
-accident.
+Search infrastructure may disappear. User-authored knowledge may not disappear by accident.
 
 ## Current application seams
 
 Unified discovery, saved searches, frequent/recent navigation, and research interactions
-compose through `ResearchWorkspaceService`. The current desktop exposes grouped Library
-discovery plus verified context/word coordinates through narrow bridge methods.
+compose through `ResearchWorkspaceService`. The desktop exposes grouped Library discovery,
+verified context/word coordinates, durable Research mutation, saved search/anchor flows, and
+full Research search controls through narrow bridge methods.
+
+Processing composes through `ProcessingCenterService`; Tauri owns only the native lifetime
+of allowlisted long-running tasks. Resume/retry semantics remain Python application policy.
 
 Incremental corpus growth composes through `TranscriptLibraryService.refresh(...)` and
-remembered roots through `LibraryLocationService`. Full `library rebuild` is the explicit
+remembered roots through `LibraryLocationService`. Full `library rebuild` is an explicit
 repair/recovery lever, not a normal “one file changed” workflow.
 
-Custody-sensitive operations compose separately through `LibraryCustodyService`:
+Custody-sensitive operations remain separate through `LibraryCustodyService`:
 
 ```bash
 echoflow library delete TRANSCRIPT_ID --scope library-view
@@ -213,19 +223,21 @@ echoflow library retention --execution-days 30
 Deletion and retention are dry-run by default. Applying a reviewed operation requires the
 plan-bound token returned by the dry run.
 
-The next desktop seam is the **Research workspace**, not another research database. It
-should browse and mutate notes/tags/collections/saved searches through narrow bridge
-operations delegating to `ResearchWorkspaceService`. Local media playback belongs behind a
-separate Tauri-owned capability and should consume verified source-relative coordinates
-without giving React arbitrary path authority.
+The next native seam is local media playback. It should consume the already verified
+source-relative cursor behind a Tauri-owned media capability without giving React arbitrary
+path authority. Lifecycle/retention UI comes after playback over the existing custody
+service rather than creating a second deletion policy.
 
 ## New abstraction test
 
-Before adding a manager, framework, registry, adapter hierarchy, generalized plugin
-system, or database wrapper, ask which concrete capability or invariant it protects.
+Before adding a manager, framework, registry, adapter hierarchy, generalized plugin system,
+or database wrapper, ask which concrete capability or invariant it protects.
 
 File count is not an architectural problem. Repeated policy, unclear ownership, and
 unprovable invariants are.
+
+The same applies to frontend styling: six skins do not justify six component palettes. One
+semantic role should have one meaning and six token values.
 
 ## Documentation contract
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -12,6 +12,7 @@ subtle bad decisions into failing tests.
 |---|---|
 | [Desktop development prerequisites](desktop-development.md) | choose browser mock, native Tauri, or real processing setup; understand Node/npm locality, Rust/Cargo, Python, and native prerequisites |
 | [Desktop source-build troubleshooting](troubleshooting.md) | symptom-first recovery for blank browser views, Cargo/Tauri/Python/WebKitGTK/Wayland failures, port collisions, and safe cleanup |
+| [Desktop themes and accessibility](desktop-accessibility.md) | semantic theme tokens, contrast invariants, native-control theming, keyboard/a11y qualification, and adding a skin safely |
 | [Testing and regression bisection](testing-and-bisect.md) | general test strategy, colocation rules, mutation anticipation, and deterministic bisect oracles |
 | [Semantic retrieval qualification](semantic-retrieval-testing.md) | property, negative, boundary, integration, and mutation coverage for lexical/semantic/hybrid search decisions |
 | [Empirical benchmarking and calibration](benchmarking.md) | measuring real execution without turning hosted CI timing into folklore |
@@ -35,6 +36,7 @@ jobs. It includes:
 - rejection of raw-HTML rendering escape hatches in the frontend;
 - a native Tauri/Rust `cargo check --locked` so browser-only builds cannot hide missing native assets, dependency drift, or host errors;
 - Playwright interaction tests plus axe accessibility checks;
+- a six-skin contrast matrix covering text, controls, focus, selection, browser `color-scheme`, and representative Research controls;
 - package build verification and clean-wheel installation; and
 - Linux, macOS, and Windows CI/platform smoke.
 
@@ -90,7 +92,8 @@ Useful tests include:
 - an empty research evidence scope returns zero transcript results rather than widening
   to the corpus;
 - a desktop evidence DTO never exposes canonical/source filesystem paths even though the
-  backend authority knows them; and
+  backend authority knows them;
+- every registered desktop skin satisfies the same semantic-token and contrast contract; and
 - an unexpected internal CLI/bridge error is masked while a known public error preserves
   its intended message/code.
 
@@ -108,7 +111,8 @@ are preferred where IDs, hashes, sequences, and evidence relationships are load-
 
 Frontend tests live beside the frontend harness. A new interactive desktop slice should
 normally include keyboard behavior, semantic-role assertions, path/capability boundary
-checks where relevant, and an axe pass in the same tranche.
+checks where relevant, and an axe pass in the same tranche. Theme-aware components inherit
+the shared contrast matrix rather than adding one-off palette tests.
 
 ## Performance qualification from here
 
@@ -120,8 +124,9 @@ Current performance work should target product workloads:
 - one-edit and large-batch research projection catch-up;
 - full research projection rebuild;
 - realistic multi-recording corpus startup and disk cost;
-- desktop Library responsiveness today;
-- desktop Research responsiveness once that workspace lands; and
+- desktop Library responsiveness;
+- desktop Research responsiveness;
+- Processing Center responsiveness while jobs are active; and
 - local media seek/playback responsiveness once the Tauri media capability lands.
 
 Representative 8/16 GB consumer machines, Apple Silicon, discrete-GPU laptops, and larger

--- a/docs/development/desktop-accessibility.md
+++ b/docs/development/desktop-accessibility.md
@@ -1,0 +1,76 @@
+# Desktop themes and accessibility
+
+EchoFlow themes are presentation, not application state. A theme may change color and visual tone; it may not change evidence, research, processing behavior, or what an interaction means.
+
+## One semantic token contract
+
+Every desktop skin supplies the same semantic CSS variables in `frontend/src/styles.css`:
+
+| Token | Meaning |
+|---|---|
+| `--bg` | application background |
+| `--surface`, `--surface-raised`, `--surface-soft` | content surfaces at increasing visual emphasis |
+| `--ink`, `--muted` | primary and secondary text |
+| `--border` | general structural boundary |
+| `--accent`, `--accent-strong`, `--accent-soft`, `--on-accent` | interactive emphasis and its readable foreground |
+| `--control-bg`, `--control-ink`, `--control-border` | native and custom form controls |
+| `--focus` | keyboard focus indicator |
+| `--danger` | destructive/error text |
+| `--selection-bg`, `--selection-ink` | selected text |
+
+Components consume those meanings. They do not own theme-specific grays, whites, blues, or dark-mode exceptions. If a component needs a new visual role, add a semantic token only when the role is genuinely distinct across the product.
+
+The theme registry in `frontend/src/themes.ts` owns the supported IDs, display names, and light/dark browser scheme. CSS owns the palette values. That split prevents the theme menu, component code, and palette definitions from becoming three competing sources of truth.
+
+## Current skins
+
+EchoFlow ships six skins through one compact **Theme** picker:
+
+- **Archive**: warm paper neutrals with restrained teal;
+- **Midnight**: charcoal surfaces with cool teal;
+- **Paper**: cool neutral paper with ink blue;
+- **Moss**: soft mineral greens;
+- **Plum**: muted aubergine on warm pale surfaces; and
+- **Ember**: warm near-black surfaces with amber emphasis.
+
+The set is intentionally varied by temperature and character without changing component semantics. Four light skins and two dark skins also exercise both browser `color-scheme` paths instead of treating dark mode as a one-off exception.
+
+Theme choice is stored only in browser-local presentation preferences. Failure to read or write that preference falls back to Archive and must never block the evidence workspace.
+
+## Contrast is a testable invariant
+
+The Playwright theme matrix checks every skin against the same WCAG-oriented thresholds:
+
+- ordinary text pairs: **4.5:1 or greater**;
+- control boundaries and focus indicators: **3:1 or greater**;
+- accent buttons use `--on-accent` rather than assuming white text; and
+- text selection has its own foreground/background pair.
+
+The current token set is deliberately above the minimums. In the checked pairs, the lowest text contrast is about **5.69:1** and the lowest non-text boundary/focus contrast is about **4.19:1**. Those margins are useful because real components can introduce antialiasing, opacity, and surrounding-color effects that make barely passing palettes brittle.
+
+`frontend/tests/theme-accessibility.spec.ts` also verifies the declared browser `color-scheme`, exercises the real Research controls in every skin, and runs axe. The normal interaction suite continues to cover semantic roles and keyboard behavior.
+
+## Native controls are part of the theme
+
+Inputs, selects, textareas, checkboxes, radio buttons, options, placeholders, disabled states, text selection, and focus indicators are normalized centrally. Every theme explicitly declares `color-scheme`, so the browser and operating system do not have to guess whether a native control belongs to a light or dark surface.
+
+Do not fix a contrast problem by adding a component-local `#666`, `#fff`, or platform-specific gray. Fix the semantic role or token. The same repair should make the control correct in Research, Processing, import, Library, and future surfaces.
+
+Browser automation cannot fully prove how an opened native select menu is painted by every Windows/macOS/Linux desktop stack. Representative-device qualification therefore still includes visual and keyboard checks for opened native controls, high-contrast/forced-colors modes, display scaling, and platform focus treatment.
+
+## Color cannot be the only signal
+
+Status, errors, selection, processing readiness, current/older evidence, disabled actions, and destructive scope must remain understandable without color. Use text, semantic structure, icons where useful, and ARIA/state attributes as appropriate. A new skin must not require a new interpretation of the interface.
+
+## Adding a skin
+
+A new theme is acceptable only when it:
+
+1. is registered once in `themes.ts`;
+2. supplies the complete semantic token set in `styles.css`;
+3. declares an explicit light or dark `color-scheme`;
+4. passes the shared contrast matrix and axe checks;
+5. does not add component-specific palette overrides; and
+6. remains legible for focused, selected, disabled, error, and form-control states.
+
+This is intentionally more restrictive than “the screenshot looks good.” The product should make unreadable UI difficult to commit.

--- a/docs/diagrams/system-architecture.svg
+++ b/docs/diagrams/system-architecture.svg
@@ -1,50 +1,48 @@
-<!-- mermaid-sha256: 6b7fcddf335ba974f41786c44ea4499384a7bbc2bee6c1249aeb8270a038dd9e -->
-<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1700 700">
+<!-- mermaid-sha256: 815e51ceb9f98f5d8c5e3d7818fdea9d368b1dcf41fe72939ef25ee303874ae3 -->
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1800 760">
   <title id="title">EchoFlow system architecture</title>
-  <desc id="desc">Source media moves through inspection, an immutable plan, transcription, and canonical JSON. Rebuildable DuckDB projections rank passages, canonical navigation verifies evidence, SQLite owns durable research, custody planning owns destructive operations, and the desktop bridge exposes narrow Library and evidence presentation with Research next.</desc>
+  <desc id="desc">Source media moves through inspection, an immutable plan, transcription, and canonical JSON. Rebuildable search ranks passages, canonical navigation verifies evidence, SQLite owns durable research, Processing Center composes execution authority, custody planning owns destructive operations, and the desktop bridge exposes current Library, Research, and Processing surfaces.</desc>
   <defs>
     <marker id="arrow" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto"><path d="M0 0L9 4.5L0 9Z" fill="#315E63"/></marker>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="5" stdDeviation="6" flood-color="#1F2930" flood-opacity="0.10"/></filter>
   </defs>
-  <rect width="1700" height="700" rx="30" fill="#FBF9F4"/>
+  <rect width="1800" height="760" rx="30" fill="#FBF9F4"/>
   <text x="70" y="62" fill="#1F2930" font-family="Inter,Segoe UI,sans-serif" font-size="29" font-weight="700">EchoFlow architecture: authority stays separated</text>
-  <text x="70" y="92" fill="#5F6762" font-family="Inter,Segoe UI,sans-serif" font-size="15">Canonical evidence, human research, derived projections, destructive custody, and desktop presentation have different jobs.</text>
+  <text x="70" y="92" fill="#5F6762" font-family="Inter,Segoe UI,sans-serif" font-size="15">Canonical evidence, human research, derived projections, processing authority, destructive custody, and desktop presentation have different jobs.</text>
 
   <g stroke="#315E63" stroke-width="3" fill="none" marker-end="url(#arrow)">
-    <path d="M235 170H300"/><path d="M500 170H565"/><path d="M765 170H830"/><path d="M1030 170H1095"/>
-    <path d="M1195 215V285H1080"/><path d="M880 330H815"/><path d="M715 330H650"/>
-    <path d="M1195 215V285H1320"/><path d="M1420 375V445H1300"/>
-    <path d="M1195 215V540H1060"/><path d="M860 585H795"/>
-    <path d="M595 585H530"/>
-    <path d="M1080 330H1015"/><path d="M915 330H850"/>
-    <path d="M750 375V445H830"/>
-    <path d="M1030 490H1095"/>
-    <path d="M1295 490H1360"/>
+    <path d="M235 165H285"/><path d="M505 165H555"/><path d="M775 165H825"/><path d="M1045 165H1095"/>
+    <path d="M1195 210V285H1035"/><path d="M815 330H765"/><path d="M545 330H495"/>
+    <path d="M1195 210V285H1365"/>
+    <path d="M385 375V445H555"/><path d="M775 490H825"/><path d="M1045 490H1095"/><path d="M1315 490H1365"/>
+    <path d="M665 210V565H825"/><path d="M935 535V510"/>
+    <path d="M1195 210V630H1095"/><path d="M875 675H825"/>
   </g>
 
   <g filter="url(#shadow)" font-family="Inter,Segoe UI,sans-serif" font-size="15" font-weight="700">
-    <g><rect x="70" y="125" width="165" height="90" rx="18" fill="#F9D5E5" stroke="#7B2E52" stroke-width="3"/><text x="152" y="163" text-anchor="middle" fill="#22151B">Source</text><text x="152" y="187" text-anchor="middle" fill="#22151B">media</text></g>
-    <g><rect x="300" y="125" width="200" height="90" rx="18" fill="#D8EEFF" stroke="#2E617B" stroke-width="3"/><text x="400" y="163" text-anchor="middle" fill="#12222A">Media + resource</text><text x="400" y="187" text-anchor="middle" fill="#12222A">inspection</text></g>
-    <g><rect x="565" y="125" width="200" height="90" rx="18" fill="#E8D9FF" stroke="#68469B" stroke-width="3"/><text x="665" y="163" text-anchor="middle" fill="#1F1630">Immutable</text><text x="665" y="187" text-anchor="middle" fill="#1F1630">local plan</text></g>
-    <g><rect x="830" y="125" width="200" height="90" rx="18" fill="#E8D9FF" stroke="#68469B" stroke-width="3"/><text x="930" y="163" text-anchor="middle" fill="#1F1630">Transcription</text><text x="930" y="187" text-anchor="middle" fill="#1F1630">+ checkpoints</text></g>
-    <g><rect x="1095" y="125" width="200" height="90" rx="18" fill="#FFF0B8" stroke="#8A6B18" stroke-width="3"/><text x="1195" y="163" text-anchor="middle" fill="#2C260F">Canonical</text><text x="1195" y="187" text-anchor="middle" fill="#2C260F">transcript JSON</text></g>
+    <g><rect x="70" y="120" width="165" height="90" rx="18" fill="#F9D5E5" stroke="#7B2E52" stroke-width="3"/><text x="152" y="158" text-anchor="middle" fill="#22151B">Source</text><text x="152" y="182" text-anchor="middle" fill="#22151B">media</text></g>
+    <g><rect x="285" y="120" width="220" height="90" rx="18" fill="#E8D9FF" stroke="#68469B" stroke-width="3"/><text x="395" y="158" text-anchor="middle" fill="#1F1630">Media + resource</text><text x="395" y="182" text-anchor="middle" fill="#1F1630">inspection</text></g>
+    <g><rect x="555" y="120" width="220" height="90" rx="18" fill="#E8D9FF" stroke="#68469B" stroke-width="3"/><text x="665" y="158" text-anchor="middle" fill="#1F1630">Immutable</text><text x="665" y="182" text-anchor="middle" fill="#1F1630">local plan</text></g>
+    <g><rect x="825" y="120" width="220" height="90" rx="18" fill="#E8D9FF" stroke="#68469B" stroke-width="3"/><text x="935" y="158" text-anchor="middle" fill="#1F1630">Transcription</text><text x="935" y="182" text-anchor="middle" fill="#1F1630">+ checkpoints</text></g>
+    <g><rect x="1095" y="120" width="200" height="90" rx="18" fill="#FFF0B8" stroke="#8A6B18" stroke-width="3"/><text x="1195" y="158" text-anchor="middle" fill="#2C260F">Canonical</text><text x="1195" y="182" text-anchor="middle" fill="#2C260F">transcript JSON</text></g>
+    <g><rect x="1365" y="285" width="200" height="90" rx="18" fill="#DDF5E3" stroke="#347A46" stroke-width="3"/><text x="1465" y="323" text-anchor="middle" fill="#142719">Derived exports</text><text x="1465" y="347" text-anchor="middle" fill="#142719">TXT / SRT / VTT</text></g>
 
-    <g><rect x="1320" y="285" width="200" height="90" rx="18" fill="#DDF5E3" stroke="#347A46" stroke-width="3"/><text x="1420" y="323" text-anchor="middle" fill="#142719">Derived exports</text><text x="1420" y="347" text-anchor="middle" fill="#142719">TXT / SRT / VTT</text></g>
-    <g><rect x="880" y="285" width="200" height="90" rx="18" fill="#DDF5E3" stroke="#347A46" stroke-width="3"/><text x="980" y="323" text-anchor="middle" fill="#142719">DuckDB search</text><text x="980" y="347" text-anchor="middle" fill="#142719">projections</text></g>
-    <g><rect x="650" y="285" width="200" height="90" rx="18" fill="#DDF5E3" stroke="#347A46" stroke-width="3"/><text x="750" y="323" text-anchor="middle" fill="#142719">Ranked</text><text x="750" y="347" text-anchor="middle" fill="#142719">passages</text></g>
-    <g><rect x="420" y="285" width="200" height="90" rx="18" fill="#FFF0B8" stroke="#8A6B18" stroke-width="3"/><text x="520" y="323" text-anchor="middle" fill="#2C260F">Verified evidence</text><text x="520" y="347" text-anchor="middle" fill="#2C260F">navigation</text></g>
+    <g><rect x="815" y="285" width="220" height="90" rx="18" fill="#DDF5E3" stroke="#347A46" stroke-width="3"/><text x="925" y="323" text-anchor="middle" fill="#142719">DuckDB search</text><text x="925" y="347" text-anchor="middle" fill="#142719">projections</text></g>
+    <g><rect x="545" y="285" width="220" height="90" rx="18" fill="#DDF5E3" stroke="#347A46" stroke-width="3"/><text x="655" y="323" text-anchor="middle" fill="#142719">Ranked</text><text x="655" y="347" text-anchor="middle" fill="#142719">passages</text></g>
+    <g><rect x="275" y="285" width="220" height="90" rx="18" fill="#FFF0B8" stroke="#8A6B18" stroke-width="3"/><text x="385" y="323" text-anchor="middle" fill="#2C260F">Verified evidence</text><text x="385" y="347" text-anchor="middle" fill="#2C260F">navigation</text></g>
 
-    <g><rect x="830" y="445" width="200" height="90" rx="18" fill="#F9D5E5" stroke="#7B2E52" stroke-width="3"/><text x="930" y="483" text-anchor="middle" fill="#22151B">SQLite research</text><text x="930" y="507" text-anchor="middle" fill="#22151B">authority</text></g>
-    <g><rect x="1095" y="445" width="200" height="90" rx="18" fill="#DDF5E3" stroke="#347A46" stroke-width="3"/><text x="1195" y="483" text-anchor="middle" fill="#142719">Research service</text><text x="1195" y="507" text-anchor="middle" fill="#142719">+ discovery</text></g>
-    <g><rect x="1360" y="445" width="200" height="90" rx="18" fill="#D8EEFF" stroke="#2E617B" stroke-width="3"/><text x="1460" y="483" text-anchor="middle" fill="#12222A">Desktop bridge</text><text x="1460" y="507" text-anchor="middle" fill="#12222A">→ React Library</text></g>
+    <g><rect x="555" y="445" width="220" height="90" rx="18" fill="#FFF0B8" stroke="#8A6B18" stroke-width="3"/><text x="665" y="483" text-anchor="middle" fill="#2C260F">SQLite research</text><text x="665" y="507" text-anchor="middle" fill="#2C260F">authority</text></g>
+    <g><rect x="825" y="445" width="220" height="90" rx="18" fill="#D8EEFF" stroke="#2E617B" stroke-width="3"/><text x="935" y="483" text-anchor="middle" fill="#12222A">Research service</text><text x="935" y="507" text-anchor="middle" fill="#12222A">+ discovery</text></g>
+    <g><rect x="1095" y="445" width="220" height="90" rx="18" fill="#D8EEFF" stroke="#2E617B" stroke-width="3"/><text x="1205" y="483" text-anchor="middle" fill="#12222A">Versioned</text><text x="1205" y="507" text-anchor="middle" fill="#12222A">desktop bridge</text></g>
+    <g><rect x="1365" y="445" width="270" height="90" rx="18" fill="#D8EEFF" stroke="#2E617B" stroke-width="3"/><text x="1500" y="483" text-anchor="middle" fill="#12222A">React Library</text><text x="1500" y="507" text-anchor="middle" fill="#12222A">Research + Processing</text></g>
 
-    <g><rect x="860" y="540" width="200" height="90" rx="18" fill="#FFD6D6" stroke="#9E3434" stroke-width="3"/><text x="960" y="578" text-anchor="middle" fill="#351616">Library custody</text><text x="960" y="602" text-anchor="middle" fill="#351616">service</text></g>
-    <g><rect x="595" y="540" width="200" height="90" rx="18" fill="#FFD6D6" stroke="#9E3434" stroke-width="3"/><text x="695" y="578" text-anchor="middle" fill="#351616">Plan-bound</text><text x="695" y="602" text-anchor="middle" fill="#351616">deletion</text></g>
-    <g><rect x="330" y="540" width="200" height="90" rx="18" fill="#E8D9FF" stroke="#68469B" stroke-width="3"/><text x="430" y="578" text-anchor="middle" fill="#1F1630">Next Research</text><text x="430" y="602" text-anchor="middle" fill="#1F1630">workspace UI</text></g>
+    <g><rect x="825" y="565" width="220" height="90" rx="18" fill="#E8D9FF" stroke="#68469B" stroke-width="3"/><text x="935" y="603" text-anchor="middle" fill="#1F1630">ProcessingCenter</text><text x="935" y="627" text-anchor="middle" fill="#1F1630">Service</text></g>
+    <g><rect x="875" y="630" width="220" height="90" rx="18" fill="#FFD6D6" stroke="#9E3434" stroke-width="3"/><text x="985" y="668" text-anchor="middle" fill="#351616">Library custody</text><text x="985" y="692" text-anchor="middle" fill="#351616">service</text></g>
+    <g><rect x="605" y="630" width="220" height="90" rx="18" fill="#FFD6D6" stroke="#9E3434" stroke-width="3"/><text x="715" y="668" text-anchor="middle" fill="#351616">Plan-bound</text><text x="715" y="692" text-anchor="middle" fill="#351616">deletion</text></g>
   </g>
 
   <g font-family="Inter,Segoe UI,sans-serif" font-size="13">
-    <rect x="70" y="650" width="1490" height="30" rx="12" fill="#ECE6DC"/>
-    <text x="815" y="670" text-anchor="middle" fill="#5F6762">Gold = evidence · pink = human/source authority · green = rebuildable views · purple = processing/next UI · red = destructive custody · blue = inspection/presentation boundary</text>
+    <rect x="70" y="726" width="1565" height="26" rx="11" fill="#ECE6DC"/>
+    <text x="852" y="744" text-anchor="middle" fill="#5F6762">Gold = evidence · pink = source authority · green = rebuildable views · purple = processing · red = destructive custody · blue = composition/presentation boundary</text>
   </g>
 </svg>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ Choose the smallest path that matches what you want to do:
 
 | Goal | First command after cloning | You do not need yet |
 |---|---|---|
-| just inspect/click the frontend with fake data | `cd frontend && npm ci && npm run dev:mock` | Python, uv, Rust, Cargo, FFmpeg, model |
+| inspect/click the frontend with fake data | `cd frontend && npm ci && npm run dev:mock` | Python, uv, Rust, Cargo, FFmpeg, model |
 | run the real native desktop window | follow the desktop prerequisites, then `npm run tauri dev` | transcription model until you process media |
 | use the Python CLI / process real recordings | `uv sync --locked --extra transcription` | frontend tooling unless you also want the GUI |
 
@@ -28,23 +28,24 @@ If a desktop source build behaves strangely, use **[Desktop source-build trouble
 The repository currently has two presentation paths over the same application services:
 
 - the Python CLI; and
-- a Tauri + React desktop shell for native import, Library discovery, verified evidence,
-  and durable Research workflows.
+- a Tauri + React desktop for import, Processing, Library search, verified evidence, and
+  durable Research workflows.
 
 ```mermaid
 flowchart LR
     A[Your recording] --> B[Inspect source and computer]
     B --> C[Choose safe local plan]
-    C --> D[Transcribe]
-    D --> E[Canonical transcript]
-    E --> F[Derived exports]
-    E --> G[Private local search]
-    G --> H[Verified evidence navigation]
-    H --> I[Durable notes tags collections]
-    I --> G
-    G --> J[Desktop Library]
-    H --> J
-    I --> K[Desktop Research]
+    C --> D[Desktop Processing]
+    D --> E[Transcribe]
+    E --> F[Canonical transcript]
+    F --> G[Derived exports]
+    F --> H[Private local search]
+    H --> I[Verified evidence navigation]
+    I --> J[Durable notes tags collections]
+    J --> H
+    H --> K[Desktop Library]
+    I --> K
+    J --> L[Desktop Research]
 
     classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
     classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
@@ -53,15 +54,16 @@ flowchart LR
     classDef inspect fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
 
     class A source
-    class B,C,D,K process
-    class E,H,I evidence
-    class F,G view
-    class J inspect
+    class B,C,D,E,L process
+    class F,I,J evidence
+    class G,H view
+    class K inspect
 ```
 
-Text fallback: source media is inspected and transcribed locally into canonical evidence;
+Text fallback: source media is inspected and processed locally into canonical evidence;
 rebuildable search and verified navigation make that evidence useful; durable research
-state stays separate; the desktop exposes import, Library, evidence, and Research workflows.
+state stays separate; the desktop exposes import, Processing, Library, evidence, and
+Research workflows.
 
 ## Fast path: inspect the frontend only
 
@@ -98,7 +100,28 @@ npm run tauri dev
 ```
 
 The debug Tauri host automatically prefers EchoFlow's repository `.venv` for backend calls.
-A transcription model is still optional until you actually ask EchoFlow to transcribe.
+A transcription model is optional until you actually process a recording.
+
+### Use the desktop Processing Center
+
+Choose **Processing** in the desktop navigation. The first-release workflow now provides:
+
+- machine and model readiness;
+- outcome-oriented processing profiles;
+- a preflight summary before execution;
+- explicit transcription start;
+- durable job status/progress;
+- native cancel;
+- resume for a compatible interrupted job versus fresh retry when you want a new plan;
+- explicit diarization/enhancement/publication intent; and
+- private execution-state discard that does not delete recordings, canonical transcripts,
+  or research.
+
+Long-running transcription is not an hour-long browser request. Python owns planning,
+resource admission, model/checkpoint rules, and transcript correctness; Tauri supervises
+allowlisted child processes; React presents the workflow.
+
+See **[Processing Center](architecture/processing-center.md)** for the exact contract.
 
 ## 1. Install the Python source build for CLI/processing work
 
@@ -123,7 +146,7 @@ transcription uses that immutable revision instead of silently reaching out to t
 
 You can skip this step when you are only inspecting the UI or browsing existing evidence.
 
-## 3. Inspect and transcribe a recording
+## 3. Inspect and transcribe a recording from the CLI
 
 ```bash
 uv run echoflow transcribe interview.m4a --dry-run
@@ -158,14 +181,15 @@ uv run echoflow transcribe focus-group.wav --diarize
 Enhancement remains private working material and may not shift the canonical timeline.
 Diarization uses anonymous recording-scoped refs rather than biometric identity.
 
-When speaker evidence exists, give a ref a durable human-facing display name:
+When speaker evidence exists, give a ref a durable human-facing display name from the CLI:
 
 ```bash
 uv run echoflow library speakers list JOB_ID
 uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
 ```
 
-`Dr. Chen` is display state. `speaker-02` remains evidence.
+`Dr. Chen` is display state. `speaker-02` remains evidence. Desktop speaker-name management
+is still on the next transcript/speaker-tools tranche.
 
 ## 6. Refresh and search the local transcript library 🔎
 
@@ -179,6 +203,9 @@ uv run echoflow library find "housing affordability"
 
 Unified discovery returns grouped transcript evidence, notes, tags, and collections. It
 does not invent one score that makes unlike objects compete with each other.
+
+In the desktop Library, the default language is deliberately ordinary: search transcripts,
+notes, tags, and collections, then open a transcript result to see the exact passage.
 
 ## 7. Keep durable research beside the evidence 📝
 
@@ -208,7 +235,13 @@ uv run echoflow library search \
   --with-notes
 ```
 
-See **[Your notes should survive the machinery](research-notes.md)** for the custody model.
+The desktop Research search uses one **Match** choice: Any of these words, All of these
+words, or Exact phrase. Retrieval, ordering, transcript/speaker/language constraints,
+research filters, result count, and context are under **Search options**. Those choices are
+still compiled to the same typed Python contract; the GUI has not become the search engine.
+
+See **[Research search](research-search.md)** and
+**[Your notes should survive the machinery](research-notes.md)**.
 
 ## 8. Remember library and recording folders when you want to
 
@@ -219,27 +252,34 @@ transcribe the file. Manual processing remains the default.
 
 See **[Durable library locations](architecture/library-locations.md)**.
 
-## 9. Know what the desktop currently does
+## 9. Change the desktop theme
+
+The header has one **Theme** dropdown with Archive, Midnight, Paper, Moss, Plum, and Ember.
+The choice is saved locally as presentation preference only.
+
+All six skins use the same semantic tokens for text, surfaces, controls, focus, errors,
+selection, and accent foregrounds. They also declare explicit browser light/dark schemes
+and run through the same contrast/axe qualification matrix. See
+**[Desktop themes and accessibility](development/desktop-accessibility.md)**.
+
+## 10. Know what the desktop currently does
 
 The current desktop journey includes:
 
-- native file/folder selection for import;
-- one-time versus remembered location choices;
+- native file/folder selection and remembered-location choices;
 - recording candidate discovery;
+- Processing readiness, model state, preflight, launch, cancel, resume/retry, and job-state discard;
 - grouped Library search across evidence and research state;
 - verified canonical context and word highlighting;
-- exact-generation Research note reopening;
-- note create/edit/delete plus saved-search lifecycle; and
-- first-class tag/collection filtering with inspectable active filters.
+- Research note create/edit/delete, saved-search lifecycle, and tag/collection filtering;
+- full Research search options and inspectable technical retrieval details;
+- exact-generation Research note reopening plus explicit anchor review/re-anchor; and
+- six persisted accessible themes.
 
 The desktop webview does not receive arbitrary SQL, shell, or raw canonical/source path
 authority.
 
-For source-build commands, dependency locking, Linux prerequisites, and cleanup, use
-**[Desktop development prerequisites](development/desktop-development.md)**. For errors, use
-**[Desktop source-build troubleshooting](development/troubleshooting.md)**.
-
-## 10. Optional semantic and hybrid search ✨
+## 11. Optional semantic and hybrid search ✨
 
 Lexical search is the dependency-light default. Semantic search helps when you remember
 the idea but not the wording; hybrid retrieval combines lexical and semantic ranks using
@@ -252,45 +292,27 @@ Read **[Semantic search, without the mystery box](semantic-search.md)**.
 
 ## What EchoFlow stores 🦝
 
-```mermaid
-flowchart TD
-    A[Original recording] --> B[Canonical transcript JSON]
-    B --> C[TXT SRT WebVTT]
-    B --> D[DuckDB lexical and semantic projections]
-    B --> E[Verified evidence anchors]
-    E --> F[SQLite notes tags collections saved searches]
-    F --> G[DuckDB research projection]
-    F --> H[Desktop Research]
-
-    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-
-    class A,F source
-    class B,E evidence
-    class C,D,G view
-    class H process
-```
-
-Text fallback: original media and canonical JSON are evidence; notes/tags/collections and
-saved searches are durable human knowledge; publication/search/research projections are
-rebuildable; the desktop Research surface consumes the same application authority.
+Original media and canonical JSON are evidence; notes/tags/collections and saved searches
+are durable human knowledge; publication/search/research projections are rebuildable;
+remembered locations and theme selection are machine-local preferences with different
+custody semantics from evidence.
 
 ## What comes next?
 
-The desktop import, Library search, verified evidence reader, durable Research workspace,
-and first-class tag/collection navigation are foundation. Next:
+Research/search, Processing Center, and the desktop comprehension/theme tranche are
+foundation. Next:
 
-1. **Finish Research** with explicit stale/unavailable-anchor review and advanced typed search controls.
-2. **Build the desktop Processing center** over existing machine/model/job/transcription authority, including adaptive zero-knob execution.
-3. **Add speaker/processing controls and Tauri-owned local media playback**.
-4. **Productize lifecycle, packaging, first run, backup/restore, and portability**.
-5. **Qualify semantic dependencies and representative hardware**.
+1. transcript and speaker tools plus provenance/details polish;
+2. Tauri-owned local media playback;
+3. lifecycle and retention UI;
+4. architecture/redundancy audit before packaging;
+5. packaging/first run/update/uninstall;
+6. backup/restore and research portability;
+7. packaged semantic custody; and
+8. representative-device qualification.
 
-The deliberately separate **[post-MVP research roadmap](post-mvp-roadmap.md)** covers
-research snapshots/diffs, REFI-QDA interoperability, evidence packets, comparison,
-evidence-linked writing/script boards, portable research bundles, and live provisional
-capture after the first desktop product is coherent.
+The deliberately separate **[post-MVP research roadmap](post-mvp-roadmap.md)** covers later
+research snapshots/diffs, interoperability, evidence packets, comparison, writing/script
+boards, portable research bundles, and live provisional capture.
 
 For the detailed first-release sequence, see **[ROADMAP.md](../ROADMAP.md)**.

--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -69,18 +69,18 @@ canonical transcript bytes and refuses missing, reordered, or non-contiguous sel
 Optional `--start-seconds` and `--end-seconds` may narrow an anchor inside that verified
 span.
 
-The desktop uses that same rule when a note is created from the verified Evidence reader.
-It sends document/generation identity and canonical coordinates through one narrow bridge
-method. If the library moved to a newer canonical generation before Save, the write is
-refused instead of silently attaching the note to different evidence.
+The desktop uses that same rule when a note is created from the Evidence reader. It sends
+document/generation identity and canonical coordinates through one narrow bridge method. If
+the library moved to a newer canonical generation before Save, the write is refused instead
+of silently attaching the note to different evidence.
 
 Existing notes can be edited in the Research workspace. A desktop edit replaces note body,
 tag assignments, and collection assignments **atomically in authoritative SQLite** and
-emits one projection-journal event. The note’s evidence anchor is not rewritten.
+emits one projection-journal event. The note's evidence anchor is not rewritten.
 
-Desktop edit/delete carries the note’s authoritative `updated_at` version. If a CLI or
+Desktop edit/delete carries the note's authoritative `updated_at` version. If a CLI or
 another local surface changed that note after it was displayed, EchoFlow refuses the stale
-write and asks the user to refresh. Local-first does not mean lost-update-safe by accident.
+write and asks the user to refresh.
 
 A note can reopen the exact canonical generation it cites. The backend reuses the same
 canonical verifier as search navigation: it hashes the stored canonical bytes, checks the
@@ -97,21 +97,10 @@ That means an older note has three honest outcomes:
 3. the old evidence is unavailable, so the durable note remains but its cited evidence
    cannot currently be reopened.
 
-There is deliberately no “close enough, use the current transcript” fallback. New note
-creation is not offered from an older-generation evidence view because that would blur the
-boundary between reviewing old evidence and authoring against current evidence.
+There is deliberately no “close enough, use the current transcript” fallback.
 
 Deletion remains explicit and narrow: deleting a note deletes that human-authored note. It
 does not delete the canonical transcript or original recording.
-
-The equivalent CLI operations remain available:
-
-```bash
-echoflow library notes edit NOTE_ID --body "Revised note text"
-echoflow library notes set-tags NOTE_ID --tag housing --tag methodology
-echoflow library notes set-collections NOTE_ID --collection "Chapter 3"
-echoflow library notes delete NOTE_ID
-```
 
 ## Navigate by tags and collections
 
@@ -121,11 +110,10 @@ Clicking a label asks the backend for authoritative filtered notes through the e
 snapshot or recreate projection rules in the browser.
 
 Multiple selected labels use **AND semantics**: every selected tag and every selected
-collection must match the same note. The Research surface keeps active filters visible,
-lets the user remove them individually or clear them all, and preserves the existing
-note → verified-evidence path from filtered results.
+collection must match the same note. The Research surface keeps active filters visible and
+preserves the note → verified-evidence path from filtered results.
 
-## Use research state to search the transcript corpus
+## Search transcript evidence with research context
 
 Research metadata can constrain transcript retrieval before scoring:
 
@@ -147,9 +135,23 @@ EchoFlow resolves human names to durable IDs, obtains a canonical evidence scope
 research projection, and ranks lexical/semantic candidates **inside that scope**. It does
 not retrieve the whole corpus and throw away results afterward.
 
-Unified workspace discovery powers the desktop Library search. Search results can show
-associated note count, tags, and collections alongside original evidence/ranking data
-without inventing one cross-type relevance score.
+The desktop now exposes the complete first-release search contract without making users
+operate the backend vocabulary. The default **Match** control is:
+
+- **Any of these words**;
+- **All of these words**; or
+- **Exact phrase**.
+
+The GUI compiles that human choice into the same typed phrase/operator request that Python
+validates and canonicalizes. Retrieval mode becomes **Search by: Wording / Meaning /
+Wording + meaning**; sorting becomes **Order results by: Relevance / Time**. Speaker,
+language, transcript, tag, collection, note-text, result-count, and context controls live
+under **Search options**.
+
+Backend retrieval provenance is still inspectable under **Technical details**. It is not
+required reading for someone trying to find an interview passage.
+
+See **[Research search](research-search.md)** for the full boundary.
 
 ## What if the transcript changes?
 
@@ -159,13 +161,12 @@ canonical SHA-256, EchoFlow does **not** silently move the old note.
 
 The old note remains durable historical user state. The projected evidence key includes
 canonical generation identity so stale annotations cannot accidentally attach to new
-evidence. Editing the prose or labels on that old note still leaves its original anchor
-unchanged. The desktop can inspect the older generation when those exact canonical bytes
-remain available and valid.
+evidence. Editing prose or labels on that old note still leaves its original anchor
+unchanged.
 
 ### Review and deliberately re-anchor an older note
 
-The desktop now has an **Evidence maintenance** surface for notes whose anchor is not the
+The desktop has an **Evidence maintenance** surface for notes whose anchor is not the
 current canonical generation. Review is read-only. EchoFlow classifies the stored anchor as:
 
 - **current verified**: it already points to the current verified generation;
@@ -176,32 +177,26 @@ current canonical generation. Review is read-only. EchoFlow classifies the store
 Older does not mean broken. An older verified anchor can remain exactly where it is for as
 long as the user wants.
 
-For a non-current anchor, EchoFlow may also prepare a **current-generation candidate**. It
-will only do so when the current library document has the same durable document identity
-and the same recorded-source SHA-256. Candidate coordinates are derived from the note's
-source-relative time span, resolved to current canonical segments, and verified through the
-normal evidence locator. EchoFlow does not search another recording for something that
-looks similar, and React never chooses a canonical path or generation.
+For a non-current anchor, EchoFlow may prepare a **current-generation candidate** only when
+the current library document has the same durable document identity and recorded-source
+SHA-256. Candidate coordinates are derived from the note's source-relative time span and
+verified through the normal evidence locator. EchoFlow does not search another recording
+for something that looks similar, and React never chooses a canonical path or generation.
 
-Reviewing the candidate still changes nothing. Re-anchoring requires a second explicit
-confirmation. That confirmation carries both the note's `updated_at` version and the
-candidate canonical SHA-256 the user reviewed. If the note or current transcript changes
-before confirmation, EchoFlow refuses the mutation and requires another review.
+Re-anchoring requires a second explicit confirmation carrying both the note's `updated_at`
+version and the candidate canonical SHA-256 the user reviewed. If the note or transcript
+changes before confirmation, EchoFlow refuses the mutation and requires another review.
 
 A successful re-anchor is one authoritative SQLite transaction:
 
-1. copy the old evidence anchor and its segment identities into durable anchor history;
+1. copy the old evidence anchor and segment identities into durable anchor history;
 2. replace the note's current anchor with the reviewed same-source candidate;
 3. advance the research projection journal once; and
 4. commit all three together or roll all three back.
 
-The old anchor therefore does not vanish. It becomes a durable provenance record attached
-to that note. Re-anchoring changes **which evidence the note currently points to**; it does
-not rewrite the fact that the note used to point somewhere else.
-
-If EchoFlow cannot derive a safe same-source candidate, the Research surface shows the
-problem and offers no re-anchor action. There is intentionally no automatic or
-cross-recording fallback.
+The old anchor therefore does not vanish. Re-anchoring changes **which evidence the note
+currently points to**; it does not rewrite the fact that the note used to point somewhere
+else.
 
 ## Why two databases?
 
@@ -215,36 +210,22 @@ cross-recording fallback.
 SQLite fits frequently mutated transactional user state. DuckDB fits local analytical
 query workloads. EchoFlow deliberately does **not** make both authoritative.
 
-```text
-SQLite authority
-      |
-      | monotonic transactional journal
-      v
-Deterministic projector
-      |
-      v
-DuckDB projection
-```
-
 If the stores disagree, SQLite wins. If DuckDB disappears, rebuild it.
 
 ## Saved searches are durable questions, not screenshots
 
 Saved searches persist typed query intent and re-resolve current evidence rather than
-freezing result snapshots. Frequent/recent tag and collection navigation is derived from
-current relationships instead of persisted popularity counters.
+freezing result snapshots. The desktop supports create, inspect, run, rename/replace, and
+delete. Whole-intent replacement uses optimistic concurrency through authoritative
+`updated_at`.
 
-The desktop now supports saved-search create, run, rename, and delete. Creation sends only
-human intent across the desktop bridge; Python constructs and validates the typed
-`SearchQuery` and owns desktop defaults. Running the search replays that typed intent
-through current research-aware retrieval, so new qualifying evidence can appear.
+Saving a search keeps the question and its choices. Running it later re-derives the current
+research evidence scope and searches the current corpus; runtime `evidence_scope` is never
+persisted as user intent.
 
-Rename edits display metadata while preserving the typed search intent server-side.
-Rename/delete carry the saved search’s `updated_at` version, and authoritative SQLite checks
-that version inside the same immediate transaction as the mutation. A stale desktop view
-cannot silently overwrite a newer CLI/local change.
-
-The tag is durable user state. “Used 147 times” is disposable navigation metadata.
+The desktop now labels these as **Saved searches**, **Save search**, and **Update saved
+search** rather than requiring the user to understand “typed intent.” The typed intent still
+exists in Python and SQLite; only the default product language changed.
 
 ## Operational logs are not a shadow research archive
 
@@ -257,24 +238,24 @@ descriptions, or raw canonical/source paths from these Research operations. The 
 research stores remain the authority for human-authored content; logs do not become a
 second notebook.
 
-## What comes next for the notebook?
+## First-release Research status
 
-The storage, evidence-address, unified-discovery, Research overview, verified note
-creation, note edit/delete/label mutation, first-class tag/collection navigation,
-exact-generation note return, saved-search lifecycle, and explicit stale/unavailable anchor
-review plus provenance-preserving re-anchor contracts are built.
+The first-release Research tranche is complete across:
 
-The remaining first-release Research tranche is now the richer typed search surface:
-phrase/ANY/ALL behavior, speaker/language/transcript constraints, inspectable research
-filters, retrieval mode, and sort without hidden interpretation.
+- authoritative notes/tags/collections;
+- unified discovery;
+- note create/edit/delete and label mutation;
+- exact-generation evidence return;
+- saved-search lifecycle and whole-intent replacement;
+- explicit stale/unavailable-anchor review and provenance-preserving re-anchor; and
+- phrase/ANY/ALL, speaker/language/transcript constraints, research filters, retrieval mode,
+  sort, result count, and context controls.
 
+Further Research work is polish or post-MVP rather than the next critical-path blocker.
 Selected evidence packets, REFI-QDA interoperability, saved-question snapshots/diffs,
 comparison workspaces, evidence-linked writing/script boards, portable research bundles,
-and live provisional capture are deliberately post-MVP work. See
+and live provisional capture remain deliberately later work. See
 **[Post-MVP research roadmap](post-mvp-roadmap.md)**.
 
 The product does not currently provide rich-text/WYSIWYG editing, semantic embeddings over
 note prose, **automatic** cross-generation re-anchoring, or collaborative sync.
-
-> **Your research state is durable. Its fast query representation is disposable. The two
-> can always meet again through exact evidence identities.**

--- a/docs/research-search.md
+++ b/docs/research-search.md
@@ -1,21 +1,68 @@
-# Typed Research search
+# Research search
 
 EchoFlow has two complementary search surfaces.
 
-The Library search is the quick doorway: enter text and search transcripts plus the human
-research layer without needing to understand retrieval controls. The Research workspace
-adds an advanced, inspectable query builder for cases where the exact search intent matters.
+**Library** is the quick doorway: type what you remember and search transcripts, notes,
+tags, and collections. **Research** adds explicit choices when you need to narrow or save a
+question. They do **not** implement separate search engines. Both end in the same Python
+search and evidence-navigation authority.
 
-They do **not** implement separate search engines. Both end in the same Python search and
-evidence-navigation authority.
+The desktop deliberately uses ordinary product language even though the backend retains a
+more exact typed model.
 
-## What the typed intent contains
+## What the user sees
 
-An advanced Research search can state:
+The main Research search asks two things up front:
+
+1. **What are you looking for?**
+2. **Match:** Any of these words / All of these words / Exact phrase.
+
+Everything else is behind **Search options**:
+
+- **Search by:** Wording / Meaning / Wording + meaning;
+- **Order results by:** Relevance / Time;
+- maximum results;
+- context around a result;
+- speakers;
+- languages;
+- interviews/transcripts;
+- tags;
+- collections;
+- text in attached notes; and
+- only results that have notes.
+
+Successful results can expose backend/model/fusion provenance under **Technical details**.
+That information remains inspectable without being a vocabulary test for someone trying to
+find an interview passage.
+
+## How the simple Match control stays rigorous
+
+The backend contract still carries separate `phrase` and `operator` properties because they
+are useful, explicit search semantics. The GUI does not ask ordinary users to manipulate
+both at once.
+
+The presentation mapping is deterministic:
+
+| Human choice | Typed request |
+|---|---|
+| Any of these words | `phrase=false`, `operator=any` |
+| All of these words | `phrase=false`, `operator=all` |
+| Exact phrase | `phrase=true`, `operator=all` |
+
+Python still validates and canonicalizes the resulting request. React has not become the
+search-semantic authority; it has simply stopped exposing two low-level knobs for one human
+choice.
+
+A saved legacy intent with `phrase=true` remains presented as **Exact phrase** regardless of
+the stored operator because exact phrase is the stronger visible semantic. Saving that
+question again canonicalizes the presentation choice to the table above.
+
+## The typed intent underneath
+
+The backend Research intent can contain:
 
 - query text;
-- exact-phrase matching or term matching;
-- ANY or ALL term operator;
+- exact-phrase flag and ANY/ALL term operator;
 - anonymous speaker-reference filters;
 - language filters;
 - transcript/document filters;
@@ -28,14 +75,14 @@ An advanced Research search can state:
 - required text in attached notes; and
 - whether qualifying evidence must have an attached research note.
 
-Those controls are represented in Python as one `ResearchSearchIntent`. The object contains a
-normal `SearchQuery`, `ResearchQueryFilters`, `RetrievalMode`, and context count. It rejects
-an `evidence_scope` supplied as user intent because evidence scope is derived state, not a
-thing the desktop is allowed to author.
+Those controls are represented in Python as one `ResearchSearchIntent`. The object contains
+a normal `SearchQuery`, `ResearchQueryFilters`, `RetrievalMode`, and context count. It
+rejects an `evidence_scope` supplied as user intent because evidence scope is derived state,
+not something the desktop is allowed to author.
 
 ```mermaid
 flowchart LR
-    A[React form values] --> B[Strict desktop DTO]
+    A[Human search choices] --> B[Strict desktop DTO]
     B --> C[ResearchSearchIntent]
     C --> D[ResearchQueryFilters]
     C --> E[SearchQuery]
@@ -56,27 +103,27 @@ flowchart LR
     class H,I evidence
 ```
 
-Text fallback: React submits form values to a strict desktop DTO. Python constructs the
-search intent and research filters, derives any evidence scope from authoritative research
-state, retrieves current transcript evidence, and verifies canonical evidence before the
-result returns to the desktop.
+Text fallback: React collects ordinary search choices and submits a strict desktop DTO.
+Python constructs and validates search intent and research filters, derives any evidence
+scope from authoritative research state, retrieves current transcript evidence, and
+verifies canonical evidence before results return to the desktop.
 
-## The browser does not interpret the query
+## The browser does not interpret evidence policy
 
-React is allowed to collect and display values. It does not:
+React is allowed to compile the documented Match presentation choice and collect/display
+other values. It does not:
 
-- parse a user query into a different matching policy;
-- decide how phrase matching interacts with term operators;
 - derive evidence scope from visible notes or labels;
 - filter a capped result set after retrieval;
 - invent semantic/lexical scores;
 - choose a canonical generation;
-- query SQLite or DuckDB directly; or
-- turn saved searches into shell commands, SQL, or opaque strings.
+- query SQLite or DuckDB directly;
+- turn saved searches into shell commands, SQL, or opaque strings; or
+- silently fall back from an unavailable semantic mode to a different retrieval mode.
 
-The backend validates the nested intent again even though browser controls already constrain
-some values. The desktop adapter uses `extra="forbid"`, so an unexpected field such as SQL,
-a filesystem path, or a derived evidence scope is not silently accepted.
+The backend validates the nested intent again even though browser controls constrain some
+values. The desktop adapter uses `extra="forbid"`, so unexpected fields such as SQL, a
+filesystem path, or a derived evidence scope are not silently accepted.
 
 Speaker, language, and transcript filters are currently explicit identifiers. The desktop
 does not fabricate authoritative dropdown options by scraping whichever results happen to
@@ -92,56 +139,61 @@ evidence scope into transcript retrieval.
 Adding research constraints therefore narrows the candidate evidence **before** lexical or
 semantic ranking. The GUI cannot reproduce or weaken that rule.
 
-## Retrieval mode remains backend-qualified
+## Wording, meaning, and both
 
-Lexical search is local and deterministic over the current transcript index. Semantic and
-hybrid modes use the existing local semantic index and embedding profile. Selecting one of
-those modes does not make it magically available: the Python backend still verifies that
+The user-facing labels map to the existing retrieval modes:
+
+| Desktop | Backend |
+|---|---|
+| Wording | lexical |
+| Meaning | semantic |
+| Wording + meaning | hybrid |
+
+Semantic and hybrid modes use the existing local semantic index and embedding profile.
+Selecting them does not make that capability magically available: Python verifies that
 semantic state exists, matches the current corpus, and can load the qualified local model.
-If not, the operation fails with the normal safe application error rather than falling back
-silently to another retrieval mode.
+If not, the operation fails with the normal safe application error rather than silently
+changing retrieval mode.
 
 A successful result returns retrieval provenance such as backend IDs, semantic profile, and
-hybrid fusion profile. These fields explain how the result set was produced; React does not
-calculate them.
+hybrid fusion profile. The desktop places those fields under **Technical details**; React
+does not calculate them.
 
-## Saved searches store the whole typed question
+## Saved searches store the whole question
 
-A saved search is durable intent, not a frozen result list. The persisted object can retain
-the same phrase/operator, transcript/speaker/language, research-filter, retrieval, sort,
-limit, and context controls used for an immediate search.
+A saved search is durable intent, not a frozen result list. It can retain the same match,
+transcript/speaker/language, research-filter, retrieval, ordering, limit, and context choices
+used for an immediate search.
 
-Creating a typed saved search converts `ResearchSearchIntent` into the existing durable
+Creating a saved search converts `ResearchSearchIntent` into the existing durable
 `SavedSearchIntent`. Runtime `evidence_scope` is deliberately omitted. Running the question
 later re-derives qualifying evidence from whatever current transcript and research state
 exists at that time.
 
-Editing a saved search now replaces **display metadata and the complete typed intent in one
+Editing a saved search replaces **display metadata and the complete typed intent in one
 authoritative SQLite transaction**. The mutation carries `expected_updated_at`; if another
 local surface changed the saved search after it was opened, EchoFlow refuses the stale write
 rather than losing the newer edit.
 
-This closes an earlier desktop gap where the backend could persist rich typed intent but the
-normal desktop could only create a text query and later rename its display metadata.
+The UI calls these actions **Save search** and **Update saved search**. “Typed intent” remains
+a maintainer concept and storage contract, not a label an ordinary user must decode.
 
 ## Desktop privacy boundary
 
-The advanced bridge returns evidence text, IDs, hashes needed for evidence identity,
+The search bridge returns evidence text, IDs/hashes needed for evidence identity,
 source-relative times, speaker display state, research labels, and retrieval provenance.
-It does not return raw canonical or original-recording filesystem paths as part of the typed
+It does not return raw canonical or original-recording filesystem paths as part of the
 search result DTO.
 
 Operational logging for saved-intent replacement records durable object identity, retrieval
 mode, context size, and filter counts. It does not log query text, note-text filters, saved
 search names/descriptions, or raw media/canonical paths.
 
-## Why keep the quick search?
+## First-release status
 
-Most people should not need the advanced controls for ordinary recall. A fast search box is
-useful precisely because EchoFlow can choose a safe simple default. The typed Research
-surface exists when a researcher needs to say exactly what question was asked and preserve
-that question for later replay.
+The complete typed Research search contract is implemented in the desktop. Remaining
+Research work is optional polish, convenience catalogs/facets, or post-MVP workflows rather
+than a blocker for playback, lifecycle UI, packaging, or portability.
 
-The product rule is therefore:
-
-> **simple by default, inspectable when needed, authoritative in Python either way.**
+The product rule remains: **simple by default, inspectable when needed, authoritative in
+Python either way.**

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { IntakeWorkspace } from "./IntakeWorkspace";
 import { ProcessingCenter } from "./ProcessingCenter";
 import { ResearchWorkspaceWithAnchorReview } from "./ResearchWorkspaceWithAnchorReview";
 import { SearchWorkspace } from "./SearchWorkspace";
+import { DEFAULT_THEME, isTheme, THEME_STORAGE_KEY } from "./themes";
 import "./processing-center.css";
 
 const client = createDesktopClient();
@@ -14,12 +15,26 @@ const processing = createProcessingClient();
 
 type View = "intake" | "processing" | "library" | "research";
 
+function initialTheme(): Theme {
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return isTheme(stored) ? stored : DEFAULT_THEME;
+  } catch {
+    return DEFAULT_THEME;
+  }
+}
+
 export function App() {
-  const [theme, setTheme] = useState<Theme>("archive");
+  const [theme, setTheme] = useState<Theme>(initialTheme);
   const [view, setView] = useState<View>("intake");
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Presentation preferences must never block the local evidence workspace.
+    }
   }, [theme]);
 
   const workspace = useMemo(() => {

--- a/frontend/src/ResearchSearchControlsPanel.tsx
+++ b/frontend/src/ResearchSearchControlsPanel.tsx
@@ -18,10 +18,11 @@ interface ResearchSearchControlsPanelProps {
   onResearchChanged?: () => void;
 }
 
+type SearchMatch = "any" | "all" | "phrase";
+
 interface SearchDraft {
   queryText: string;
-  phrase: boolean;
-  operator: "any" | "all";
+  match: SearchMatch;
   speakerRefs: string;
   languages: string;
   documentIds: string;
@@ -37,8 +38,7 @@ interface SearchDraft {
 
 const EMPTY_DRAFT: SearchDraft = {
   queryText: "",
-  phrase: false,
-  operator: "any",
+  match: "any",
   speakerRefs: "",
   languages: "",
   documentIds: "",
@@ -59,11 +59,16 @@ function splitList(value: string): string[] {
     .filter(Boolean);
 }
 
+function matchFromIntent(intent: ResearchSearchIntent): SearchMatch {
+  if (intent.phrase) return "phrase";
+  return intent.operator;
+}
+
 function draftToIntent(draft: SearchDraft): ResearchSearchIntent {
   return {
     query_text: draft.queryText,
-    phrase: draft.phrase,
-    operator: draft.operator,
+    phrase: draft.match === "phrase",
+    operator: draft.match === "any" ? "any" : "all",
     speaker_refs: splitList(draft.speakerRefs),
     languages: splitList(draft.languages),
     document_ids: splitList(draft.documentIds),
@@ -81,8 +86,7 @@ function draftToIntent(draft: SearchDraft): ResearchSearchIntent {
 function intentToDraft(intent: ResearchSearchIntent): SearchDraft {
   return {
     queryText: intent.query_text,
-    phrase: intent.phrase,
-    operator: intent.operator,
+    match: matchFromIntent(intent),
     speakerRefs: intent.speaker_refs.join(", "),
     languages: intent.languages.join(", "),
     documentIds: intent.document_ids.join(", "),
@@ -97,26 +101,36 @@ function intentToDraft(intent: ResearchSearchIntent): SearchDraft {
   };
 }
 
+function matchLabel(intent: ResearchSearchIntent): string {
+  if (intent.phrase) return "Exact phrase";
+  return intent.operator === "all" ? "All of these words" : "Any of these words";
+}
+
+function retrievalLabel(mode: string): string {
+  if (mode === "semantic") return "Meaning";
+  if (mode === "hybrid") return "Wording + meaning";
+  return "Wording";
+}
+
 function IntentSummary({ intent }: { intent: ResearchSearchIntent }) {
   const chips = [
-    `phrase: ${intent.phrase ? "exact" : "off"}`,
-    `operator: ${intent.operator.toUpperCase()}`,
-    `mode: ${intent.retrieval_mode}`,
-    `sort: ${intent.sort}`,
-    `limit: ${intent.limit}`,
-    `context: ${intent.context_segments}`,
-    ...intent.speaker_refs.map((value) => `speaker: ${value}`),
-    ...intent.languages.map((value) => `language: ${value}`),
-    ...intent.document_ids.map((value) => `transcript: ${value}`),
-    ...intent.tags.map((value) => `tag: ${value}`),
-    ...intent.collections.map((value) => `collection: ${value}`),
-    ...(intent.note_text ? [`note text: ${intent.note_text}`] : []),
-    ...(intent.with_notes ? ["must have research notes"] : []),
+    `Match: ${matchLabel(intent)}`,
+    `Search by: ${retrievalLabel(intent.retrieval_mode)}`,
+    `Order: ${intent.sort === "timeline" ? "Time" : "Relevance"}`,
+    `Results: ${intent.limit}`,
+    `Context: ${intent.context_segments}`,
+    ...intent.speaker_refs.map((value) => `Speaker: ${value}`),
+    ...intent.languages.map((value) => `Language: ${value}`),
+    ...intent.document_ids.map((value) => `Transcript: ${value}`),
+    ...intent.tags.map((value) => `Tag: ${value}`),
+    ...intent.collections.map((value) => `Collection: ${value}`),
+    ...(intent.note_text ? [`Notes containing: ${intent.note_text}`] : []),
+    ...(intent.with_notes ? ["Only results with notes"] : []),
   ];
 
   return (
-    <div className="typed-search-intent" aria-label="Applied search intent">
-      <strong>Applied by EchoFlow</strong>
+    <div className="typed-search-intent" aria-label="Search details">
+      <strong>Search details</strong>
       <code>{intent.query_text}</code>
       <div className="typed-search-pills">
         {chips.map((chip) => (
@@ -146,9 +160,7 @@ export function ResearchSearchControlsPanel({
   const [busy, setBusy] = useState(false);
   const [savedBusy, setSavedBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState(
-    "Compose a typed evidence query. Python owns how every control is interpreted.",
-  );
+  const [status, setStatus] = useState("Search transcript evidence and your research.");
 
   const loadSavedSearches = useCallback(async () => {
     const overview = await client.researchOverview();
@@ -160,7 +172,7 @@ export function ResearchSearchControlsPanel({
       setError(
         caught instanceof Error
           ? caught.message
-          : "EchoFlow could not read saved search metadata.",
+          : "EchoFlow could not read your saved searches.",
       );
     });
   }, [loadSavedSearches, revision]);
@@ -179,14 +191,14 @@ export function ResearchSearchControlsPanel({
       setResult(next);
       setDraft(intentToDraft(next.intent));
       setStatus(
-        `${next.evidence.length} verified evidence result${next.evidence.length === 1 ? "" : "s"}. EchoFlow returned the canonicalized intent shown below.`,
+        `${next.evidence.length} verified evidence result${next.evidence.length === 1 ? "" : "s"}.`,
       );
     } catch (caught) {
       setResult(null);
       setError(
         caught instanceof Error
           ? caught.message
-          : "EchoFlow could not execute that typed research search.",
+          : "EchoFlow could not run that research search.",
       );
     } finally {
       setBusy(false);
@@ -208,12 +220,10 @@ export function ResearchSearchControlsPanel({
       setSavedDescription(saved.description ?? "");
       await loadSavedSearches();
       onResearchChanged?.();
-      setStatus(`Saved “${saved.name}” with its full typed search intent.`);
+      setStatus(`Saved “${saved.name}”.`);
     } catch (caught) {
       setError(
-        caught instanceof Error
-          ? caught.message
-          : "EchoFlow could not save that typed research search.",
+        caught instanceof Error ? caught.message : "EchoFlow could not save that search.",
       );
     } finally {
       setSavedBusy(false);
@@ -229,12 +239,10 @@ export function ResearchSearchControlsPanel({
       setDraft(intentToDraft(inspected.intent));
       setSavedName(inspected.name);
       setSavedDescription(inspected.description ?? "");
-      setStatus(`Loaded “${inspected.name}” into the typed intent editor.`);
+      setStatus(`Loaded “${inspected.name}”.`);
     } catch (caught) {
       setError(
-        caught instanceof Error
-          ? caught.message
-          : "EchoFlow could not inspect that saved search.",
+        caught instanceof Error ? caught.message : "EchoFlow could not open that saved search.",
       );
     } finally {
       setSavedBusy(false);
@@ -258,14 +266,10 @@ export function ResearchSearchControlsPanel({
       setSavedDescription(updated.description ?? "");
       await loadSavedSearches();
       onResearchChanged?.();
-      setStatus(
-        `Updated “${updated.name}”. Display metadata and typed query intent committed together.`,
-      );
+      setStatus(`Updated “${updated.name}”.`);
     } catch (caught) {
       setError(
-        caught instanceof Error
-          ? caught.message
-          : "EchoFlow could not update that saved search.",
+        caught instanceof Error ? caught.message : "EchoFlow could not update that saved search.",
       );
     } finally {
       setSavedBusy(false);
@@ -276,191 +280,182 @@ export function ResearchSearchControlsPanel({
     setEditingSaved(null);
     setSavedName("");
     setSavedDescription("");
-    setStatus("The current typed controls can be saved as a new durable research question.");
+    setStatus("The current search can be saved for later.");
   }
 
   async function createNote(body: string) {
     if (!selectedEvidence) throw new Error("Verified evidence is no longer open.");
     await client.createResearchNote(selectedEvidence, body);
     onResearchChanged?.();
-    setStatus("Saved a research note to the verified current evidence window.");
+    setStatus("Saved a note to this evidence passage.");
   }
 
   return (
     <section className="typed-search-shell" aria-labelledby="typed-search-title">
       <div className="typed-search-heading">
         <div>
-          <p className="mini-label">Advanced evidence search</p>
-          <h2 id="typed-search-title">Make the question inspectable.</h2>
-          <p>
-            These controls are presentation only. Python validates and executes the complete
-            intent, including research-state constraints and retrieval mode.
-          </p>
+          <p className="mini-label">Research search</p>
+          <h2 id="typed-search-title">What are you looking for?</h2>
+          <p>Search transcript evidence, then narrow it with the options you actually need.</p>
         </div>
-        <span className="typed-search-authority">Python authority</span>
       </div>
 
       <form className="typed-search-form" onSubmit={(event) => void executeSearch(event)}>
         <label className="typed-search-query">
-          Query
+          Search
           <input
             type="search"
             required
             maxLength={4096}
             value={draft.queryText}
             onChange={(event) => updateDraft("queryText", event.target.value)}
-            placeholder="What evidence are you looking for?"
+            placeholder="Words, a phrase, a topic…"
           />
         </label>
 
-        <fieldset className="typed-search-group">
-          <legend>Text matching</legend>
-          <label className="typed-search-check">
-            <input
-              type="checkbox"
-              checked={draft.phrase}
-              onChange={(event) => updateDraft("phrase", event.target.checked)}
-            />
-            Exact phrase
-          </label>
-          <label>
-            Term operator
-            <select
-              value={draft.operator}
-              onChange={(event) =>
-                updateDraft("operator", event.target.value as "any" | "all")
-              }
-            >
-              <option value="any">ANY term</option>
-              <option value="all">ALL terms</option>
-            </select>
-          </label>
-        </fieldset>
+        <label className="typed-search-match">
+          Match
+          <select
+            value={draft.match}
+            onChange={(event) => updateDraft("match", event.target.value as SearchMatch)}
+          >
+            <option value="any">Any of these words</option>
+            <option value="all">All of these words</option>
+            <option value="phrase">Exact phrase</option>
+          </select>
+        </label>
 
-        <fieldset className="typed-search-group typed-search-three">
-          <legend>Retrieval and result shape</legend>
-          <label>
-            Retrieval mode
-            <select
-              value={draft.retrievalMode}
-              onChange={(event) =>
-                updateDraft(
-                  "retrievalMode",
-                  event.target.value as "lexical" | "semantic" | "hybrid",
-                )
-              }
-            >
-              <option value="lexical">Lexical</option>
-              <option value="semantic">Semantic</option>
-              <option value="hybrid">Hybrid</option>
-            </select>
-          </label>
-          <label>
-            Sort
-            <select
-              value={draft.sort}
-              onChange={(event) =>
-                updateDraft("sort", event.target.value as "relevance" | "timeline")
-              }
-            >
-              <option value="relevance">Relevance</option>
-              <option value="timeline">Timeline</option>
-            </select>
-          </label>
-          <label>
-            Result limit
-            <input
-              type="number"
-              min={1}
-              max={1000}
-              value={draft.limit}
-              onChange={(event) => updateDraft("limit", event.target.value)}
-            />
-          </label>
-          <label>
-            Context segments
-            <input
-              type="number"
-              min={0}
-              max={10}
-              value={draft.contextSegments}
-              onChange={(event) => updateDraft("contextSegments", event.target.value)}
-            />
-          </label>
-        </fieldset>
+        <details className="typed-search-options">
+          <summary>Search options</summary>
+          <div className="typed-search-options-body">
+            <fieldset className="typed-search-group typed-search-three">
+              <legend>Results</legend>
+              <label>
+                Search by
+                <select
+                  value={draft.retrievalMode}
+                  onChange={(event) =>
+                    updateDraft(
+                      "retrievalMode",
+                      event.target.value as "lexical" | "semantic" | "hybrid",
+                    )
+                  }
+                >
+                  <option value="lexical">Wording</option>
+                  <option value="semantic">Meaning</option>
+                  <option value="hybrid">Wording + meaning</option>
+                </select>
+              </label>
+              <label>
+                Order results by
+                <select
+                  value={draft.sort}
+                  onChange={(event) =>
+                    updateDraft("sort", event.target.value as "relevance" | "timeline")
+                  }
+                >
+                  <option value="relevance">Relevance</option>
+                  <option value="timeline">Time</option>
+                </select>
+              </label>
+              <label>
+                Maximum results
+                <input
+                  type="number"
+                  min={1}
+                  max={1000}
+                  value={draft.limit}
+                  onChange={(event) => updateDraft("limit", event.target.value)}
+                />
+              </label>
+              <label>
+                Context around result
+                <input
+                  type="number"
+                  min={0}
+                  max={10}
+                  value={draft.contextSegments}
+                  onChange={(event) => updateDraft("contextSegments", event.target.value)}
+                />
+              </label>
+            </fieldset>
 
-        <fieldset className="typed-search-group typed-search-grid">
-          <legend>Transcript evidence filters</legend>
-          <label>
-            Speaker refs
-            <input
-              value={draft.speakerRefs}
-              onChange={(event) => updateDraft("speakerRefs", event.target.value)}
-              placeholder="speaker-1, speaker-2"
-            />
-          </label>
-          <label>
-            Languages
-            <input
-              value={draft.languages}
-              onChange={(event) => updateDraft("languages", event.target.value)}
-              placeholder="en, fr"
-            />
-          </label>
-          <label className="typed-search-wide">
-            Transcript IDs
-            <input
-              value={draft.documentIds}
-              onChange={(event) => updateDraft("documentIds", event.target.value)}
-              placeholder="interview-42, interview-43"
-            />
-          </label>
-        </fieldset>
+            <fieldset className="typed-search-group typed-search-grid">
+              <legend>Transcripts</legend>
+              <label>
+                Speakers
+                <input
+                  value={draft.speakerRefs}
+                  onChange={(event) => updateDraft("speakerRefs", event.target.value)}
+                  placeholder="speaker-1, speaker-2"
+                />
+              </label>
+              <label>
+                Languages
+                <input
+                  value={draft.languages}
+                  onChange={(event) => updateDraft("languages", event.target.value)}
+                  placeholder="en, fr"
+                />
+              </label>
+              <label className="typed-search-wide">
+                Interviews or transcripts
+                <input
+                  value={draft.documentIds}
+                  onChange={(event) => updateDraft("documentIds", event.target.value)}
+                  placeholder="interview-42, interview-43"
+                />
+              </label>
+            </fieldset>
 
-        <fieldset className="typed-search-group typed-search-grid">
-          <legend>Research-state filters</legend>
-          <label>
-            Tags
-            <input
-              value={draft.tags}
-              onChange={(event) => updateDraft("tags", event.target.value)}
-              placeholder="governance, follow-up"
-            />
-          </label>
-          <label>
-            Collections
-            <input
-              value={draft.collections}
-              onChange={(event) => updateDraft("collections", event.target.value)}
-              placeholder="Oral histories"
-            />
-          </label>
-          <label className="typed-search-wide">
-            Note text
-            <input
-              value={draft.noteText}
-              onChange={(event) => updateDraft("noteText", event.target.value)}
-              placeholder="Only evidence related to notes containing…"
-            />
-          </label>
-          <label className="typed-search-check typed-search-wide">
-            <input
-              type="checkbox"
-              checked={draft.withNotes}
-              onChange={(event) => updateDraft("withNotes", event.target.checked)}
-            />
-            Require associated research notes
-          </label>
-        </fieldset>
+            <fieldset className="typed-search-group typed-search-grid">
+              <legend>Your research</legend>
+              <label>
+                Tags
+                <input
+                  value={draft.tags}
+                  onChange={(event) => updateDraft("tags", event.target.value)}
+                  placeholder="governance, follow-up"
+                />
+              </label>
+              <label>
+                Collections
+                <input
+                  value={draft.collections}
+                  onChange={(event) => updateDraft("collections", event.target.value)}
+                  placeholder="Oral histories"
+                />
+              </label>
+              <label className="typed-search-wide">
+                Notes containing
+                <input
+                  value={draft.noteText}
+                  onChange={(event) => updateDraft("noteText", event.target.value)}
+                  placeholder="follow up"
+                />
+              </label>
+              <label className="typed-search-check typed-search-wide">
+                <input
+                  type="checkbox"
+                  checked={draft.withNotes}
+                  onChange={(event) => updateDraft("withNotes", event.target.checked)}
+                />
+                Only results with notes
+              </label>
+            </fieldset>
+
+            <p className="typed-search-option-note">
+              Meaning and Wording + meaning require a qualified local semantic index. If it
+              is not ready, EchoFlow will explain what needs attention rather than silently
+              changing the search.
+            </p>
+          </div>
+        </details>
 
         <div className="typed-search-actions">
           <button type="submit" disabled={busy || savedBusy}>
-            {busy ? "Searching…" : "Run typed search"}
+            {busy ? "Searching…" : "Search"}
           </button>
-          <p>
-            Semantic and hybrid modes require qualified local semantic state. EchoFlow will
-            refuse the request if that backend state is unavailable or stale.
-          </p>
         </div>
       </form>
 
@@ -476,29 +471,33 @@ export function ResearchSearchControlsPanel({
       {result && (
         <div className="typed-search-results">
           <IntentSummary intent={result.intent} />
-          <div className="typed-search-provenance">
-            <strong>Retrieval provenance</strong>
-            <span>{result.retrieval.mode}</span>
-            {result.retrieval.lexical_backend_id && (
-              <span>lexical: {result.retrieval.lexical_backend_id}</span>
-            )}
-            {result.retrieval.semantic_backend_id && (
-              <span>semantic: {result.retrieval.semantic_backend_id}</span>
-            )}
-            {result.retrieval.fusion_profile && (
-              <span>fusion: {result.retrieval.fusion_profile}</span>
-            )}
-            {result.retrieval.semantic_profile && (
-              <span>
-                model: {result.retrieval.semantic_profile.model_id} @ {result.retrieval.semantic_profile.resolved_revision}
-              </span>
-            )}
-          </div>
+          <details className="typed-search-technical">
+            <summary>Technical details</summary>
+            <div className="typed-search-provenance">
+              <strong>Retrieval</strong>
+              <span>{result.retrieval.mode}</span>
+              {result.retrieval.lexical_backend_id && (
+                <span>lexical: {result.retrieval.lexical_backend_id}</span>
+              )}
+              {result.retrieval.semantic_backend_id && (
+                <span>semantic: {result.retrieval.semantic_backend_id}</span>
+              )}
+              {result.retrieval.fusion_profile && (
+                <span>fusion: {result.retrieval.fusion_profile}</span>
+              )}
+              {result.retrieval.semantic_profile && (
+                <span>
+                  model: {result.retrieval.semantic_profile.model_id} @{" "}
+                  {result.retrieval.semantic_profile.resolved_revision}
+                </span>
+              )}
+            </div>
+          </details>
 
           {result.evidence.length === 0 ? (
-            <p className="typed-search-empty">No current verified evidence matched.</p>
+            <p className="typed-search-empty">No verified transcript passages matched.</p>
           ) : (
-            <div className="typed-search-evidence" aria-label="Typed search evidence results">
+            <div className="typed-search-evidence" aria-label="Research search results">
               {result.evidence.map((evidence) => (
                 <article
                   key={`${evidence.document_id}:${evidence.canonical_sha256}:${evidence.segment_ids.join(":")}`}
@@ -526,7 +525,7 @@ export function ResearchSearchControlsPanel({
                     className="open-evidence-button"
                     onClick={() => setSelectedEvidence(evidence)}
                   >
-                    Open verified evidence
+                    Open evidence
                   </button>
                 </article>
               ))}
@@ -539,7 +538,7 @@ export function ResearchSearchControlsPanel({
         <EvidenceReader
           evidence={selectedEvidence}
           generationState="current"
-          resultLabel="Typed search result"
+          resultLabel="Research search result"
           onClose={() => setSelectedEvidence(null)}
           onCreateNote={createNote}
         />
@@ -548,8 +547,8 @@ export function ResearchSearchControlsPanel({
       <section className="typed-saved-searches" aria-labelledby="typed-saved-title">
         <div className="typed-saved-heading">
           <div>
-            <p className="mini-label">Durable questions</p>
-            <h3 id="typed-saved-title">Save or revise the whole intent.</h3>
+            <p className="mini-label">Saved searches</p>
+            <h3 id="typed-saved-title">Save or update this search.</h3>
           </div>
           <button type="button" onClick={newSavedSearch} disabled={savedBusy}>
             New saved search
@@ -557,7 +556,7 @@ export function ResearchSearchControlsPanel({
         </div>
 
         <div className="typed-saved-layout">
-          <div className="typed-saved-list" aria-label="Saved searches available to edit">
+          <div className="typed-saved-list" aria-label="Saved searches">
             {savedSearches.length === 0 ? (
               <p>No saved searches yet.</p>
             ) : (
@@ -570,7 +569,7 @@ export function ResearchSearchControlsPanel({
                   onClick={() => void inspectSavedSearch(saved)}
                 >
                   <strong>{saved.name}</strong>
-                  <span>{saved.retrieval_mode}</span>
+                  <span>{retrievalLabel(saved.retrieval_mode)}</span>
                 </button>
               ))
             )}
@@ -583,7 +582,7 @@ export function ResearchSearchControlsPanel({
                 value={savedName}
                 maxLength={200}
                 onChange={(event) => setSavedName(event.target.value)}
-                placeholder="A durable research question"
+                placeholder="A search you want to return to"
               />
             </label>
             <label>
@@ -592,13 +591,13 @@ export function ResearchSearchControlsPanel({
                 value={savedDescription}
                 maxLength={4000}
                 onChange={(event) => setSavedDescription(event.target.value)}
-                placeholder="Optional context for future you"
+                placeholder="Optional context"
               />
             </label>
             {editingSaved && <IntentSummary intent={editingSaved.intent} />}
             <p>
-              Saving uses the controls above. EchoFlow validates and stores them as typed
-              intent, never as a rendered command or frozen result list.
+              Saving keeps these search choices. Running it later searches the evidence and
+              research that exist then; it does not freeze today&apos;s results.
             </p>
             <button
               type="button"
@@ -607,11 +606,7 @@ export function ResearchSearchControlsPanel({
                 void (editingSaved ? replaceSavedIntent() : createSavedIntent())
               }
             >
-              {savedBusy
-                ? "Saving…"
-                : editingSaved
-                  ? "Save metadata + typed intent"
-                  : "Save current typed intent"}
+              {savedBusy ? "Saving…" : editingSaved ? "Update saved search" : "Save search"}
             </button>
           </div>
         </div>

--- a/frontend/src/ResearchWorkspace.tsx
+++ b/frontend/src/ResearchWorkspace.tsx
@@ -57,6 +57,12 @@ function toggleLabel(values: string[], label: string): string[] {
   return normalizeLabels([...values, label]);
 }
 
+function retrievalLabel(mode: string): string {
+  if (mode === "semantic") return "Meaning";
+  if (mode === "hybrid") return "Wording + meaning";
+  return "Wording";
+}
+
 export function ResearchWorkspace({
   client,
   theme,
@@ -65,6 +71,9 @@ export function ResearchWorkspace({
   const [overview, setOverview] = useState<ResearchOverview | null>(null);
   const [busy, setBusy] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [mutationMessage, setMutationMessage] = useState<string | null>(null);
+  const [reader, setReader] = useState<ReaderState | null>(null);
+
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
   const [deleteNoteId, setDeleteNoteId] = useState<string | null>(null);
   const [mutatingNoteId, setMutatingNoteId] = useState<string | null>(null);
@@ -72,8 +81,6 @@ export function ResearchWorkspace({
   const [draftBody, setDraftBody] = useState("");
   const [draftTags, setDraftTags] = useState("");
   const [draftCollections, setDraftCollections] = useState("");
-  const [mutationMessage, setMutationMessage] = useState<string | null>(null);
-  const [reader, setReader] = useState<ReaderState | null>(null);
 
   const [activeTags, setActiveTags] = useState<string[]>([]);
   const [activeCollections, setActiveCollections] = useState<string[]>([]);
@@ -107,7 +114,7 @@ export function ResearchWorkspace({
       setError(
         caught instanceof Error
           ? caught.message
-          : "EchoFlow could not open the local research workspace.",
+          : "EchoFlow could not open your research.",
       );
     } finally {
       setBusy(false);
@@ -133,7 +140,7 @@ export function ResearchWorkspace({
         setActiveTags([]);
         setActiveCollections([]);
         setFilteredNotes(null);
-        if (announce) setMutationMessage("Showing all research notes.");
+        if (announce) setMutationMessage("Showing all notes.");
         return;
       }
       const result = await client.filterResearchNotes(nextTags, nextCollections);
@@ -150,7 +157,7 @@ export function ResearchWorkspace({
       setError(
         caught instanceof Error
           ? caught.message
-          : "EchoFlow could not apply those research filters.",
+          : "EchoFlow could not apply those filters.",
       );
     } finally {
       setFilterBusy(false);
@@ -199,7 +206,7 @@ export function ResearchWorkspace({
       cancelEdit();
       await loadOverview();
       await refreshActiveFilters();
-      setMutationMessage("Note saved. Its verified evidence anchor is unchanged.");
+      setMutationMessage("Note saved. Its transcript passage is unchanged.");
     } catch (caught) {
       setError(
         caught instanceof Error ? caught.message : "EchoFlow could not update that note.",
@@ -219,7 +226,7 @@ export function ResearchWorkspace({
       if (editingNoteId === note.note_id) cancelEdit();
       await loadOverview();
       await refreshActiveFilters();
-      setMutationMessage("Note deleted. Transcript evidence was not deleted.");
+      setMutationMessage("Note deleted. The transcript was not deleted.");
     } catch (caught) {
       setError(
         caught instanceof Error ? caught.message : "EchoFlow could not delete that note.",
@@ -242,15 +249,15 @@ export function ResearchWorkspace({
       });
       setMutationMessage(
         opened.current
-          ? "Opened this note’s current verified evidence."
-          : "Opened the exact older evidence generation cited by this note. Nothing was rebound.",
+          ? "Opened the transcript passage cited by this note."
+          : "Opened the exact older transcript version cited by this note. Nothing was moved.",
       );
     } catch (caught) {
       setReader(null);
       setError(
         caught instanceof Error
           ? caught.message
-          : "EchoFlow could not verify the evidence cited by that note.",
+          : "EchoFlow could not verify the transcript passage cited by that note.",
       );
     } finally {
       setOpeningNoteId(null);
@@ -281,12 +288,12 @@ export function ResearchWorkspace({
       setSavedQuery("");
       setSavedDescription("");
       await loadOverview();
-      setMutationMessage(`Saved “${created.name}” as durable search intent.`);
+      setMutationMessage(`Saved “${created.name}”.`);
     } catch (caught) {
       setError(
         caught instanceof Error
           ? caught.message
-          : "EchoFlow could not save that research question.",
+          : "EchoFlow could not save that search.",
       );
     } finally {
       setMutatingSavedId(null);
@@ -315,7 +322,7 @@ export function ResearchWorkspace({
       );
       setEditingSavedId(null);
       await loadOverview();
-      setMutationMessage(`Renamed saved search to “${updated.name}”. Its typed query is unchanged.`);
+      setMutationMessage(`Renamed saved search to “${updated.name}”.`);
     } catch (caught) {
       setError(
         caught instanceof Error
@@ -337,7 +344,7 @@ export function ResearchWorkspace({
       if (editingSavedId === saved.saved_search_id) setEditingSavedId(null);
       if (savedRun?.saved_search.saved_search_id === saved.saved_search_id) setSavedRun(null);
       await loadOverview();
-      setMutationMessage("Saved search deleted. Transcript evidence and research notes were untouched.");
+      setMutationMessage("Saved search deleted. Notes and transcripts were not deleted.");
     } catch (caught) {
       setError(
         caught instanceof Error
@@ -356,9 +363,7 @@ export function ResearchWorkspace({
     try {
       const result = await client.runSavedSearch(saved);
       setSavedRun(result);
-      setMutationMessage(
-        `Ran “${result.saved_search.name}” against current evidence and research relationships.`,
-      );
+      setMutationMessage(`Ran “${result.saved_search.name}” against what is in your library now.`);
     } catch (caught) {
       setSavedRun(null);
       setError(
@@ -378,21 +383,20 @@ export function ResearchWorkspace({
     <>
       <WorkspaceHeader
         eyebrow="Research"
-        title="Your research layer."
+        title="Research"
         theme={theme}
         onThemeChange={onThemeChange}
       />
 
       <section className="research-intro" aria-labelledby="research-title">
         <div>
-          <p className="section-kicker">03 · Human knowledge stays human knowledge</p>
-          <h2 id="research-title">Notes beside evidence, not trapped inside an index.</h2>
+          <p className="section-kicker">Notes and saved searches</p>
+          <h2 id="research-title">Keep your notes connected to the transcript.</h2>
         </div>
         <div className="research-intro-copy">
           <p>
-            Browse and edit authoritative research, reopen the exact evidence it cites, and
-            replay durable search intent against what exists now. The webview never decides
-            which canonical generation counts as evidence.
+            Browse and edit notes, narrow them with tags or collections, reopen the exact
+            transcript passage they cite, and run saved searches against what exists now.
           </p>
           <button
             className="research-refresh"
@@ -405,17 +409,17 @@ export function ResearchWorkspace({
             }
             onClick={() => void refreshResearch()}
           >
-            {busy || filterBusy ? "Refreshing…" : "Refresh research"}
+            {busy || filterBusy ? "Refreshing…" : "Refresh"}
           </button>
         </div>
       </section>
 
       <p className="research-status" role="status">
         {busy
-          ? "Reading local research state…"
+          ? "Opening your research…"
           : overview
             ? `${overview.notes.length} notes · ${overview.tags.length} tags · ${overview.collections.length} collections · ${overview.saved_searches.length} saved searches`
-            : "Research state is unavailable."}
+            : "Research could not be opened."}
       </p>
 
       {mutationMessage && (
@@ -446,16 +450,16 @@ export function ResearchWorkspace({
         <section className="research-run-results" aria-labelledby="saved-run-title">
           <div className="research-panel-heading">
             <div>
-              <p className="mini-label">Current replay</p>
+              <p className="mini-label">Saved search results</p>
               <h2 id="saved-run-title">{savedRun.saved_search.name}</h2>
               <p>
-                Query: <code>{savedRun.query}</code>
+                Search: <code>{savedRun.query}</code>
               </p>
             </div>
             <span className="research-count">{savedRun.evidence.length}</span>
           </div>
           {savedRun.evidence.length === 0 ? (
-            <p className="research-empty">No current evidence matches this saved intent.</p>
+            <p className="research-empty">No transcript passages match this saved search right now.</p>
           ) : (
             <div className="research-run-list">
               {savedRun.evidence.map((evidence) => (
@@ -486,7 +490,7 @@ export function ResearchWorkspace({
           <section className="research-panel research-notes" aria-labelledby="research-notes">
             <div className="research-panel-heading">
               <div>
-                <p className="mini-label">Authoritative annotations</p>
+                <p className="mini-label">Your notes</p>
                 <h2 id="research-notes">Notes</h2>
               </div>
               <span className="research-count">{visibleNotes.length}</span>
@@ -552,7 +556,7 @@ export function ResearchWorkspace({
               <p className="research-empty">
                 {hasActiveFilters
                   ? "No notes match every selected label."
-                  : "No research notes yet."}
+                  : "No notes yet."}
               </p>
             ) : (
               <div className="research-note-list">
@@ -618,8 +622,8 @@ export function ResearchWorkspace({
                             </label>
                           </div>
                           <p className="research-anchor-note">
-                            Editing changes only your note and labels. The exact canonical
-                            evidence generation and coordinates stay unchanged.
+                            Editing changes your note and labels. The transcript passage it
+                            points to stays the same.
                           </p>
                           <div className="research-note-actions">
                             <button type="submit" disabled={mutating || !draftBody.trim()}>
@@ -716,8 +720,8 @@ export function ResearchWorkspace({
                           aria-label="Delete note confirmation"
                         >
                           <p>
-                            Delete this human-authored note? Its canonical transcript and
-                            original recording are not part of this operation.
+                            Delete this note? This does not delete the transcript or original
+                            recording.
                           </p>
                           <div className="research-note-actions">
                             <button
@@ -749,7 +753,7 @@ export function ResearchWorkspace({
             <section className="research-panel saved-searches" aria-labelledby="saved-searches">
               <div className="research-panel-heading">
                 <div>
-                  <p className="mini-label">Durable questions</p>
+                  <p className="mini-label">Saved searches</p>
                   <h2 id="saved-searches">Saved searches</h2>
                 </div>
                 <span className="research-count">{overview.saved_searches.length}</span>
@@ -791,8 +795,8 @@ export function ResearchWorkspace({
                   />
                 </label>
                 <p>
-                  EchoFlow saves typed intent, not today’s result list. Running it later asks the
-                  same question of current evidence and research relationships.
+                  Saving keeps this question. Running it later searches what is in your
+                  library then; it does not freeze today&apos;s results.
                 </p>
                 <button
                   type="submit"
@@ -842,10 +846,7 @@ export function ResearchWorkspace({
                                 }
                               />
                             </label>
-                            <p>
-                              Rename edits display metadata only. The backend preserves the typed
-                              query intent.
-                            </p>
+                            <p>Renaming changes only the saved search&apos;s display name and description.</p>
                             <div className="saved-search-actions">
                               <button type="submit" disabled={mutating || !savedDraftName.trim()}>
                                 {mutating ? "Saving…" : "Save name"}
@@ -863,7 +864,7 @@ export function ResearchWorkspace({
                           <>
                             <div className="saved-search-title-row">
                               <strong>{saved.name}</strong>
-                              <span>{saved.retrieval_mode}</span>
+                              <span>{retrievalLabel(saved.retrieval_mode)}</span>
                             </div>
                             {saved.description && <p>{saved.description}</p>}
                             <code>{saved.query_text}</code>
@@ -903,8 +904,8 @@ export function ResearchWorkspace({
                             aria-label={`Delete saved search ${saved.name}`}
                           >
                             <p>
-                              Delete this durable question? Notes, transcripts, and recordings are
-                              not part of this operation.
+                              Delete this saved search? Notes, transcripts, and recordings
+                              are not part of this operation.
                             </p>
                             <div className="saved-search-actions">
                               <button
@@ -935,12 +936,12 @@ export function ResearchWorkspace({
             <section className="research-panel" aria-labelledby="research-labels">
               <div className="research-panel-heading">
                 <div>
-                  <p className="mini-label">Current vocabulary</p>
+                  <p className="mini-label">Organize</p>
                   <h2 id="research-labels">Labels</h2>
                 </div>
               </div>
               <p className="research-filter-explainer">
-                Select more than one label to narrow notes by every selected tag and collection.
+                Select more than one label to show notes that match every selected tag and collection.
               </p>
               <div className="label-section">
                 <h3>Tags</h3>

--- a/frontend/src/ResearchWorkspaceWithAnchorReview.tsx
+++ b/frontend/src/ResearchWorkspaceWithAnchorReview.tsx
@@ -18,6 +18,7 @@ export function ResearchWorkspaceWithAnchorReview({
   onThemeChange,
 }: ResearchWorkspaceWithAnchorReviewProps) {
   const [workspaceRevision, setWorkspaceRevision] = useState(0);
+  const researchChanged = () => setWorkspaceRevision((current) => current + 1);
 
   return (
     <>
@@ -27,10 +28,14 @@ export function ResearchWorkspaceWithAnchorReview({
         theme={theme}
         onThemeChange={onThemeChange}
       />
-      <ResearchSearchControlsPanel client={client} revision={workspaceRevision} />
+      <ResearchSearchControlsPanel
+        client={client}
+        revision={workspaceRevision}
+        onResearchChanged={researchChanged}
+      />
       <ResearchAnchorReviewPanel
         client={client}
-        onReanchored={() => setWorkspaceRevision((current) => current + 1)}
+        onReanchored={researchChanged}
       />
     </>
   );

--- a/frontend/src/SearchWorkspace.tsx
+++ b/frontend/src/SearchWorkspace.tsx
@@ -26,9 +26,7 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
   );
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState(
-    "Search transcripts and the research knowledge attached to them.",
-  );
+  const [status, setStatus] = useState("Search transcripts and your research.");
 
   useEffect(() => {
     function focusSearch(event: KeyboardEvent) {
@@ -55,15 +53,11 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
     try {
       const next = await client.discoverWorkspace(text);
       setReport(next);
-      setStatus(
-        `${next.total_count} result${next.total_count === 1 ? "" : "s"} across evidence and research state.`,
-      );
+      setStatus(`${next.total_count} result${next.total_count === 1 ? "" : "s"}.`);
     } catch (caught) {
       setReport(null);
       setError(
-        caught instanceof Error
-          ? caught.message
-          : "EchoFlow could not search the local workspace.",
+        caught instanceof Error ? caught.message : "EchoFlow could not search your library.",
       );
     } finally {
       setBusy(false);
@@ -72,39 +66,32 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
 
   function openEvidence(item: WorkspaceEvidenceResult) {
     setSelectedEvidence(item);
-    setStatus(
-      `Opened verified evidence from ${item.document_id} at ${formatEvidenceTime(item.seek_seconds)}.`,
-    );
+    setStatus(`Opened ${item.document_id} at ${formatEvidenceTime(item.seek_seconds)}.`);
   }
 
   async function createNote(body: string) {
     if (selectedEvidence === null) {
-      throw new Error("Verified evidence is no longer open.");
+      throw new Error("That transcript passage is no longer open.");
     }
     const created = await client.createResearchNote(selectedEvidence, body);
-    setStatus(
-      `Saved note ${created.note_id} to verified evidence from ${created.document_id}.`,
-    );
+    setStatus(`Note saved to ${created.document_id}.`);
   }
 
   return (
     <>
       <WorkspaceHeader
         eyebrow="Library"
-        title="Search your evidence."
+        title="Search your library."
         theme={theme}
         onThemeChange={onThemeChange}
       />
 
       <section className="search-intro" aria-labelledby="search-title">
         <div>
-          <p className="section-kicker">02 · Find the evidence, then follow it back</p>
-          <h2 id="search-title">One search across transcripts and your research layer.</h2>
+          <p className="section-kicker">Search</p>
+          <h2 id="search-title">Search transcripts, notes, tags, and collections.</h2>
         </div>
-        <p>
-          Results stay grouped by type. EchoFlow does not invent a common score between
-          transcript evidence, notes, tags, and collections.
-        </p>
+        <p>Open a transcript result to see the exact passage and its surrounding context.</p>
       </section>
 
       <form className="global-search" role="search" onSubmit={(event) => void search(event)}>
@@ -112,9 +99,7 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
           Search EchoFlow
         </label>
         <div className="search-control">
-          <span aria-hidden="true" className="search-glyph">
-            ⌕
-          </span>
+          <span aria-hidden="true" className="search-glyph">⌕</span>
           <input
             id="workspace-search"
             ref={inputRef}
@@ -132,14 +117,8 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
         </div>
       </form>
 
-      <p className="search-status" role="status">
-        {status}
-      </p>
-      {error && (
-        <p className="error-banner search-error" role="alert">
-          {error}
-        </p>
-      )}
+      <p className="search-status" role="status">{status}</p>
+      {error && <p className="error-banner search-error" role="alert">{error}</p>}
 
       {selectedEvidence && (
         <EvidenceReader
@@ -154,66 +133,48 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
           <section className="result-group" aria-labelledby="evidence-results">
             <div className="result-group-heading">
               <div>
-                <p className="mini-label">Verified transcript evidence</p>
-                <h2 id="evidence-results">Evidence</h2>
+                <p className="mini-label">Transcripts</p>
+                <h2 id="evidence-results">Transcript passages</h2>
               </div>
-              <span
-                className="result-count"
-                aria-label={`${report.evidence.length} evidence results`}
-              >
+              <span className="result-count" aria-label={`${report.evidence.length} transcript results`}>
                 {report.evidence.length}
               </span>
             </div>
             {report.evidence.length === 0 ? (
-              <p className="empty-result">No transcript evidence matched.</p>
+              <p className="empty-result">No transcript passages matched.</p>
             ) : (
               <div className="result-list">
                 {report.evidence.map((item) => (
-                  <article
-                    className="evidence-result"
-                    key={`${item.document_id}:${item.segment_ids.join(",")}`}
-                  >
+                  <article className="evidence-result" key={`${item.document_id}:${item.segment_ids.join(",")}`}>
                     <div className="result-meta">
                       <span>{item.document_id}</span>
-                      <time dateTime={`PT${item.seek_seconds}S`}>
-                        {formatEvidenceTime(item.seek_seconds)}
-                      </time>
+                      <time dateTime={`PT${item.seek_seconds}S`}>{formatEvidenceTime(item.seek_seconds)}</time>
                       <span>{item.languages.join(", ") || "language unknown"}</span>
                     </div>
                     <p className="result-text">{item.text}</p>
-                    <div
-                      className="evidence-coordinate"
-                      data-seek-seconds={item.seek_seconds}
-                    >
-                      <strong>Verified seek point</strong>
+                    <div className="evidence-coordinate" data-seek-seconds={item.seek_seconds}>
+                      <strong>Transcript location</strong>
                       <span>
-                        {formatEvidenceTime(item.seek_seconds)} · {item.segment_ids.length}{" "}
-                        canonical segment{item.segment_ids.length === 1 ? "" : "s"}
+                        {formatEvidenceTime(item.seek_seconds)} · {item.segment_ids.length} segment{item.segment_ids.length === 1 ? "" : "s"}
                       </span>
                     </div>
-                    <div className="result-pills" aria-label="Evidence metadata">
+                    <div className="result-pills" aria-label="Transcript metadata">
                       {item.speakers.map((speaker) => (
                         <span key={speaker.speaker_ref}>
                           {speaker.display_label ?? speaker.speaker_ref}
                           {speaker.display_label ? ` · ${speaker.speaker_ref}` : ""}
                         </span>
                       ))}
-                      {item.note_count > 0 && (
-                        <span>
-                          {item.note_count} note{item.note_count === 1 ? "" : "s"}
-                        </span>
-                      )}
-                      {item.tags.map((tag) => (
-                        <span key={`tag:${tag}`}>#{tag}</span>
-                      ))}
+                      {item.note_count > 0 && <span>{item.note_count} note{item.note_count === 1 ? "" : "s"}</span>}
+                      {item.tags.map((tag) => <span key={`tag:${tag}`}>#{tag}</span>)}
                     </div>
                     <button
                       type="button"
                       className="open-evidence-button"
-                      aria-label={`Open verified evidence from ${item.document_id} at ${formatEvidenceTime(item.seek_seconds)}`}
+                      aria-label={`Open transcript passage from ${item.document_id} at ${formatEvidenceTime(item.seek_seconds)}`}
                       onClick={() => openEvidence(item)}
                     >
-                      Open verified evidence
+                      Open transcript passage
                     </button>
                   </article>
                 ))}
@@ -224,13 +185,10 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
           <section className="result-group" aria-labelledby="note-results">
             <div className="result-group-heading">
               <div>
-                <p className="mini-label">Human-authored knowledge</p>
+                <p className="mini-label">Research</p>
                 <h2 id="note-results">Notes</h2>
               </div>
-              <span
-                className="result-count"
-                aria-label={`${report.notes.length} note results`}
-              >
+              <span className="result-count" aria-label={`${report.notes.length} note results`}>
                 {report.notes.length}
               </span>
             </div>
@@ -242,21 +200,13 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
                   <article className="note-result" key={item.note_id}>
                     <div className="result-meta">
                       <span>{item.document_id}</span>
-                      <time dateTime={`PT${item.start_seconds}S`}>
-                        {formatEvidenceTime(item.start_seconds)}
-                      </time>
-                      <span>
-                        {item.current ? "current evidence" : "older evidence generation"}
-                      </span>
+                      <time dateTime={`PT${item.start_seconds}S`}>{formatEvidenceTime(item.start_seconds)}</time>
+                      <span>{item.current ? "current transcript" : "earlier transcript version"}</span>
                     </div>
                     <p className="result-text">{item.body}</p>
                     <div className="result-pills">
-                      {item.tags.map((tag) => (
-                        <span key={`note-tag:${tag}`}>#{tag}</span>
-                      ))}
-                      {item.collections.map((collection) => (
-                        <span key={`note-collection:${collection}`}>{collection}</span>
-                      ))}
+                      {item.tags.map((tag) => <span key={`note-tag:${tag}`}>#{tag}</span>)}
+                      {item.collections.map((collection) => <span key={`note-collection:${collection}`}>{collection}</span>)}
                     </div>
                   </article>
                 ))}
@@ -265,50 +215,22 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
           </section>
 
           <div className="named-result-grid">
-            <section
-              className="result-group compact-group"
-              aria-labelledby="tag-results"
-            >
+            <section className="result-group compact-group" aria-labelledby="tag-results">
               <div className="result-group-heading">
                 <h2 id="tag-results">Tags</h2>
-                <span
-                  className="result-count"
-                  aria-label={`${report.tags.length} tag results`}
-                >
-                  {report.tags.length}
-                </span>
+                <span className="result-count" aria-label={`${report.tags.length} tag results`}>{report.tags.length}</span>
               </div>
               <div className="named-results">
-                {report.tags.length === 0 ? (
-                  <p className="empty-result">No tags matched.</p>
-                ) : (
-                  report.tags.map((item) => (
-                    <span key={item.tag_id}>#{item.name}</span>
-                  ))
-                )}
+                {report.tags.length === 0 ? <p className="empty-result">No tags matched.</p> : report.tags.map((item) => <span key={item.tag_id}>#{item.name}</span>)}
               </div>
             </section>
-            <section
-              className="result-group compact-group"
-              aria-labelledby="collection-results"
-            >
+            <section className="result-group compact-group" aria-labelledby="collection-results">
               <div className="result-group-heading">
                 <h2 id="collection-results">Collections</h2>
-                <span
-                  className="result-count"
-                  aria-label={`${report.collections.length} collection results`}
-                >
-                  {report.collections.length}
-                </span>
+                <span className="result-count" aria-label={`${report.collections.length} collection results`}>{report.collections.length}</span>
               </div>
               <div className="named-results">
-                {report.collections.length === 0 ? (
-                  <p className="empty-result">No collections matched.</p>
-                ) : (
-                  report.collections.map((item) => (
-                    <span key={item.collection_id}>{item.name}</span>
-                  ))
-                )}
+                {report.collections.length === 0 ? <p className="empty-result">No collections matched.</p> : report.collections.map((item) => <span key={item.collection_id}>{item.name}</span>)}
               </div>
             </section>
           </div>

--- a/frontend/src/components/WorkspaceHeader.tsx
+++ b/frontend/src/components/WorkspaceHeader.tsx
@@ -1,4 +1,6 @@
-export type Theme = "archive" | "midnight";
+import { THEMES, type Theme } from "../themes";
+
+export type { Theme } from "../themes";
 
 interface WorkspaceHeaderProps {
   eyebrow: string;
@@ -19,24 +21,20 @@ export function WorkspaceHeader({
         <p className="eyebrow">{eyebrow}</p>
         <h1>{title}</h1>
       </div>
-      <div className="theme-switch" role="group" aria-label="Appearance">
-        <button
-          type="button"
-          className={theme === "archive" ? "theme-active" : ""}
-          aria-pressed={theme === "archive"}
-          onClick={() => onThemeChange("archive")}
+      <label className="theme-picker">
+        <span>Theme</span>
+        <select
+          aria-label="Theme"
+          value={theme}
+          onChange={(event) => onThemeChange(event.target.value as Theme)}
         >
-          Archive
-        </button>
-        <button
-          type="button"
-          className={theme === "midnight" ? "theme-active" : ""}
-          aria-pressed={theme === "midnight"}
-          onClick={() => onThemeChange("midnight")}
-        >
-          Midnight
-        </button>
-      </div>
+          {THEMES.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
     </header>
   );
 }

--- a/frontend/src/research-search-controls.css
+++ b/frontend/src/research-search-controls.css
@@ -5,7 +5,7 @@
   border-radius: 24px;
   overflow: hidden;
   background: var(--surface-raised);
-  box-shadow: 0 18px 52px rgba(27, 42, 45, 0.07);
+  box-shadow: var(--shadow);
 }
 
 .typed-search-heading,
@@ -38,22 +38,10 @@
   line-height: 1.6;
 }
 
-.typed-search-authority {
-  flex: 0 0 auto;
-  border: 1px solid var(--accent);
-  border-radius: 999px;
-  padding: 7px 11px;
-  color: var(--accent-strong);
-  background: var(--accent-soft);
-  font-size: 0.68rem;
-  font-weight: 780;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
 .typed-search-form {
   padding: 22px 24px;
   display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.34fr);
   gap: 18px;
 }
 
@@ -75,11 +63,11 @@
 .typed-saved-editor textarea {
   width: 100%;
   box-sizing: border-box;
-  border: 1px solid var(--border);
+  border: 1px solid var(--control-border);
   border-radius: 12px;
   padding: 10px 12px;
-  background: var(--surface-raised);
-  color: var(--ink);
+  background: var(--control-bg);
+  color: var(--control-ink);
   font: inherit;
   font-size: 0.88rem;
   line-height: 1.45;
@@ -87,18 +75,17 @@
   text-transform: none;
 }
 
-.typed-search-form input:focus-visible,
-.typed-search-form select:focus-visible,
-.typed-saved-editor input:focus-visible,
-.typed-saved-editor textarea:focus-visible,
-.typed-search-shell button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+.typed-search-query input { font-size: 1rem; }
+.typed-search-options { grid-column: 1 / -1; border: 1px solid var(--border); border-radius: 16px; background: var(--surface-soft); }
+.typed-search-options > summary,
+.typed-search-technical > summary {
+  cursor: pointer;
+  padding: 13px 15px;
+  color: var(--ink);
+  font-size: 0.8rem;
+  font-weight: 740;
 }
-
-.typed-search-query input {
-  font-size: 1rem;
-}
+.typed-search-options-body { display: grid; gap: 14px; padding: 0 14px 14px; }
 
 .typed-search-group {
   margin: 0;
@@ -118,17 +105,9 @@
   font-weight: 760;
 }
 
-.typed-search-three {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.typed-search-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.typed-search-wide {
-  grid-column: 1 / -1;
-}
+.typed-search-three { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.typed-search-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.typed-search-wide { grid-column: 1 / -1; }
 
 .typed-search-form .typed-search-check {
   display: flex;
@@ -142,12 +121,11 @@
   color: var(--ink);
 }
 
-.typed-search-check input {
-  width: auto;
-  margin: 0;
-}
+.typed-search-check input { width: auto; margin: 0; }
+.typed-search-option-note { margin: 0; color: var(--muted); font-size: 0.76rem; line-height: 1.55; }
 
 .typed-search-actions {
+  grid-column: 1 / -1;
   display: flex;
   align-items: center;
   gap: 16px;
@@ -158,10 +136,10 @@
 .typed-saved-editor > button,
 .typed-saved-list button,
 .typed-search-evidence button {
-  border: 1px solid var(--border);
+  border: 1px solid var(--control-border);
   border-radius: 999px;
-  background: var(--surface-raised);
-  color: var(--ink);
+  background: var(--control-bg);
+  color: var(--control-ink);
   font: inherit;
   cursor: pointer;
 }
@@ -183,18 +161,8 @@
   color: var(--accent-strong);
 }
 
-.typed-search-shell button:disabled {
-  cursor: progress;
-  opacity: 0.62;
-}
-
-.typed-search-actions p,
-.typed-saved-editor > p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.74rem;
-  line-height: 1.55;
-}
+.typed-search-shell button:disabled { cursor: progress; }
+.typed-saved-editor > p { margin: 0; color: var(--muted); font-size: 0.74rem; line-height: 1.55; }
 
 .typed-search-status {
   margin: 0;
@@ -202,10 +170,7 @@
   color: var(--muted);
   font-size: 0.76rem;
 }
-
-.typed-search-error {
-  margin: 0 24px 20px;
-}
+.typed-search-error { margin: 0 24px 20px; }
 
 .typed-search-results {
   border-top: 1px solid var(--border);
@@ -229,19 +194,9 @@
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
-
-.typed-search-intent code {
-  overflow-wrap: anywhere;
-  color: var(--ink);
-}
-
+.typed-search-intent code { overflow-wrap: anywhere; color: var(--ink); }
 .typed-search-pills,
-.typed-search-provenance {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-}
-
+.typed-search-provenance { display: flex; flex-wrap: wrap; gap: 7px; }
 .typed-search-pills span,
 .typed-search-provenance span {
   border: 1px solid var(--border);
@@ -253,64 +208,25 @@
   font-weight: 680;
 }
 
-.typed-search-provenance {
-  align-items: center;
-}
+.typed-search-technical { border: 1px solid var(--border); border-radius: 14px; background: var(--surface-soft); }
+.typed-search-technical .typed-search-provenance { padding: 0 14px 14px; align-items: center; }
+.typed-search-provenance > strong { margin-right: 3px; }
 
-.typed-search-provenance > strong {
-  margin-right: 3px;
-}
-
-.typed-search-evidence {
-  display: grid;
-  gap: 12px;
-}
-
+.typed-search-evidence { display: grid; gap: 12px; }
 .typed-search-evidence article {
   border: 1px solid var(--border);
   border-radius: 16px;
   padding: 16px;
   background: var(--surface-raised);
 }
+.typed-search-evidence article > p { margin: 10px 0 14px; line-height: 1.6; }
+.typed-search-result-meta { display: flex; justify-content: space-between; gap: 12px; color: var(--muted); font-size: 0.74rem; }
+.typed-search-evidence button { margin-top: 14px; padding: 8px 12px; font-size: 0.75rem; font-weight: 720; }
+.typed-search-empty { margin: 0; color: var(--muted); }
 
-.typed-search-evidence article > p {
-  margin: 10px 0 14px;
-  line-height: 1.6;
-}
-
-.typed-search-result-meta {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  color: var(--muted);
-  font-size: 0.74rem;
-}
-
-.typed-search-evidence button {
-  margin-top: 14px;
-  padding: 8px 12px;
-  font-size: 0.75rem;
-  font-weight: 720;
-}
-
-.typed-search-empty {
-  margin: 0;
-  color: var(--muted);
-}
-
-.typed-saved-searches {
-  border-top: 1px solid var(--border);
-}
-
-.typed-saved-heading h3 {
-  font-size: 1rem;
-}
-
-.typed-saved-layout {
-  display: grid;
-  grid-template-columns: minmax(220px, 0.7fr) minmax(0, 1.3fr);
-}
-
+.typed-saved-searches { border-top: 1px solid var(--border); }
+.typed-saved-heading h3 { font-size: 1rem; }
+.typed-saved-layout { display: grid; grid-template-columns: minmax(220px, 0.7fr) minmax(0, 1.3fr); }
 .typed-saved-list {
   border-right: 1px solid var(--border);
   padding: 14px;
@@ -319,84 +235,33 @@
   gap: 8px;
   background: color-mix(in srgb, var(--surface-soft) 48%, var(--surface-raised));
 }
-
-.typed-saved-list > p {
-  margin: 8px;
-  color: var(--muted);
-  font-size: 0.78rem;
-}
-
+.typed-saved-list > p { margin: 8px; color: var(--muted); font-size: 0.78rem; }
 .typed-saved-list button {
-  width: 100%;
-  border-radius: 12px;
-  padding: 10px 12px;
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  text-align: left;
+  width: 100%; border-radius: 12px; padding: 10px 12px; display: flex; justify-content: space-between; gap: 10px; text-align: left;
 }
-
-.typed-saved-list button[aria-pressed="true"] {
-  border-color: var(--accent);
-  background: var(--accent-soft);
-}
-
-.typed-saved-list button strong {
-  font-size: 0.78rem;
-}
-
-.typed-saved-list button span {
-  color: var(--muted);
-  font-size: 0.66rem;
-  text-transform: uppercase;
-}
-
-.typed-saved-editor {
-  min-width: 0;
-  padding: 18px 20px;
-  display: grid;
-  gap: 14px;
-}
-
-.typed-saved-editor textarea {
-  min-height: 76px;
-  resize: vertical;
-}
-
-.typed-saved-editor .typed-search-intent {
-  margin-top: 2px;
-}
+.typed-saved-list button[aria-pressed="true"] { border-color: var(--accent); background: var(--accent-soft); }
+.typed-saved-list button strong { font-size: 0.78rem; }
+.typed-saved-list button span { color: var(--muted); font-size: 0.66rem; text-transform: uppercase; }
+.typed-saved-editor { min-width: 0; padding: 18px 20px; display: grid; gap: 14px; }
+.typed-saved-editor textarea { min-height: 76px; resize: vertical; }
+.typed-saved-editor .typed-search-intent { margin-top: 2px; }
 
 @media (max-width: 900px) {
-  .typed-search-three {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .typed-saved-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .typed-saved-list {
-    border-right: 0;
-    border-bottom: 1px solid var(--border);
-  }
+  .typed-search-three { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .typed-saved-layout { grid-template-columns: 1fr; }
+  .typed-saved-list { border-right: 0; border-bottom: 1px solid var(--border); }
 }
 
 @media (max-width: 680px) {
   .typed-search-heading,
   .typed-saved-heading,
-  .typed-search-actions {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
+  .typed-search-actions { align-items: flex-start; flex-direction: column; }
+  .typed-search-form { grid-template-columns: 1fr; }
+  .typed-search-match,
+  .typed-search-options,
+  .typed-search-actions { grid-column: auto; }
   .typed-search-group,
   .typed-search-three,
-  .typed-search-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .typed-search-wide {
-    grid-column: auto;
-  }
+  .typed-search-grid { grid-template-columns: 1fr; }
+  .typed-search-wide { grid-column: auto; }
 }

--- a/frontend/src/search.css
+++ b/frontend/src/search.css
@@ -81,7 +81,7 @@
   border-radius: 11px;
   padding: 10px 16px;
   background: var(--accent);
-  color: #fff;
+  color: var(--on-accent);
   font-weight: 720;
 }
 .search-control button:disabled { opacity: 0.5; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2,46 +2,166 @@
   font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
+  color-scheme: light;
   --bg: #f3efe7;
   --surface: #fbf9f4;
   --surface-raised: #ffffff;
   --surface-soft: #ece6dc;
   --ink: #1f2930;
-  --muted: #5f6762;
-  --border: #d9d1c4;
+  --muted: #56605b;
+  --border: #8b8276;
   --accent: #315e63;
   --accent-strong: #24494d;
   --accent-soft: #dce9e6;
-  --focus: #a46d19;
+  --on-accent: #ffffff;
+  --focus: #8b5b10;
   --danger: #8a3f43;
+  --control-bg: #ffffff;
+  --control-ink: #1f2930;
+  --control-border: #786f63;
+  --selection-bg: #315e63;
+  --selection-ink: #ffffff;
   --shadow: 0 24px 70px rgba(58, 47, 35, 0.08);
   color: var(--ink);
   background: var(--bg);
 }
 
 :root[data-theme="midnight"] {
+  color-scheme: dark;
   --bg: #111519;
   --surface: #171d22;
   --surface-raised: #1e252b;
   --surface-soft: #242d34;
   --ink: #eef2ef;
-  --muted: #aab6b5;
-  --border: #42515a;
+  --muted: #b8c2c0;
+  --border: #71818a;
   --accent: #79b9b0;
-  --accent-strong: #a3d2ca;
+  --accent-strong: #b8e0d9;
   --accent-soft: #203b3d;
+  --on-accent: #0d1a1b;
   --focus: #e4b85d;
-  --danger: #e38c92;
+  --danger: #f0a0a6;
+  --control-bg: #171d22;
+  --control-ink: #eef2ef;
+  --control-border: #82929b;
+  --selection-bg: #79b9b0;
+  --selection-ink: #0d1a1b;
   --shadow: 0 30px 80px rgba(0, 0, 0, 0.24);
+}
+
+:root[data-theme="paper"] {
+  color-scheme: light;
+  --bg: #f5f6f8;
+  --surface: #ffffff;
+  --surface-raised: #ffffff;
+  --surface-soft: #e9edf3;
+  --ink: #1d2430;
+  --muted: #536074;
+  --border: #7e8998;
+  --accent: #3f5f9d;
+  --accent-strong: #2f4d85;
+  --accent-soft: #e0e8f7;
+  --on-accent: #ffffff;
+  --focus: #8a5b0a;
+  --danger: #9a3f4c;
+  --control-bg: #ffffff;
+  --control-ink: #1d2430;
+  --control-border: #6f7c8d;
+  --selection-bg: #3f5f9d;
+  --selection-ink: #ffffff;
+  --shadow: 0 24px 70px rgba(45, 57, 76, 0.08);
+}
+
+:root[data-theme="moss"] {
+  color-scheme: light;
+  --bg: #f2f4ed;
+  --surface: #fbfcf7;
+  --surface-raised: #ffffff;
+  --surface-soft: #e5eadf;
+  --ink: #263027;
+  --muted: #566253;
+  --border: #7d8a78;
+  --accent: #3f6b4c;
+  --accent-strong: #2f573b;
+  --accent-soft: #dce9dd;
+  --on-accent: #ffffff;
+  --focus: #956319;
+  --danger: #914047;
+  --control-bg: #ffffff;
+  --control-ink: #263027;
+  --control-border: #71806c;
+  --selection-bg: #3f6b4c;
+  --selection-ink: #ffffff;
+  --shadow: 0 24px 70px rgba(47, 70, 47, 0.08);
+}
+
+:root[data-theme="plum"] {
+  color-scheme: light;
+  --bg: #f5f0f5;
+  --surface: #fcf9fc;
+  --surface-raised: #ffffff;
+  --surface-soft: #ece3ed;
+  --ink: #302633;
+  --muted: #655766;
+  --border: #907f92;
+  --accent: #76527c;
+  --accent-strong: #5b3d61;
+  --accent-soft: #eadfec;
+  --on-accent: #ffffff;
+  --focus: #996218;
+  --danger: #98414b;
+  --control-bg: #ffffff;
+  --control-ink: #302633;
+  --control-border: #7c6c7f;
+  --selection-bg: #76527c;
+  --selection-ink: #ffffff;
+  --shadow: 0 24px 70px rgba(68, 45, 70, 0.08);
+}
+
+:root[data-theme="ember"] {
   color-scheme: dark;
+  --bg: #17130f;
+  --surface: #1d1813;
+  --surface-raised: #251e18;
+  --surface-soft: #2c241c;
+  --ink: #f5efe7;
+  --muted: #c9bcae;
+  --border: #8d7a68;
+  --accent: #d08a45;
+  --accent-strong: #f1b879;
+  --accent-soft: #4a3020;
+  --on-accent: #24170c;
+  --focus: #f1c56e;
+  --danger: #f2a0a0;
+  --control-bg: #1d1813;
+  --control-ink: #f5efe7;
+  --control-border: #9c8875;
+  --selection-bg: #d08a45;
+  --selection-ink: #24170c;
+  --shadow: 0 30px 80px rgba(0, 0, 0, 0.28);
 }
 
 * { box-sizing: border-box; }
 html, body, #root { min-height: 100%; margin: 0; }
 body { min-width: 320px; background: var(--bg); color: var(--ink); }
-button, input { font: inherit; }
+button, input, select, textarea { font: inherit; }
 button { color: inherit; }
-button:focus-visible, input:focus-visible, summary:focus-visible {
+input, select, textarea {
+  color: var(--control-ink);
+  background: var(--control-bg);
+  border-color: var(--control-border);
+}
+select, option { color-scheme: inherit; }
+option { color: var(--control-ink); background: var(--control-bg); }
+input::placeholder, textarea::placeholder { color: var(--muted); opacity: 1; }
+input:disabled, select:disabled, textarea:disabled, button:disabled { opacity: 0.58; }
+input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
+::selection { background: var(--selection-bg); color: var(--selection-ink); }
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
   outline: 3px solid var(--focus);
   outline-offset: 3px;
 }
@@ -72,7 +192,7 @@ button:focus-visible, input:focus-visible, summary:focus-visible {
   text-align: left; display: flex; gap: 10px; align-items: center; color: var(--muted);
 }
 .nav-item-active { background: var(--surface-soft); color: var(--ink); font-weight: 650; }
-.nav-item:disabled { opacity: 0.54; }
+.nav-item:disabled { opacity: 0.58; }
 .privacy-note {
   margin-top: auto; display: flex; gap: 10px; padding: 14px; border: 1px solid var(--border);
   border-radius: 14px; background: var(--surface);
@@ -87,9 +207,24 @@ button:focus-visible, input:focus-visible, summary:focus-visible {
   margin: 0; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.14em; color: var(--muted); font-weight: 720;
 }
 h1 { margin: 7px 0 0; font-size: clamp(2rem, 4vw, 3.8rem); line-height: 0.98; letter-spacing: -0.055em; font-weight: 690; }
-.theme-switch { border: 1px solid var(--border); background: var(--surface); padding: 4px; border-radius: 999px; display: flex; }
-.theme-switch button { border: 0; background: transparent; border-radius: 999px; padding: 7px 11px; color: var(--muted); font-size: 0.75rem; }
-.theme-switch .theme-active { background: var(--ink); color: var(--surface); }
+.theme-picker {
+  display: grid;
+  gap: 5px;
+  min-width: 150px;
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 720;
+}
+.theme-picker span { padding-left: 4px; text-transform: uppercase; letter-spacing: 0.09em; }
+.theme-picker select {
+  width: 100%;
+  border: 1px solid var(--control-border);
+  border-radius: 12px;
+  padding: 8px 32px 8px 10px;
+  background: var(--control-bg);
+  color: var(--control-ink);
+  font-size: 0.78rem;
+}
 
 .intro-copy { max-width: 1180px; margin: 72px auto 24px; display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(260px, 0.75fr); gap: 48px; align-items: end; }
 .intro-copy h2 { margin: 10px 0 0; max-width: 760px; font-size: clamp(1.5rem, 3vw, 2.65rem); line-height: 1.08; letter-spacing: -0.04em; font-weight: 650; }
@@ -117,18 +252,18 @@ h1 { margin: 7px 0 0; font-size: clamp(2rem, 4vw, 3.8rem); line-height: 0.98; le
 .retention-choice legend { padding-top: 22px; margin-bottom: 8px; font-weight: 700; letter-spacing: -0.02em; }
 .choice-card { border: 1px solid var(--border); border-radius: 15px; padding: 15px; display: flex; align-items: flex-start; gap: 12px; background: var(--surface-raised); }
 .choice-active { border-color: var(--accent); background: var(--accent-soft); }
-.choice-card input { margin-top: 3px; accent-color: var(--accent); }
+.choice-card input { margin-top: 3px; }
 .choice-card span, .checkbox-row span { display: grid; gap: 4px; }
 .choice-card small, .checkbox-row small { color: var(--muted); line-height: 1.45; }
 .advanced-card { margin: 0 26px 24px; border: 1px solid var(--border); border-radius: 15px; background: var(--surface-raised); }
 .advanced-card summary { cursor: pointer; padding: 15px 17px; font-weight: 680; }
 .checkbox-row { display: flex; gap: 12px; padding: 0 17px 17px; align-items: flex-start; }
-.checkbox-row input { margin-top: 4px; accent-color: var(--accent); }
+.checkbox-row input { margin-top: 4px; }
 .action-row { border-top: 1px solid var(--border); padding: 20px 26px; display: flex; justify-content: space-between; gap: 24px; align-items: center; }
 .status-copy { color: var(--muted); line-height: 1.5; font-size: 0.8rem; max-width: 680px; }
-.primary-action { border: 0; border-radius: 12px; background: var(--accent); color: #fff; padding: 11px 16px; font-weight: 720; white-space: nowrap; }
+.primary-action { border: 0; border-radius: 12px; background: var(--accent); color: var(--on-accent); padding: 11px 16px; font-weight: 720; white-space: nowrap; }
 .primary-action:hover:not(:disabled) { background: var(--accent-strong); }
-.primary-action:disabled { opacity: 0.45; cursor: not-allowed; }
+.primary-action:disabled { cursor: not-allowed; }
 .error-banner { margin: 0 26px 22px; color: var(--danger); font-weight: 650; }
 
 .lower-grid { max-width: 1180px; margin: 18px auto 0; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
@@ -148,6 +283,7 @@ h1 { margin: 7px 0 0; font-size: clamp(2rem, 4vw, 3.8rem); line-height: 0.98; le
 
 @media (max-width: 680px) {
   .topbar { display: grid; }
+  .theme-picker { width: min(100%, 240px); }
   .picker-grid, .lower-grid { grid-template-columns: 1fr; }
   .picker-card { min-height: 128px; }
   .action-row { align-items: stretch; flex-direction: column; }

--- a/frontend/src/themes.ts
+++ b/frontend/src/themes.ts
@@ -1,0 +1,17 @@
+export const THEMES = [
+  { id: "archive", label: "Archive", scheme: "light" },
+  { id: "midnight", label: "Midnight", scheme: "dark" },
+  { id: "paper", label: "Paper", scheme: "light" },
+  { id: "moss", label: "Moss", scheme: "light" },
+  { id: "plum", label: "Plum", scheme: "light" },
+  { id: "ember", label: "Ember", scheme: "dark" },
+] as const;
+
+export type Theme = (typeof THEMES)[number]["id"];
+
+export const DEFAULT_THEME: Theme = "archive";
+export const THEME_STORAGE_KEY = "echoflow.theme.v1";
+
+export function isTheme(value: string | null): value is Theme {
+  return value !== null && THEMES.some((theme) => theme.id === value);
+}

--- a/frontend/tests/import.spec.ts
+++ b/frontend/tests/import.spec.ts
@@ -48,10 +48,10 @@ test("transcript libraries never offer automatic processing", async ({ page }) =
   await expect(page.getByRole("status")).toContainText("reconciled with EchoFlow's local index");
 });
 
-test("theme switching preserves semantics and accessibility", async ({ page }) => {
+test("theme switching uses the compact picker and preserves semantics", async ({ page }) => {
   await page.goto("/?e2e=1");
 
-  await page.getByRole("button", { name: "Midnight" }).click();
+  await page.getByLabel("Theme").selectOption("midnight");
   await expect(page.locator("html")).toHaveAttribute("data-theme", "midnight");
   await expect(page.getByRole("heading", { name: "Add local evidence without giving up custody." })).toBeVisible();
 

--- a/frontend/tests/research-anchor-review.spec.ts
+++ b/frontend/tests/research-anchor-review.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@playwright/test";
 async function openResearch(page: import("@playwright/test").Page) {
   await page.goto("/?e2e=1");
   await page.getByRole("button", { name: "Research" }).click();
-  await expect(page.getByRole("heading", { name: "Your research layer." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Research", exact: true })).toBeVisible();
 }
 
 test("Susan can review an older anchor before deliberately re-anchoring it", async ({

--- a/frontend/tests/research-search-controls.spec.ts
+++ b/frontend/tests/research-search-controls.spec.ts
@@ -1,58 +1,58 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
-async function openTypedSearch(page: import("@playwright/test").Page) {
+async function openResearchSearch(page: import("@playwright/test").Page) {
   await page.goto("/?e2e=1");
   await page.getByRole("button", { name: "Research" }).click();
-  const panel = page.getByRole("region", { name: "Make the question inspectable." });
+  const panel = page.getByRole("region", { name: "What are you looking for?" });
   await expect(panel).toBeVisible();
   return panel;
 }
 
-test("typed Research search keeps advanced intent inspectable and evidence navigable", async ({
-  page,
-}) => {
-  const panel = await openTypedSearch(page);
+test("Research search exposes human choices while preserving advanced intent", async ({ page }) => {
+  const panel = await openResearchSearch(page);
 
-  await panel.getByLabel("Query").fill("governance reform");
-  await panel.getByLabel("Exact phrase").check();
-  await panel.getByLabel("Term operator").selectOption("all");
-  await panel.getByLabel("Retrieval mode").selectOption("lexical");
-  await panel.getByLabel("Sort").selectOption("timeline");
-  await panel.getByLabel("Result limit").fill("25");
-  await panel.getByLabel("Context segments").fill("2");
-  await panel.getByLabel("Speaker refs").fill("speaker-1");
+  await panel.getByLabel("Search").fill("governance reform");
+  await panel.getByLabel("Match").selectOption("phrase");
+  await panel.getByText("Search options", { exact: true }).click();
+  await panel.getByLabel("Search by").selectOption("lexical");
+  await panel.getByLabel("Order results by").selectOption("timeline");
+  await panel.getByLabel("Maximum results").fill("25");
+  await panel.getByLabel("Context around result").fill("2");
+  await panel.getByLabel("Speakers").fill("speaker-1");
   await panel.getByLabel("Languages").fill("en");
-  await panel.getByLabel("Transcript IDs").fill("interview-42");
+  await panel.getByLabel("Interviews or transcripts").fill("interview-42");
   await panel.getByLabel("Tags").fill("governance");
   await panel.getByLabel("Collections").fill("Oral histories");
-  await panel.getByLabel("Note text").fill("follow up");
-  await panel.getByLabel("Require associated research notes").check();
+  await panel.getByLabel("Notes containing").fill("follow up");
+  await panel.getByLabel("Only results with notes").check();
 
-  await panel.getByRole("button", { name: "Run typed search" }).click();
+  await panel.getByRole("button", { name: "Search", exact: true }).click();
 
-  const applied = panel.getByLabel("Applied search intent").first();
+  const applied = panel.getByLabel("Search details").first();
   await expect(applied).toContainText("governance reform");
-  await expect(applied).toContainText("phrase: exact");
-  await expect(applied).toContainText("operator: ALL");
-  await expect(applied).toContainText("mode: lexical");
-  await expect(applied).toContainText("sort: timeline");
-  await expect(applied).toContainText("speaker: speaker-1");
-  await expect(applied).toContainText("language: en");
-  await expect(applied).toContainText("transcript: interview-42");
-  await expect(applied).toContainText("tag: governance");
-  await expect(applied).toContainText("collection: Oral histories");
-  await expect(applied).toContainText("note text: follow up");
-  await expect(applied).toContainText("must have research notes");
+  await expect(applied).toContainText("Match: Exact phrase");
+  await expect(applied).toContainText("Search by: Wording");
+  await expect(applied).toContainText("Order: Time");
+  await expect(applied).toContainText("Speaker: speaker-1");
+  await expect(applied).toContainText("Language: en");
+  await expect(applied).toContainText("Transcript: interview-42");
+  await expect(applied).toContainText("Tag: governance");
+  await expect(applied).toContainText("Collection: Oral histories");
+  await expect(applied).toContainText("Notes containing: follow up");
+  await expect(applied).toContainText("Only results with notes");
 
-  await expect(panel.getByText("Retrieval provenance")).toBeVisible();
-  const results = panel.getByLabel("Typed search evidence results");
+  await panel.getByText("Technical details", { exact: true }).click();
+  await expect(panel.getByText("Retrieval", { exact: true })).toBeVisible();
+  const results = panel.getByLabel("Research search results");
   await expect(results).toContainText("interview-42");
-  await results.getByRole("button", { name: "Open verified evidence" }).click();
+  await results.getByRole("button", { name: "Open evidence" }).click();
   const reader = page.getByRole("complementary", { name: "Evidence reader" });
   await expect(reader.getByText("Current verified canonical generation")).toBeVisible();
   await reader.getByRole("button", { name: "Close" }).click();
 
+  await expect(panel.getByText("Python authority")).toHaveCount(0);
+  await expect(panel.getByText("Term operator")).toHaveCount(0);
   await expect(page.getByText("canonical_path")).toHaveCount(0);
   await expect(page.getByText("source_path")).toHaveCount(0);
   await expect(page.getByText("/Users/")).toHaveCount(0);
@@ -61,39 +61,35 @@ test("typed Research search keeps advanced intent inspectable and evidence navig
   expect(accessibility.violations).toEqual([]);
 });
 
-test("saved Research questions can replace their whole typed intent", async ({ page }) => {
-  const panel = await openTypedSearch(page);
+test("saved Research questions can replace the whole search without backend vocabulary", async ({ page }) => {
+  const panel = await openResearchSearch(page);
 
-  const savedList = panel.getByLabel("Saved searches available to edit");
+  const savedList = panel.getByLabel("Saved searches");
   await savedList.getByRole("button", { name: /Governance follow-up/ }).click();
-  const existing = panel.getByLabel("Applied search intent");
+  const existing = panel.getByLabel("Search details");
   await expect(existing).toContainText("governance");
-  await expect(existing).toContainText("tag: governance");
-  await expect(existing).toContainText("must have research notes");
+  await expect(existing).toContainText("Tag: governance");
+  await expect(existing).toContainText("Only results with notes");
 
-  await panel.getByLabel("Query").fill("oversight failure");
-  await panel.getByLabel("Term operator").selectOption("all");
-  await panel.getByLabel("Sort").selectOption("timeline");
+  await panel.getByLabel("Search").fill("oversight failure");
+  await panel.getByLabel("Match").selectOption("all");
+  await panel.getByText("Search options", { exact: true }).click();
+  await panel.getByLabel("Order results by").selectOption("timeline");
   await panel.getByLabel("Languages").fill("en, fr");
   await panel.getByLabel("Tags").fill("oversight, governance");
   await panel.getByLabel("Name").fill("Oversight follow-up");
   await panel.getByLabel("Description").fill("Revised durable question");
-  await panel
-    .getByRole("button", { name: "Save metadata + typed intent" })
-    .click();
+  await panel.getByRole("button", { name: "Update saved search" }).click();
 
-  await expect(panel).toContainText(
-    "Display metadata and typed query intent committed together.",
-  );
-  const updated = panel.getByLabel("Applied search intent");
+  await expect(panel.getByRole("status")).toContainText("Updated “Oversight follow-up”");
+  const updated = panel.getByLabel("Search details");
   await expect(updated).toContainText("oversight failure");
-  await expect(updated).toContainText("phrase: off");
-  await expect(updated).toContainText("operator: ALL");
-  await expect(updated).toContainText("sort: timeline");
-  await expect(updated).toContainText("language: en");
-  await expect(updated).toContainText("language: fr");
-  await expect(updated).toContainText("tag: oversight");
-  await expect(updated).toContainText("tag: governance");
+  await expect(updated).toContainText("Match: All of these words");
+  await expect(updated).toContainText("Order: Time");
+  await expect(updated).toContainText("Language: en");
+  await expect(updated).toContainText("Language: fr");
+  await expect(updated).toContainText("Tag: oversight");
+  await expect(updated).toContainText("Tag: governance");
   await expect(savedList.getByRole("button", { name: /Oversight follow-up/ })).toBeVisible();
 
   const accessibility = await new AxeBuilder({ page }).analyze();

--- a/frontend/tests/research-search-controls.spec.ts
+++ b/frontend/tests/research-search-controls.spec.ts
@@ -81,7 +81,7 @@ test("saved Research questions can replace the whole search without backend voca
   await panel.getByLabel("Description").fill("Revised durable question");
   await panel.getByRole("button", { name: "Update saved search" }).click();
 
-  await expect(panel.getByRole("status")).toContainText("Updated “Oversight follow-up”");
+  await expect(panel.locator(".typed-search-status")).toContainText("Updated “Oversight follow-up”");
   const updated = panel.getByLabel("Search details");
   await expect(updated).toContainText("oversight failure");
   await expect(updated).toContainText("Match: All of these words");

--- a/frontend/tests/research-search-controls.spec.ts
+++ b/frontend/tests/research-search-controls.spec.ts
@@ -12,7 +12,7 @@ async function openResearchSearch(page: import("@playwright/test").Page) {
 test("Research search exposes human choices while preserving advanced intent", async ({ page }) => {
   const panel = await openResearchSearch(page);
 
-  await panel.getByLabel("Search").fill("governance reform");
+  await panel.getByRole("searchbox", { name: "Search", exact: true }).fill("governance reform");
   await panel.getByLabel("Match").selectOption("phrase");
   await panel.getByText("Search options", { exact: true }).click();
   await panel.getByLabel("Search by").selectOption("lexical");
@@ -71,7 +71,7 @@ test("saved Research questions can replace the whole search without backend voca
   await expect(existing).toContainText("Tag: governance");
   await expect(existing).toContainText("Only results with notes");
 
-  await panel.getByLabel("Search").fill("oversight failure");
+  await panel.getByRole("searchbox", { name: "Search", exact: true }).fill("oversight failure");
   await panel.getByLabel("Match").selectOption("all");
   await panel.getByText("Search options", { exact: true }).click();
   await panel.getByLabel("Order results by").selectOption("timeline");

--- a/frontend/tests/research.spec.ts
+++ b/frontend/tests/research.spec.ts
@@ -172,24 +172,27 @@ test("Susan can reopen a note against its exact older canonical generation", asy
 test("Susan can create rename run and delete durable saved-search intent", async ({ page }) => {
   await openResearch(page);
 
-  await page.getByLabel("Saved search name").fill("Methods sweep");
-  await page.getByLabel("Saved search query").fill("methodology");
-  await page.getByLabel("Saved search description").fill("Questions across current interviews");
-  await page.getByRole("button", { name: "Save search" }).click();
-  await expect(page.getByText("Methods sweep", { exact: true })).toBeVisible();
+  const navigation = page.getByLabel("Research navigation");
+  await navigation.getByLabel("Saved search name").fill("Methods sweep");
+  await navigation.getByLabel("Saved search query").fill("methodology");
+  await navigation
+    .getByLabel("Saved search description")
+    .fill("Questions across current interviews");
+  await navigation.getByRole("button", { name: "Save search", exact: true }).click();
+  await expect(navigation.getByText("Methods sweep", { exact: true })).toBeVisible();
 
-  const initialSavedCard = page
+  const initialSavedCard = navigation
     .locator(".saved-search-list article")
     .filter({ hasText: "methodology" });
   await initialSavedCard.getByRole("button", { name: "Rename" }).click();
 
-  const savedEditor = page.locator(".saved-search-editor");
+  const savedEditor = initialSavedCard.locator(".saved-search-editor");
   await savedEditor
     .getByLabel("Saved search name for methodology")
     .fill("Methods follow-up");
   await savedEditor.getByRole("button", { name: "Save name" }).click();
 
-  const savedCard = page
+  const savedCard = navigation
     .locator(".saved-search-list article")
     .filter({ hasText: "Methods follow-up" });
   await expect(savedCard.getByText("Methods follow-up", { exact: true })).toBeVisible();
@@ -209,7 +212,7 @@ test("Susan can create rename run and delete durable saved-search intent", async
     "Notes, transcripts, and recordings are not part of this operation",
   );
   await savedCard.getByRole("button", { name: "Delete saved search" }).click();
-  await expect(page.getByText("Methods follow-up", { exact: true })).toHaveCount(0);
+  await expect(navigation.getByText("Methods follow-up", { exact: true })).toHaveCount(0);
   await expect(
     page.getByText("Saved search deleted. Notes and transcripts were not deleted."),
   ).toBeVisible();

--- a/frontend/tests/research.spec.ts
+++ b/frontend/tests/research.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@playwright/test";
 async function openResearch(page: import("@playwright/test").Page) {
   await page.goto("/?e2e=1");
   await page.getByRole("button", { name: "Research" }).click();
-  await expect(page.getByRole("heading", { name: "Your research layer." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Research", exact: true })).toBeVisible();
 }
 
 test("Susan can browse authoritative research state without database knowledge", async ({
@@ -32,6 +32,9 @@ test("Susan can browse authoritative research state without database knowledge",
   await expect(navigation.getByRole("button", { name: "#governance" })).toBeVisible();
   await expect(navigation.getByRole("button", { name: "Oral histories" })).toBeVisible();
 
+  await expect(page.getByText("Human knowledge stays human knowledge")).toHaveCount(0);
+  await expect(page.getByText("authoritative annotations", { exact: false })).toHaveCount(0);
+  await expect(page.getByText("durable questions", { exact: false })).toHaveCount(0);
   await expect(page.getByText("/Users/")).toHaveCount(0);
   await expect(page.getByText("canonical_path")).toHaveCount(0);
   await expect(page.getByText("source_path")).toHaveCount(0);
@@ -43,7 +46,7 @@ test("Susan can browse authoritative research state without database knowledge",
 test("research workspace refresh remains keyboard reachable", async ({ page }) => {
   await openResearch(page);
 
-  const refresh = page.getByRole("button", { name: "Refresh research" });
+  const refresh = page.getByRole("button", { name: "Refresh", exact: true });
   await refresh.focus();
   await expect(refresh).toBeFocused();
   await page.keyboard.press("Enter");
@@ -115,7 +118,7 @@ test("Susan can edit labels and explicitly delete a durable research note", asyn
   await noteCard.getByRole("button", { name: "Save note" }).click();
 
   await expect(
-    page.getByText("Note saved. Its verified evidence anchor is unchanged."),
+    page.getByText("Note saved. Its transcript passage is unchanged."),
   ).toBeVisible();
   await expect(
     noteCard.getByText("Compare governance with the follow-up interview."),
@@ -125,12 +128,12 @@ test("Susan can edit labels and explicitly delete a durable research note", asyn
 
   await noteCard.getByRole("button", { name: "Delete note" }).click();
   await expect(noteCard.getByLabel("Delete note confirmation")).toContainText(
-    "canonical transcript and original recording are not part of this operation",
+    "This does not delete the transcript or original recording",
   );
   await noteCard.getByRole("button", { name: "Delete note permanently" }).click();
 
   await expect(
-    page.getByText("Note deleted. Transcript evidence was not deleted."),
+    page.getByText("Note deleted. The transcript was not deleted."),
   ).toBeVisible();
   await expect(
     page.getByText("Compare governance with the follow-up interview."),
@@ -156,7 +159,7 @@ test("Susan can reopen a note against its exact older canonical generation", asy
   await expect(reader.getByText("Preserved research evidence")).toBeVisible();
   await expect(reader.getByRole("heading", { name: "Attach a note to this evidence" })).toHaveCount(0);
   await expect(
-    page.getByText("Opened the exact older evidence generation cited by this note. Nothing was rebound."),
+    page.getByText("Opened the exact older transcript version cited by this note. Nothing was moved."),
   ).toBeVisible();
   await expect(page.getByText("/Users/")).toHaveCount(0);
   await expect(page.getByText("canonical_path")).toHaveCount(0);
@@ -208,7 +211,7 @@ test("Susan can create rename run and delete durable saved-search intent", async
   await savedCard.getByRole("button", { name: "Delete saved search" }).click();
   await expect(page.getByText("Methods follow-up", { exact: true })).toHaveCount(0);
   await expect(
-    page.getByText("Saved search deleted. Transcript evidence and research notes were untouched."),
+    page.getByText("Saved search deleted. Notes and transcripts were not deleted."),
   ).toBeVisible();
 
   const results = await new AxeBuilder({ page }).analyze();

--- a/frontend/tests/research.spec.ts
+++ b/frontend/tests/research.spec.ts
@@ -186,7 +186,7 @@ test("Susan can create rename run and delete durable saved-search intent", async
     .filter({ hasText: "methodology" });
   await initialSavedCard.getByRole("button", { name: "Rename" }).click();
 
-  const savedEditor = initialSavedCard.locator(".saved-search-editor");
+  const savedEditor = navigation.locator(".saved-search-editor");
   await savedEditor
     .getByLabel("Saved search name for methodology")
     .fill("Methods follow-up");

--- a/frontend/tests/theme-accessibility.spec.ts
+++ b/frontend/tests/theme-accessibility.spec.ts
@@ -1,0 +1,121 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+import { THEMES } from "../src/themes";
+
+type Rgb = [number, number, number];
+
+function parseHex(value: string): Rgb {
+  const hex = value.trim().replace(/^#/, "");
+  if (!/^[0-9a-f]{6}$/i.test(hex)) throw new Error(`Expected six-digit hex color, got ${value}`);
+  return [
+    Number.parseInt(hex.slice(0, 2), 16),
+    Number.parseInt(hex.slice(2, 4), 16),
+    Number.parseInt(hex.slice(4, 6), 16),
+  ];
+}
+
+function luminance(rgb: Rgb): number {
+  const channels = rgb.map((channel) => {
+    const value = channel / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(left: string, right: string): number {
+  const a = luminance(parseHex(left));
+  const b = luminance(parseHex(right));
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+const TEXT_PAIRS = [
+  ["--ink", "--bg"],
+  ["--muted", "--bg"],
+  ["--ink", "--surface"],
+  ["--muted", "--surface"],
+  ["--accent-strong", "--surface"],
+  ["--on-accent", "--accent"],
+  ["--control-ink", "--control-bg"],
+  ["--danger", "--surface-raised"],
+  ["--selection-ink", "--selection-bg"],
+] as const;
+
+const NON_TEXT_PAIRS = [
+  ["--control-border", "--control-bg"],
+  ["--focus", "--surface-raised"],
+] as const;
+
+for (const theme of THEMES) {
+  test(`${theme.label} theme qualifies text, controls, native scheme, and Research a11y`, async ({ page }) => {
+    await page.goto("/?e2e=1");
+    await page.getByLabel("Theme").selectOption(theme.id);
+    await expect(page.locator("html")).toHaveAttribute("data-theme", theme.id);
+
+    const snapshot = await page.evaluate(() => {
+      const style = getComputedStyle(document.documentElement);
+      const names = [
+        "--bg",
+        "--surface",
+        "--surface-raised",
+        "--ink",
+        "--muted",
+        "--accent",
+        "--accent-strong",
+        "--on-accent",
+        "--focus",
+        "--danger",
+        "--control-bg",
+        "--control-ink",
+        "--control-border",
+        "--selection-bg",
+        "--selection-ink",
+      ];
+      return {
+        colorScheme: style.colorScheme,
+        tokens: Object.fromEntries(names.map((name) => [name, style.getPropertyValue(name).trim()])),
+      };
+    });
+
+    expect(snapshot.colorScheme).toContain(theme.scheme);
+    for (const [foreground, background] of TEXT_PAIRS) {
+      expect(
+        contrast(snapshot.tokens[foreground], snapshot.tokens[background]),
+        `${theme.label}: ${foreground} on ${background}`,
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+    for (const [foreground, background] of NON_TEXT_PAIRS) {
+      expect(
+        contrast(snapshot.tokens[foreground], snapshot.tokens[background]),
+        `${theme.label}: ${foreground} on ${background}`,
+      ).toBeGreaterThanOrEqual(3);
+    }
+
+    await page.getByRole("button", { name: "Research" }).click();
+    const panel = page.getByRole("region", { name: "What are you looking for?" });
+    await panel.getByText("Search options", { exact: true }).click();
+    const select = panel.getByLabel("Search by");
+    await expect(select).toBeVisible();
+    const controlStyle = await select.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { color: style.color, backgroundColor: style.backgroundColor };
+    });
+    expect(controlStyle.color).not.toBe(controlStyle.backgroundColor);
+
+    const accessibility = await new AxeBuilder({ page }).analyze();
+    expect(accessibility.violations).toEqual([]);
+  });
+}
+
+test("theme picker is compact, complete, and persists locally", async ({ page }) => {
+  await page.goto("/?e2e=1");
+
+  const picker = page.getByLabel("Theme");
+  await expect(picker.locator("option")).toHaveCount(THEMES.length);
+  await expect(page.getByRole("button", { name: "Archive" })).toHaveCount(0);
+  await picker.selectOption("plum");
+  await page.reload();
+
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "plum");
+  await expect(page.getByLabel("Theme")).toHaveValue("plum");
+});

--- a/frontend/tests/theme-accessibility.spec.ts
+++ b/frontend/tests/theme-accessibility.spec.ts
@@ -15,18 +15,29 @@ function parseHex(value: string): Rgb {
   ];
 }
 
-function luminance(rgb: Rgb): number {
-  const channels = rgb.map((channel) => {
-    const value = channel / 255;
-    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
-  });
-  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+function normalizeChannel(channel: number): number {
+  const value = channel / 255;
+  return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+function luminance([red, green, blue]: Rgb): number {
+  return (
+    0.2126 * normalizeChannel(red) +
+    0.7152 * normalizeChannel(green) +
+    0.0722 * normalizeChannel(blue)
+  );
 }
 
 function contrast(left: string, right: string): number {
   const a = luminance(parseHex(left));
   const b = luminance(parseHex(right));
   return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+function token(tokens: Record<string, string>, name: string): string {
+  const value = tokens[name];
+  if (!value) throw new Error(`Missing required semantic theme token: ${name}`);
+  return value;
 }
 
 const TEXT_PAIRS = [
@@ -80,13 +91,13 @@ for (const theme of THEMES) {
     expect(snapshot.colorScheme).toContain(theme.scheme);
     for (const [foreground, background] of TEXT_PAIRS) {
       expect(
-        contrast(snapshot.tokens[foreground], snapshot.tokens[background]),
+        contrast(token(snapshot.tokens, foreground), token(snapshot.tokens, background)),
         `${theme.label}: ${foreground} on ${background}`,
       ).toBeGreaterThanOrEqual(4.5);
     }
     for (const [foreground, background] of NON_TEXT_PAIRS) {
       expect(
-        contrast(snapshot.tokens[foreground], snapshot.tokens[background]),
+        contrast(token(snapshot.tokens, foreground), token(snapshot.tokens, background)),
         `${theme.label}: ${foreground} on ${background}`,
       ).toBeGreaterThanOrEqual(3);
     }

--- a/frontend/tests/workspace.spec.ts
+++ b/frontend/tests/workspace.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@playwright/test";
 async function openLibrary(page: import("@playwright/test").Page) {
   await page.goto("/?e2e=1");
   await page.getByRole("button", { name: "Library" }).click();
-  await expect(page.getByRole("heading", { name: "Search your evidence." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Search your library." })).toBeVisible();
 }
 
 async function searchWorkspace(
@@ -20,11 +20,11 @@ test("Susan can search grouped evidence and research state", async ({ page }) =>
   await openLibrary(page);
   await searchWorkspace(page);
 
-  await expect(page.getByRole("heading", { name: "Evidence", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Transcript passages", exact: true })).toBeVisible();
   await expect(
     page.getByText("We started the ABC program after the second interview round."),
   ).toBeVisible();
-  await expect(page.getByText("Verified seek point")).toBeVisible();
+  await expect(page.getByText("Transcript location")).toBeVisible();
   await expect(page.locator("[data-seek-seconds='862.43']")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Notes", exact: true })).toBeVisible();
   await expect(
@@ -40,7 +40,7 @@ test("Susan can open a verified transcript window from a search result", async (
   await openLibrary(page);
   await searchWorkspace(page);
 
-  await page.getByRole("button", { name: /Open verified evidence from interview-42/ }).click();
+  await page.getByRole("button", { name: /Open transcript passage from interview-42/ }).click();
 
   const reader = page.getByRole("complementary", { name: "Evidence reader" });
   await expect(reader).toBeVisible();
@@ -71,7 +71,7 @@ test("Susan can open a verified transcript window from a search result", async (
 test("Susan can save a durable note from a verified evidence window", async ({ page }) => {
   await openLibrary(page);
   await searchWorkspace(page);
-  await page.getByRole("button", { name: /Open verified evidence from interview-42/ }).click();
+  await page.getByRole("button", { name: /Open transcript passage from interview-42/ }).click();
 
   const reader = page.getByRole("complementary", { name: "Evidence reader" });
   const body = "Compare this passage with the follow-up interview.";
@@ -123,7 +123,7 @@ test("transcript and note markup remains inert text", async ({ page }) => {
   ).toBeVisible();
   await expect(page.locator(".result-groups img")).toHaveCount(0);
 
-  await page.getByRole("button", { name: /Open verified evidence from interview-42/ }).click();
+  await page.getByRole("button", { name: /Open transcript passage from interview-42/ }).click();
   const reader = page.getByRole("complementary", { name: "Evidence reader" });
   await expect(reader.locator("mark")).toHaveText(hostile);
   await expect(reader.locator("img")).toHaveCount(0);


### PR DESCRIPTION
## What changed

This PR turns the live-use feedback after #87 into one desktop-comprehension tranche instead of treating each symptom as a component-local patch.

### Theme system

- replaces the two side-by-side theme buttons with one compact **Theme** picker;
- keeps Archive and Midnight and adds four deliberately distinct skins: Paper, Moss, Plum, and Ember;
- centralizes the supported theme IDs/names/schemes in one registry;
- keeps one semantic token contract across every skin instead of six component palettes;
- adds explicit light/dark `color-scheme`, semantic native-control foreground/background/border tokens, focus tokens, selection tokens, and `on-accent` text;
- persists the selected theme as machine-local presentation state only;
- adds a six-theme Playwright qualification matrix with WCAG-oriented contrast assertions plus axe coverage.

The weakest checked text pair is ~5.69:1 and the weakest checked control/focus pair is ~4.19:1, leaving margin above the 4.5:1 / 3:1 thresholds.

### Research / Library comprehension

- removes the visible **Python authority** badge and other architecture-first default copy;
- replaces separate phrase + term-operator controls with one human **Match** choice: Any of these words / All of these words / Exact phrase;
- moves retrieval mode, sort, result count/context, speakers, languages, transcripts, tags, collections, and note filters under **Search options**;
- relabels lexical / semantic / hybrid as **Wording / Meaning / Wording + meaning** while preserving the same typed Python request contract;
- moves backend/model/fusion provenance under **Technical details** rather than presenting it as normal search vocabulary;
- simplifies the Library and Research headings/status/help text while retaining custody-specific language where the user is actually making an evidence-sensitive or destructive decision;
- makes typed saved-search mutations refresh the surrounding Research workspace rather than leaving sibling presentation stale.

Python still validates/canonicalizes search intent, derives research scopes, owns retrieval policy, and verifies evidence. React is only compiling documented human choices into the existing typed request.

### Documentation truth sync

Updates the current-truth docs after #87 so they no longer describe Processing Center or the first-release Research search tranche as future work:

- `README.md`
- `ROADMAP.md`
- `docs/README.md`
- `docs/getting-started.md`
- `docs/research-notes.md`
- `docs/research-search.md`
- `docs/architecture/README.md`
- `docs/development/README.md`
- synchronized `docs/diagrams/system-architecture.svg`
- new `docs/development/desktop-accessibility.md`

The revised roadmap marks Research/search, Processing Center, and this desktop-comprehension/theme tranche as first-release foundation, with transcript/speaker tools → native playback → lifecycle UI → architecture/redundancy audit → packaging → portability → packaged semantic custody → representative-device qualification remaining.

## Architectural guardrails

- canonical transcript/evidence and human research custody are unchanged;
- no raw source/canonical path authority is added to React;
- theme state is presentation-only and failure to persist it cannot block the evidence workspace;
- themes share semantic roles rather than duplicating colors in feature components;
- browser/native form controls receive explicit theme treatment instead of relying on OS/browser inference;
- exact evidence and older-generation language remains explicit where correctness requires it.

## Qualification added/updated

- Library and Research Playwright flows updated for the ordinary-language UI;
- Research search still exercises the complete typed query contract and exact evidence return;
- every registered theme gets contrast assertions, explicit browser-scheme checks, representative real-control checks, and axe;
- theme selection persistence is covered;
- architecture Mermaid/static fallback synchronization is updated.

## History note

Repository history only contains the committed Archive/Midnight implementation from #72; there was no lost four-skin implementation to recover. The additional four skins are therefore new variants built on the existing semantic-token architecture rather than a recreation of undocumented history.
