### PR TITLE
feat(desktop): add generation-bound transcript and speaker tools

### DIFF
--- a/.github/workflows/mutation-transcript-tools.yml
+++ b/.github/workflows/mutation-transcript-tools.yml
@@ -1,0 +1,60 @@
+name: Transcript Tools Mutation
+
+# Mutation testing remains a targeted qualification tool rather than a routine PR tax.
+# Run this workflow when transcript inspection, speaker naming, presentation, or post-hoc
+# publication policy changes.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: transcript-tools-mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    name: Targeted transcript-tools Poodle mutation
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.33"
+          enable-cache: true
+
+      - name: Install locked development dependencies
+        run: uv sync --locked --all-groups --extra transcription
+
+      - name: Establish transcript-tools qualification baseline
+        run: >-
+          uv run pytest
+          src/echoflow/library/tests/test_transcript_tools.py
+          src/echoflow/library/tests/test_speaker_labels.py
+          src/echoflow/library/tests/test_speaker_presentation.py
+          src/echoflow/transcription/tests/test_export.py
+          src/echoflow/desktop/tests/test_transcript_tools_bridge.py
+          --cov=echoflow
+          --cov-context=test
+          --cov-report=
+          --cov-fail-under=0
+
+      - name: Mutate transcript-tooling decisions
+        run: >-
+          uv run poodle
+          -w 4
+          --only src/echoflow/library/transcript_tools.py
+          --only src/echoflow/library/speaker_label_service.py
+          --only src/echoflow/transcription/export.py
+          --only src/echoflow/desktop/transcript_tools_bridge.py

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -269,7 +269,34 @@ jobs:
 
       - name: Install native media tools (Windows)
         if: runner.os == 'Windows'
-        run: choco install ffmpeg --yes --no-progress
+        shell: pwsh
+        run: |
+          if ((Get-Command ffmpeg -ErrorAction SilentlyContinue) -and
+              (Get-Command ffprobe -ErrorAction SilentlyContinue)) {
+            Write-Host "ffmpeg and ffprobe are already available"
+            exit 0
+          }
+
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            Write-Host "Chocolatey ffmpeg install attempt $attempt of 3"
+            choco install ffmpeg --yes --no-progress
+            if ($LASTEXITCODE -eq 0) {
+              exit 0
+            }
+            if ($attempt -lt 3) {
+              Start-Sleep -Seconds (10 * $attempt)
+            }
+          }
+
+          if (Get-Command winget -ErrorAction SilentlyContinue) {
+            Write-Host "Chocolatey unavailable; trying the winget manifest as fallback"
+            winget install --id Gyan.FFmpeg --exact --accept-package-agreements --accept-source-agreements --disable-interactivity
+            if ($LASTEXITCODE -eq 0) {
+              exit 0
+            }
+          }
+
+          throw "Could not install ffmpeg from the Windows package managers"
 
       - name: Verify native media tools
         run: >-

--- a/README.md
+++ b/README.md
@@ -2,42 +2,28 @@
 
 **A private, local-first workspace for recorded evidence.**
 
-EchoFlow turns audio and video into reproducible canonical transcripts, preserves source
-and processing provenance, lets people search a private corpus and navigate results back
-to exact verified evidence, and keeps notes, tags, collections, speaker labels, and saved
-research questions as durable user-owned knowledge.
+EchoFlow turns audio and video into reproducible canonical transcripts, preserves source and processing provenance, lets people search a private corpus and navigate results back to exact verified evidence, and keeps notes, tags, collections, speaker labels, and saved research questions as durable user-owned knowledge.
 
-Transcription is the engine room, not the whole product. EchoFlow also inspects the
-machine, chooses a safe local execution strategy, manages model custody, survives
-interrupted work, keeps word-level timing and anonymous-speaker evidence, publishes
-portable transcript views, incrementally reconciles an evolving library, and gives
-deletion the same explicit custody rules as creation.
+Transcription is the engine room, not the whole product. EchoFlow also inspects the machine, chooses a safe local execution strategy, manages model custody, survives interrupted work, keeps word-level timing and anonymous-speaker evidence, publishes portable transcript views, incrementally reconciles an evolving library, and gives deletion the same explicit custody rules as creation.
 
-Canonical transcript JSON is authoritative transcript evidence. Human-authored research
-state is authoritative user knowledge. DuckDB search/research projections and publication
-formats are rebuildable. The original recording is read-only throughout normal processing
-and can only be deleted through a separate explicit provenance-checked operation.
+Canonical transcript JSON is authoritative transcript evidence. Human-authored research state is authoritative user knowledge. DuckDB search/research projections and publication formats are rebuildable. The original recording is read-only throughout normal processing and can only be deleted through a separate explicit provenance-checked operation.
 
-> **EchoFlow's product rule:** do complicated work locally, keep the evidence
-> understandable, portable, and owned by the user.
+> **EchoFlow's product rule:** do complicated work locally, keep the evidence understandable, portable, and owned by the user.
 
-Start with **[docs/README.md](docs/README.md)** for human-facing documentation or
-**[Getting started](docs/getting-started.md)** for the shortest clone-to-transcript path.
+Start with **[docs/README.md](docs/README.md)** for human-facing documentation or **[Getting started](docs/getting-started.md)** for the shortest clone-to-transcript path.
 
 ## What can it do right now?
 
-EchoFlow is pre-production, but the backend and desktop now cover the first coherent path
-from importing a recording through local processing, evidence search, and durable research.
+EchoFlow is pre-production, but the backend and desktop cover a coherent path from importing a recording through local processing, evidence search, durable research, and post-processing transcript/speaker management.
 
 | Area | Current foundation |
 |---|---|
 | Local transcription | faster-whisper CPU/int8 and CUDA-capable strategies with explicit managed model revisions |
 | Hardware awareness | process-visible CPU/RAM, affinity/cgroup limits, accelerator topology, engine capability negotiation, resource admission |
 | Media handling | FFprobe inspection, deterministic stream selection, FFmpeg canonicalization, exact source-relative work windows |
-| Word/time evidence | source-relative word timestamps, preserved temporal provenance, deterministic human elapsed coordinates |
 | Reliability | private checkpoints, validated resume, contiguous checkpoint ordering, bounded accelerated prefetch |
 | Languages | multilingual decoding plus conservative local text-language attribution |
-| Speakers | optional anonymous recording-scoped diarization, word-level handoffs, durable display labels, honest overlap/mixed presentation |
+| Speakers | optional anonymous recording-scoped diarization, word-level handoffs, generation-bound display labels, honest overlap/mixed presentation |
 | Difficult audio | optional deterministic FFmpeg noise suppression with provenance/timeline checks |
 | Model custody | explicit inventory, recommendation, install, revalidation, immutable revision pinning/removal |
 | Transcript output | canonical JSON plus deterministic TXT, SRT, WebVTT publication views |
@@ -48,10 +34,11 @@ from importing a recording through local processing, evidence search, and durabl
 | Saved searches | durable typed query intent that re-resolves current evidence instead of freezing result snapshots |
 | Safe lifecycle | typed plan-bound deletion scopes plus private execution-state retention that preserves evidence/human work by default |
 | Incremental library | cheap refresh/reconciliation plus durable transcript and recording locations |
-| Processing Center | desktop readiness, machine/model state, preflight, start/cancel, resume versus retry, job-state discard, diarization/enhancement/publication intent |
-| Desktop presentation | Tauri + React import, Library, verified evidence reader, Research, Processing, six semantic-token themes with a compact persisted picker |
-| Accessibility | keyboard/semantic-role tests, axe, explicit light/dark browser schemes, and a six-skin contrast matrix |
-| Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, Playwright/axe, package verification |
+| Processing Center | readiness, machine/model state, preflight, supervised start/cancel, resume versus retry, job-state discard, diarization/enhancement/publication intent |
+| Transcript tools | generation-bound transcript/provenance inspection, speaker naming/removal, overlap-aware transcript view, post-hoc TXT/SRT/VTT publication |
+| Desktop presentation | Tauri + React Intake, Processing, Library, verified evidence reader, Research, transcript tools, and eight semantic-token themes |
+| Accessibility | keyboard/semantic-role tests, axe, explicit light/dark browser schemes, and an eight-skin contrast matrix |
+| Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, Playwright/axe, package verification, targeted mutation qualification |
 
 ## From recording to useful evidence
 
@@ -97,55 +84,37 @@ flowchart LR
 
 </details>
 
-Text fallback: source media is inspected and transcribed locally into canonical JSON;
-rebuildable search finds passages; canonical verification turns results back into evidence;
-durable human research attaches to that evidence; custody planning keeps destructive work
-explicit.
+Text fallback: source media is inspected and transcribed locally into canonical JSON; rebuildable search finds passages; canonical verification turns results back into evidence; durable human research attaches to that evidence; custody planning keeps destructive work explicit.
 
-Search ranking is not source truth. A result points back to canonical transcript
-coordinates, and navigation verifies that generation before presenting precise evidence
-or accepting a durable note anchor.
+Search ranking is not source truth. A result points back to canonical transcript coordinates, and navigation verifies that generation before presenting precise evidence or accepting a durable note anchor.
 
 ## Desktop status
 
-The Tauri + React desktop is no longer only an import/search shell. It currently provides:
+The Tauri + React desktop currently provides:
 
 - native file/folder selection and remembered-location permissions;
 - recording discovery without automatic processing side effects;
-- a Processing Center for readiness, model state, job state, preflight, launch, cancel,
-  resume/retry distinction, and private-state discard;
+- a Processing Center for readiness, model state, job state, preflight, launch, cancel, resume/retry distinction, and private-state discard;
 - Library search across transcripts, notes, tags, and collections;
 - verified evidence context and source-relative cursor coordinates;
-- Research note create/edit/delete, tag/collection navigation, saved-search lifecycle,
-  typed retrieval controls, exact-generation evidence return, and explicit anchor review;
-- six accessible presentation skins through one compact theme picker; and
+- Research note create/edit/delete, tag/collection navigation, saved-search lifecycle, typed retrieval controls, exact-generation evidence return, and explicit anchor review;
+- transcript details/provenance, generation-safe speaker-name management, explicit speaker-overlap presentation, and post-hoc derived publication;
+- eight accessible presentation skins through one compact theme picker; and
 - persisted presentation preference without mixing theme state into evidence or research.
 
-The browser/webview does **not** receive raw canonical/source filesystem paths for evidence
-navigation. Rust owns native desktop capability; Python owns application rules; React owns
-presentation.
+The browser/webview does **not** receive canonical/source filesystem paths for evidence navigation or transcript tools. Rust owns native desktop capability; Python owns application/evidence/custody rules; React owns presentation and explicit user intent.
 
-The current Research UI deliberately translates backend vocabulary into ordinary choices.
-For example, the user chooses **Any of these words**, **All of these words**, or **Exact
-phrase** instead of separately operating phrase and term-operator plumbing. Retrieval,
-ordering, filters, result count, and context live under **Search options**; backend retrieval
-provenance remains available under **Technical details**.
+Transcript tools are generation-bound. A long-lived UI cannot silently rename a speaker in a newer transcript generation: every inspect/mutation/publication request carries the exact canonical SHA-256 the user opened, and Python rejects stale identity. See **[Transcript and speaker tools](docs/transcript-tools.md)**.
 
-There are still no end-user installers or Releases. The supported path remains a source
-build while packaging and first-run behavior are qualified.
+There are still no end-user installers or Releases. The supported path remains a source build while packaging and first-run behavior are qualified.
 
 ## Themes and accessibility
 
-EchoFlow currently ships **Archive, Midnight, Paper, Moss, Plum, and Ember**. They are not
-six independent CSS systems. Every skin supplies the same semantic roles for background,
-surfaces, text, borders, accent/on-accent, form controls, focus, errors, and selection.
-Components consume those roles rather than inventing per-screen colors.
+EchoFlow ships **Archive, Midnight, Paper, Moss, Plum, Ember, Pride, and Monochrome**. They are not eight independent CSS systems. Every skin supplies the same semantic roles for background, surfaces, text, borders, accent/on-accent, controls, focus, errors, and selection.
 
-Every theme explicitly declares its browser `color-scheme`. Playwright checks the same
-contrast pairs across all six skins, including form-control boundaries and focus state, and
-runs axe against representative Research controls. Read
-**[Desktop themes and accessibility](docs/development/desktop-accessibility.md)** for the
-contract.
+Pride adds a decorative rainbow edge while leaving status meaning in text/structure. Monochrome is intentionally grayscale rather than another tinted dark theme. Every registered skin declares its native browser `color-scheme` and automatically enters the same Playwright WCAG-oriented contrast matrix and axe qualification.
+
+Read **[Desktop themes and accessibility](docs/development/desktop-accessibility.md)** for the contract.
 
 ## Install the current source build
 
@@ -163,8 +132,6 @@ For the native desktop, follow **[Desktop development prerequisites](docs/develo
 
 ## Plan, transcribe, and resume from the CLI
 
-The CLI remains useful for automation and source-build qualification:
-
 ```bash
 uv run echoflow models recommend
 uv run echoflow models install small
@@ -172,88 +139,54 @@ uv run echoflow transcribe interview.m4a --dry-run
 uv run echoflow transcribe interview.m4a
 ```
 
-Add publication formats when useful:
+Add derived publication formats when useful:
 
 ```bash
 uv run echoflow transcribe interview.m4a --export txt --export srt --export vtt
 ```
 
-Resume a validated interrupted job with the original input and job ID:
+Resume a validated interrupted job:
 
 ```bash
 uv run echoflow transcribe interview.m4a --resume JOB_ID
 ```
 
-Model acquisition is explicit and network-bearing. Transcription does not silently
-download faster-whisper weights. Resume rechecks source identity and current resource
-admission rather than silently changing the execution contract.
+Model acquisition is explicit and network-bearing. Resume rechecks source identity and current resource admission rather than silently changing the execution contract.
 
-## Search, annotate, and save useful questions
+## Search, annotate, and name speakers
 
 ```bash
 uv run echoflow library rebuild
-uv run echoflow library refresh
 uv run echoflow library search "housing insecurity"
 uv run echoflow library find "housing insecurity" --context-segments 1
+uv run echoflow library speakers list JOB_ID
+uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
+uv run echoflow library speakers transcript JOB_ID
 ```
 
-Research metadata can constrain transcript retrieval before scoring:
+Speaker names are durable user-authored state. `speaker-02` remains anonymous machine-produced evidence; the human label is separate and generation-bound.
 
-```bash
-uv run echoflow library search \
-  "housing affordability" \
-  --tag methodology \
-  --collection "Chapter 3" \
-  --with-notes
-```
-
-The notebook itself is durable user state:
-
-```bash
-uv run echoflow library notes add JOB_ID segment-000042 \
-  --body "Compare this with the 2024 survey." \
-  --tag methodology \
-  --collection "Chapter 3"
-```
-
-Saved searches persist the question, not today's answer:
-
-```bash
-uv run echoflow library saved save "Housing chapter" "rent burden" \
-  --tag housing --mode hybrid
-uv run echoflow library saved run "Housing chapter"
-```
+Research metadata can constrain retrieval, and saved searches persist the question rather than today's result snapshot. See **[Research search](docs/research-search.md)** and **[Research notes](docs/research-notes.md)**.
 
 ## Delete exactly what you mean
 
-Deletion is dry-run first. This only removes the transcript from rebuildable active search
-state:
+Deletion is dry-run first:
 
 ```bash
 uv run echoflow library delete JOB_ID --scope library-view
 ```
 
-The plan prints every action, preserved attached notes, affected document-scoped saved
-searches, and a confirmation token. Nothing changes until the same request is repeated
-with that token.
+The plan prints actions and a confirmation token. Nothing changes until the same request is repeated with that token. `canonical-transcript` does **not** imply `research-notes`, `saved-searches`, or `source-recording`.
 
-`canonical-transcript` does **not** imply `research-notes`, `saved-searches`, or
-`source-recording`. Shared tags/collections are never cascade-deleted merely because one
-transcript or note disappears.
-
-Age-based retention is narrower still:
+Age-based retention is narrower:
 
 ```bash
 uv run echoflow library retention --execution-days 30
 ```
 
-It can delete only old private job workspaces. Canonical transcripts, human research,
-source media, and lightweight lifecycle manifests are preserved.
+It can delete old private execution work while preserving canonical transcripts, human research, source media, and lightweight lifecycle manifests. Read **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)** for the exact contract.
 
-Read **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)** for
-the exact contract.
-
-## What belongs to you? 🦝
+## What belongs to you?
 
 | Artifact | Role | Rebuildable? |
 |---|---|---|
@@ -262,44 +195,30 @@ the exact contract.
 | Speaker display labels | user-authored knowledge | **No** |
 | Notes, tags, collections, evidence anchors | user-authored knowledge | **No** |
 | Saved searches | user-authored query intent | **No** |
-| Remembered library/recording locations | durable app preference | **No, but machine-local** |
-| Theme preference | machine-local presentation preference | Yes / non-evidence |
+| Remembered locations | durable machine-local app preference | **No** |
+| Theme preference | presentation preference | Yes / non-evidence |
 | TXT/SRT/WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
-| Lexical/semantic search state | private search projections | Yes |
-| Research query projection | rebuildable view over durable research state | Yes |
+| Lexical/semantic/research query projections | private derived state | Yes |
 
-A database is allowed to make evidence useful. It is not allowed to become the only place
-unique evidence or human research exists.
+A database is allowed to make evidence useful. It is not allowed to become the only place unique evidence or human research exists.
 
 ## For maintainers
 
-Start with **[docs/architecture/README.md](docs/architecture/README.md)**, especially
-**[Processing Center](docs/architecture/processing-center.md)**,
-**[Corpus search](docs/architecture/corpus-search.md)**,
-**[Durable research state](docs/architecture/research-state.md)**,
-**[Library lifecycle](docs/architecture/library-lifecycle.md)**,
-**[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and
-**[SECURITY.md](SECURITY.md)**.
+Start with **[docs/architecture/README.md](docs/architecture/README.md)**, **[Processing Center](docs/architecture/processing-center.md)**, **[Transcript and speaker tools](docs/transcript-tools.md)**, **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and **[frontend/SECURITY.md](frontend/SECURITY.md)**.
 
-Normal qualification includes Ruff lint/format/security rules, strict mypy, Vulture,
-Radon, branch coverage, locked dependency audit, package builds, clean-wheel verification,
-frontend type/build/audit gates, Playwright/axe, the theme contrast matrix, and
-Linux/macOS/Windows CI.
+Normal qualification includes Ruff, strict mypy, Vulture, Radon, branch coverage, dependency audit, package verification, TypeScript/build/audit gates, native Cargo compilation, Playwright/axe, the eight-theme contrast matrix, targeted Poodle mutation workflows, and Linux/macOS/Windows CI. See **[Frontend testing strategy](docs/development/frontend-testing.md)** for frontend/backend test ownership.
 
 ## Where the project goes next
 
-Research/search and the first Processing Center workflow are built. The next first-release
-sequence is:
+Research/search, Processing, desktop comprehension/themes, and transcript/speaker tools are built. The next first-release sequence is:
 
-1. transcript and speaker tools plus provenance/details polish;
-2. Tauri-owned local audio/video playback from verified source-relative coordinates;
-3. lifecycle and retention UI over the existing plan-bound custody backend;
-4. architecture/redundancy audit before packaging freezes seams;
-5. packaging, first-run storage setup, signed updates, and evidence-safe uninstall;
-6. backup/restore plus selected research portability;
-7. packaged semantic-model/dependency custody; and
-8. representative-device qualification across ordinary consumer hardware and hostile path,
-   disk, interruption, upgrade, and accessibility cases.
+1. Tauri-owned local audio/video playback from verified source-relative coordinates;
+2. lifecycle and retention UI over the existing plan-bound custody backend;
+3. architecture/redundancy audit before packaging freezes seams;
+4. packaging, first-run storage setup, signed updates, and evidence-safe uninstall;
+5. backup/restore plus selected research portability;
+6. packaged semantic-model/dependency custody; and
+7. representative-device qualification across ordinary consumer hardware and hostile path, disk, interruption, upgrade, and accessibility cases.
 
-See **[ROADMAP.md](ROADMAP.md)** for the capability matrix and exact sequencing.
+See **[ROADMAP.md](ROADMAP.md)** for the capability audit and sequencing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,16 +1,8 @@
 # EchoFlow roadmap 🗺️✨
 
-EchoFlow is becoming a **private local workspace for recorded evidence**.
+EchoFlow is becoming a **private local workspace for recorded evidence**. Its job is not to out-engine every speech-recognition runtime. Its job is to make local transcription dependable, resumable, inspectable, searchable, navigable, annotatable, portable, and safe on ordinary computers while keeping source evidence and human-authored knowledge under clear custody.
 
-Its job is not to out-engine every speech-recognition runtime. Its job is to make local
-transcription dependable, resumable, inspectable, searchable, navigable, annotatable, and
-portable on ordinary computers while keeping source evidence and human-authored knowledge
-under clear custody.
-
-Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe
-a file?” through a substantial backend foundation into a native desktop that can import,
-process, search, verify, and annotate local evidence. This roadmap is a productization map,
-not a list of every class or CLI command.
+Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe a file?” through a substantial backend foundation into a native desktop that can import, process, search, verify, annotate, inspect speakers/provenance, and publish derived transcript views. This roadmap is a productization map, not a class inventory.
 
 ```mermaid
 flowchart LR
@@ -56,89 +48,47 @@ flowchart LR
 
 </details>
 
-Text fallback: EchoFlow already spans local media, reliable transcription, canonical
-evidence, retrieval, verified navigation, durable research, lifecycle contracts,
-incremental refresh, remembered locations, native import, Library discovery, the verified
-evidence reader, the Research evidence loop, and the desktop Processing Center. Remaining
-first-release work is primarily transcript/speaker polish, playback, lifecycle UI,
-architecture cleanup, packaging, portability, semantic packaging, and real-device
-qualification.
+Text fallback: EchoFlow already spans local media, reliable transcription, canonical evidence, lexical/semantic/hybrid retrieval, verified navigation, durable research, lifecycle contracts, incremental refresh, remembered locations, native import, Processing, Library, Research, transcript/speaker tools, and an accessible multi-theme shell. The next first-release work is native playback, lifecycle UI, architecture cleanup, packaging, portability, packaged semantic custody, and real-device qualification.
 
-# What is foundation now
+# First-release foundation now
 
-The word **foundation** below means the contract exists in code and is protected by tests.
-It does not mean every capability has finished UX polish or packaged-product qualification.
+“Foundation” means the authority exists in code and is protected by tests. It does not mean installers and representative-device qualification are finished.
 
-## Local execution, media, model custody, and Processing Center
+## Local processing and model custody
 
-EchoFlow inspects process-visible CPU/memory, physical accelerator topology, and engine
-capabilities before admitting a concrete local strategy. FFprobe provides deterministic
-media inspection and stream selection; FFmpeg provides canonical local normalization and
-optional deterministic enhancement. Work windows, checkpoint ordering, and resume remain
-source-relative and provenance-bound.
+EchoFlow inspects effective CPU/memory and accelerator topology before admitting a local strategy. FFprobe owns deterministic media inspection and stream selection; FFmpeg owns canonical normalization and optional deterministic enhancement. Managed model revisions are explicit, verified, and pinned before transcription.
 
-Model acquisition is explicit and network-bearing. Managed model revisions are verified
-and pinned before transcription; EchoFlow does not hide model download inside ASR.
+The Processing Center presents readiness, model state, preflight, supervised start/cancel, durable job status, checkpoint resume, fresh retry, and private execution-state discard. Python remains authoritative for planning, admission, model custody, resume compatibility, and transcript correctness. Tauri owns allowlisted long-running child-process lifetime. React submits intent and presents state.
 
-The desktop Processing Center now productizes those authorities. A user can inspect machine
-and model readiness, preflight a selected recording, choose outcome-oriented processing
-intent, start supervised local work, follow durable job state, cancel a native child,
-distinguish resume from fresh retry, and discard private execution state without deleting
-published evidence or research. Python remains authoritative for planning, admission,
-checkpoint compatibility, transcript correctness, model custody, and durable lifecycle;
-Tauri owns allowlisted long-running child-process lifetime; React owns presentation and
-explicit user intent.
+## Canonical evidence and transcript tools
 
-## Canonical evidence and publication
+Canonical JSON is authoritative transcript evidence. It retains source/execution provenance, source-relative segment and word timing, language evidence, optional anonymous speaker evidence, and enhancement provenance. TXT, SRT, and WebVTT are deterministic publications, not transcript authority.
 
-Canonical JSON is authoritative transcript evidence. It retains source/execution
-provenance, source-relative segment and word timing, language evidence, optional speaker
-evidence, and optional enhancement provenance.
+The desktop transcript-tools tranche is now implemented. Library results can open generation-bound tools for:
 
-TXT, SRT, and WebVTT are deterministic publications. They are useful views, not transcript
-authority. The original recording remains read-only during normal processing.
+- transcript/source availability and provenance details;
+- selected audio-stream inspection;
+- human display-name editing while anonymous speaker refs remain visible;
+- speaker-aware reading with explicit overlap/mixed/unattributed states; and
+- post-hoc TXT/SRT/WebVTT publication to a native-selected destination.
 
-## Retrieval and verified navigation
+Every transcript-tool operation carries `(document_id, canonical_sha256)`. Python refuses stale generations rather than letting a long-lived UI silently mutate newer speaker numbering. Tauri exposes a fixed transcript-tools command and Python bridge allowlist; React never parses canonical JSON or receives canonical/source paths.
 
-The library has a database-neutral retrieval contract, DuckDB lexical projection,
-BM25-style ranking, optional semantic chunks/embeddings, hybrid reciprocal-rank fusion,
-and exact generation identity through `(document_id, canonical_sha256)`.
+See **[Transcript and speaker tools](docs/transcript-tools.md)** and **[Speaker display names](docs/speaker-names.md)**.
 
-Search ranking and evidence navigation remain separate. A ranked passage becomes precise
-evidence only after EchoFlow reopens the canonical transcript, verifies generation
-identity, resolves exact segment/word coordinates, and returns a source-relative seek
-coordinate.
+## Retrieval and durable research
 
-## Durable research workspace
+The library has a database-neutral retrieval contract, DuckDB lexical projection, BM25-style ranking, optional semantic chunks/embeddings, hybrid reciprocal-rank fusion, and exact-generation evidence identity.
 
-Authoritative SQLite owns notes, tags, collections, current evidence anchors, superseded
-anchor history, and saved-search intent. A monotonic journal drives a rebuildable DuckDB
-research projection. `ResearchWorkspaceService` composes those stores with verified
-transcript retrieval.
+Search ranking and evidence navigation remain separate. A ranked passage becomes precise evidence only after EchoFlow verifies canonical generation and resolves exact segment/word coordinates.
 
-The desktop supports note create/edit/delete, tag/collection navigation, exact-generation
-note return, saved-search create/run/update/delete, stale/unavailable anchor review,
-provenance-preserving same-source re-anchor, and the full typed Research search contract.
-Saved questions persist intent, not result snapshots.
+Authoritative SQLite owns notes, tags, collections, anchor history, and saved-search intent. DuckDB research/search state is rebuildable. The desktop supports note create/edit/delete, tag/collection navigation, saved-search lifecycle, typed Research search, exact-generation return, and explicit stale-anchor review/re-anchor.
 
-The UI no longer asks ordinary users to operate backend vocabulary directly. One **Match**
-choice compiles Any words / All words / Exact phrase into the same typed search intent;
-retrieval, ordering, filters, result count, and context are grouped under **Search options**.
-Technical provenance remains inspectable without being the default interface.
+## Safe lifecycle and locations
 
-## Safe deletion, refresh, and locations
+Deletion is dry-run-first and plan-bound. Source-recording deletion requires its own explicit guard and provenance verification. Retention is intentionally narrower and may remove old private execution work without silently deleting canonical transcripts, source media, or human research.
 
-`LibraryCustodyService` provides dry-run-first typed deletion. Confirmation is bound to the
-exact canonical generation, requested/effective scopes, mutation set, and relevant
-preserved dependencies. Source deletion requires explicit `source-recording`, a second
-`--allow-source` switch, and current provenance verification.
-
-Normal library refresh reconciles changed canonical generations without reopening every
-unchanged transcript. Remembered transcript and recording locations persist explicit user
-permission. Missing removable roots stay remembered but unavailable.
-
-The default recording policy is manual. Discovery does not itself open, hash, probe, copy,
-or transcribe candidate media.
+Remembered recording/transcript locations are durable permissions. Recording discovery itself does not hash, probe, copy, or transcribe candidate media. Automatic processing remains a separate explicit policy.
 
 ## Desktop presentation and accessibility
 
@@ -151,160 +101,88 @@ EchoFlow Desktop
 └── Python EchoFlow               application and evidence rules
 ```
 
-The shell now has six skins: Archive, Midnight, Paper, Moss, Plum, and Ember. They share one
-semantic token contract for surfaces, text, controls, focus, errors, selection, and accent
-foregrounds. Theme selection is a compact persisted dropdown and remains presentation-only
-state.
+The shell now has eight skins: **Archive, Midnight, Paper, Moss, Plum, Ember, Pride, and Monochrome**. All use one semantic token contract for surfaces, text, controls, focus, errors, selection, and accent foregrounds. Pride's rainbow is decorative-only; Monochrome is deliberately grayscale. Theme preference is local presentation state and never evidence/research state.
 
-Every skin declares its browser light/dark `color-scheme`. Playwright checks the same
-WCAG-oriented text and control contrast pairs across all themes and runs axe against real
-Research controls. Components should not add theme-specific colors or assume that accent
-buttons always use white text.
+Playwright iterates every registered skin through WCAG-oriented contrast pairs, real native-style controls, browser `color-scheme`, and axe. See **[Desktop themes and accessibility](docs/development/desktop-accessibility.md)**.
 
-React still does not receive arbitrary shell, SQL/database, model-provider, or raw
-evidence-path capability. Presentation convenience is not permission to move application
-or custody policy into the webview.
+# Capability → desktop audit
 
-# Capability → desktop productization audit
-
-“Backend ready” means a tested application/CLI contract already exists. “Implemented” means
-the first-release desktop workflow exists; it may still have polish or packaging work.
-
-| Capability | Authority available today | Desktop today | Remaining product work | Planned slice |
-|---|---|---|---|---|
-| First-run initialization | private workspace/output allocation and config validation | source-build startup | storage-location onboarding, repair UX | Packaging / first run |
-| Health diagnostics | doctor/system/resource checks | **implemented** in Processing readiness | richer repair guidance | Processing polish |
-| Hardware/resource policy | effective CPU/RAM/accelerator inspection, profiles, admission | **implemented** in readiness + preflight | representative-device calibration | Device qualification |
-| Managed model custody | inventory, recommendation, install, verification/revalidation/removal | **implemented** through Processing/native tasks | download-progress and offline polish | Processing polish |
-| Native import and remembered locations | durable transcript/recording roots and discovery permissions | **implemented** | location management/forget polish | Settings / library polish |
-| Recording discovery | side-effect-free candidate discovery | **implemented** | source availability polish | Library polish |
-| Job lifecycle | durable status/progress/failure/resumability/discard | **implemented** in Processing | history/detail polish | Processing polish |
-| Transcription planning | probe, stream, strategy, resource and disk admission | **implemented** preflight | presentation refinement | Processing complete |
-| Transcription execution | local execution with checkpoints/resume | **implemented** through Tauri-supervised worker | packaged-runtime qualification | Packaging |
-| Difficult-audio enhancement | deterministic FFmpeg suppression with provenance checks | **implemented** as explicit processing intent | explanation/result presentation | Transcript tools |
-| Anonymous diarization | recording-scoped speaker evidence | **implemented** as explicit processing intent | speaker result presentation/management | Speaker tools |
-| Speaker display labels | durable human names without biometric claims | labels appear in evidence | rename/manage speakers | Speaker tools |
-| Canonical JSON authority | reproducible transcript + provenance | consumed by evidence views | provenance/details inspector | Transcript tools |
-| TXT/SRT/WebVTT publication | deterministic derived exports | publication intent available in processing | destination/export management polish | Transcript tools |
-| Lexical BM25 retrieval | private corpus ranking | **implemented** | ordinary-language polish complete in current tranche | Research/search complete |
-| Semantic + hybrid retrieval | local semantic index + RRF | **implemented** in typed desktop controls when qualified | packaged dependency/model custody | Semantic qualification |
-| Verified evidence navigation | generation verification, context, exact timing, seek | **implemented** | media playback | Playback |
-| Unified discovery | transcript/note/tag/collection groups | **implemented** | optional object actions | Research/search complete |
-| Research notes | exact-generation durable anchors/history | **implemented** | optional editing polish | Research/search complete |
-| Tags and collections | durable relationships + rebuildable projection | **implemented** navigation/filter/assignment | dedicated management optional | Research polish |
-| Saved searches | durable typed intent + current re-resolution | **implemented** whole-intent lifecycle | optional organization polish | Research/search complete |
-| Safe deletion | typed dry-run plans + exact confirmation binding | none | custody review UI | Lifecycle UI |
-| Retention | execution-state-only age policies | none | preview/settings/results | Lifecycle UI |
-| Local source playback | verified source-relative coordinate exists | none | Tauri media capability and transport | Native playback |
-| Themes/accessibility | semantic palette + browser presentation | **implemented** six-skin picker + contrast/axe matrix | representative OS native-control qualification | Desktop comprehension complete |
-| Desktop packaging | Python wheel + source build | development Tauri shell | managed runtime, FFmpeg/native deps, installers | Packaging |
-| Updates/uninstall | custody semantics defined | none | signed updates; uninstall never implies evidence deletion | Packaging |
-| Backup/restore | authority boundaries identify irreplaceable state | none | manifest, restore/reconcile UX | Portability |
-| Research export | stable evidence identities/coordinates exist | none | CSV/JSONL/Markdown selected export | Portability |
-| Packaged semantic custody | dependency/model rules designed | advanced source-build capability | locked stack, immutable model, offline behavior | Semantic qualification |
-| Representative hardware | resource-planning contracts exist | CI smoke | 8/16 GB, Apple Silicon, dGPU, 32/64 GB real-device qualification | Release qualification |
+| Capability | Authority | Desktop status | Remaining first-release work |
+|---|---|---|---|
+| Machine/resource policy | Python runner/admission | implemented | representative-device calibration |
+| Model custody | verified pinned managed revisions | implemented | progress/offline/package polish |
+| Import/locations | durable permissions/discovery | implemented | settings/forget polish |
+| Processing | plan, execute, checkpoint, resume/retry | implemented | packaging/device qualification |
+| Enhancement/diarization intent | Python plan/execution | implemented | result polish continues through transcript view |
+| Canonical JSON | authoritative evidence | implemented consumer views | packaging/backup |
+| Speaker labels | generation-bound human state | **implemented desktop management** | optional dedicated organization polish |
+| Speaker transcript | backend derived presentation | **implemented** | playback-linked reading later |
+| Provenance/details | canonical verified inspection | **implemented** | richer troubleshooting optional |
+| TXT/SRT/WebVTT | deterministic derived publication | **implemented post-hoc desktop flow** | optional export organization |
+| Lexical/semantic/hybrid search | private retrieval | implemented | packaged semantic custody |
+| Verified evidence navigation | exact generation + timing/seek | implemented | native media playback |
+| Notes/tags/collections | SQLite authority | implemented | optional management polish |
+| Saved searches | durable typed intent | implemented | optional organization polish |
+| Safe deletion/retention | typed plan-bound backend | backend ready | **desktop lifecycle UI** |
+| Native source playback | verified seek coordinate exists | none | **next tranche** |
+| Themes/accessibility | semantic palette + browser/native controls | **8 skins qualified** | representative OS/forced-colors checks |
+| Frontend tests | strict TS/build + Playwright/axe | primary surfaces covered | grow with features, avoid duplicated backend policy |
+| Packaging | Python wheel + source Tauri | development only | managed runtime/installers/update/uninstall |
+| Backup/restore | authority boundaries known | none | manifest/reconcile/restore UI |
+| Representative hardware | policy contracts + platform CI | partial | real 8/16 GB, Apple/dGPU/high-DPI qualification |
 
 # Product critical path
 
 ## 1. Research/search complete
 
-The first-release Research circuit is coherent: **find evidence → verify → annotate →
-organize → save/replay a question → return to exact evidence → deliberately maintain an
-anchor when necessary**. Phrase/ANY/ALL semantics, speaker/language/transcript constraints,
-research filters, retrieval mode, sort, limits, context, saved whole-intent replacement,
-and retrieval provenance all exist.
-
-The current comprehension tranche changes presentation, not authority. Human choices are
-compiled to the same typed request and Python continues to canonicalize, validate, derive
-research scopes, execute retrieval, and select evidence generations.
+The first-release Research circuit is coherent: find evidence → verify → annotate → organize → save/replay a question → return to exact evidence → deliberately maintain an anchor when necessary.
 
 ## 2. Processing Center complete
 
-The first Processing workflow now exists over readiness, model state, durable jobs,
-preflight, explicit launch, native supervision, cancel, resume versus retry, and private
-execution-state discard. See **[Processing Center](docs/architecture/processing-center.md)**.
-
-“Complete” here means the first-release control loop exists. Packaging, representative
-hardware, richer model-download presentation, and transcript/result tooling still remain.
+The first Processing control loop exists over readiness, model state, durable jobs, preflight, launch, native supervision, cancel, resume versus retry, and private-state discard.
 
 ## 3. Desktop comprehension + theme system complete
 
-The desktop now uses ordinary search language, hides architecture-only labels from default
-Research interactions, keeps advanced controls behind a clear disclosure, and places
-retrieval provenance under Technical details.
+Ordinary users see human search language rather than Python/database vocabulary. The theme system has one registry, semantic tokens, local persistence, explicit browser schemes, native-control theming, and eight-skin contrast/a11y qualification.
 
-The theme system has one registry, one semantic token contract, a compact six-skin picker,
-local persistence, explicit browser light/dark schemes, centralized native form-control
-theming, and automated contrast/accessibility qualification. See
-**[Desktop themes and accessibility](docs/development/desktop-accessibility.md)**.
+## 4. Transcript and speaker tools complete
 
-## 4. Transcript and speaker tools
+The first desktop transcript-inspection loop now exists. Generation-bound backend services own speaker names, overlap-aware presentation, provenance/details, and deterministic post-hoc publication. The React layer submits intent and never becomes canonical authority.
 
-Next, make produced evidence easier to inspect and manage without duplicating Processing
-controls:
+Frontend coverage now explicitly spans Intake, Processing, Library/evidence, transcript tools, Research/search/anchor maintenance, themes, development mode, hostile text rendering, path non-disclosure, and accessibility. Backend decision-heavy transcript tools also have property tests and a dedicated targeted Poodle workflow. See **[Frontend testing strategy](docs/development/frontend-testing.md)**.
 
-- speaker display-name editing while anonymous refs remain evidence identity;
-- clearer language/speaker transcript presentation;
-- selected audio-stream detail where multiple legitimate streams exist;
-- publication/export destination workflow; and
-- provenance/transcript details for troubleshooting and audit.
+## 5. Native playback ← next
 
-## 5. Native playback
+Let the existing verified source-relative coordinate drive local audio/video without giving React arbitrary path authority. Rust should own file/media capability; Python should own source identity/evidence rules; the webview should receive playback state and safe coordinates.
 
-Let the existing verified source-relative coordinate drive local audio/video without giving
-React arbitrary path authority. Rust owns file/media capability; Python owns source identity
-and evidence rules; the webview receives playback state and safe coordinates.
-
-Qualification includes moved/unavailable sources, source mismatch, keyboard transport,
-reduced motion, long media, and seeking around exact word boundaries.
+Qualification must include moved/unavailable sources, source mismatch, keyboard transport, reduced motion, long media, and seeking around exact word boundaries.
 
 ## 6. Lifecycle + retention UI
 
-Productize existing custody contracts before a packaged app invites large local corpora:
-
-- dry-run deletion plan review;
-- plan-bound confirmation;
-- explicit source/canonical/research/export/execution scopes;
-- source-recording second guard; and
-- retention preview/result state.
+Productize the existing custody contracts before a packaged app invites large local corpora: dry-run plan review, plan-bound confirmation, explicit scopes, source-recording second guard, and retention preview/result state.
 
 ## 7. Architecture/redundancy audit
 
-Do this **before packaging freezes seams**. Audit bridge DTOs, Pydantic request models,
-React client glue, serializers, service composition, fixtures, Tauri supervisor patterns,
-stale compatibility paths, and duplicated documentation. Refactor where policy is repeated
-or ownership is unclear, not merely where two files look similar.
+Do this before packaging freezes seams. Audit bridge DTOs, Pydantic models, React client glue, serializers, service composition, fixtures, Tauri supervisor patterns, stale compatibility paths, and duplicated documentation. Refactor policy duplication or unclear ownership, not merely similar-looking files.
 
 ## 8. Packaging + first run + update/uninstall
 
-Ship a managed Python runtime/sidecar, FFmpeg/native dependencies, Windows/macOS/Linux
-delivery, storage-location onboarding, signed updates, and evidence-safe uninstall
-semantics.
+Ship a managed Python runtime/sidecar, FFmpeg/native dependencies, Windows/macOS/Linux delivery, storage onboarding/repair, signed updates, and evidence-safe uninstall semantics.
 
 ## 9. Backup/restore + research portability
 
-Back up canonical evidence and authoritative research, rebuild projections on restore,
-reconcile machine-local paths, and export selected research with stable evidence identities.
+Back up canonical evidence and authoritative research, rebuild projections on restore, reconcile machine-local paths, and export selected research with stable evidence identity.
 
 ## 10. Packaged semantic custody
 
-Lock and qualify embedding dependencies, immutable model acquisition, private cache/offline
-behavior, corpus compatibility, and upgrade semantics as an ordinary product feature.
+Lock/qualify embedding dependencies, immutable model acquisition, private cache/offline behavior, corpus compatibility, and upgrade semantics as an ordinary product feature.
 
 ## 11. Representative-device qualification
 
-Qualify 8 GB Windows, 16 GB commodity systems, Apple Silicon, dGPU laptops, 32/64 GB
-systems, Unicode/long paths, external disks, low disk, crashes, interrupted downloads,
-offline use, upgrades/reinstall, display scaling, native controls, keyboard use, and
-accessibility.
+Qualify 8 GB Windows, 16 GB commodity systems, Apple Silicon, dGPU laptops, 32/64 GB systems, Unicode/long paths, external disks, low disk, crashes, interrupted downloads, offline use, upgrades/reinstall, scaling, native controls, keyboard use, forced colors, and accessibility.
 
 # Later research-native work
 
-Snapshots/diffs, REFI-QDA interoperability, evidence packets, comparison workspaces,
-evidence-linked writing/script boards, portable research bundles, and live provisional
-capture remain intentionally separate from the first-release critical path. See
-**[Post-MVP research roadmap](docs/post-mvp-roadmap.md)**.
+Snapshots/diffs, REFI-QDA interoperability, evidence packets, comparison workspaces, evidence-linked writing/script boards, portable research bundles, and live provisional capture remain intentionally separate from the first-release path.
 
-The sequencing rule remains simple: do not add a larger research superstructure while the
-ordinary desktop still lacks playback, lifecycle UI, packaging, portability, and real-device
-qualification.
+The sequencing rule remains simple: do not build a larger research superstructure while the ordinary desktop still lacks playback, lifecycle UI, packaging, portability, and real-device qualification.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,62 +2,56 @@
 
 EchoFlow is a **private, local-first workspace for recorded evidence**.
 
-It can inspect a recording, choose a safe way to run on the computer you actually have,
-transcribe locally, survive interruptions, preserve provenance, search a private corpus,
-navigate results back to verified canonical evidence, keep research notes attached to that
-evidence, save reusable research questions, and expose the main workflow through a native
-desktop shell.
+It can inspect a recording, choose a safe way to run on the computer you actually have, transcribe locally, survive interruptions, preserve provenance, search a private corpus, navigate results back to verified canonical evidence, keep research notes attached to that evidence, save reusable research questions, manage generation-bound speaker labels, inspect transcript provenance, and publish derived transcript views through a native desktop shell.
 
-You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, or desktop
-IPC to use the product. Those are implementation details. The desktop should speak in
-recordings, transcripts, searches, notes, processing, and evidence.
+You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, or desktop IPC to use the product. Those are implementation details. The desktop should speak in recordings, transcripts, searches, notes, processing, speakers, and evidence.
 
-> **The short version:** your recording stays yours, canonical JSON remains inspectable
-> evidence, your notes and saved searches remain your knowledge, and most machinery built
-> around those things can be thrown away and rebuilt.
+> **The short version:** your recording stays yours, canonical JSON remains inspectable evidence, your notes/speaker names/saved searches remain your knowledge, and most machinery built around those things can be thrown away and rebuilt.
 
 ## What can EchoFlow do today?
 
 | You want to… | EchoFlow currently… |
 |---|---|
 | Transcribe privately | runs faster-whisper locally from a verified managed model |
-| Avoid melting a smaller laptop | inspects process-visible CPU, RAM, and compatible acceleration before choosing a strategy |
-| Use the desktop to process a recording | provides readiness, model state, preflight, start/cancel, job progress, resume versus retry, and private-state discard in Processing |
+| Avoid melting a smaller laptop | inspects effective CPU/RAM and compatible acceleration before choosing a strategy |
+| Process from the desktop | provides readiness, model state, preflight, supervised start/cancel, progress, resume versus retry, and private-state discard |
 | Survive interruption | checkpoints completed work and validates the original contract on resume |
-| Keep the original recording intact | treats source media as read-only during normal processing and writes artifacts separately |
+| Keep the original intact | treats source media as read-only during normal processing and writes artifacts separately |
 | Handle audio/video | selects one audio stream deterministically and canonicalizes locally |
 | Clean noisy audio | optionally applies deterministic local suppression with provenance/timeline checks |
 | Work across languages | supports multilingual decoding plus conservative local language attribution |
-| Distinguish speakers | preserves optional anonymous recording-scoped speaker evidence without claiming identity |
-| Publish useful formats | produces canonical JSON plus rebuildable TXT/SRT/WebVTT |
+| Distinguish speakers | preserves anonymous recording-scoped speaker evidence without claiming identity |
+| Name known speakers | stores human display names separately and binds them to the exact canonical generation |
+| Read handoffs/overlap | presents single-speaker, overlap, mixed, and unattributed spans without flattening uncertainty |
+| Inspect a transcript | shows verified generation, selected audio stream, source availability, and processing provenance |
+| Publish useful formats | produces canonical JSON plus rebuildable TXT/SRT/WebVTT, including post-hoc desktop publication |
 | Search a private corpus | supports lexical BM25, optional semantic retrieval, hybrid RRF, and inspectable Research search options |
 | Follow a result to evidence | verifies canonical generation and returns justified segment/word/context/seek coordinates |
 | Keep durable research | stores notes/tags/collections in authoritative private SQLite anchored to exact evidence |
-| Edit research safely | atomically replaces note prose/labels and refuses stale desktop writes |
-| Navigate research labels | filters notes through authoritative tag/collection semantics and keeps selected filters inspectable |
-| Reuse research questions | stores and edits full typed saved-search intent, then re-resolves current evidence |
-| Remember libraries | persists explicit transcript/recording location permissions without copying user media |
+| Reuse questions | stores and edits full typed saved-search intent, then re-resolves current evidence |
+| Remember libraries | persists explicit transcript/recording permissions without copying user media |
 | Refresh an evolving corpus | incrementally reconciles changed canonical generations and can verify tracked evidence |
 | Remove something safely | plans typed deletion scopes before mutation and binds confirmation to the exact plan |
-| Change appearance | offers Archive, Midnight, Paper, Moss, Plum, and Ember through one persisted, accessible Theme picker |
+| Change appearance | offers Archive, Midnight, Paper, Moss, Plum, Ember, Pride, and Monochrome through one accessible Theme picker |
 
 ## Pick your doorway
 
 - **[Getting started](getting-started.md)** for the source-build path, desktop path, and first transcript.
-- **[Processing Center](architecture/processing-center.md)** for what the desktop processing workflow owns and what remains authoritative in Python/Tauri.
+- **[Processing Center](architecture/processing-center.md)** for the desktop processing authority split.
+- **[Transcript and speaker tools](transcript-tools.md)** for generation-bound details, speaker management, overlap presentation, and post-hoc publication.
 - **[Find things across the whole local library](library-discovery.md)** for grouped Library discovery.
 - **[Research search](research-search.md)** for Match, Search options, saved searches, and the typed backend contract beneath the ordinary UI.
-- **[Your notes should survive the machinery](research-notes.md)** for notes, tags, collections, saved research intent, and evidence-anchor maintenance.
+- **[Your notes should survive the machinery](research-notes.md)** for notes, tags, collections, saved research intent, and anchor maintenance.
 - **[From search result to the exact evidence](evidence-navigation.md)** for verified canonical navigation and the evidence reader/cursor.
-- **[Transcript time without calculator gymnastics](time-navigation.md)** for timeline and source-relative coordinate semantics.
-- **[Give the anonymous speakers names](speaker-names.md)** for user-authored speaker labels.
+- **[Transcript time without calculator gymnastics](time-navigation.md)** for timeline and source-relative coordinates.
+- **[Give the anonymous speakers names](speaker-names.md)** for human-authored display labels and generation semantics.
 - **[Semantic search, without the mystery box](semantic-search.md)** for local semantic/hybrid retrieval.
-- **[Desktop themes and accessibility](development/desktop-accessibility.md)** for the semantic token system and contrast qualification.
+- **[Desktop themes and accessibility](development/desktop-accessibility.md)** for the eight-skin semantic token system and contrast qualification.
+- **[Frontend testing strategy](development/frontend-testing.md)** for frontend/backend test ownership and mutation policy.
 - **[Safe deletion and retention](architecture/safe-deletion-retention.md)** for custody-aware deletion.
 - **[Post-MVP research roadmap](post-mvp-roadmap.md)** for later research-native workflows.
-- **[SECURITY.md](../SECURITY.md)** for the security boundary.
-- **[Architecture](architecture/README.md)** for maintainers.
-- **[Development docs](development/)** for prerequisites, testing, accessibility, benchmarking, and quality gates.
+- **[SECURITY.md](../SECURITY.md)** for the repository security boundary.
+- **[Architecture](architecture/README.md)** and **[Development docs](development/)** for maintainers.
 
 ## The EchoFlow family portrait
 
@@ -103,11 +97,7 @@ flowchart LR
 
 </details>
 
-Text fallback: canonical evidence feeds rebuildable search; search resolves back to verified
-evidence; durable notes/tags/collections and saved searches remain authoritative human
-knowledge; lifecycle and refresh reuse those identities; the desktop Library and Research
-surfaces consume the same application contracts. Processing sits alongside those surfaces
-as the desktop doorway into the existing local execution authorities.
+Text fallback: canonical evidence feeds rebuildable search; search resolves back to verified evidence; durable notes/tags/collections, speaker labels, and saved searches remain authoritative human knowledge; lifecycle and refresh reuse those identities; the desktop Processing, Library, transcript-tools, and Research surfaces consume the same application authorities.
 
 ## What belongs to you, and what can the raccoon rebuild? 🦝
 
@@ -118,50 +108,35 @@ as the desktop doorway into the existing local execution authorities.
 | Speaker display labels | user-authored knowledge | **No** |
 | Research notes, tags, collections, anchors | user-authored knowledge | **No** |
 | Saved searches | user-authored query intent | **No** |
-| Remembered library/recording locations | machine-local app preference | **No, but reconcile on another machine** |
-| Theme preference | machine-local presentation preference | Yes / non-evidence |
+| Remembered locations | machine-local app preference | **No, but reconcile on another machine** |
+| Theme preference | presentation preference | Yes / non-evidence |
 | TXT / SRT / WebVTT | publication views | Yes |
 | Normalized/enhanced working audio | private processing material | Yes |
 | Checkpoint workspace after publication | execution/recovery state | Usually disposable |
-| Lexical/semantic search databases | derived search projections | Yes |
-| Research query projection | derived view over durable research state | Yes |
+| Lexical/semantic/research databases | derived projections | Yes |
 
-If deleting a search projection destroys unique human-authored information, something has
-gone very wrong.
+If deleting a search projection destroys unique human-authored information, something has gone very wrong.
 
 ## The desktop today
 
-The first-release Research circuit and Processing Center are both built. Research search
-uses ordinary product language by default: **Any of these words**, **All of these words**,
-or **Exact phrase**; advanced retrieval, ordering, filters, result count, and context are
-under **Search options**. Technical retrieval provenance remains available under
-**Technical details**.
+Research/search, the Processing Center, desktop comprehension/themes, and transcript/speaker tools are now coherent first-release slices.
 
-Processing exposes machine/model readiness, durable jobs, preflight, explicit launch,
-native cancellation, resume versus retry, and safe private-state discard without moving
-planning or evidence authority into React.
+Research uses ordinary product language by default. Processing presents backend planning/admission rather than duplicating it. Transcript tools pass exact generation identity into Python for details, speaker mutation, and publication. The webview does not parse canonical evidence or receive canonical/source paths.
 
-Appearance is now one compact Theme dropdown rather than one button per skin. All six
-skins share the same semantic control/text/focus tokens and the same contrast/a11y test
-matrix.
+Appearance remains one compact picker. All eight skins share the same semantic text/control/focus contract and the same registry-driven contrast/a11y matrix.
 
 ## What comes next
 
 The next critical path is:
 
-1. transcript and speaker tools plus provenance/details polish;
-2. Tauri-owned local media playback from verified source-relative coordinates;
-3. lifecycle and retention UI over the existing custody backend;
-4. architecture/redundancy audit before packaging;
-5. packaging, first run, signed updates, and evidence-safe uninstall;
-6. backup/restore and selected research portability;
-7. packaged semantic custody; and
-8. representative-device qualification.
+1. Tauri-owned local media playback from verified source-relative coordinates;
+2. lifecycle and retention UI over the existing custody backend;
+3. architecture/redundancy audit before packaging;
+4. packaging, first run, signed updates, and evidence-safe uninstall;
+5. backup/restore and selected research portability;
+6. packaged semantic custody; and
+7. representative-device qualification.
 
-Only after the first desktop product is coherent do the deliberately separate
-**[post-MVP research features](post-mvp-roadmap.md)** become normal roadmap work.
+Only after the first desktop product is coherent do the deliberately separate **[post-MVP research features](post-mvp-roadmap.md)** become normal roadmap work.
 
-See **[ROADMAP.md](../ROADMAP.md)** for the capability matrix and detailed sequencing.
-
-The editorial and Mermaid visual rules live in
-**[documentation-style.md](documentation-style.md)**.
+See **[ROADMAP.md](../ROADMAP.md)** for the capability audit and detailed sequencing. Editorial/Mermaid rules live in **[documentation-style.md](documentation-style.md)**.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,166 +1,110 @@
 # EchoFlow development docs 🧪🔧
 
-This is where the project stops saying “EchoFlow tries very hard not to melt your laptop”
-and starts showing **how we prove that claim is not merely aspirational prose**.
-
-The development docs are for maintainers, contributors, and anyone who enjoys turning
-subtle bad decisions into failing tests.
+This area explains how EchoFlow turns architecture claims into failing tests instead of hoping the screenshots are persuasive.
 
 ## Start here
 
 | Page | What it is for |
 |---|---|
-| [Desktop development prerequisites](desktop-development.md) | choose browser mock, native Tauri, or real processing setup; understand Node/npm locality, Rust/Cargo, Python, and native prerequisites |
-| [Desktop source-build troubleshooting](troubleshooting.md) | symptom-first recovery for blank browser views, Cargo/Tauri/Python/WebKitGTK/Wayland failures, port collisions, and safe cleanup |
-| [Desktop themes and accessibility](desktop-accessibility.md) | semantic theme tokens, contrast invariants, native-control theming, keyboard/a11y qualification, and adding a skin safely |
-| [Testing and regression bisection](testing-and-bisect.md) | general test strategy, colocation rules, mutation anticipation, and deterministic bisect oracles |
-| [Semantic retrieval qualification](semantic-retrieval-testing.md) | property, negative, boundary, integration, and mutation coverage for lexical/semantic/hybrid search decisions |
+| [Desktop development prerequisites](desktop-development.md) | browser mock, native Tauri, real processing, Node/Rust/Python/native prerequisites |
+| [Desktop source-build troubleshooting](troubleshooting.md) | symptom-first recovery for Tauri/Python/WebKitGTK/Wayland/port failures and safe cleanup |
+| [Desktop themes and accessibility](desktop-accessibility.md) | semantic theme contract, eight skins, contrast/native-control rules, adding a skin safely |
+| [Frontend testing strategy](frontend-testing.md) | frontend/backend test ownership, Processing/Library/Research/transcript-tools coverage, and why Stryker is not currently a routine tool |
+| [Testing and regression bisection](testing-and-bisect.md) | repository-wide test strategy, colocation, mutation anticipation, deterministic bisect oracles |
+| [Semantic retrieval qualification](semantic-retrieval-testing.md) | property, negative, boundary, integration, and mutation coverage for lexical/semantic/hybrid retrieval |
 | [Empirical benchmarking and calibration](benchmarking.md) | measuring real execution without turning hosted CI timing into folklore |
-| [Documentation style](../documentation-style.md) | current-truth rules, Mermaid palette, accessibility, and editorial voice |
+| [Documentation style](../documentation-style.md) | current-truth rules, Mermaid portability/accessibility, editorial voice |
 
-## The current quality gate
+## Current PR quality gate
 
-Normal pull-request qualification is staged so cheap failures stop expensive native/media
-jobs. It includes:
+Cheap checks stop expensive jobs where possible. Normal pull-request qualification includes:
 
-- locked Python dependency verification and audit;
-- Mermaid visibility/syntax/palette verification before expensive runners;
-- Ruff lint/format/security rules;
+- locked Python dependency verification and runtime dependency audit;
+- Mermaid documentation portability verification;
+- Ruff lint/format/security;
 - strict mypy;
 - Vulture dead-code checks;
 - Radon complexity/maintainability reporting;
-- pytest with branch coverage and a **90% aggregate gate**;
-- locked frontend dependency installation and audit;
-- an explicit JavaScript/Rust Tauri version-family consistency check;
-- TypeScript checking plus a production Vite build;
-- rejection of raw-HTML rendering escape hatches in the frontend;
-- a native Tauri/Rust `cargo check --locked` so browser-only builds cannot hide missing native assets, dependency drift, or host errors;
-- Playwright interaction tests plus axe accessibility checks;
-- a six-skin contrast matrix covering text, controls, focus, selection, browser `color-scheme`, and representative Research controls;
-- package build verification and clean-wheel installation; and
-- Linux, macOS, and Windows CI/platform smoke.
+- pytest branch coverage with a 90% aggregate gate;
+- frontend locked dependency install and high-severity audit;
+- Tauri JavaScript/Rust version-family consistency;
+- strict TypeScript and production Vite build;
+- rejection of `dangerouslySetInnerHTML` in the frontend;
+- native `cargo check --locked`;
+- Playwright interaction/negative/boundary tests across Intake, Processing, Library, transcript tools, and Research;
+- axe accessibility coverage;
+- an eight-skin WCAG-oriented contrast/native-control matrix;
+- package build plus clean-wheel installation; and
+- Linux/macOS/Windows platform smoke.
 
-Do not memorialize the current total test count as a project-health metric. It becomes
-stale with the next useful test and says less than the behavioral gates above. Dated PR or
-audit records may preserve historical counts when they are evidence about that event.
+Do not turn a current test count into a health metric. Counts go stale; behavioral gates are the evidence.
 
-## The quality philosophy
+## Quality philosophy
 
-EchoFlow has decision-heavy code: resource admission, model custody, stale-state
-rejection, resume, cleanup ordering, search filtering, rank composition, evidence
-anchoring, transactional user state, projection recovery, desktop capability boundaries,
-and privacy rules.
+EchoFlow has decision-heavy application code: resource admission, model custody, canonical-generation verification, resume, cleanup ordering, search filtering/rank composition, evidence anchoring, transactional user state, projection recovery, speaker authority, derived publication, desktop allowlists, and privacy boundaries.
 
-Line/branch coverage alone cannot prove those decisions are correct.
+Branch coverage alone cannot prove those decisions are right. Use several independent oracles:
 
-```mermaid
-flowchart LR
-    A[Named behavioral tests] --> B[Negative and boundary cases]
-    B --> C[Property tests]
-    C --> D[Integration and package tests]
-    D --> E[Branch coverage and static gates]
-    E --> F[Targeted mutation qualification]
-    F --> G[Frontend interaction and a11y]
-    G --> H[Cross-platform package evidence]
-    H --> I[Representative real-device evidence]
+1. named behavioral examples;
+2. negative and boundary cases;
+3. Hypothesis/property tests for invariants;
+4. integration/package tests;
+5. static and coverage gates;
+6. targeted mutation qualification;
+7. browser interaction/accessibility; and
+8. cross-platform plus representative-device evidence.
 
-    classDef inspect fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef success fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
+## Test the authority, not a copy of it
 
-    class A,B,C inspect
-    class D,E,F process
-    class G success
-    class H,I evidence
-```
+Useful examples include:
 
-Text fallback: named behavior, negative/boundary/property coverage, integration/static
-gates, targeted mutation testing, frontend accessibility, cross-platform packages, and
-representative-device evidence protect different classes of failure.
+- a stale `(document_id, canonical_sha256)` cannot rename a speaker in a newer generation;
+- a tampered canonical transcript is rejected before transcript details or publication are trusted;
+- an unknown transcript-tools method cannot reach an application service;
+- rebuilding DuckDB does not erase human speaker names or notes;
+- an empty research evidence scope returns no transcript results rather than widening to the corpus;
+- a desktop evidence/transcript-tools DTO omits canonical/source filesystem paths;
+- every registered skin satisfies the same semantic-token contrast contract; and
+- hostile transcript HTML remains inert text in the WebView.
 
-## No tautologies
+Avoid tests that assign X and assert X equals X, or frontend mocks that independently reimplement the business rule supposedly being tested.
 
-A test should prove an observable contract, not restate the implementation.
+## Colocation and mutation
 
-Useful tests include:
+Tests live beside the capability whose contract they protect. Shared fixtures stay at the narrowest useful scope. Built distributions exclude test packages.
 
-- a failed SQLite mutation leaves neither the user row nor journal event committed;
-- replaying projection changes converges to the same DuckDB state;
-- an old canonical generation does not match a new segment that reuses the same friendly
-  segment ID;
-- an empty research evidence scope returns zero transcript results rather than widening
-  to the corpus;
-- a desktop evidence DTO never exposes canonical/source filesystem paths even though the
-  backend authority knows them;
-- every registered desktop skin satisfies the same semantic-token and contrast contract; and
-- an unexpected internal CLI/bridge error is masked while a known public error preserves
-  its intended message/code.
+Hypothesis is preferred for generated invariants and sequences. Explicit fixtures/builders are preferred when hashes, identities, ordering, and evidence relationships are load-bearing.
 
-Avoid tests that simply assign X and assert X equals X, mock-only call counting where no
-behavioral contract depends on the call, or assertions that duplicate a constant from the
-same function under test.
+Poodle mutation workflows are targeted/manual qualification. They are not routine PR gates because mutating the complete Python tree on every pull request would add substantial latency while weakening signal. Transcript retrieval/semantic behavior and transcript-tools generation/speaker/publication behavior have dedicated mutation workflows.
 
-## Colocation
+The frontend currently does not use Stryker. That is deliberate: decision-heavy product rules belong in Python, while React primarily owns presentation and interaction. See [Frontend testing strategy](frontend-testing.md) for the criteria that would justify adding a JavaScript mutation layer later.
 
-Tests live with the capability whose contract they protect. Shared fixtures stay at the
-narrowest useful scope. Built distributions exclude test packages.
+## Frontend contract
 
-Hypothesis is preferred for invariants and generated sequences. Explicit fixtures/builders
-are preferred where IDs, hashes, sequences, and evidence relationships are load-bearing.
+A new interactive desktop slice should normally include semantic-role/keyboard assertions, an axe pass, positive behavior, at least one meaningful negative/boundary case, and path/capability assertions when sensitive local state is involved.
 
-Frontend tests live beside the frontend harness. A new interactive desktop slice should
-normally include keyboard behavior, semantic-role assertions, path/capability boundary
-checks where relevant, and an axe pass in the same tranche. Theme-aware components inherit
-the shared contrast matrix rather than adding one-off palette tests.
+Theme-aware components inherit the shared registry-driven contrast matrix. Do not create a private palette test for every component.
 
-## Performance qualification from here
+## Performance qualification
 
-Current performance work should target product workloads:
+Product measurements should focus on:
 
-- incremental transcript-library refresh versus full rebuild;
+- incremental library refresh versus full rebuild;
 - warm/cold unified discovery;
-- tag/collection/note-text constrained lexical and semantic search;
-- one-edit and large-batch research projection catch-up;
-- full research projection rebuild;
-- realistic multi-recording corpus startup and disk cost;
-- desktop Library responsiveness;
-- desktop Research responsiveness;
-- Processing Center responsiveness while jobs are active; and
-- local media seek/playback responsiveness once the Tauri media capability lands.
+- constrained lexical/semantic/hybrid retrieval;
+- research projection catch-up/rebuild;
+- realistic multi-recording startup and disk cost;
+- Library and Research responsiveness;
+- Processing responsiveness while jobs are active;
+- transcript-tools inspection/presentation on large canonical files; and
+- local media seek/playback once native playback lands.
 
-Representative 8/16 GB consumer machines, Apple Silicon, discrete-GPU laptops, and larger
-workstations should calibrate policy. Hosted runner timing remains supporting evidence,
-not a substitute for hardware qualification.
+For transcript tools, canonical-byte verification is intentionally retained at the backend boundary. If profiling demonstrates material UI latency, optimize with a generation-keyed verified backend reader/cache and explicit invalidation, not a React cache that weakens custody.
 
-## Mermaid regression discipline
+Representative 8/16 GB consumer machines, Apple Silicon, dGPU laptops, and larger workstations should calibrate resource policy. Hosted runner timing is supporting evidence, not hardware qualification.
 
-GitHub's own documentation accepts Mermaid inside an exact `mermaid` fence and uses the
-classic `graph TD;` form. EchoFlow also uses `flowchart`. **Do not encode a false rule that
-one spelling is required.**
+## Documentation regressions
 
-The August 2026 regression had two concrete presentation failures:
+Mermaid source remains directly visible and a static SVG may exist only as a secondary fallback. Do not hide Mermaid behind a fallback or strip the established palette. `scripts/verify_mermaid_docs.py` protects the portable source/fallback contract.
 
-1. a one-shot normalizer stripped `classDef`/class assignments and removed EchoFlow's
-   established palette; and
-2. a later fallback experiment made hand-maintained SVGs the primary visible diagrams and
-   hid Mermaid inside collapsed `<details>`. Those SVGs used `currentColor`, which is a bad
-   dependency for an externally loaded image expected to remain legible across GitHub
-   themes.
-
-The verifier therefore protects direct visible Mermaid fences, simple GitHub-supported
-`graph`/`flowchart` syntax, approved colors when `classDef` is used, and the absence of the
-old primary-SVG/hide-Mermaid pattern.
-
-A separately maintained static SVG fallback is acceptable only as a **secondary fallback**
-for rich-rendering outages, with deliberate fixed light/dark-safe colors and accessible
-text. It must never replace or hide the Mermaid source.
-
-## Documentation voice
-
-Development docs use the medium-personality register from
-[documentation-style.md](../documentation-style.md): exact commands and contracts, but
-enough explanation that a new contributor can understand why a test exists before reading
-the mutant it is trying to kill.
-
-💃 Happy breaking.
+Development docs should explain enough of the rule that a new contributor understands why a test exists before reading the mutant it is meant to kill.

--- a/docs/development/desktop-accessibility.md
+++ b/docs/development/desktop-accessibility.md
@@ -1,10 +1,10 @@
 # Desktop themes and accessibility
 
-EchoFlow themes are presentation, not application state. A theme may change color and visual tone; it may not change evidence, research, processing behavior, or what an interaction means.
+EchoFlow themes are presentation, not application state. A skin may change color and visual tone; it may not change evidence, research, processing behavior, or what an interaction means.
 
 ## One semantic token contract
 
-Every desktop skin supplies the same semantic CSS variables in `frontend/src/styles.css`:
+Every desktop skin supplies the same semantic CSS roles:
 
 | Token | Meaning |
 |---|---|
@@ -12,65 +12,69 @@ Every desktop skin supplies the same semantic CSS variables in `frontend/src/sty
 | `--surface`, `--surface-raised`, `--surface-soft` | content surfaces at increasing visual emphasis |
 | `--ink`, `--muted` | primary and secondary text |
 | `--border` | general structural boundary |
-| `--accent`, `--accent-strong`, `--accent-soft`, `--on-accent` | interactive emphasis and its readable foreground |
+| `--accent`, `--accent-strong`, `--accent-soft`, `--on-accent` | interactive emphasis and readable foreground |
 | `--control-bg`, `--control-ink`, `--control-border` | native and custom form controls |
 | `--focus` | keyboard focus indicator |
-| `--danger` | destructive/error text |
+| `--danger` | destructive/error text role |
 | `--selection-bg`, `--selection-ink` | selected text |
 
-Components consume those meanings. They do not own theme-specific grays, whites, blues, or dark-mode exceptions. If a component needs a new visual role, add a semantic token only when the role is genuinely distinct across the product.
+The six original palettes live in `frontend/src/styles.css`; additive product skins may live in a dedicated palette sheet such as `theme-extras.css`, but they still implement exactly this contract. Components consume semantic meanings. They do not own theme-specific whites, grays, blues, or dark-mode exceptions.
 
-The theme registry in `frontend/src/themes.ts` owns the supported IDs, display names, and light/dark browser scheme. CSS owns the palette values. That split prevents the theme menu, component code, and palette definitions from becoming three competing sources of truth.
+The registry in `frontend/src/themes.ts` is the only source for supported IDs, labels, and browser light/dark scheme. CSS owns values. That keeps the theme menu, component code, and palettes from becoming competing registries.
 
 ## Current skins
 
-EchoFlow ships six skins through one compact **Theme** picker:
+EchoFlow ships eight skins through one compact **Theme** picker:
 
 - **Archive**: warm paper neutrals with restrained teal;
 - **Midnight**: charcoal surfaces with cool teal;
 - **Paper**: cool neutral paper with ink blue;
 - **Moss**: soft mineral greens;
-- **Plum**: muted aubergine on warm pale surfaces; and
-- **Ember**: warm near-black surfaces with amber emphasis.
+- **Plum**: muted aubergine on warm pale surfaces;
+- **Ember**: warm near-black surfaces with amber emphasis;
+- **Pride**: a high-contrast plum/paper interface with a decorative rainbow edge; and
+- **Monochrome**: deliberately grayscale near-black surfaces with white interaction emphasis.
 
-The set is intentionally varied by temperature and character without changing component semantics. Four light skins and two dark skins also exercise both browser `color-scheme` paths instead of treating dark mode as a one-off exception.
+Pride's rainbow is decoration only. Status, selection, errors, readiness, speaker overlap, and destructive actions remain understandable without it. Monochrome is not merely another blue-black dark theme: all semantic color tokens are grayscale, which is separately asserted in browser tests.
 
-Theme choice is stored only in browser-local presentation preferences. Failure to read or write that preference falls back to Archive and must never block the evidence workspace.
+Theme choice is browser-local presentation preference. Failure to read or write it falls back to Archive and must never block the evidence workspace.
 
-## Contrast is a testable invariant
+## Contrast is a product invariant
 
-The Playwright theme matrix checks every skin against the same WCAG-oriented thresholds:
+`frontend/tests/theme-accessibility.spec.ts` iterates the registry, so a newly registered skin automatically enters the same qualification matrix. It checks:
 
-- ordinary text pairs: **4.5:1 or greater**;
-- control boundaries and focus indicators: **3:1 or greater**;
-- accent buttons use `--on-accent` rather than assuming white text; and
-- text selection has its own foreground/background pair.
+- ordinary text pairs at **4.5:1 or greater**;
+- control boundaries and focus indicators at **3:1 or greater**;
+- accent buttons through `--on-accent` rather than an assumed white foreground;
+- selection foreground/background;
+- declared browser `color-scheme`;
+- actual Research native controls; and
+- axe against the rendered page.
 
-The current token set is deliberately above the minimums. In the checked pairs, the lowest text contrast is about **5.69:1** and the lowest non-text boundary/focus contrast is about **4.19:1**. Those margins are useful because real components can introduce antialiasing, opacity, and surrounding-color effects that make barely passing palettes brittle.
+Do not tune a palette to a screenshot and then add exceptions until it passes. If the semantic pairs fail, fix the palette.
 
-`frontend/tests/theme-accessibility.spec.ts` also verifies the declared browser `color-scheme`, exercises the real Research controls in every skin, and runs axe. The normal interaction suite continues to cover semantic roles and keyboard behavior.
+## Native controls are part of the skin
 
-## Native controls are part of the theme
+Inputs, selects, textareas, checkboxes, radios, options, placeholders, disabled states, selection, and focus are normalized centrally. Every theme declares `color-scheme`, so browser/OS controls receive the correct native light/dark context.
 
-Inputs, selects, textareas, checkboxes, radio buttons, options, placeholders, disabled states, text selection, and focus indicators are normalized centrally. Every theme explicitly declares `color-scheme`, so the browser and operating system do not have to guess whether a native control belongs to a light or dark surface.
+Do not fix contrast with a component-local `#666`, `#fff`, or platform gray. Fix the semantic role. The same repair should work in Intake, Processing, Library, Research, and transcript tools.
 
-Do not fix a contrast problem by adding a component-local `#666`, `#fff`, or platform-specific gray. Fix the semantic role or token. The same repair should make the control correct in Research, Processing, import, Library, and future surfaces.
-
-Browser automation cannot fully prove how an opened native select menu is painted by every Windows/macOS/Linux desktop stack. Representative-device qualification therefore still includes visual and keyboard checks for opened native controls, high-contrast/forced-colors modes, display scaling, and platform focus treatment.
+Browser automation cannot fully prove how an opened native menu is painted by every Windows/macOS/Linux stack. Representative-device qualification still includes opened controls, forced/high-contrast modes, scaling, keyboard traversal, and platform focus treatment.
 
 ## Color cannot be the only signal
 
-Status, errors, selection, processing readiness, current/older evidence, disabled actions, and destructive scope must remain understandable without color. Use text, semantic structure, icons where useful, and ARIA/state attributes as appropriate. A new skin must not require a new interpretation of the interface.
+Status, errors, selection, processing readiness, current/older evidence, speaker overlap, disabled actions, and destructive scope all require text or semantic structure in addition to color. The transcript-tools overlap view, for example, says **Overlap** and lists both evidence refs; border treatment is secondary decoration.
 
 ## Adding a skin
 
-A new theme is acceptable only when it:
+A new skin is acceptable only when it:
 
 1. is registered once in `themes.ts`;
-2. supplies the complete semantic token set in `styles.css`;
+2. supplies the complete semantic token contract;
 3. declares an explicit light or dark `color-scheme`;
 4. passes the shared contrast matrix and axe checks;
-5. does not add component-specific palette overrides; and
-6. remains legible for focused, selected, disabled, error, and form-control states.
+5. does not add component-specific palette overrides;
+6. remains legible for focused, selected, disabled, error, and native-control states; and
+7. does not use color as the only carrier of product meaning.
 
-This is intentionally more restrictive than “the screenshot looks good.” The product should make unreadable UI difficult to commit.
+This is intentionally more restrictive than “the screenshot looks good.” Unreadable UI should be difficult to commit.

--- a/docs/development/frontend-testing.md
+++ b/docs/development/frontend-testing.md
@@ -1,0 +1,92 @@
+# Frontend testing strategy
+
+EchoFlow tests the desktop according to its architecture: React proves presentation and human interaction; Python proves application, evidence, custody, and resource decisions; Rust proves narrow native capability wiring and process lifetime.
+
+The goal is not equal tool counts in every language. The goal is to place each behavioral oracle beside the authority it can actually judge.
+
+## Frontend layers
+
+### TypeScript and production build
+
+Strict TypeScript, `noUncheckedIndexedAccess`, and `exactOptionalPropertyTypes` catch DTO drift and unsafe optional-state assumptions. The production Vite build catches bundling/import errors that a type-only pass can miss.
+
+### Pure presentation contracts
+
+`frontend/tests/frontend-contracts.spec.ts` uses the Playwright test runner without a page fixture for deterministic presentation helpers and registries. Current examples cover:
+
+- unique/stable theme IDs and labels;
+- registered light/dark scheme metadata;
+- rejection of theme lookalikes; and
+- evidence-time formatting at negative, minute, and hour boundaries.
+
+These tests are deliberately small. A pure frontend helper belongs here only when it is genuinely presentation logic.
+
+### Browser interaction
+
+Playwright exercises every primary desktop surface:
+
+- Intake and remembered locations;
+- Processing readiness, preflight, supervised start, resume, and fresh retry;
+- Library search and verified evidence navigation;
+- Transcript and speaker tools;
+- Research notes, filtering, saved searches, typed search, and anchor maintenance; and
+- development-mode behavior.
+
+Tests use semantic roles and accessible names where possible. A selector that depends on implementation-only class names should have a specific reason.
+
+### Accessibility and themes
+
+Axe runs on representative rendered workflows. Theme qualification iterates the registry so every skin receives the same text/control/focus/selection contrast checks and browser `color-scheme` assertion.
+
+Pride has a dedicated assertion that its rainbow remains decorative. Monochrome has a dedicated assertion that its semantic palette is actually grayscale. Neither special test replaces the shared contrast matrix.
+
+### Security-oriented browser assertions
+
+Frontend tests explicitly check that:
+
+- transcript/research strings containing HTML remain inert text;
+- evidence and transcript-tool views do not expose canonical/source filesystem paths;
+- speaker display labels do not erase anonymous evidence refs; and
+- post-hoc publication reports safe filenames instead of rendering the selected destination path.
+
+## Why there is no Stryker gate today
+
+Stryker is useful when JavaScript/TypeScript contains decision-heavy pure logic whose tests should kill semantic mutations. EchoFlow deliberately keeps those decisions out of React.
+
+The important mutants in the current transcript-tools tranche are questions such as:
+
+- does a stale canonical digest get accepted?;
+- can a label cross transcript generations?;
+- can an unknown speaker ref be named?;
+- does publication skip canonical verification?;
+- can collision policy overwrite a file?; and
+- can an unallowlisted desktop method execute?
+
+Those decisions live in Python, so Poodle is the meaningful mutation tool for them. Installing Stryker solely to mutate JSX branches would increase dependency/runtime surface without improving evidence-policy assurance.
+
+This is not a permanent ban. Add a frontend mutation layer when all of the following are true:
+
+1. decision-heavy pure frontend modules actually exist;
+2. those decisions are correctly presentation-owned rather than leaked backend policy;
+3. ordinary tests give the mutant runner stable deterministic oracles; and
+4. mutation runtime is targeted rather than turning every pull request into a full-tree search.
+
+## Backend mutation qualification
+
+Poodle workflows are manual/targeted by design. Routine PR CI already runs static analysis, branch coverage, package checks, browser tests, native compilation, dependency audit, and platform smoke. Full mutation runs are qualification jobs for changed decision-heavy surfaces, not a mandatory tax on every typo.
+
+Transcript tools have a dedicated mutation workflow covering generation, speaker, and publication decisions. The broader transcript-library mutation workflow continues to cover retrieval/semantic decisions.
+
+## Adding a desktop feature
+
+A new interactive slice should normally ship with:
+
+- typed frontend request/response contracts;
+- positive interaction coverage;
+- at least one meaningful negative/boundary case;
+- keyboard/semantic-role coverage where interactive;
+- axe on the rendered slice;
+- explicit path/capability assertions if sensitive local state is involved; and
+- backend property/mutation tests when the feature changes decision-heavy application policy.
+
+If writing the browser test requires recreating a backend rule in the mock or component, inspect the architecture first. The better fix may be moving that rule back behind the Python service boundary.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,72 +2,21 @@
 
 This is the **use-the-thing** guide.
 
-EchoFlow is a private, local-first workspace for recorded evidence. You do not need to
-understand the architecture to use it: EchoFlow owns resource planning, model custody,
-recovery, transcript storage, search projections, and evidence verification so you can
-concentrate on the recording and the research.
+EchoFlow is a private, local-first workspace for recorded evidence. You do not need to understand CUDA, DuckDB, SQLite, model revisions, or desktop IPC to use it. Python owns those application/evidence decisions so the desktop can speak in recordings, transcripts, speakers, searches, notes, and evidence.
 
-If you want the tour first, visit **[Welcome to EchoFlow](README.md)**.
+EchoFlow is still pre-production. There is no polished signed installer yet, so the supported path is a source/developer checkout.
 
-## Before we begin
-
-EchoFlow is still pre-production. There is no polished signed desktop installer yet, so the
-current path is a source/developer checkout. That does **not** mean every source-build task
-requires the entire stack.
-
-Choose the smallest path that matches what you want to do:
+## Pick the smallest setup
 
 | Goal | First command after cloning | You do not need yet |
 |---|---|---|
-| inspect/click the frontend with fake data | `cd frontend && npm ci && npm run dev:mock` | Python, uv, Rust, Cargo, FFmpeg, model |
-| run the real native desktop window | follow the desktop prerequisites, then `npm run tauri dev` | transcription model until you process media |
-| use the Python CLI / process real recordings | `uv sync --locked --extra transcription` | frontend tooling unless you also want the GUI |
+| inspect/click the frontend with fake local data | `cd frontend && npm ci && npm run dev:mock` | Python, uv, Rust, FFmpeg, model |
+| run the native desktop window | follow desktop prerequisites, then `npm run tauri dev` | transcription model until processing media |
+| use the Python CLI / process recordings | `uv sync --locked --extra transcription` | frontend tooling unless you want the GUI |
 
-If a desktop source build behaves strangely, use **[Desktop source-build troubleshooting](development/troubleshooting.md)**. It starts from the error message and explains both the cause and the remedy.
+If a source build behaves strangely, use **[Desktop source-build troubleshooting](development/troubleshooting.md)**.
 
-The repository currently has two presentation paths over the same application services:
-
-- the Python CLI; and
-- a Tauri + React desktop for import, Processing, Library search, verified evidence, and
-  durable Research workflows.
-
-```mermaid
-flowchart LR
-    A[Your recording] --> B[Inspect source and computer]
-    B --> C[Choose safe local plan]
-    C --> D[Desktop Processing]
-    D --> E[Transcribe]
-    E --> F[Canonical transcript]
-    F --> G[Derived exports]
-    F --> H[Private local search]
-    H --> I[Verified evidence navigation]
-    I --> J[Durable notes tags collections]
-    J --> H
-    H --> K[Desktop Library]
-    I --> K
-    J --> L[Desktop Research]
-
-    classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
-    classDef process fill:#E8D9FF,stroke:#68469B,stroke-width:2px,color:#1F1630
-    classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
-    classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
-    classDef inspect fill:#D8EEFF,stroke:#2E617B,stroke-width:2px,color:#12222A
-
-    class A source
-    class B,C,D,E,L process
-    class F,I,J evidence
-    class G,H view
-    class K inspect
-```
-
-Text fallback: source media is inspected and processed locally into canonical evidence;
-rebuildable search and verified navigation make that evidence useful; durable research
-state stays separate; the desktop exposes import, Processing, Library, evidence, and
-Research workflows.
-
-## Fast path: inspect the frontend only
-
-You need a supported Node/npm installation, then:
+## Frontend-only mock path
 
 ```bash
 git clone https://github.com/SSD1805/EchoFlow.git
@@ -77,18 +26,11 @@ npm run doctor:desktop -- --mode=mock
 npm run dev:mock
 ```
 
-`npm ci` installs into `frontend/node_modules/`; it is not a global install. `dev:mock`
-intentionally uses fake local data so the browser never pretends it has Tauri filesystem or
-Python authority.
-
-If you run plain `npm run dev` in a browser, EchoFlow shows a development-mode explanation
-rather than silently falling back to mock data. Plain `dev` is also the Vite server used by
-the real Tauri host.
+`dev:mock` intentionally uses fake local data. Plain `npm run dev` in a browser shows a development-mode explanation rather than pretending the browser has Tauri/Python filesystem authority.
 
 ## Native desktop path
 
-Read **[Desktop development prerequisites](development/desktop-development.md)** before the
-first native build. On a prepared machine:
+Read **[Desktop development prerequisites](development/desktop-development.md)** before the first native build. On a prepared machine:
 
 ```bash
 cd EchoFlow
@@ -99,117 +41,105 @@ npm run doctor:desktop
 npm run tauri dev
 ```
 
-The debug Tauri host automatically prefers EchoFlow's repository `.venv` for backend calls.
-A transcription model is optional until you actually process a recording.
+The debug Tauri host prefers the repository `.venv` for local backend calls.
 
-### Use the desktop Processing Center
+## 1. Add or remember recordings
 
-Choose **Processing** in the desktop navigation. The first-release workflow now provides:
+Use **Add evidence** to select recordings, existing transcript JSON, or folders you want EchoFlow to remember. Remembered locations are explicit permissions, not media custody.
 
-- machine and model readiness;
-- outcome-oriented processing profiles;
-- a preflight summary before execution;
-- explicit transcription start;
-- durable job status/progress;
-- native cancel;
-- resume for a compatible interrupted job versus fresh retry when you want a new plan;
-- explicit diarization/enhancement/publication intent; and
-- private execution-state discard that does not delete recordings, canonical transcripts,
-  or research.
+Recording discovery does not itself hash, probe, copy, or transcribe candidates. Manual processing remains the default unless you explicitly choose a different processing policy.
 
-Long-running transcription is not an hour-long browser request. Python owns planning,
-resource admission, model/checkpoint rules, and transcript correctness; Tauri supervises
-allowlisted child processes; React presents the workflow.
+## 2. Process a recording
 
-See **[Processing Center](architecture/processing-center.md)** for the exact contract.
+Choose **Processing**. The current control loop includes:
 
-## 1. Install the Python source build for CLI/processing work
+- machine/resource readiness;
+- managed model state;
+- outcome-oriented processing profile;
+- backend preflight before execution;
+- optional deterministic enhancement;
+- optional anonymous diarization;
+- derived publication intent;
+- supervised local start/cancel;
+- durable job progress/state;
+- checkpoint resume versus fresh retry; and
+- private execution-state discard that does not delete source media, canonical transcript evidence, or research.
 
-From the repository root:
+Long transcription is not an hour-long WebView request. Python plans/admisses/executes; Tauri supervises allowlisted child processes; React presents status and user intent.
+
+See **[Processing Center](architecture/processing-center.md)**.
+
+## 3. Process from the CLI when useful
 
 ```bash
 uv sync --locked --extra transcription
 uv run echoflow init
 uv run echoflow doctor
-uv run echoflow runner
-```
-
-## 2. Install a transcription model when you want to transcribe
-
-```bash
 uv run echoflow models recommend
 uv run echoflow models install small
-```
-
-Model acquisition is explicitly network-bearing. Once a verified managed model is local,
-transcription uses that immutable revision instead of silently reaching out to the network.
-
-You can skip this step when you are only inspecting the UI or browsing existing evidence.
-
-## 3. Inspect and transcribe a recording from the CLI
-
-```bash
 uv run echoflow transcribe interview.m4a --dry-run
 uv run echoflow transcribe interview.m4a
 ```
 
-The durable transcript is canonical JSON. Add publication views when useful:
+Publication views can be requested with:
 
 ```bash
 uv run echoflow transcribe interview.m4a --export txt --export srt --export vtt
 ```
 
-EchoFlow may canonicalize the selected audio stream into private working audio. The
-original recording is not overwritten.
-
-## 4. Resume an interrupted job
+Resume a validated interrupted job with:
 
 ```bash
 uv run echoflow transcribe interview.m4a --resume JOB_ID
 ```
 
-Resume rechecks source identity and current resources and restores the original execution
-contract rather than silently changing models, streams, preprocessing, or alignment.
+Resume rechecks source identity and current resource admission rather than silently changing the original execution contract.
 
-## 5. Optional: enhancement and anonymous speakers
-
-```bash
-uv run echoflow transcribe noisy-interview.wav --enhance
-uv run echoflow transcribe focus-group.wav --diarize
-```
-
-Enhancement remains private working material and may not shift the canonical timeline.
-Diarization uses anonymous recording-scoped refs rather than biometric identity.
-
-When speaker evidence exists, give a ref a durable human-facing display name from the CLI:
-
-```bash
-uv run echoflow library speakers list JOB_ID
-uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
-```
-
-`Dr. Chen` is display state. `speaker-02` remains evidence. Desktop speaker-name management
-is still on the next transcript/speaker-tools tranche.
-
-## 6. Refresh and search the local transcript library 🔎
+## 4. Search the Library
 
 ```bash
 uv run echoflow library rebuild
 uv run echoflow library refresh
-uv run echoflow library refresh --verify
 uv run echoflow library search "housing insecurity"
-uv run echoflow library find "housing affordability"
+uv run echoflow library find "housing affordability" --context-segments 1
 ```
 
-Unified discovery returns grouped transcript evidence, notes, tags, and collections. It
-does not invent one score that makes unlike objects compete with each other.
+In the desktop **Library**, search transcripts, notes, tags, and collections. A transcript result can open either:
 
-In the desktop Library, the default language is deliberately ordinary: search transcripts,
-notes, tags, and collections, then open a transcript result to see the exact passage.
+- **Open transcript passage** for exact verified context and the source-relative cursor; or
+- **Transcript tools** for transcript/speaker management on that exact canonical generation.
 
-## 7. Keep durable research beside the evidence 📝
+## 5. Use transcript and speaker tools
 
-Notes, tags, collections, and saved searches are authoritative local user state.
+From a transcript result, choose **Transcript tools**. EchoFlow verifies `(document_id, canonical_sha256)` before returning details or accepting mutations.
+
+The panel can show:
+
+- verified generation identity;
+- duration/language/segment/speaker summary;
+- whether the source recording is currently available;
+- selected audio-stream and processing provenance under **Technical details**;
+- anonymous speaker refs with optional human display names;
+- a derived speaker transcript with explicit **Speaker**, **Overlap**, **Mixed speakers**, and **Unattributed** states; and
+- post-hoc TXT/SRT/WebVTT publication to a native-selected folder.
+
+Speaker names never replace anonymous evidence refs. If you save `Dr. Chen` for `speaker-02`, the desktop keeps `speaker-02` visible.
+
+If the transcript changed since the view was opened, Python refuses the stale operation rather than applying a name or publication request to a newer generation.
+
+See **[Transcript and speaker tools](transcript-tools.md)** and **[Give the anonymous speakers names](speaker-names.md)**.
+
+CLI speaker tools remain available:
+
+```bash
+uv run echoflow library speakers list JOB_ID
+uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
+uv run echoflow library speakers transcript JOB_ID
+```
+
+## 6. Keep durable research
+
+Notes, tags, collections, anchors, and saved searches are authoritative local user state.
 
 ```bash
 uv run echoflow library notes add JOB_ID segment-000042 \
@@ -218,101 +148,57 @@ uv run echoflow library notes add JOB_ID segment-000042 \
   --collection "Chapter 3"
 ```
 
-Saved searches persist typed query intent rather than today's result snapshot:
+The desktop Research search uses one **Match** choice: Any of these words, All of these words, or Exact phrase. Retrieval, ordering, transcript/speaker/language constraints, research filters, result count, and context live under **Search options**. Technical retrieval provenance stays under **Technical details**.
 
-```bash
-uv run echoflow library saved save "Housing chapter" "rent burden" \
-  --tag housing --mode hybrid
-uv run echoflow library saved run "Housing chapter"
-```
+See **[Research search](research-search.md)** and **[Research notes](research-notes.md)**.
 
-Research metadata can constrain transcript search before ranking:
+## 7. Change the appearance
 
-```bash
-uv run echoflow library search \
-  "housing affordability" \
-  --tag methodology \
-  --with-notes
-```
+The header has one **Theme** dropdown with:
 
-The desktop Research search uses one **Match** choice: Any of these words, All of these
-words, or Exact phrase. Retrieval, ordering, transcript/speaker/language constraints,
-research filters, result count, and context are under **Search options**. Those choices are
-still compiled to the same typed Python contract; the GUI has not become the search engine.
+- Archive;
+- Midnight;
+- Paper;
+- Moss;
+- Plum;
+- Ember;
+- Pride; and
+- Monochrome.
 
-See **[Research search](research-search.md)** and
-**[Your notes should survive the machinery](research-notes.md)**.
+The choice is local presentation preference only. All eight skins use the same semantic tokens for text, surfaces, controls, focus, errors, selection, and accent foreground. Pride's rainbow is decorative; Monochrome is deliberately grayscale. Every registered skin runs through the same contrast/axe qualification.
 
-## 8. Remember library and recording folders when you want to
+See **[Desktop themes and accessibility](development/desktop-accessibility.md)**.
 
-Remembered locations are explicit durable preferences, not automatic media custody.
-A transcript-library root can participate in later refresh; a recording-source root can be
-scanned cheaply for candidates. Discovery does **not** itself open, hash, FFprobe, copy, or
-transcribe the file. Manual processing remains the default.
+## 8. Know the trust boundary
 
-See **[Durable library locations](architecture/library-locations.md)**.
+The desktop WebView does not receive arbitrary SQL, shell, subprocess, database, or raw canonical/source filesystem authority.
 
-## 9. Change the desktop theme
+Ordinary desktop calls go through a fixed Python bridge. Transcript tools use a separate fixed Tauri command/Python module with an explicit allowlist. React submits typed intent; Python remains application/evidence authority.
 
-The header has one **Theme** dropdown with Archive, Midnight, Paper, Moss, Plum, and Ember.
-The choice is saved locally as presentation preference only.
+See **[frontend/SECURITY.md](../frontend/SECURITY.md)**.
 
-All six skins use the same semantic tokens for text, surfaces, controls, focus, errors,
-selection, and accent foregrounds. They also declare explicit browser light/dark schemes
-and run through the same contrast/axe qualification matrix. See
-**[Desktop themes and accessibility](development/desktop-accessibility.md)**.
+## 9. Optional semantic/hybrid search
 
-## 10. Know what the desktop currently does
+Lexical search is the dependency-light default. Semantic search helps when you remember the idea but not the wording; hybrid retrieval combines lexical/semantic ranking using reciprocal rank fusion.
 
-The current desktop journey includes:
+The semantic foundation remains advanced source-build setup until packaged dependency/model custody is qualified.
 
-- native file/folder selection and remembered-location choices;
-- recording candidate discovery;
-- Processing readiness, model state, preflight, launch, cancel, resume/retry, and job-state discard;
-- grouped Library search across evidence and research state;
-- verified canonical context and word highlighting;
-- Research note create/edit/delete, saved-search lifecycle, and tag/collection filtering;
-- full Research search options and inspectable technical retrieval details;
-- exact-generation Research note reopening plus explicit anchor review/re-anchor; and
-- six persisted accessible themes.
+See **[Semantic search](semantic-search.md)**.
 
-The desktop webview does not receive arbitrary SQL, shell, or raw canonical/source path
-authority.
+## What EchoFlow stores
 
-## 11. Optional semantic and hybrid search ✨
-
-Lexical search is the dependency-light default. Semantic search helps when you remember
-the idea but not the wording; hybrid retrieval combines lexical and semantic ranks using
-reciprocal rank fusion.
-
-The semantic foundation remains advanced setup because the locked project dependency
-graph does not yet include Sentence Transformers as a normal packaged semantic extra.
-
-Read **[Semantic search, without the mystery box](semantic-search.md)**.
-
-## What EchoFlow stores 🦝
-
-Original media and canonical JSON are evidence; notes/tags/collections and saved searches
-are durable human knowledge; publication/search/research projections are rebuildable;
-remembered locations and theme selection are machine-local preferences with different
-custody semantics from evidence.
+Original media and canonical JSON are evidence. Notes/tags/collections, saved searches, and speaker names are durable human knowledge. Search/research projections and TXT/SRT/WebVTT are derived/rebuildable. Remembered locations and theme selection are machine-local preferences with different custody semantics from evidence.
 
 ## What comes next?
 
-Research/search, Processing Center, and the desktop comprehension/theme tranche are
-foundation. Next:
+Research/search, Processing, desktop comprehension/themes, and transcript/speaker tools are foundation. Next:
 
-1. transcript and speaker tools plus provenance/details polish;
-2. Tauri-owned local media playback;
-3. lifecycle and retention UI;
-4. architecture/redundancy audit before packaging;
-5. packaging/first run/update/uninstall;
-6. backup/restore and research portability;
-7. packaged semantic custody; and
-8. representative-device qualification.
-
-The deliberately separate **[post-MVP research roadmap](post-mvp-roadmap.md)** covers later
-research snapshots/diffs, interoperability, evidence packets, comparison, writing/script
-boards, portable research bundles, and live provisional capture.
+1. Tauri-owned local audio/video playback from verified source-relative coordinates;
+2. lifecycle and retention UI;
+3. architecture/redundancy audit before packaging;
+4. packaging/first run/update/uninstall;
+5. backup/restore and research portability;
+6. packaged semantic custody; and
+7. representative-device qualification.
 
 For the detailed first-release sequence, see **[ROADMAP.md](../ROADMAP.md)**.

--- a/docs/speaker-names.md
+++ b/docs/speaker-names.md
@@ -8,61 +8,58 @@ speaker-02
 speaker-03
 ```
 
-That is excellent for provenance and terrible for remembering which person was Dr. Chen.
-
-EchoFlow therefore keeps **two different facts** instead of pretending they are the same:
+That is good provenance and inconvenient human memory. EchoFlow therefore keeps two different facts:
 
 - `speaker-02` is machine-produced diarization evidence;
-- `Dr. Chen` is a name **you** assigned to that anonymous speaker in this transcript
-  generation.
+- `Dr. Chen` is a name **you** assigned to that anonymous speaker in one exact transcript generation.
 
 The friendly label never rewrites the evidence underneath it.
 
-```mermaid
-flowchart LR
-    A[Anonymous diarization evidence] --> B[speaker-02]
-    B --> C[Canonical transcript coordinates]
-    B --> D[User display label]
-    D --> E[Dr. Chen plus speaker-02]
+## Desktop
+
+From a Library transcript result, open **Transcript tools**. The **Name anonymous speakers** section shows the anonymous evidence ref beside an editable display name. Saving `Dr. Chen` produces presentation such as:
+
+```text
+Dr. Chen · speaker-02
 ```
 
-Text fallback: the anonymous speaker ref remains evidence; the human name is separate
-user-authored presentation state bound to that exact transcript generation.
+Removing the display name removes only the human-authored label. The anonymous ref remains canonical/diarization identity.
 
-🦝 **The raccoon may rebuild the search index. The raccoon may not eat your names.**
+The desktop also exposes **Open speaker transcript**, which presents backend-derived spans as **Speaker**, **Overlap**, **Mixed speakers**, or **Unattributed**. When two speakers are simultaneously active, EchoFlow lists both rather than choosing a winner.
 
-## Naming a speaker
+See **[Transcript and speaker tools](transcript-tools.md)** for the desktop authority, publication, security, and testing contract.
 
-First make sure the transcript is present in the local library, then inspect its anonymous
-speaker refs:
+## CLI
+
+Inspect anonymous refs:
 
 ```bash
 echoflow library speakers list TRANSCRIPT_ID
 ```
 
-Assign a human-readable display label:
+Assign a display label:
 
 ```bash
 echoflow library speakers name TRANSCRIPT_ID speaker-02 "Dr. Chen"
 ```
 
-EchoFlow keeps `speaker-02` as the evidence reference and can present:
-
-```text
-Dr. Chen (speaker-02)
-```
-
-If you change your mind:
+Remove it:
 
 ```bash
 echoflow library speakers forget-name TRANSCRIPT_ID speaker-02
+```
+
+Read the derived speaker presentation:
+
+```bash
+echoflow library speakers transcript TRANSCRIPT_ID
 ```
 
 Every command also supports `--json` for machine-readable output.
 
 ## Why not replace `speaker-02` with the name?
 
-Because those statements come from different authorities.
+Those statements come from different authorities.
 
 Diarization says:
 
@@ -72,17 +69,11 @@ You say:
 
 > I know this person is Dr. Chen, so show me that name while I work.
 
-Overwriting one with the other would destroy the distinction between machine-produced
-evidence and human knowledge. That distinction matters for reproducibility, correction,
-auditing, search, and durable research notes.
+Overwriting one with the other would destroy the distinction between machine-produced evidence and human knowledge. That distinction matters for reproducibility, correction, auditing, search, and durable research.
 
-## What if the transcript changes?
+## Generation binding
 
-Speaker numbering is meaningful only inside the canonical transcript generation that
-produced it.
-
-A re-transcription could change speaker boundaries. Tomorrow's `speaker-02` could even
-represent somebody different from today's `speaker-02`.
+Speaker numbering is meaningful only inside the canonical transcript generation that produced it. A re-transcription can change speaker boundaries, and tomorrow's `speaker-02` could represent somebody different from today's `speaker-02`.
 
 A display label is therefore bound to:
 
@@ -92,137 +83,52 @@ transcript ID
 + anonymous speaker ref
 ```
 
-If the canonical transcript changes, EchoFlow **keeps the old user-authored label** but
-refuses to silently apply it to the new generation.
+If the canonical transcript changes, EchoFlow keeps old user-authored label state but does not silently apply it to the new generation.
 
-```mermaid
-flowchart TD
-    A[Canonical generation A] --> B[speaker-02]
-    B --> C[Dr. Chen label]
-    A --> D[Canonical generation B]
-    D --> E[speaker-02]
-    C --> F[Retained historical user state]
-    C -. not silently reused .-> E
-```
+This rule is especially important in a long-lived desktop view. Every transcript-tools inspect, speaker transcript, set-label, remove-label, and publication request carries the exact canonical SHA-256 the user opened. Python checks that expected generation at the service/mutation boundary. If the library changed meanwhile, the request fails and the user reopens the current transcript rather than mutating reused speaker numbering.
 
-That is slightly fussy on purpose. EchoFlow would rather require an explicit human action
-than confidently attach Dr. Chen to the wrong person.
+## Handoffs and overlap
 
-## What about speaker handoffs inside one transcript segment?
+Word-level timing matters. A mixed ASR segment may have no single segment-level `speaker_ref` because the speaker changes halfway through. Individual aligned words can still carry `speaker-01` and `speaker-02` evidence.
 
-Word-level timing matters here.
+The speaker-label service inspects both segment-level and aligned-word speaker evidence, so those speakers remain available to name even when the enclosing sentence cannot honestly be assigned to one person.
 
-A mixed ASR segment may have no single segment-level `speaker_ref` because the speaker
-changes halfway through. Its individual aligned words can still carry `speaker-01` and
-`speaker-02` evidence.
-
-The speaker-label service inspects **both segment-level and aligned-word speaker evidence**,
-so those speakers remain available to name even when the enclosing sentence cannot
-honestly be assigned to one person.
-
-## Reading handoffs and overlap without flattening them
-
-The derived speaker transcript view combines canonical word timing with the preserved
-speaker-turn timeline:
-
-```bash
-echoflow library speakers transcript TRANSCRIPT_ID
-```
-
-A clean handoff can become two readable spans:
+The derived speaker transcript combines canonical word timing with the preserved speaker-turn timeline:
 
 ```text
 00:00:04.100  Interviewer (speaker-01)       single-speaker  What happened next?
 00:00:05.900  Dr. Chen (speaker-02)          single-speaker  We moved the samples.
 ```
 
-If two diarized speakers are simultaneously active over the same aligned word interval,
-EchoFlow does not choose a winner:
+If two diarized speakers are simultaneously active over the same aligned word interval, EchoFlow does not choose a winner:
 
 ```text
 00:00:12.200  Interviewer (speaker-01)
               + Dr. Chen (speaker-02)         overlap         Sorry…
 ```
 
-If a coarse segment contains more than one speaker but lacks word timing precise enough
-to assign its text, the view says `mixed-unresolved` rather than pretending the whole
-sentence belongs to either person.
+If a coarse segment contains more than one speaker but lacks word timing precise enough to assign its text, the view says `mixed-unresolved` rather than pretending the whole sentence belongs to either person.
 
-```mermaid
-flowchart LR
-    A[Canonical word timing] --> D[Derived speaker presentation]
-    B[Speaker-turn timeline] --> D
-    C[User display labels] --> D
-    D --> E[single-speaker]
-    D --> F[overlap]
-    D --> G[mixed-unresolved]
-    D --> H[unattributed]
-```
+One conservative rule matters: if a canonical aligned word is unattributed, presentation will not promote it to one named speaker merely because a diarization turn overlaps. Presentation may expose multi-speaker overlap; it does not manufacture a stronger single-speaker claim than canonical evidence supports.
 
-This view is **derived presentation**, not a new canonical transcript. Numeric
-source-relative seconds and original anonymous refs remain visible in JSON, along with
-the canonical transcript SHA-256 that produced the view.
+## Search
 
-One conservative rule matters: if a canonical aligned word is unattributed, presentation
-will not promote it to one named speaker merely because a diarization turn overlaps.
-Presentation may expose additional multi-speaker overlap, but it does not manufacture a
-stronger single-speaker claim than canonical evidence supports.
+Ordinary transcript-library search consumes the same current-generation display-label state. Ranking and speaker filters still operate on anonymous evidence refs. Human results may show the friendly label while machine-readable evidence keeps the ref separately.
 
-## Do the names show up when I search too?
+The navigation layer resolves names only for the exact canonical generation behind the result and batches label lookup per generation.
 
-Yes. Ordinary transcript-library search consumes the same current display-label state.
+See **[From search result to the exact evidence](evidence-navigation.md)** for highlighting, context, source seek behavior, and evidence coordinates reused by notes.
 
-If you assigned:
+## Storage and custody
 
-```text
-speaker-02 → Dr. Chen
-```
+Speaker names are private user-authored state, not rebuildable search state. They live under EchoFlow's private application state using the atomic private-file boundary, separate from canonical evidence, lexical/semantic indexes, research projection state, and checkpoints.
 
-then a human search result can show:
+Rebuilding lexical, semantic, or research projections must not erase names. A later consolidation into the transactional research-state store is possible if it earns its value, but presentation code should continue to depend on the application service rather than a physical adapter.
 
-```text
-Dr. Chen (speaker-02)
-```
+## Not biometric identification
 
-Machine-readable output keeps `speaker-02` in `speaker_refs` and exposes the friendly
-label separately. Ranking and speaker filters still operate on anonymous evidence refs.
+Speaker display labels are not biometric identification. EchoFlow does not infer that `speaker-01` in two recordings is the same person and does not search for somebody's identity from their voice.
 
-The navigation layer resolves names only for the exact canonical generation behind the
-result and batches label lookup per generation.
+Overlap-aware presentation also does not perform source separation. Separating mixed speech into estimated sources would be a materially heavier later capability with its own compute, model-custody, and provenance requirements.
 
-See **[From search result to the exact evidence](evidence-navigation.md)** for
-highlighting, context, source seek behavior, and the evidence coordinate reused by notes.
-
-## Where are these labels stored?
-
-Speaker names are **private user-authored state**, not rebuildable search state.
-
-They currently live under EchoFlow's private application state using the existing atomic
-private-file boundary, separate from:
-
-- canonical transcript evidence;
-- the lexical DuckDB index;
-- semantic chunks and vectors;
-- SQLite research notes/tags/collections; and
-- checkpoint/recovery machinery.
-
-This means rebuilding lexical, semantic, or research query projections must not erase the
-names you assigned.
-
-A later consolidation into the transactional research-state store is possible if it earns
-its value, but presentation code should continue to use the application service rather
-than depend on the physical adapter.
-
-## What this does not do
-
-Speaker display labels are not biometric identification. EchoFlow does not infer that
-`speaker-01` in two recordings is the same person, and it does not search for somebody's
-identity from their voice.
-
-Overlap-aware presentation also does not perform source separation. It represents
-simultaneous speaker evidence using the timeline EchoFlow already has. Separating
-mixed speech into estimated sources remains later and materially heavier, with its own
-compute, model-custody, and provenance requirements.
-
-For the underlying diarization evidence model, security gate, and overlap rules, see
-**[Anonymous speaker diarization](architecture/diarization.md)**.
+For the underlying diarization evidence/security gate, see **[Anonymous speaker diarization](architecture/diarization.md)**.

--- a/docs/transcript-tools.md
+++ b/docs/transcript-tools.md
@@ -1,0 +1,87 @@
+# Transcript and speaker tools
+
+EchoFlow's desktop transcript tools make a produced canonical transcript easier to inspect, name, read, and publish without turning React into a second transcript authority.
+
+## Authority boundary
+
+A transcript-tools view is opened with exactly:
+
+```text
+document_id
+canonical_sha256
+```
+
+Python re-resolves that identity against the current library and verifies canonical bytes before returning transcript details or accepting a mutation. React never parses canonical JSON and never decides whether a displayed generation is still current.
+
+This matters because speaker refs such as `speaker-02` are recording/generation-scoped evidence. A newer transcription may reuse the same friendly ref for a different voice cluster. Every inspect, speaker transcript, speaker-label mutation, and publication request therefore carries the canonical digest that the user actually opened. If the generation changed, EchoFlow refuses the operation and requires the view to be reopened.
+
+## What the desktop can do
+
+From a Library transcript result, **Transcript tools** provides:
+
+- transcript duration, language, segment/speaker counts, source availability, and generation identity;
+- selected audio-stream detail and processing provenance under **Technical details**;
+- human display-name editing while anonymous speaker refs remain visible;
+- a derived speaker transcript that preserves handoffs, overlap, mixed-unresolved, and unattributed states; and
+- post-hoc TXT, SRT, and WebVTT publication to a user-selected folder.
+
+These features reuse existing Python authorities. They do not rewrite canonical transcript evidence.
+
+## Speaker names remain human knowledge
+
+Diarization says that some interval belongs to an anonymous ref such as `speaker-02`. A user may separately say that they know this person as `Dr. Chen`.
+
+The desktop can then show:
+
+```text
+Dr. Chen · speaker-02
+```
+
+The anonymous ref remains visible and remains the evidence identity. Removing a name removes only the human-authored label. It does not alter diarization evidence or search coordinates.
+
+For the underlying storage and generation semantics, see [Speaker display names](speaker-names.md).
+
+## Speaker-aware reading is derived presentation
+
+The speaker transcript combines verified canonical word timing, the stored diarization turn timeline, and current-generation display labels. The backend returns explicit span kinds:
+
+- `single-speaker`;
+- `overlap`;
+- `mixed-unresolved`; and
+- `unattributed`.
+
+React maps those to ordinary labels such as **Speaker**, **Overlap**, **Mixed speakers**, and **Unattributed**. It does not choose a winner when two speakers overlap, promote uncertain text to a single speaker, or derive new speaker assignments.
+
+## Post-hoc publication
+
+TXT, SRT, and WebVTT are deterministic derived views. The flow is deliberately narrow:
+
+1. Tauri opens a native folder picker;
+2. React submits the selected destination, requested formats, document ID, and expected canonical digest;
+3. Python verifies the generation;
+4. Python renders the formats and allocates collision-safe filenames; and
+5. the desktop receives publication filenames, not source/canonical paths.
+
+Presentation code does not implement subtitle timing, speaker cue rules, or filename collision policy.
+
+## Desktop security boundary
+
+Tauri exposes a dedicated `transcript_tools_request` command that invokes the fixed Python module `echoflow.desktop.transcript_tools_bridge`. The webview cannot supply a Python module or arbitrary command.
+
+The bridge has a closed method allowlist for inspect, speaker presentation, speaker-label set/remove, and publication. Requests are versioned and size bounded. Method parameters are validated through closed Pydantic schemas before an application service is called.
+
+The transcript-tools DTO intentionally omits canonical/source paths and the selected publication directory from responses.
+
+## Testing
+
+Backend qualification includes positive, negative, and boundary tests for generation binding, tampered canonical bytes, missing source recordings, speaker mutation, export collisions, and invalid method/format requests. Hypothesis exercises invalid generation-digest inputs. A targeted manual Poodle workflow mutates the decision-heavy transcript-tool services.
+
+Frontend Playwright coverage verifies transcript details, path non-disclosure, speaker rename/remove behavior, explicit overlap presentation, format selection/publication, the zero-format boundary, and axe accessibility. The theme matrix independently qualifies the panel's shared semantic colors through the global token contract.
+
+Mutation testing remains concentrated in Python because canonical-generation, custody, speaker, and export decisions belong there. Stryker is not currently installed merely to mutate presentation JSX. If meaningful decision-heavy pure frontend modules emerge later, a JavaScript mutation layer can be added where it tests real policy rather than compensating for misplaced business logic.
+
+## Performance
+
+Transcript inspection intentionally verifies canonical bytes before trusting them. That is linear I/O in one canonical JSON file and is bounded by EchoFlow's canonical-read limit. The speaker transcript is loaded lazily so opening transcript details does not pay for a second presentation pass unless requested.
+
+Do not optimize this by caching unverified/stale canonical content in React. If profiling later shows canonical verification becoming a real interactive bottleneck at large corpus/file sizes, optimize behind a generation-keyed backend reader/cache with explicit invalidation.

--- a/frontend/SECURITY.md
+++ b/frontend/SECURITY.md
@@ -4,48 +4,64 @@ The desktop client is a presentation and native-host boundary over EchoFlow's lo
 
 ## Trust boundary
 
-The React/WebView layer may display sensitive transcript text, research notes, tags, collection names, speaker labels, and user-selected local paths. Those values are data. They must never be treated as trusted markup or executable content.
+The React/WebView layer may display sensitive transcript text, research notes, tags, collection names, speaker labels, and paths the user has explicitly selected. Those values are data. They must never become trusted markup or executable content.
 
-The desktop frontend does not receive arbitrary SQL, shell, database, or filesystem capabilities. Tauri exposes only the permissions required by the current human workflow, and the Rust host forwards a versioned, size-bounded request to the fixed `python -m echoflow.desktop.bridge` entry point. Python validates the method and method-specific parameters with closed schemas before application services run.
+The frontend does not receive arbitrary SQL, shell, database, model-provider, or filesystem capabilities. Tauri exposes narrow commands for specific human workflows. Python validates versioned, size-bounded requests with closed schemas before application services run.
 
-Adding a new desktop capability therefore requires all three layers to agree deliberately:
+The ordinary desktop bridge is fixed to `python -m echoflow.desktop.bridge`. Transcript inspection and speaker management use the separate fixed `python -m echoflow.desktop.transcript_tools_bridge` entry point through Tauri's `transcript_tools_request` command. The webview cannot choose either Python module, substitute a shell command, or provide an arbitrary backend method. The transcript-tools bridge currently allowlists only inspect, speaker presentation, speaker-label set/remove, and deterministic publication operations.
+
+Adding a desktop capability requires all three layers to agree deliberately:
 
 1. a typed frontend request/response contract;
 2. an explicit Tauri/native capability when native privilege is required; and
-3. a validated Python bridge method that delegates to an existing application service.
+3. a validated Python bridge method that delegates to an application service.
 
-The frontend must not bypass those services by opening DuckDB, SQLite, arbitrary local files, or subprocesses directly.
+React must not recreate application policy by opening DuckDB, SQLite, canonical JSON, arbitrary local files, or subprocesses directly.
+
+## Generation-bound transcript mutations
+
+A long-lived desktop view can become stale while the library changes. Speaker numbering is meaningful only inside the canonical transcript generation that produced it. Every transcript-tools inspect, speaker presentation, label mutation, and publication request therefore carries `(document_id, canonical_sha256)`.
+
+Python verifies that generation at the service boundary. A stale desktop view is rejected rather than silently applying a human label or publication request to a newer generation that happens to reuse `speaker-02` or a segment identifier. React may present the rejection and ask the user to reopen the transcript; it may not reconcile generations itself.
 
 ## Rendering untrusted local content
 
-React's normal text rendering is the default boundary for transcript and research content. `dangerouslySetInnerHTML` is prohibited in the EchoFlow frontend unless a future security review introduces an explicit sanitizer and a narrowly documented use case. CI rejects its use today.
+React's normal text rendering is the default boundary for transcript and research content. `dangerouslySetInnerHTML` is prohibited unless a future security review adds an explicit sanitizer and a narrowly documented use case. CI rejects its use today.
 
-Search snippets, note bodies, participant-provided text, filenames, and metadata must be rendered as text. A malicious recording filename or transcript containing HTML or script syntax must remain inert text in the WebView.
+Search snippets, note bodies, participant-provided text, filenames, speaker labels, and metadata remain text. A malicious recording filename or transcript containing HTML/script syntax must remain inert in the WebView.
 
-The packaged frontend uses no remote fonts, scripts, stylesheets, or analytics. Network-bearing product behavior must be explicit and separately designed rather than smuggled through presentation code.
+The packaged frontend uses no remote fonts, scripts, stylesheets, analytics, or application telemetry. Network-bearing product behavior must be explicit and separately designed rather than smuggled through presentation code.
 
 ## Path and evidence disclosure
 
-Local paths are sensitive. Intake may intentionally show paths the user just selected because that is part of the command result they requested. Search/discovery responses are narrower: the desktop bridge returns evidence identity, verified segment/word coordinates, seek time, speaker display state, and research metadata without returning canonical or source filesystem paths.
+Local paths are sensitive. Intake may intentionally show paths the user has just selected because reviewing that selection is part of the requested action. Evidence navigation and transcript tooling are narrower.
 
-The frontend must not copy path-bearing values into telemetry or routine logs. EchoFlow currently has no application telemetry.
+Search/discovery responses return evidence identity, verified segment/word coordinates, seek time, speaker display state, and research metadata without canonical/source filesystem paths. Transcript-tools responses return generation identity, source availability/provenance, speaker state, and publication **filenames**, not canonical/source paths or the selected publication directory. The native folder dialog returns a destination only to the local client so it can submit that explicit intent to Python.
+
+The frontend must not copy path-bearing values into routine logs. EchoFlow currently has no application telemetry.
+
+## Derived publication
+
+TXT, SRT, and WebVTT are derived views, not transcript authority. React chooses requested formats and a user-selected destination. Python verifies the expected canonical generation, renders the formats, applies collision-safe filename allocation, writes the files, and returns safe filenames. Presentation code must not implement subtitle timing, speaker cue rules, or collision policy.
 
 ## Content Security Policy and Tauri capabilities
 
 Production and development Content Security Policies are separate. Production does not permit the Vite development WebSocket endpoint. Development may allow the local HMR WebSocket required by Vite. Script execution remains restricted to the application origin.
 
-The main window capability currently grants Tauri's core defaults plus the native open dialog. New permissions should be added one at a time with a concrete user workflow and security rationale. Broad shell, filesystem, process, or database permissions are not acceptable substitutes for a typed application method.
+The main window capability grants Tauri's core defaults plus the native open dialog and explicit EchoFlow commands. New permissions should be added one at a time with a concrete user workflow and security rationale. Broad shell, filesystem, process, or database permissions are not acceptable substitutes for a typed application method.
 
 ## Frontend dependency supply chain
 
-Build and test dependencies are security-relevant even when they are not shipped as runtime JavaScript. Vite, its compiler/bundler graph, Playwright, and other development packages execute code during development or CI and can influence generated application assets.
+Build and test dependencies are security-relevant even when they are not shipped as runtime JavaScript. Vite, Playwright, Tauri tooling, and compiler/bundler dependencies execute during development or CI and influence generated assets.
 
-`frontend/package-lock.json` is therefore part of the security boundary. CI installs with `npm ci` and fails on high-severity advisories across the complete locked dependency graph, not only production dependencies. Dependency updates that change native build bindings or browser automation versions must still pass TypeScript, the production build, Playwright, and accessibility tests.
+`frontend/package-lock.json` is therefore part of the security boundary. CI installs with `npm ci` and fails on high-severity advisories across the complete locked graph. Dependency updates that change native bindings or browser automation versions must pass TypeScript, production build, native Cargo, Playwright, accessibility, and platform-smoke checks.
 
-Do not hand-edit lockfile integrity hashes. Regenerate the lockfile with npm from the pinned manifest and review the resulting dependency graph.
+Do not hand-edit lockfile integrity hashes.
 
 ## What current tests prove
 
-Playwright plus axe verifies browser-level interaction and automated accessibility behavior for covered workflows. Python tests verify the bridge allowlist, schema validation, error masking, and application semantics. These checks do not prove that the host OS, system WebView, Tauri runtime, Node/npm registry, native dependencies, or a compromised same-user process are trustworthy.
+Python tests cover allowlists, schema validation, stale-generation rejection, error masking, speaker authority, deterministic publication, collision behavior, and other application semantics. Hypothesis exercises generation-bound input invariants. Targeted Poodle mutation workflows challenge decision-heavy backend code without making every pull request pay the full mutation cost.
 
-Packaging, code signing, update integrity, managed Python runtime custody, and representative-device WebView qualification remain separate release milestones.
+Frontend tests cover each primary workspace, transcript-tool interactions, hostile-text rendering, keyboard paths, path/capability boundaries, theme persistence/contrast, and axe. Pride and Monochrome use the same semantic-token qualification as every other skin.
+
+These checks do not prove that the host OS, system WebView, Tauri runtime, registry infrastructure, native dependencies, or a compromised same-user process are trustworthy. Packaging, signing, update integrity, managed Python runtime custody, and representative-device WebView qualification remain separate release milestones.

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -46,14 +46,15 @@ fn python_exit_message() -> String {
     }
 }
 
-fn run_backend_request(request: Value) -> Result<Value, String> {
-    let encoded = serde_json::to_vec(&request).map_err(|_| "Could not encode desktop request".to_string())?;
+fn run_python_request(module: &'static str, request: Value) -> Result<Value, String> {
+    let encoded = serde_json::to_vec(&request)
+        .map_err(|_| "Could not encode desktop request".to_string())?;
     if encoded.len() > MAX_REQUEST_BYTES {
         return Err("Desktop request exceeded the safe size limit".to_string());
     }
 
     let mut child = Command::new(configured_python())
-        .args(["-m", "echoflow.desktop.bridge"])
+        .args(["-m", module])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -80,9 +81,18 @@ fn run_backend_request(request: Value) -> Result<Value, String> {
         .map_err(|_| "EchoFlow's local Python service returned an invalid response".to_string())
 }
 
-#[tauri::command]
-pub async fn desktop_request(request: Value) -> Result<Value, String> {
-    tauri::async_runtime::spawn_blocking(move || run_backend_request(request))
+async fn request_module(module: &'static str, request: Value) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || run_python_request(module, request))
         .await
         .map_err(|_| "EchoFlow's local service task could not be completed".to_string())?
+}
+
+#[tauri::command]
+pub async fn desktop_request(request: Value) -> Result<Value, String> {
+    request_module("echoflow.desktop.bridge", request).await
+}
+
+#[tauri::command]
+pub async fn transcript_tools_request(request: Value) -> Result<Value, String> {
+    request_module("echoflow.desktop.transcript_tools_bridge", request).await
 }

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             backend::desktop_request,
+            backend::transcript_tools_request,
             processing::processing_start_task,
             processing::processing_task_status,
             processing::processing_cancel_task,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { createDesktopClient } from "./api/desktop";
 import { createProcessingClient } from "./api/processing";
+import { createTranscriptToolsClient } from "./api/transcriptTools";
 import { type Theme } from "./components/WorkspaceHeader";
 import { IntakeWorkspace } from "./IntakeWorkspace";
 import { ProcessingCenter } from "./ProcessingCenter";
@@ -9,9 +10,11 @@ import { ResearchWorkspaceWithAnchorReview } from "./ResearchWorkspaceWithAnchor
 import { SearchWorkspace } from "./SearchWorkspace";
 import { DEFAULT_THEME, isTheme, THEME_STORAGE_KEY } from "./themes";
 import "./processing-center.css";
+import "./theme-extras.css";
 
 const client = createDesktopClient();
 const processing = createProcessingClient();
+const transcriptTools = createTranscriptToolsClient();
 
 type View = "intake" | "processing" | "library" | "research";
 
@@ -54,7 +57,14 @@ export function App() {
       );
     }
     if (view === "library") {
-      return <SearchWorkspace client={client} theme={theme} onThemeChange={setTheme} />;
+      return (
+        <SearchWorkspace
+          client={client}
+          transcriptTools={transcriptTools}
+          theme={theme}
+          onThemeChange={setTheme}
+        />
+      );
     }
     return (
       <ResearchWorkspaceWithAnchorReview

--- a/frontend/src/SearchWorkspace.tsx
+++ b/frontend/src/SearchWorkspace.tsx
@@ -6,24 +6,34 @@ import type {
   WorkspaceDiscoveryReport,
   WorkspaceEvidenceResult,
 } from "./api/desktop";
+import type {
+  TranscriptGenerationRef,
+  TranscriptToolsClient,
+} from "./api/transcriptTools";
 import { WorkspaceHeader, type Theme } from "./components/WorkspaceHeader";
 import { EvidenceReader } from "./EvidenceReader";
 import { formatEvidenceTime } from "./format";
+import { TranscriptToolsPanel } from "./TranscriptToolsPanel";
 import "./search.css";
 
 interface SearchWorkspaceProps {
   client: DesktopClient;
+  transcriptTools: TranscriptToolsClient;
   theme: Theme;
   onThemeChange: (theme: Theme) => void;
 }
 
-export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspaceProps) {
+export function SearchWorkspace({
+  client,
+  transcriptTools,
+  theme,
+  onThemeChange,
+}: SearchWorkspaceProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
   const [report, setReport] = useState<WorkspaceDiscoveryReport | null>(null);
-  const [selectedEvidence, setSelectedEvidence] = useState<WorkspaceEvidenceResult | null>(
-    null,
-  );
+  const [selectedEvidence, setSelectedEvidence] = useState<WorkspaceEvidenceResult | null>(null);
+  const [selectedTools, setSelectedTools] = useState<TranscriptGenerationRef | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState("Search transcripts and your research.");
@@ -50,6 +60,7 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
     setBusy(true);
     setError(null);
     setSelectedEvidence(null);
+    setSelectedTools(null);
     try {
       const next = await client.discoverWorkspace(text);
       setReport(next);
@@ -65,8 +76,18 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
   }
 
   function openEvidence(item: WorkspaceEvidenceResult) {
+    setSelectedTools(null);
     setSelectedEvidence(item);
     setStatus(`Opened ${item.document_id} at ${formatEvidenceTime(item.seek_seconds)}.`);
+  }
+
+  function openTools(item: WorkspaceEvidenceResult) {
+    setSelectedEvidence(null);
+    setSelectedTools({
+      document_id: item.document_id,
+      canonical_sha256: item.canonical_sha256,
+    });
+    setStatus(`Opening transcript tools for ${item.document_id}.`);
   }
 
   async function createNote(body: string) {
@@ -91,7 +112,7 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
           <p className="section-kicker">Search</p>
           <h2 id="search-title">Search transcripts, notes, tags, and collections.</h2>
         </div>
-        <p>Open a transcript result to see the exact passage and its surrounding context.</p>
+        <p>Open a transcript result to see the exact passage, manage speakers, or publish a derived copy.</p>
       </section>
 
       <form className="global-search" role="search" onSubmit={(event) => void search(event)}>
@@ -125,6 +146,14 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
           evidence={selectedEvidence}
           onClose={() => setSelectedEvidence(null)}
           onCreateNote={createNote}
+        />
+      )}
+
+      {selectedTools && (
+        <TranscriptToolsPanel
+          client={transcriptTools}
+          generation={selectedTools}
+          onClose={() => setSelectedTools(null)}
         />
       )}
 
@@ -168,14 +197,24 @@ export function SearchWorkspace({ client, theme, onThemeChange }: SearchWorkspac
                       {item.note_count > 0 && <span>{item.note_count} note{item.note_count === 1 ? "" : "s"}</span>}
                       {item.tags.map((tag) => <span key={`tag:${tag}`}>#{tag}</span>)}
                     </div>
-                    <button
-                      type="button"
-                      className="open-evidence-button"
-                      aria-label={`Open transcript passage from ${item.document_id} at ${formatEvidenceTime(item.seek_seconds)}`}
-                      onClick={() => openEvidence(item)}
-                    >
-                      Open transcript passage
-                    </button>
+                    <div className="result-actions">
+                      <button
+                        type="button"
+                        className="open-evidence-button"
+                        aria-label={`Open transcript passage from ${item.document_id} at ${formatEvidenceTime(item.seek_seconds)}`}
+                        onClick={() => openEvidence(item)}
+                      >
+                        Open transcript passage
+                      </button>
+                      <button
+                        type="button"
+                        className="secondary-action"
+                        aria-label={`Open transcript tools for ${item.document_id}`}
+                        onClick={() => openTools(item)}
+                      >
+                        Transcript tools
+                      </button>
+                    </div>
                   </article>
                 ))}
               </div>

--- a/frontend/src/TranscriptToolsPanel.tsx
+++ b/frontend/src/TranscriptToolsPanel.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
+
+import type {
+  TranscriptExportFormat,
+  TranscriptGenerationRef,
+  TranscriptSpeaker,
+  TranscriptSpeakerSpan,
+  TranscriptToolsClient,
+  TranscriptToolsSnapshot,
+} from "./api/transcriptTools";
+import { formatEvidenceTime } from "./format";
+import "./transcript-tools.css";
+
+interface TranscriptToolsPanelProps {
+  client: TranscriptToolsClient;
+  generation: TranscriptGenerationRef;
+  onClose: () => void;
+}
+
+const FORMAT_LABELS: Record<TranscriptExportFormat, string> = {
+  txt: "Plain text",
+  srt: "SubRip subtitles",
+  vtt: "WebVTT subtitles",
+};
+
+const SPAN_LABELS: Record<TranscriptSpeakerSpan["kind"], string> = {
+  "single-speaker": "Speaker",
+  overlap: "Overlap",
+  "mixed-unresolved": "Mixed speakers",
+  unattributed: "Unattributed",
+};
+
+function speakerText(speaker: TranscriptSpeaker): string {
+  return speaker.display_label
+    ? `${speaker.display_label} · ${speaker.speaker_ref}`
+    : speaker.speaker_ref;
+}
+
+export function TranscriptToolsPanel({
+  client,
+  generation,
+  onClose,
+}: TranscriptToolsPanelProps) {
+  const [snapshot, setSnapshot] = useState<TranscriptToolsSnapshot | null>(null);
+  const [spans, setSpans] = useState<TranscriptSpeakerSpan[] | null>(null);
+  const [names, setNames] = useState<Record<string, string>>({});
+  const [formats, setFormats] = useState<TranscriptExportFormat[]>(["txt"]);
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState("Opening this verified transcript generation…");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setBusy(true);
+    setError(null);
+    void client
+      .inspect(generation)
+      .then((next) => {
+        if (!active) return;
+        setSnapshot(next);
+        setNames(
+          Object.fromEntries(
+            next.speakers.map((speaker) => [speaker.speaker_ref, speaker.display_label ?? ""]),
+          ),
+        );
+        setStatus("Transcript tools are ready for this verified generation.");
+      })
+      .catch((caught) => {
+        if (!active) return;
+        setError(
+          caught instanceof Error ? caught.message : "EchoFlow could not open transcript tools.",
+        );
+        setStatus("Transcript tools could not be opened.");
+      })
+      .finally(() => {
+        if (active) setBusy(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [client, generation]);
+
+  function replaceSpeaker(next: TranscriptSpeaker) {
+    setSnapshot((current) =>
+      current
+        ? {
+            ...current,
+            speakers: current.speakers.map((speaker) =>
+              speaker.speaker_ref === next.speaker_ref ? next : speaker,
+            ),
+          }
+        : current,
+    );
+    setNames((current) => ({
+      ...current,
+      [next.speaker_ref]: next.display_label ?? "",
+    }));
+    setSpans(null);
+  }
+
+  async function saveName(event: FormEvent<HTMLFormElement>, speakerRef: string) {
+    event.preventDefault();
+    const label = names[speakerRef]?.trim() ?? "";
+    if (!label) {
+      setError("Enter a speaker name before saving it.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await client.setSpeakerLabel(generation, speakerRef, label);
+      replaceSpeaker(next);
+      setStatus(`${speakerRef} is now shown as ${next.display_label}.`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "EchoFlow could not save that name.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeName(speakerRef: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      await client.removeSpeakerLabel(generation, speakerRef);
+      replaceSpeaker({
+        speaker_ref: speakerRef,
+        display_label: null,
+        display_name: speakerRef,
+      });
+      setStatus(`Removed the display name for ${speakerRef}. The anonymous evidence ref remains.`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "EchoFlow could not remove that name.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function loadSpans() {
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await client.speakerSpans(generation);
+      setSpans(next);
+      setStatus(`Opened ${next.length} speaker-aware transcript span${next.length === 1 ? "" : "s"}.`);
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "EchoFlow could not open the speaker transcript.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function toggleFormat(format: TranscriptExportFormat) {
+    setFormats((current) =>
+      current.includes(format)
+        ? current.filter((candidate) => candidate !== format)
+        : [...current, format],
+    );
+  }
+
+  async function publish() {
+    if (formats.length === 0) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const destination = await client.chooseDestinationFolder();
+      if (destination === null) {
+        setStatus("Publication cancelled. No transcript export was created.");
+        return;
+      }
+      const result = await client.publish(generation, destination, formats);
+      const filenames = result.publications.map((item) => item.filename).join(", ");
+      setStatus(`Published ${result.publications.length} file${result.publications.length === 1 ? "" : "s"}: ${filenames}.`);
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "EchoFlow could not publish those transcript views.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <aside className="transcript-tools" aria-labelledby="transcript-tools-title">
+      <header className="transcript-tools-header">
+        <div>
+          <p className="mini-label">Transcript</p>
+          <h2 id="transcript-tools-title">Transcript tools</h2>
+        </div>
+        <button type="button" className="quiet-button" onClick={onClose}>
+          Close
+        </button>
+      </header>
+
+      <p className="transcript-tools-status" role="status">{status}</p>
+      {error && <p className="error-banner" role="alert">{error}</p>}
+
+      {snapshot && (
+        <>
+          <section className="transcript-summary" aria-labelledby="transcript-summary-title">
+            <div>
+              <p className="mini-label">Current verified generation</p>
+              <h3 id="transcript-summary-title">{snapshot.details.document_id}</h3>
+            </div>
+            <dl className="transcript-summary-grid">
+              <div><dt>Duration</dt><dd>{formatEvidenceTime(snapshot.details.duration_seconds)}</dd></div>
+              <div><dt>Language</dt><dd>{snapshot.details.detected_languages.join(", ") || "Unknown"}</dd></div>
+              <div><dt>Segments</dt><dd>{snapshot.details.segment_count}</dd></div>
+              <div><dt>Speakers</dt><dd>{snapshot.details.speaker_count}</dd></div>
+              <div><dt>Source recording</dt><dd>{snapshot.details.source_available ? "Available locally" : "Not currently available"}</dd></div>
+              <div><dt>Canonical generation</dt><dd><code>{snapshot.details.canonical_sha256.slice(0, 12)}…</code></dd></div>
+            </dl>
+          </section>
+
+          <section className="speaker-tools" aria-labelledby="speaker-tools-title">
+            <div className="transcript-section-heading">
+              <div>
+                <p className="mini-label">People</p>
+                <h3 id="speaker-tools-title">Name anonymous speakers</h3>
+              </div>
+              <button type="button" className="secondary-action" disabled={busy} onClick={() => void loadSpans()}>
+                Open speaker transcript
+              </button>
+            </div>
+            <p className="transcript-tools-explainer">
+              Names are your private labels. EchoFlow keeps the anonymous speaker reference beside them as evidence.
+            </p>
+            <div className="speaker-roster">
+              {snapshot.speakers.length === 0 ? (
+                <p>No anonymous speaker evidence is present in this transcript.</p>
+              ) : (
+                snapshot.speakers.map((speaker) => (
+                  <form
+                    className="speaker-row"
+                    key={speaker.speaker_ref}
+                    onSubmit={(event) => void saveName(event, speaker.speaker_ref)}
+                  >
+                    <div className="speaker-identity">
+                      <strong>{speakerText(speaker)}</strong>
+                      <code>{speaker.speaker_ref}</code>
+                    </div>
+                    <label>
+                      <span>Display name</span>
+                      <input
+                        value={names[speaker.speaker_ref] ?? ""}
+                        maxLength={200}
+                        aria-label={`Display name for ${speaker.speaker_ref}`}
+                        onChange={(event) =>
+                          setNames((current) => ({
+                            ...current,
+                            [speaker.speaker_ref]: event.target.value,
+                          }))
+                        }
+                      />
+                    </label>
+                    <div className="speaker-actions">
+                      <button type="submit" className="secondary-action" disabled={busy}>
+                        Save name
+                      </button>
+                      {speaker.display_label && (
+                        <button type="button" className="quiet-button" disabled={busy} onClick={() => void removeName(speaker.speaker_ref)}>
+                          Remove name
+                        </button>
+                      )}
+                    </div>
+                  </form>
+                ))
+              )}
+            </div>
+          </section>
+
+          {spans && (
+            <section className="speaker-transcript" aria-labelledby="speaker-transcript-title">
+              <div className="transcript-section-heading">
+                <div>
+                  <p className="mini-label">Derived reading view</p>
+                  <h3 id="speaker-transcript-title">Speaker transcript</h3>
+                </div>
+                <button type="button" className="quiet-button" onClick={() => setSpans(null)}>Hide</button>
+              </div>
+              <div className="speaker-span-list">
+                {spans.map((span) => (
+                  <article className="speaker-span" data-kind={span.kind} key={`${span.segment_id}:${span.start_seconds}`}>
+                    <div className="speaker-span-meta">
+                      <time dateTime={`PT${span.start_seconds}S`}>{formatEvidenceTime(span.start_seconds)}</time>
+                      <strong>{SPAN_LABELS[span.kind]}</strong>
+                      <span>{span.speakers.map((speaker) => speaker.display_name).join(" + ") || "No speaker attributed"}</span>
+                    </div>
+                    <p>{span.text}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+          )}
+
+          <section className="publication-tools" aria-labelledby="publication-tools-title">
+            <p className="mini-label">Derived files</p>
+            <h3 id="publication-tools-title">Publish a transcript copy</h3>
+            <p className="transcript-tools-explainer">
+              These are disposable views of the verified canonical transcript. Publishing does not change the evidence underneath them.
+            </p>
+            <fieldset>
+              <legend>Formats</legend>
+              {(Object.keys(FORMAT_LABELS) as TranscriptExportFormat[]).map((format) => (
+                <label key={format}>
+                  <input
+                    type="checkbox"
+                    checked={formats.includes(format)}
+                    onChange={() => toggleFormat(format)}
+                  />
+                  <span>{FORMAT_LABELS[format]}</span>
+                </label>
+              ))}
+            </fieldset>
+            <button type="button" className="primary-action" disabled={busy || formats.length === 0} onClick={() => void publish()}>
+              Choose folder and publish
+            </button>
+          </section>
+
+          <details className="transcript-technical-details">
+            <summary>Technical details</summary>
+            <dl>
+              <div><dt>Engine</dt><dd>{snapshot.details.engine.name} {snapshot.details.engine.package_version}</dd></div>
+              <div><dt>Model</dt><dd>{snapshot.details.engine.model}</dd></div>
+              <div><dt>Model revision</dt><dd><code>{snapshot.details.engine.model_revision}</code></dd></div>
+              <div><dt>Execution</dt><dd>{snapshot.details.engine.device} / {snapshot.details.engine.compute_type}</dd></div>
+              <div><dt>Audio stream</dt><dd>#{snapshot.details.audio_stream_index}</dd></div>
+              <div><dt>Decode</dt><dd>{snapshot.details.decode_strategy}</dd></div>
+              <div><dt>Profile</dt><dd>{snapshot.details.profile}{snapshot.details.provisional ? " · provisional" : ""}</dd></div>
+              <div><dt>Diarization</dt><dd>{snapshot.details.diarization ? `${snapshot.details.diarization.provider} ${snapshot.details.diarization.package_version}` : "Not used"}</dd></div>
+              <div><dt>Enhancement</dt><dd>{snapshot.details.enhancement?.provider ?? "Not used"}</dd></div>
+            </dl>
+          </details>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/TranscriptToolsPanel.tsx
+++ b/frontend/src/TranscriptToolsPanel.tsx
@@ -236,6 +236,7 @@ export function TranscriptToolsPanel({
                   <form
                     className="speaker-row"
                     key={speaker.speaker_ref}
+                    aria-label={`Speaker ${speaker.speaker_ref}`}
                     onSubmit={(event) => void saveName(event, speaker.speaker_ref)}
                   >
                     <div className="speaker-identity">

--- a/frontend/src/api/transcriptTools.ts
+++ b/frontend/src/api/transcriptTools.ts
@@ -160,13 +160,13 @@ class TauriTranscriptToolsClient implements TranscriptToolsClient {
   }
 
   inspect(ref: TranscriptGenerationRef): Promise<TranscriptToolsSnapshot> {
-    return this.request("transcripts.tools.inspect", ref);
+    return this.request("transcripts.tools.inspect", { ...ref });
   }
 
   async speakerSpans(ref: TranscriptGenerationRef): Promise<TranscriptSpeakerSpan[]> {
     const result = await this.request<{ spans: TranscriptSpeakerSpan[] }>(
       "transcripts.tools.speakers",
-      ref,
+      { ...ref },
     );
     return result.spans;
   }

--- a/frontend/src/api/transcriptTools.ts
+++ b/frontend/src/api/transcriptTools.ts
@@ -1,0 +1,364 @@
+export type TranscriptExportFormat = "txt" | "srt" | "vtt";
+export type SpeakerPresentationKind =
+  | "single-speaker"
+  | "overlap"
+  | "mixed-unresolved"
+  | "unattributed";
+
+export interface TranscriptGenerationRef {
+  document_id: string;
+  canonical_sha256: string;
+}
+
+export interface TranscriptSpeaker {
+  speaker_ref: string;
+  display_label: string | null;
+  display_name: string;
+}
+
+export interface TranscriptEngineDetails {
+  name: string;
+  package_version: string;
+  model: string;
+  model_revision: string;
+  device: string;
+  compute_type: string;
+}
+
+export interface TranscriptDiarizationDetails {
+  provider: string;
+  package_version: string;
+  model: string;
+  model_revision: string | null;
+  mode: string;
+}
+
+export interface TranscriptEnhancementDetails {
+  provider: string;
+  provider_version: string;
+  operation: string;
+  model_id: string | null;
+  model_revision: string | null;
+}
+
+export interface TranscriptDetails extends TranscriptGenerationRef {
+  source_sha256: string;
+  source_available: boolean;
+  source_size_bytes: number;
+  source_modified_ns: number;
+  container_format: string;
+  duration_seconds: number;
+  audio_stream_index: number;
+  profile: string;
+  provisional: boolean;
+  decode_strategy: string;
+  detected_language: string | null;
+  detected_languages: string[];
+  segment_count: number;
+  speaker_count: number;
+  engine: TranscriptEngineDetails;
+  diarization: TranscriptDiarizationDetails | null;
+  enhancement: TranscriptEnhancementDetails | null;
+}
+
+export interface TranscriptToolsSnapshot {
+  details: TranscriptDetails;
+  speakers: TranscriptSpeaker[];
+}
+
+export interface PresentedSpeaker {
+  speaker_ref: string;
+  display_label: string | null;
+  display_name: string;
+}
+
+export interface TranscriptSpeakerSpan {
+  document_id: string;
+  canonical_sha256: string;
+  segment_id: string;
+  start_seconds: number;
+  end_seconds: number;
+  text: string;
+  kind: SpeakerPresentationKind;
+  overlap: boolean;
+  speakers: PresentedSpeaker[];
+}
+
+export interface TranscriptPublication {
+  format: TranscriptExportFormat;
+  filename: string;
+}
+
+export interface TranscriptPublishResult {
+  canonical_sha256: string;
+  publications: TranscriptPublication[];
+}
+
+interface TranscriptToolsError {
+  code: string;
+  message: string;
+}
+
+interface TranscriptToolsResponse<T> {
+  protocol_version: 1;
+  request_id: string;
+  ok: boolean;
+  result: T | null;
+  error: TranscriptToolsError | null;
+}
+
+export interface TranscriptToolsClient {
+  inspect(ref: TranscriptGenerationRef): Promise<TranscriptToolsSnapshot>;
+  speakerSpans(ref: TranscriptGenerationRef): Promise<TranscriptSpeakerSpan[]>;
+  setSpeakerLabel(
+    ref: TranscriptGenerationRef,
+    speakerRef: string,
+    label: string,
+  ): Promise<TranscriptSpeaker>;
+  removeSpeakerLabel(ref: TranscriptGenerationRef, speakerRef: string): Promise<boolean>;
+  chooseDestinationFolder(): Promise<string | null>;
+  publish(
+    ref: TranscriptGenerationRef,
+    destination: string,
+    formats: TranscriptExportFormat[],
+  ): Promise<TranscriptPublishResult>;
+}
+
+function assertResponse<T>(value: unknown): TranscriptToolsResponse<T> {
+  if (!value || typeof value !== "object") {
+    throw new Error("EchoFlow transcript tools returned an invalid response");
+  }
+  const candidate = value as Partial<TranscriptToolsResponse<T>>;
+  if (
+    candidate.protocol_version !== 1 ||
+    typeof candidate.request_id !== "string" ||
+    typeof candidate.ok !== "boolean"
+  ) {
+    throw new Error("EchoFlow transcript tools returned an incompatible response");
+  }
+  return candidate as TranscriptToolsResponse<T>;
+}
+
+class TauriTranscriptToolsClient implements TranscriptToolsClient {
+  private async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const request = {
+      protocol_version: 1,
+      request_id: crypto.randomUUID(),
+      method,
+      params,
+    };
+    const response = assertResponse<T>(
+      await invoke<unknown>("transcript_tools_request", { request }),
+    );
+    if (!response.ok || response.result === null) {
+      throw new Error(
+        response.error?.message ?? "EchoFlow could not complete that transcript-tools request",
+      );
+    }
+    return response.result;
+  }
+
+  inspect(ref: TranscriptGenerationRef): Promise<TranscriptToolsSnapshot> {
+    return this.request("transcripts.tools.inspect", ref);
+  }
+
+  async speakerSpans(ref: TranscriptGenerationRef): Promise<TranscriptSpeakerSpan[]> {
+    const result = await this.request<{ spans: TranscriptSpeakerSpan[] }>(
+      "transcripts.tools.speakers",
+      ref,
+    );
+    return result.spans;
+  }
+
+  setSpeakerLabel(
+    ref: TranscriptGenerationRef,
+    speakerRef: string,
+    label: string,
+  ): Promise<TranscriptSpeaker> {
+    return this.request("transcripts.tools.speaker.set", {
+      ...ref,
+      speaker_ref: speakerRef,
+      label,
+    });
+  }
+
+  async removeSpeakerLabel(
+    ref: TranscriptGenerationRef,
+    speakerRef: string,
+  ): Promise<boolean> {
+    const result = await this.request<{ removed: boolean }>(
+      "transcripts.tools.speaker.remove",
+      { ...ref, speaker_ref: speakerRef },
+    );
+    return result.removed;
+  }
+
+  async chooseDestinationFolder(): Promise<string | null> {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const selected = await open({ multiple: false, directory: true });
+    return typeof selected === "string" ? selected : null;
+  }
+
+  publish(
+    ref: TranscriptGenerationRef,
+    destination: string,
+    formats: TranscriptExportFormat[],
+  ): Promise<TranscriptPublishResult> {
+    return this.request("transcripts.tools.publish", {
+      ...ref,
+      destination,
+      formats,
+    });
+  }
+}
+
+const MOCK_GENERATION: TranscriptGenerationRef = {
+  document_id: "interview-42",
+  canonical_sha256: "a".repeat(64),
+};
+
+function sameGeneration(ref: TranscriptGenerationRef): boolean {
+  return (
+    ref.document_id === MOCK_GENERATION.document_id &&
+    ref.canonical_sha256 === MOCK_GENERATION.canonical_sha256
+  );
+}
+
+class MockTranscriptToolsClient implements TranscriptToolsClient {
+  private labels = new Map<string, string>([["speaker-1", "Participant A"]]);
+
+  private requireGeneration(ref: TranscriptGenerationRef): void {
+    if (!sameGeneration(ref)) {
+      throw new Error("Transcript generation changed; reopen transcript tools before editing");
+    }
+  }
+
+  private speaker(speakerRef: string): TranscriptSpeaker {
+    const displayLabel = this.labels.get(speakerRef) ?? null;
+    return {
+      speaker_ref: speakerRef,
+      display_label: displayLabel,
+      display_name: displayLabel ? `${displayLabel} (${speakerRef})` : speakerRef,
+    };
+  }
+
+  async inspect(ref: TranscriptGenerationRef): Promise<TranscriptToolsSnapshot> {
+    this.requireGeneration(ref);
+    return {
+      details: {
+        ...MOCK_GENERATION,
+        source_sha256: "b".repeat(64),
+        source_available: true,
+        source_size_bytes: 48_391_232,
+        source_modified_ns: 1,
+        container_format: "m4a",
+        duration_seconds: 1460.4,
+        audio_stream_index: 0,
+        profile: "balanced",
+        provisional: false,
+        decode_strategy: "direct",
+        detected_language: "en",
+        detected_languages: ["en"],
+        segment_count: 128,
+        speaker_count: 2,
+        engine: {
+          name: "faster-whisper",
+          package_version: "1.2.1",
+          model: "small",
+          model_revision: "mock-small-revision",
+          device: "cpu",
+          compute_type: "int8",
+        },
+        diarization: {
+          provider: "pyannote.audio",
+          package_version: "4.0.0",
+          model: "speaker-diarization-community-1",
+          model_revision: "mock-diarization-revision",
+          mode: "anonymous_turns_v1",
+        },
+        enhancement: null,
+      },
+      speakers: [this.speaker("speaker-1"), this.speaker("speaker-2")],
+    };
+  }
+
+  async speakerSpans(ref: TranscriptGenerationRef): Promise<TranscriptSpeakerSpan[]> {
+    this.requireGeneration(ref);
+    return [
+      {
+        ...MOCK_GENERATION,
+        segment_id: "segment-17",
+        start_seconds: 862.1,
+        end_seconds: 864.4,
+        text: "We started the program.",
+        kind: "single-speaker",
+        overlap: false,
+        speakers: [this.speaker("speaker-1")],
+      },
+      {
+        ...MOCK_GENERATION,
+        segment_id: "segment-18",
+        start_seconds: 864.4,
+        end_seconds: 865.8,
+        text: "Yes, exactly.",
+        kind: "overlap",
+        overlap: true,
+        speakers: [this.speaker("speaker-1"), this.speaker("speaker-2")],
+      },
+    ];
+  }
+
+  async setSpeakerLabel(
+    ref: TranscriptGenerationRef,
+    speakerRef: string,
+    label: string,
+  ): Promise<TranscriptSpeaker> {
+    this.requireGeneration(ref);
+    const normalized = label.trim();
+    if (!normalized) throw new Error("Speaker name cannot be blank");
+    if (!["speaker-1", "speaker-2"].includes(speakerRef)) {
+      throw new Error("Speaker is not present in this transcript generation");
+    }
+    this.labels.set(speakerRef, normalized);
+    return this.speaker(speakerRef);
+  }
+
+  async removeSpeakerLabel(
+    ref: TranscriptGenerationRef,
+    speakerRef: string,
+  ): Promise<boolean> {
+    this.requireGeneration(ref);
+    return this.labels.delete(speakerRef);
+  }
+
+  async chooseDestinationFolder(): Promise<string> {
+    return "/Users/susan/Research/Exports";
+  }
+
+  async publish(
+    ref: TranscriptGenerationRef,
+    _destination: string,
+    formats: TranscriptExportFormat[],
+  ): Promise<TranscriptPublishResult> {
+    this.requireGeneration(ref);
+    const unique = [...new Set(formats)];
+    if (unique.length === 0 || unique.length > 3) {
+      throw new Error("Choose between one and three transcript formats");
+    }
+    return {
+      canonical_sha256: ref.canonical_sha256,
+      publications: unique.map((format) => ({
+        format,
+        filename: `${ref.document_id}.${format}`,
+      })),
+    };
+  }
+}
+
+export function createTranscriptToolsClient(): TranscriptToolsClient {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("e2e") === "1"
+    ? new MockTranscriptToolsClient()
+    : new TauriTranscriptToolsClient();
+}

--- a/frontend/src/theme-extras.css
+++ b/frontend/src/theme-extras.css
@@ -1,0 +1,63 @@
+:root[data-theme="pride"] {
+  color-scheme: light;
+  --bg: #fff7fb;
+  --surface: #ffffff;
+  --surface-raised: #ffffff;
+  --surface-soft: #f5e7f1;
+  --ink: #251f28;
+  --muted: #625665;
+  --border: #8b7789;
+  --accent: #6d2f7d;
+  --accent-strong: #552160;
+  --accent-soft: #f0dcec;
+  --on-accent: #ffffff;
+  --focus: #005a73;
+  --danger: #8f3341;
+  --control-bg: #ffffff;
+  --control-ink: #251f28;
+  --control-border: #786878;
+  --selection-bg: #6d2f7d;
+  --selection-ink: #ffffff;
+  --shadow: 0 24px 70px rgba(88, 41, 78, 0.1);
+}
+
+:root[data-theme="pride"] body::before {
+  content: "";
+  position: fixed;
+  inset: 0 0 auto;
+  height: 4px;
+  z-index: 1000;
+  pointer-events: none;
+  background: linear-gradient(
+    90deg,
+    #e40303 0 16.666%,
+    #ff8c00 16.666% 33.333%,
+    #ffed00 33.333% 50%,
+    #008026 50% 66.666%,
+    #24408e 66.666% 83.333%,
+    #732982 83.333% 100%
+  );
+}
+
+:root[data-theme="monochrome"] {
+  color-scheme: dark;
+  --bg: #080808;
+  --surface: #111111;
+  --surface-raised: #181818;
+  --surface-soft: #222222;
+  --ink: #f7f7f7;
+  --muted: #c2c2c2;
+  --border: #8a8a8a;
+  --accent: #f7f7f7;
+  --accent-strong: #ffffff;
+  --accent-soft: #2c2c2c;
+  --on-accent: #080808;
+  --focus: #ffffff;
+  --danger: #efefef;
+  --control-bg: #111111;
+  --control-ink: #f7f7f7;
+  --control-border: #a0a0a0;
+  --selection-bg: #f7f7f7;
+  --selection-ink: #080808;
+  --shadow: 0 30px 80px rgba(0, 0, 0, 0.5);
+}

--- a/frontend/src/themes.ts
+++ b/frontend/src/themes.ts
@@ -5,6 +5,8 @@ export const THEMES = [
   { id: "moss", label: "Moss", scheme: "light" },
   { id: "plum", label: "Plum", scheme: "light" },
   { id: "ember", label: "Ember", scheme: "dark" },
+  { id: "pride", label: "Pride", scheme: "light" },
+  { id: "monochrome", label: "Monochrome", scheme: "dark" },
 ] as const;
 
 export type Theme = (typeof THEMES)[number]["id"];

--- a/frontend/src/transcript-tools.css
+++ b/frontend/src/transcript-tools.css
@@ -1,0 +1,205 @@
+.transcript-tools {
+  max-width: 1180px;
+  margin: 28px auto;
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.transcript-tools-header,
+.transcript-section-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.transcript-tools-header {
+  padding: 22px 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.transcript-tools h2,
+.transcript-tools h3,
+.transcript-tools p,
+.transcript-tools dl {
+  margin-top: 0;
+}
+
+.transcript-tools h2 { margin-bottom: 0; }
+.transcript-tools h3 { margin-bottom: 8px; }
+
+.transcript-tools-status {
+  margin: 0;
+  padding: 13px 24px;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-soft);
+}
+
+.transcript-tools > .error-banner { margin: 18px 24px 0; }
+
+.transcript-summary,
+.speaker-tools,
+.speaker-transcript,
+.publication-tools,
+.transcript-technical-details {
+  padding: 24px;
+  border-top: 1px solid var(--border);
+}
+
+.transcript-summary { border-top: 0; }
+
+.transcript-summary-grid,
+.transcript-technical-details dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 0;
+}
+
+.transcript-summary-grid > div,
+.transcript-technical-details dl > div {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-raised);
+}
+
+.transcript-summary-grid dt,
+.transcript-technical-details dt {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 680;
+}
+
+.transcript-summary-grid dd,
+.transcript-technical-details dd {
+  margin: 5px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.transcript-tools-explainer {
+  max-width: 760px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.speaker-roster,
+.speaker-span-list {
+  display: grid;
+  gap: 12px;
+}
+
+.speaker-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.8fr) minmax(220px, 1.2fr) auto;
+  gap: 14px;
+  align-items: end;
+  padding: 15px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface-raised);
+}
+
+.speaker-identity,
+.speaker-row label {
+  display: grid;
+  gap: 6px;
+}
+
+.speaker-identity code,
+.speaker-span-meta,
+.transcript-technical-details code {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.speaker-row label > span {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 680;
+}
+
+.speaker-row input {
+  width: 100%;
+  border: 1px solid var(--control-border);
+  border-radius: 10px;
+  padding: 9px 10px;
+}
+
+.speaker-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.speaker-span {
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface-raised);
+}
+
+.speaker-span[data-kind="overlap"] {
+  border-width: 2px;
+}
+
+.speaker-span-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  align-items: baseline;
+}
+
+.speaker-span-meta strong { color: var(--ink); }
+.speaker-span p { margin: 9px 0 0; line-height: 1.55; }
+
+.publication-tools fieldset {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  border: 0;
+  padding: 0;
+  margin: 0 0 16px;
+}
+
+.publication-tools legend {
+  width: 100%;
+  margin-bottom: 8px;
+  font-weight: 680;
+}
+
+.publication-tools label {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-raised);
+}
+
+.transcript-technical-details summary {
+  cursor: pointer;
+  font-weight: 680;
+}
+
+.transcript-technical-details[open] summary { margin-bottom: 16px; }
+
+@media (max-width: 820px) {
+  .transcript-summary-grid,
+  .transcript-technical-details dl,
+  .speaker-row {
+    grid-template-columns: 1fr;
+  }
+
+  .transcript-tools-header,
+  .transcript-section-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/frontend/tests/frontend-contracts.spec.ts
+++ b/frontend/tests/frontend-contracts.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+
+import { formatEvidenceTime } from "../src/format";
+import { DEFAULT_THEME, isTheme, THEMES } from "../src/themes";
+
+test("theme registry has one stable identifier and label per skin", () => {
+  const ids = THEMES.map((theme) => theme.id);
+  const labels = THEMES.map((theme) => theme.label);
+
+  expect(new Set(ids).size).toBe(ids.length);
+  expect(new Set(labels).size).toBe(labels.length);
+  expect(ids).toEqual([
+    "archive",
+    "midnight",
+    "paper",
+    "moss",
+    "plum",
+    "ember",
+    "pride",
+    "monochrome",
+  ]);
+  expect(DEFAULT_THEME).toBe("archive");
+});
+
+test("theme validation accepts registered values and rejects lookalikes", () => {
+  for (const theme of THEMES) {
+    expect(isTheme(theme.id)).toBe(true);
+    expect(["light", "dark"]).toContain(theme.scheme);
+  }
+  for (const invalid of [null, "", "Archive", "PRIDE", "dark", "unknown"] as const) {
+    expect(isTheme(invalid)).toBe(false);
+  }
+});
+
+test("evidence time formatting is deterministic at minute and hour boundaries", () => {
+  expect(formatEvidenceTime(-10)).toBe("0:00");
+  expect(formatEvidenceTime(0)).toBe("0:00");
+  expect(formatEvidenceTime(59.999)).toBe("0:59");
+  expect(formatEvidenceTime(60)).toBe("1:00");
+  expect(formatEvidenceTime(3599.999)).toBe("59:59");
+  expect(formatEvidenceTime(3600)).toBe("1:00:00");
+  expect(formatEvidenceTime(3661.9)).toBe("1:01:01");
+});
+
+test("Pride and Monochrome advertise the correct native scheme", () => {
+  expect(THEMES.find((theme) => theme.id === "pride")?.scheme).toBe("light");
+  expect(THEMES.find((theme) => theme.id === "monochrome")?.scheme).toBe("dark");
+});

--- a/frontend/tests/processing.spec.ts
+++ b/frontend/tests/processing.spec.ts
@@ -1,0 +1,59 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+async function openProcessing(page: import("@playwright/test").Page) {
+  await page.goto("/?e2e=1");
+  await page.getByRole("button", { name: "Processing" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Turn recordings into durable evidence." }),
+  ).toBeVisible();
+  await expect(page.getByText("Private workspace is ready")).toBeVisible();
+}
+
+test("Processing Center presents backend readiness and stays accessible", async ({ page }) => {
+  await openProcessing(page);
+
+  await expect(page.getByText("healthy", { exact: true })).toBeVisible();
+  await expect(page.getByText("8 threads visible")).toBeVisible();
+  await expect(page.getByText("FFmpeg and FFprobe are available")).toBeVisible();
+  await expect(page.getByText("DuckDB")).toHaveCount(0);
+  await expect(page.getByText("SQLite")).toHaveCount(0);
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations).toEqual([]);
+});
+
+test("Susan can choose a recording and obtain a backend preflight before start", async ({ page }) => {
+  await openProcessing(page);
+
+  await page.getByRole("button", { name: "Choose recording" }).click();
+  await expect(page.getByRole("status")).toContainText("interview-01.m4a selected");
+  await page.getByRole("button", { name: "Run preflight" }).click();
+
+  const preflight = page.getByLabel("Backend transcription preflight");
+  await expect(preflight).toBeVisible();
+  await expect(page.getByRole("status")).toContainText("Preflight complete");
+  await expect(page.getByRole("button", { name: "Start local transcription" })).toBeEnabled();
+});
+
+test("starting work uses the supervised local-task path", async ({ page }) => {
+  await openProcessing(page);
+  await page.getByRole("button", { name: "Choose recording" }).click();
+  await page.getByRole("button", { name: "Run preflight" }).click();
+  await page.getByRole("button", { name: "Start local transcription" }).click();
+
+  await expect(page.getByRole("status")).toContainText("supervised local process");
+  await expect(page.getByText(/Transcribing interview-01\.m4a/)).toBeVisible();
+});
+
+test("interrupted work offers resume and a fresh retry as distinct actions", async ({ page }) => {
+  await openProcessing(page);
+
+  await expect(page.getByText("oral-history-07.m4a", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Resume checkpoint" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Plan fresh retry" }).first()).toBeVisible();
+
+  await page.getByRole("button", { name: "Plan fresh retry" }).first().click();
+  await expect(page.getByRole("status")).toContainText("Fresh retry preflight complete");
+  await expect(page.getByRole("status")).toContainText("interrupted job was not changed");
+});

--- a/frontend/tests/processing.spec.ts
+++ b/frontend/tests/processing.spec.ts
@@ -42,7 +42,10 @@ test("starting work uses the supervised local-task path", async ({ page }) => {
   await page.getByRole("button", { name: "Run preflight" }).click();
   await page.getByRole("button", { name: "Start local transcription" }).click();
 
-  await expect(page.getByRole("status")).toContainText("supervised local process");
+  const launchStatus = page
+    .getByRole("status")
+    .filter({ hasText: "Transcription launched as a supervised local process" });
+  await expect(launchStatus).toBeVisible();
   await expect(page.getByText(/Transcribing interview-01\.m4a/)).toBeVisible();
 });
 

--- a/frontend/tests/theme-accessibility.spec.ts
+++ b/frontend/tests/theme-accessibility.spec.ts
@@ -124,9 +124,9 @@ test("theme picker is compact, complete, and persists locally", async ({ page })
   const picker = page.getByLabel("Theme");
   await expect(picker.locator("option")).toHaveCount(THEMES.length);
   await expect(page.getByRole("button", { name: "Archive" })).toHaveCount(0);
-  await picker.selectOption("plum");
+  await picker.selectOption("monochrome");
   await page.reload();
 
-  await expect(page.locator("html")).toHaveAttribute("data-theme", "plum");
-  await expect(page.getByLabel("Theme")).toHaveValue("plum");
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "monochrome");
+  await expect(page.getByLabel("Theme")).toHaveValue("monochrome");
 });

--- a/frontend/tests/theme-special.spec.ts
+++ b/frontend/tests/theme-special.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+const MONOCHROME_TOKENS = [
+  "--bg",
+  "--surface",
+  "--surface-raised",
+  "--surface-soft",
+  "--ink",
+  "--muted",
+  "--border",
+  "--accent",
+  "--accent-strong",
+  "--accent-soft",
+  "--on-accent",
+  "--focus",
+  "--danger",
+  "--control-bg",
+  "--control-ink",
+  "--control-border",
+  "--selection-bg",
+  "--selection-ink",
+] as const;
+
+function isGray(hex: string): boolean {
+  const normalized = hex.trim().replace(/^#/, "");
+  if (!/^[0-9a-f]{6}$/i.test(normalized)) return false;
+  return normalized.slice(0, 2) === normalized.slice(2, 4) && normalized.slice(2, 4) === normalized.slice(4, 6);
+}
+
+test("Pride uses decoration without changing the semantic theme contract", async ({ page }) => {
+  await page.goto("/?e2e=1");
+  await page.getByLabel("Theme").selectOption("pride");
+
+  const decoration = await page.evaluate(() =>
+    getComputedStyle(document.body, "::before").backgroundImage,
+  );
+  expect(decoration).toContain("linear-gradient");
+  await expect(page.locator("html")).toHaveCSS("color-scheme", /light/);
+});
+
+test("Monochrome semantic colors are genuinely grayscale", async ({ page }) => {
+  await page.goto("/?e2e=1");
+  await page.getByLabel("Theme").selectOption("monochrome");
+
+  const tokens = await page.evaluate((names) => {
+    const style = getComputedStyle(document.documentElement);
+    return Object.fromEntries(names.map((name) => [name, style.getPropertyValue(name).trim()]));
+  }, MONOCHROME_TOKENS);
+
+  for (const name of MONOCHROME_TOKENS) {
+    expect(isGray(tokens[name] ?? ""), `${name} should be grayscale`).toBe(true);
+  }
+  await expect(page.locator("html")).toHaveCSS("color-scheme", /dark/);
+});

--- a/frontend/tests/transcript-tools.spec.ts
+++ b/frontend/tests/transcript-tools.spec.ts
@@ -40,7 +40,7 @@ test("speaker labels change presentation without replacing anonymous evidence re
 
   await form.getByRole("button", { name: "Remove name" }).click();
   await expect(panel.getByRole("status")).toContainText("anonymous evidence ref remains");
-  await expect(form.getByText("speaker-2", { exact: true })).toBeVisible();
+  await expect(form.getByRole("code")).toHaveText("speaker-2");
 });
 
 test("speaker transcript represents overlap explicitly instead of flattening it", async ({ page }) => {

--- a/frontend/tests/transcript-tools.spec.ts
+++ b/frontend/tests/transcript-tools.spec.ts
@@ -1,0 +1,75 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+async function openTranscriptTools(page: import("@playwright/test").Page) {
+  await page.goto("/?e2e=1");
+  await page.getByRole("button", { name: "Library" }).click();
+  await page.getByRole("searchbox", { name: "Search EchoFlow" }).fill("ABC");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  await page.getByRole("button", { name: "Open transcript tools for interview-42" }).click();
+  const panel = page.getByRole("complementary", { name: "Transcript tools" });
+  await expect(panel.getByRole("heading", { name: "interview-42" })).toBeVisible();
+  return panel;
+}
+
+test("transcript tools expose verified details without filesystem paths", async ({ page }) => {
+  const panel = await openTranscriptTools(page);
+
+  await expect(panel.getByText("24:20")).toBeVisible();
+  await expect(panel.getByText("128", { exact: true })).toBeVisible();
+  await expect(panel.getByText("Available locally")).toBeVisible();
+  await expect(panel.getByText("aaaaaaaaaaaa…")).toBeVisible();
+  await expect(panel.getByText(/\/Users\//)).toHaveCount(0);
+  await expect(panel.getByText("canonical_path")).toHaveCount(0);
+  await expect(panel.getByText("source_path")).toHaveCount(0);
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations).toEqual([]);
+});
+
+test("speaker labels change presentation without replacing anonymous evidence refs", async ({ page }) => {
+  const panel = await openTranscriptTools(page);
+  const input = panel.getByRole("textbox", { name: "Display name for speaker-2" });
+  const form = panel.locator("form").filter({ has: input });
+
+  await input.fill("Dr. Chen");
+  await form.getByRole("button", { name: "Save name" }).click();
+  await expect(panel.getByRole("status")).toContainText("speaker-2 is now shown as Dr. Chen");
+  await expect(form.getByText("Dr. Chen · speaker-2")).toBeVisible();
+  await expect(form.getByText("speaker-2", { exact: true })).toBeVisible();
+
+  await form.getByRole("button", { name: "Remove name" }).click();
+  await expect(panel.getByRole("status")).toContainText("anonymous evidence ref remains");
+  await expect(form.getByText("speaker-2", { exact: true })).toBeVisible();
+});
+
+test("speaker transcript represents overlap explicitly instead of flattening it", async ({ page }) => {
+  const panel = await openTranscriptTools(page);
+
+  await panel.getByRole("button", { name: "Open speaker transcript" }).click();
+  const transcript = panel.getByRole("heading", { name: "Speaker transcript" }).locator("..").locator("..");
+  await expect(transcript.getByText("Overlap", { exact: true })).toBeVisible();
+  await expect(transcript.getByText("Participant A (speaker-1) + speaker-2")).toBeVisible();
+  await expect(transcript.getByText("Yes, exactly.")).toBeVisible();
+});
+
+test("post-hoc publication chooses formats but never renders the destination path", async ({ page }) => {
+  const panel = await openTranscriptTools(page);
+
+  await panel.getByRole("checkbox", { name: "SubRip subtitles" }).check();
+  await panel.getByRole("checkbox", { name: "WebVTT subtitles" }).check();
+  await panel.getByRole("button", { name: "Choose folder and publish" }).click();
+
+  await expect(panel.getByRole("status")).toContainText("Published 3 files");
+  await expect(panel.getByRole("status")).toContainText("interview-42.txt");
+  await expect(panel.getByRole("status")).toContainText("interview-42.srt");
+  await expect(panel.getByRole("status")).toContainText("interview-42.vtt");
+  await expect(panel.getByText(/\/Users\//)).toHaveCount(0);
+});
+
+test("publication requires at least one selected derived format", async ({ page }) => {
+  const panel = await openTranscriptTools(page);
+
+  await panel.getByRole("checkbox", { name: "Plain text" }).uncheck();
+  await expect(panel.getByRole("button", { name: "Choose folder and publish" })).toBeDisabled();
+});

--- a/frontend/tests/transcript-tools.spec.ts
+++ b/frontend/tests/transcript-tools.spec.ts
@@ -29,8 +29,8 @@ test("transcript tools expose verified details without filesystem paths", async 
 
 test("speaker labels change presentation without replacing anonymous evidence refs", async ({ page }) => {
   const panel = await openTranscriptTools(page);
-  const input = panel.getByRole("textbox", { name: "Display name for speaker-2" });
-  const form = panel.locator("form").filter({ has: input });
+  const form = panel.getByRole("form", { name: "Speaker speaker-2" });
+  const input = form.getByRole("textbox", { name: "Display name for speaker-2" });
 
   await input.fill("Dr. Chen");
   await form.getByRole("button", { name: "Save name" }).click();
@@ -47,7 +47,7 @@ test("speaker transcript represents overlap explicitly instead of flattening it"
   const panel = await openTranscriptTools(page);
 
   await panel.getByRole("button", { name: "Open speaker transcript" }).click();
-  const transcript = panel.getByRole("heading", { name: "Speaker transcript" }).locator("..").locator("..");
+  const transcript = panel.getByRole("region", { name: "Speaker transcript" });
   await expect(transcript.getByText("Overlap", { exact: true })).toBeVisible();
   await expect(transcript.getByText("Participant A (speaker-1) + speaker-2")).toBeVisible();
   await expect(transcript.getByText("Yes, exactly.")).toBeVisible();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,8 @@ only_files = [
     "src/echoflow/library/retrieval.py",
     "src/echoflow/library/semantic.py",
     "src/echoflow/library/service.py",
+    "src/echoflow/library/speaker_label_service.py",
+    "src/echoflow/library/transcript_tools.py",
     "src/echoflow/media/models.py",
     "src/echoflow/media/probe.py",
     "src/echoflow/model_management/catalog.py",
@@ -162,6 +164,7 @@ only_files = [
     "src/echoflow/transcription/segmentation.py",
     "src/echoflow/transcription/speaker_models.py",
     "src/echoflow/transcription/strategy.py",
+    "src/echoflow/desktop/transcript_tools_bridge.py",
     "src/echoflow/workspace/models.py",
     "src/echoflow/workspace/service.py",
 ]

--- a/src/echoflow/desktop/tests/test_transcript_tools_bridge.py
+++ b/src/echoflow/desktop/tests/test_transcript_tools_bridge.py
@@ -1,11 +1,22 @@
+import io
+import json
+import sys
+
 import pytest
 from pydantic import ValidationError
 
 from echoflow.desktop.transcript_tools_bridge import (
     dispatch_transcript_tools,
     handle_request,
+    main,
 )
+from echoflow.library.errors import TranscriptToolingError
 from echoflow.library.speaker_label_service import SpeakerRosterEntry
+from echoflow.library.speaker_presentation import (
+    PresentedSpeaker,
+    SpeakerPresentationKind,
+    SpeakerPresentationSpan,
+)
 from echoflow.library.transcript_tools import (
     TranscriptDetails,
     TranscriptDiarizationDetails,
@@ -70,7 +81,18 @@ class ToolingStub:
 
     def speaker_spans(self, document_id: str, *, expected_canonical_sha256: str):
         self.calls.append(("spans", (document_id, expected_canonical_sha256)))
-        return ()
+        return (
+            SpeakerPresentationSpan(
+                document_id=document_id,
+                canonical_sha256=expected_canonical_sha256,
+                segment_id="segment-1",
+                start_seconds=1.0,
+                end_seconds=2.0,
+                text="Hello",
+                speakers=(PresentedSpeaker("speaker-01", "Interviewer"),),
+                kind=SpeakerPresentationKind.SINGLE,
+            ),
+        )
 
     def set_speaker_label(
         self,
@@ -120,6 +142,38 @@ class ToolingStub:
         )
 
 
+class EchoFlowFailureStub(ToolingStub):
+    def inspect(self, document_id: str, *, expected_canonical_sha256: str):
+        raise TranscriptToolingError("Transcript tools are unavailable")
+
+
+class ValueFailureStub(ToolingStub):
+    def inspect(self, document_id: str, *, expected_canonical_sha256: str):
+        raise ValueError("Bad transcript-tools value")
+
+
+class UnexpectedFailureStub(ToolingStub):
+    def inspect(self, document_id: str, *, expected_canonical_sha256: str):
+        raise RuntimeError("private implementation detail")
+
+
+class BinaryInput:
+    def __init__(self, payload: bytes) -> None:
+        self.buffer = io.BytesIO(payload)
+
+
+def _valid_request() -> dict[str, object]:
+    return {
+        "protocol_version": 1,
+        "request_id": "request-1",
+        "method": "transcripts.tools.inspect",
+        "params": {
+            "document_id": "interview-1",
+            "canonical_sha256": "a" * 64,
+        },
+    }
+
+
 def test_inspect_serialization_exposes_details_without_paths() -> None:
     stub = ToolingStub()
     digest = "a" * 64
@@ -139,6 +193,31 @@ def test_inspect_serialization_exposes_details_without_paths() -> None:
     )
     assert "path" not in str(result).lower()
     assert stub.calls == [("inspect", ("interview-1", digest))]
+
+
+def test_speaker_span_and_remove_methods_are_closed_and_serialized() -> None:
+    stub = ToolingStub()
+    digest = "a" * 64
+
+    spans = dispatch_transcript_tools(
+        "transcripts.tools.speakers",
+        {"document_id": "interview-1", "canonical_sha256": digest},
+        stub,  # type: ignore[arg-type]
+    )
+    removed = dispatch_transcript_tools(
+        "transcripts.tools.speaker.remove",
+        {
+            "document_id": "interview-1",
+            "canonical_sha256": digest,
+            "speaker_ref": " speaker-01 ",
+        },
+        stub,  # type: ignore[arg-type]
+    )
+
+    assert spans["spans"][0]["kind"] == "single-speaker"  # type: ignore[index]
+    assert spans["spans"][0]["overlap"] is False  # type: ignore[index]
+    assert removed == {"removed": True}
+    assert stub.calls[-1] == ("remove", ("interview-1", digest, "speaker-01"))
 
 
 def test_set_label_trims_human_input_before_application_call() -> None:
@@ -169,6 +248,7 @@ def test_set_label_trims_human_input_before_application_call() -> None:
         {"document_id": "x", "canonical_sha256": "A" * 64},
         {"document_id": "x", "canonical_sha256": "a" * 63},
         {"document_id": "", "canonical_sha256": "a" * 64},
+        {"document_id": "   ", "canonical_sha256": "a" * 64},
         {"document_id": "x", "canonical_sha256": "a" * 64, "extra": True},
     ],
 )
@@ -178,6 +258,57 @@ def test_inspect_rejects_invalid_or_extra_request_values(
     with pytest.raises(ValidationError):
         dispatch_transcript_tools(
             "transcripts.tools.inspect",
+            params,
+            ToolingStub(),  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    ("method", "params"),
+    [
+        (
+            "transcripts.tools.speaker.set",
+            {
+                "document_id": "interview-1",
+                "canonical_sha256": "a" * 64,
+                "speaker_ref": "   ",
+                "label": "Interviewer",
+            },
+        ),
+        (
+            "transcripts.tools.speaker.set",
+            {
+                "document_id": "interview-1",
+                "canonical_sha256": "a" * 64,
+                "speaker_ref": "speaker-01",
+                "label": "   ",
+            },
+        ),
+        (
+            "transcripts.tools.speaker.remove",
+            {
+                "document_id": "interview-1",
+                "canonical_sha256": "a" * 64,
+                "speaker_ref": "   ",
+            },
+        ),
+        (
+            "transcripts.tools.publish",
+            {
+                "document_id": "interview-1",
+                "canonical_sha256": "a" * 64,
+                "destination": "   ",
+                "formats": ["txt"],
+            },
+        ),
+    ],
+)
+def test_trimmed_blank_mutation_values_are_rejected(
+    method: str, params: dict[str, object]
+) -> None:
+    with pytest.raises(ValidationError):
+        dispatch_transcript_tools(
+            method,
             params,
             ToolingStub(),  # type: ignore[arg-type]
         )
@@ -226,6 +357,53 @@ def test_publish_requires_one_to_three_closed_formats() -> None:
         )
 
 
+def test_handle_request_success_preserves_request_identity() -> None:
+    response = handle_request(
+        _valid_request(),
+        ToolingStub(),  # type: ignore[arg-type]
+    )
+
+    assert response["ok"] is True
+    assert response["request_id"] == "request-1"
+    assert response["error"] is None
+
+
+@pytest.mark.parametrize(
+    ("stub", "expected_code", "expected_message"),
+    [
+        (
+            EchoFlowFailureStub(),
+            "internal_error",
+            "Transcript tools are unavailable",
+        ),
+        (ValueFailureStub(), "invalid_request", "Bad transcript-tools value"),
+        (
+            UnexpectedFailureStub(),
+            "internal_error",
+            "EchoFlow could not complete that transcript-tools request",
+        ),
+    ],
+)
+def test_handle_request_translates_failures_without_leaking_details(
+    stub: ToolingStub,
+    expected_code: str,
+    expected_message: str,
+) -> None:
+    response = handle_request(
+        _valid_request(),
+        stub,  # type: ignore[arg-type]
+    )
+
+    assert response["ok"] is False
+    assert response["request_id"] == "request-1"
+    assert response["result"] is None
+    assert response["error"] == {
+        "code": expected_code,
+        "message": expected_message,
+    }
+    assert "private implementation detail" not in str(response)
+
+
 def test_unknown_operation_is_denied_before_service_dispatch() -> None:
     stub = ToolingStub()
     response = handle_request(
@@ -244,3 +422,36 @@ def test_unknown_operation_is_denied_before_service_dispatch() -> None:
         "message": "Transcript-tools request is invalid",
     }
     assert stub.calls == []
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, payload: bytes) -> dict[str, object]:
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdin", BinaryInput(payload))
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    assert main() == 0
+    return json.loads(stdout.getvalue())
+
+
+def test_main_rejects_invalid_json_without_starting_application(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _run_main(monkeypatch, b"{")
+
+    assert response["ok"] is False
+    assert response["error"] == {
+        "code": "invalid_request",
+        "message": "Transcript-tools request was not valid JSON",
+    }
+
+
+def test_main_rejects_oversized_request_before_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _run_main(monkeypatch, b"x" * (128 * 1024 + 1))
+
+    assert response["ok"] is False
+    assert response["error"] == {
+        "code": "invalid_request",
+        "message": "Transcript-tools request exceeded the safe size limit",
+    }

--- a/src/echoflow/desktop/tests/test_transcript_tools_bridge.py
+++ b/src/echoflow/desktop/tests/test_transcript_tools_bridge.py
@@ -1,0 +1,245 @@
+import pytest
+from pydantic import ValidationError
+
+from echoflow.desktop.transcript_tools_bridge import (
+    dispatch_transcript_tools,
+    handle_request,
+)
+from echoflow.library.speaker_label_service import SpeakerRosterEntry
+from echoflow.library.transcript_tools import (
+    TranscriptDetails,
+    TranscriptDiarizationDetails,
+    TranscriptEngineDetails,
+    TranscriptEnhancementDetails,
+    TranscriptPublication,
+    TranscriptPublicationResult,
+    TranscriptToolingSnapshot,
+)
+from echoflow.transcription.export import TranscriptExportFormat
+
+
+class ToolingStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
+
+    def inspect(self, document_id: str, *, expected_canonical_sha256: str):
+        self.calls.append(("inspect", (document_id, expected_canonical_sha256)))
+        return TranscriptToolingSnapshot(
+            details=TranscriptDetails(
+                document_id=document_id,
+                source_sha256="b" * 64,
+                canonical_sha256=expected_canonical_sha256,
+                source_available=True,
+                source_size_bytes=100,
+                source_modified_ns=1,
+                container_format="m4a",
+                duration_seconds=12.5,
+                audio_stream_index=0,
+                profile="balanced",
+                provisional=False,
+                decode_strategy="direct",
+                detected_language="en",
+                detected_languages=("en",),
+                segment_count=3,
+                speaker_count=1,
+                engine=TranscriptEngineDetails(
+                    name="faster-whisper",
+                    package_version="1.2.1",
+                    model="small",
+                    model_revision="rev",
+                    device="cpu",
+                    compute_type="int8",
+                ),
+                diarization=TranscriptDiarizationDetails(
+                    provider="pyannote.audio",
+                    package_version="4.0.0",
+                    model="community-1",
+                    model_revision="rev",
+                    mode="anonymous_turns_v1",
+                ),
+                enhancement=TranscriptEnhancementDetails(
+                    provider="ffmpeg-afftdn",
+                    provider_version="7.1",
+                    operation="afftdn",
+                    model_id=None,
+                    model_revision=None,
+                ),
+            ),
+            speakers=(SpeakerRosterEntry("speaker-01", "Interviewer"),),
+        )
+
+    def speaker_spans(self, document_id: str, *, expected_canonical_sha256: str):
+        self.calls.append(("spans", (document_id, expected_canonical_sha256)))
+        return ()
+
+    def set_speaker_label(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        speaker_ref: str,
+        label: str,
+    ):
+        self.calls.append(
+            ("set", (document_id, expected_canonical_sha256, speaker_ref, label))
+        )
+        return SpeakerRosterEntry(speaker_ref, label)
+
+    def remove_speaker_label(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        speaker_ref: str,
+    ) -> bool:
+        self.calls.append(
+            ("remove", (document_id, expected_canonical_sha256, speaker_ref))
+        )
+        return True
+
+    def publish(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        destination: str,
+        formats: tuple[TranscriptExportFormat, ...],
+    ):
+        self.calls.append(
+            (
+                "publish",
+                (document_id, expected_canonical_sha256, destination, formats),
+            )
+        )
+        return TranscriptPublicationResult(
+            canonical_sha256=expected_canonical_sha256,
+            publications=tuple(
+                TranscriptPublication(format=item, filename=f"interview.{item.value}")
+                for item in formats
+            ),
+        )
+
+
+def test_inspect_serialization_exposes_details_without_paths() -> None:
+    stub = ToolingStub()
+    digest = "a" * 64
+
+    result = dispatch_transcript_tools(
+        "transcripts.tools.inspect",
+        {"document_id": " interview-1 ", "canonical_sha256": digest},
+        stub,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(result, dict)
+    assert result["details"]["canonical_sha256"] == digest  # type: ignore[index]
+    assert result["details"]["audio_stream_index"] == 0  # type: ignore[index]
+    assert (
+        result["speakers"][0]["display_name"]  # type: ignore[index]
+        == "Interviewer (speaker-01)"
+    )
+    assert "path" not in str(result).lower()
+    assert stub.calls == [("inspect", ("interview-1", digest))]
+
+
+def test_set_label_trims_human_input_before_application_call() -> None:
+    stub = ToolingStub()
+    digest = "a" * 64
+
+    result = dispatch_transcript_tools(
+        "transcripts.tools.speaker.set",
+        {
+            "document_id": "interview-1",
+            "canonical_sha256": digest,
+            "speaker_ref": " speaker-01 ",
+            "label": " Interviewer ",
+        },
+        stub,  # type: ignore[arg-type]
+    )
+
+    assert result["display_label"] == "Interviewer"  # type: ignore[index]
+    assert stub.calls[-1] == (
+        "set",
+        ("interview-1", digest, "speaker-01", "Interviewer"),
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"document_id": "x", "canonical_sha256": "A" * 64},
+        {"document_id": "x", "canonical_sha256": "a" * 63},
+        {"document_id": "", "canonical_sha256": "a" * 64},
+        {"document_id": "x", "canonical_sha256": "a" * 64, "extra": True},
+    ],
+)
+def test_inspect_rejects_invalid_or_extra_request_values(
+    params: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        dispatch_transcript_tools(
+            "transcripts.tools.inspect",
+            params,
+            ToolingStub(),  # type: ignore[arg-type]
+        )
+
+
+def test_publish_requires_one_to_three_closed_formats() -> None:
+    digest = "a" * 64
+    stub = ToolingStub()
+
+    result = dispatch_transcript_tools(
+        "transcripts.tools.publish",
+        {
+            "document_id": "interview-1",
+            "canonical_sha256": digest,
+            "destination": "selected-export-folder",
+            "formats": ["txt", "vtt"],
+        },
+        stub,  # type: ignore[arg-type]
+    )
+
+    assert [
+        item["format"] for item in result["publications"]  # type: ignore[index]
+    ] == ["txt", "vtt"]
+    with pytest.raises(ValidationError):
+        dispatch_transcript_tools(
+            "transcripts.tools.publish",
+            {
+                "document_id": "interview-1",
+                "canonical_sha256": digest,
+                "destination": "selected-export-folder",
+                "formats": [],
+            },
+            stub,  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValidationError):
+        dispatch_transcript_tools(
+            "transcripts.tools.publish",
+            {
+                "document_id": "interview-1",
+                "canonical_sha256": digest,
+                "destination": "selected-export-folder",
+                "formats": ["pdf"],
+            },
+            stub,  # type: ignore[arg-type]
+        )
+
+
+def test_unknown_operation_is_denied_before_service_dispatch() -> None:
+    stub = ToolingStub()
+    response = handle_request(
+        {
+            "protocol_version": 1,
+            "request_id": "request-1",
+            "method": "transcripts.tools.shell",
+            "params": {},
+        },
+        stub,  # type: ignore[arg-type]
+    )
+
+    assert response["ok"] is False
+    assert response["error"] == {
+        "code": "invalid_request",
+        "message": "Transcript-tools request is invalid",
+    }
+    assert stub.calls == []

--- a/src/echoflow/desktop/tests/test_transcript_tools_bridge.py
+++ b/src/echoflow/desktop/tests/test_transcript_tools_bridge.py
@@ -199,7 +199,8 @@ def test_publish_requires_one_to_three_closed_formats() -> None:
     )
 
     assert [
-        item["format"] for item in result["publications"]  # type: ignore[index]
+        item["format"]
+        for item in result["publications"]  # type: ignore[index]
     ] == ["txt", "vtt"]
     with pytest.raises(ValidationError):
         dispatch_transcript_tools(

--- a/src/echoflow/desktop/transcript_tools_bridge.py
+++ b/src/echoflow/desktop/transcript_tools_bridge.py
@@ -1,0 +1,313 @@
+"""Typed desktop bridge adapter for transcript and speaker tooling."""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import redirect_stdout
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from echoflow.app.app_container import AppContainer
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.speaker_label_service import SpeakerRosterEntry
+from echoflow.library.speaker_presentation import (
+    SpeakerPresentationService,
+    SpeakerPresentationSpan,
+)
+from echoflow.library.transcript_tools import TranscriptDetails, TranscriptToolsService
+from echoflow.transcription.export import TranscriptExportFormat
+
+_PROTOCOL_VERSION = 1
+_MAX_REQUEST_BYTES = 128 * 1024
+
+TranscriptToolMethod = Literal[
+    "transcripts.tools.inspect",
+    "transcripts.tools.speakers",
+    "transcripts.tools.speaker.set",
+    "transcripts.tools.speaker.remove",
+    "transcripts.tools.publish",
+]
+
+
+class _Request(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    protocol_version: Literal[1]
+    request_id: str = Field(min_length=1, max_length=128)
+    method: TranscriptToolMethod
+    params: dict[str, object] = Field(default_factory=dict)
+
+
+class _GenerationParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    document_id: str = Field(min_length=1, max_length=1_024)
+    canonical_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @field_validator("document_id")
+    @classmethod
+    def strip_document_id(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("document_id cannot be blank")
+        return stripped
+
+
+class _SetSpeakerLabelParams(_GenerationParams):
+    speaker_ref: str = Field(min_length=1, max_length=200)
+    label: str = Field(min_length=1, max_length=200)
+
+    @field_validator("speaker_ref", "label")
+    @classmethod
+    def strip_speaker_text(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("speaker values cannot be blank")
+        return stripped
+
+
+class _RemoveSpeakerLabelParams(_GenerationParams):
+    speaker_ref: str = Field(min_length=1, max_length=200)
+
+    @field_validator("speaker_ref")
+    @classmethod
+    def strip_speaker_ref(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("speaker_ref cannot be blank")
+        return stripped
+
+
+class _PublishParams(_GenerationParams):
+    destination: str = Field(min_length=1, max_length=32_768)
+    formats: tuple[TranscriptExportFormat, ...] = Field(min_length=1, max_length=3)
+
+    @field_validator("destination")
+    @classmethod
+    def strip_destination(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("destination cannot be blank")
+        return stripped
+
+
+def _serialize_speaker(speaker: SpeakerRosterEntry) -> dict[str, object]:
+    return {
+        "speaker_ref": speaker.speaker_ref,
+        "display_label": speaker.display_label,
+        "display_name": speaker.display_name,
+    }
+
+
+def _serialize_details(details: TranscriptDetails) -> dict[str, object]:
+    return {
+        "document_id": details.document_id,
+        "source_sha256": details.source_sha256,
+        "canonical_sha256": details.canonical_sha256,
+        "source_available": details.source_available,
+        "source_size_bytes": details.source_size_bytes,
+        "source_modified_ns": details.source_modified_ns,
+        "container_format": details.container_format,
+        "duration_seconds": details.duration_seconds,
+        "audio_stream_index": details.audio_stream_index,
+        "profile": details.profile,
+        "provisional": details.provisional,
+        "decode_strategy": details.decode_strategy,
+        "detected_language": details.detected_language,
+        "detected_languages": list(details.detected_languages),
+        "segment_count": details.segment_count,
+        "speaker_count": details.speaker_count,
+        "engine": {
+            "name": details.engine.name,
+            "package_version": details.engine.package_version,
+            "model": details.engine.model,
+            "model_revision": details.engine.model_revision,
+            "device": details.engine.device,
+            "compute_type": details.engine.compute_type,
+        },
+        "diarization": (
+            None
+            if details.diarization is None
+            else {
+                "provider": details.diarization.provider,
+                "package_version": details.diarization.package_version,
+                "model": details.diarization.model,
+                "model_revision": details.diarization.model_revision,
+                "mode": details.diarization.mode,
+            }
+        ),
+        "enhancement": (
+            None
+            if details.enhancement is None
+            else {
+                "provider": details.enhancement.provider,
+                "provider_version": details.enhancement.provider_version,
+                "operation": details.enhancement.operation,
+                "model_id": details.enhancement.model_id,
+                "model_revision": details.enhancement.model_revision,
+            }
+        ),
+    }
+
+
+def _serialize_span(span: SpeakerPresentationSpan) -> dict[str, object]:
+    return span.to_dict()
+
+
+def dispatch_transcript_tools(
+    method: str,
+    params: dict[str, object],
+    service: TranscriptToolsService,
+) -> object:
+    if method == "transcripts.tools.inspect":
+        parsed = _GenerationParams.model_validate(params)
+        snapshot = service.inspect(
+            parsed.document_id,
+            expected_canonical_sha256=parsed.canonical_sha256,
+        )
+        return {
+            "details": _serialize_details(snapshot.details),
+            "speakers": [_serialize_speaker(item) for item in snapshot.speakers],
+        }
+
+    if method == "transcripts.tools.speakers":
+        parsed = _GenerationParams.model_validate(params)
+        spans = service.speaker_spans(
+            parsed.document_id,
+            expected_canonical_sha256=parsed.canonical_sha256,
+        )
+        return {"spans": [_serialize_span(span) for span in spans]}
+
+    if method == "transcripts.tools.speaker.set":
+        parsed = _SetSpeakerLabelParams.model_validate(params)
+        speaker = service.set_speaker_label(
+            parsed.document_id,
+            expected_canonical_sha256=parsed.canonical_sha256,
+            speaker_ref=parsed.speaker_ref,
+            label=parsed.label,
+        )
+        return _serialize_speaker(speaker)
+
+    if method == "transcripts.tools.speaker.remove":
+        parsed = _RemoveSpeakerLabelParams.model_validate(params)
+        removed = service.remove_speaker_label(
+            parsed.document_id,
+            expected_canonical_sha256=parsed.canonical_sha256,
+            speaker_ref=parsed.speaker_ref,
+        )
+        return {"removed": removed}
+
+    if method == "transcripts.tools.publish":
+        parsed = _PublishParams.model_validate(params)
+        published = service.publish(
+            parsed.document_id,
+            expected_canonical_sha256=parsed.canonical_sha256,
+            destination=parsed.destination,
+            formats=parsed.formats,
+        )
+        return {
+            "canonical_sha256": published.canonical_sha256,
+            "publications": [
+                {"format": item.format.value, "filename": item.filename}
+                for item in published.publications
+            ],
+        }
+
+    raise ValueError("Unsupported transcript-tools method")
+
+
+def _success(request_id: str, result: object) -> dict[str, object]:
+    return {
+        "protocol_version": _PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": True,
+        "result": result,
+        "error": None,
+    }
+
+
+def _failure(request_id: str, *, code: str, message: str) -> dict[str, object]:
+    return {
+        "protocol_version": _PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": False,
+        "result": None,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _service(container: AppContainer) -> TranscriptToolsService:
+    labels = container.speaker_label_store()
+    return TranscriptToolsService(
+        index=container.transcript_index(),
+        speaker_labels=container.speaker_labels(),
+        speaker_presentation=SpeakerPresentationService(
+            index=container.transcript_index(),
+            label_store=labels,
+            file_manager=container.file_manager(),
+        ),
+        file_manager=container.file_manager(),
+    )
+
+
+def handle_request(payload: object, service: TranscriptToolsService) -> dict[str, object]:
+    request_id = "unknown"
+    try:
+        request = _Request.model_validate(payload)
+        request_id = request.request_id
+        return _success(
+            request_id,
+            dispatch_transcript_tools(request.method, request.params, service),
+        )
+    except ValidationError:
+        return _failure(
+            request_id,
+            code="invalid_request",
+            message="Transcript-tools request is invalid",
+        )
+    except EchoFlowError as exc:
+        return _failure(
+            request_id,
+            code=exc.code.value,
+            message=exc.public_message,
+        )
+    except ValueError as exc:
+        return _failure(request_id, code="invalid_request", message=str(exc))
+    except Exception:
+        return _failure(
+            request_id,
+            code="internal_error",
+            message="EchoFlow could not complete that transcript-tools request",
+        )
+
+
+def main() -> int:
+    raw = sys.stdin.buffer.read(_MAX_REQUEST_BYTES + 1)
+    if len(raw) > _MAX_REQUEST_BYTES:
+        response = _failure(
+            "unknown",
+            code="invalid_request",
+            message="Transcript-tools request exceeded the safe size limit",
+        )
+    else:
+        try:
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            response = _failure(
+                "unknown",
+                code="invalid_request",
+                message="Transcript-tools request was not valid JSON",
+            )
+        else:
+            with redirect_stdout(sys.stderr):
+                container = AppContainer()
+                response = handle_request(payload, _service(container))
+    sys.stdout.write(json.dumps(response, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/echoflow/desktop/transcript_tools_bridge.py
+++ b/src/echoflow/desktop/transcript_tools_bridge.py
@@ -252,7 +252,9 @@ def _service(container: AppContainer) -> TranscriptToolsService:
     )
 
 
-def handle_request(payload: object, service: TranscriptToolsService) -> dict[str, object]:
+def handle_request(
+    payload: object, service: TranscriptToolsService
+) -> dict[str, object]:
     request_id = "unknown"
     try:
         request = _Request.model_validate(payload)

--- a/src/echoflow/library/errors.py
+++ b/src/echoflow/library/errors.py
@@ -25,6 +25,12 @@ class SpeakerLabelStateError(TranscriptLibraryError):
     exit_code = 2
 
 
+class TranscriptToolingError(TranscriptLibraryError):
+    """Transcript inspection, speaker management, or publication failed safely."""
+
+    exit_code = 2
+
+
 class EvidenceNavigationError(TranscriptLibraryError):
     """A ranked result cannot be reconciled safely with canonical evidence."""
 

--- a/src/echoflow/library/speaker_label_service.py
+++ b/src/echoflow/library/speaker_label_service.py
@@ -42,8 +42,16 @@ class SpeakerLabelService:
         self.store = store
         self.file_manager = file_manager
 
-    def roster(self, document_id: str) -> tuple[SpeakerRosterEntry, ...]:
-        document = self._document(document_id)
+    def roster(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str | None = None,
+    ) -> tuple[SpeakerRosterEntry, ...]:
+        document = self._document(
+            document_id,
+            expected_canonical_sha256=expected_canonical_sha256,
+        )
         refs = canonical_speaker_refs(document, self.file_manager)
         labels = {
             item.speaker_ref: item.label for item in self.store.current_labels(document)
@@ -62,8 +70,12 @@ class SpeakerLabelService:
         *,
         speaker_ref: str,
         label: str,
+        expected_canonical_sha256: str | None = None,
     ) -> SpeakerDisplayLabel:
-        document = self._document(document_id)
+        document = self._document(
+            document_id,
+            expected_canonical_sha256=expected_canonical_sha256,
+        )
         refs = canonical_speaker_refs(document, self.file_manager)
         if speaker_ref not in refs:
             raise SpeakerLabelStateError(
@@ -71,10 +83,18 @@ class SpeakerLabelService:
             )
         return self.store.set_label(document, speaker_ref=speaker_ref, label=label)
 
-    def remove_label(self, document_id: str, *, speaker_ref: str) -> bool:
-        return self.store.remove_label(
-            self._document(document_id), speaker_ref=speaker_ref
+    def remove_label(
+        self,
+        document_id: str,
+        *,
+        speaker_ref: str,
+        expected_canonical_sha256: str | None = None,
+    ) -> bool:
+        document = self._document(
+            document_id,
+            expected_canonical_sha256=expected_canonical_sha256,
         )
+        return self.store.remove_label(document, speaker_ref=speaker_ref)
 
     def display_labels(
         self,
@@ -96,7 +116,12 @@ class SpeakerLabelService:
             if item.speaker_ref in requested
         }
 
-    def _document(self, document_id: str) -> IndexedDocument:
+    def _document(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str | None = None,
+    ) -> IndexedDocument:
         document = next(
             (
                 item
@@ -108,5 +133,12 @@ class SpeakerLabelService:
         if document is None:
             raise SpeakerLabelStateError(
                 "Transcript is not present in the local library; rebuild the library first"
+            )
+        if (
+            expected_canonical_sha256 is not None
+            and document.canonical_sha256 != expected_canonical_sha256
+        ):
+            raise SpeakerLabelStateError(
+                "Transcript changed since this view was opened; reopen it before editing speaker names"
             )
         return document

--- a/src/echoflow/library/tests/test_transcript_tools.py
+++ b/src/echoflow/library/tests/test_transcript_tools.py
@@ -127,7 +127,8 @@ def _service(
     index = DocumentIndex((document,))
     files = LocalFileManager()
     labels = SpeakerLabelStore(
-        tmp_path / "speaker-labels.json", files  # type: ignore[arg-type]
+        tmp_path / "speaker-labels.json",
+        files,  # type: ignore[arg-type]
     )
     label_service = SpeakerLabelService(
         index=index,  # type: ignore[arg-type]
@@ -185,7 +186,9 @@ def test_inspect_reports_missing_source_without_invalidating_canonical_evidence(
 def test_generation_guard_rejects_stale_desktop_mutation(tmp_path: Path) -> None:
     service, _ = _service(tmp_path)
 
-    with pytest.raises(TranscriptToolingError, match="changed since this view was opened"):
+    with pytest.raises(
+        TranscriptToolingError, match="changed since this view was opened"
+    ):
         service.set_speaker_label(
             "job-1",
             expected_canonical_sha256="b" * 64,
@@ -194,7 +197,9 @@ def test_generation_guard_rejects_stale_desktop_mutation(tmp_path: Path) -> None
         )
 
 
-def test_label_mutation_preserves_anonymous_ref_and_can_be_removed(tmp_path: Path) -> None:
+def test_label_mutation_preserves_anonymous_ref_and_can_be_removed(
+    tmp_path: Path,
+) -> None:
     service, digest = _service(tmp_path)
 
     named = service.set_speaker_label(
@@ -213,9 +218,12 @@ def test_label_mutation_preserves_anonymous_ref_and_can_be_removed(tmp_path: Pat
         expected_canonical_sha256=digest,
         speaker_ref="speaker-01",
     )
-    assert service.inspect(
-        "job-1", expected_canonical_sha256=digest
-    ).speakers[0].display_label is None
+    assert (
+        service.inspect("job-1", expected_canonical_sha256=digest)
+        .speakers[0]
+        .display_label
+        is None
+    )
 
 
 def test_speaker_presentation_is_generation_bound(tmp_path: Path) -> None:
@@ -231,7 +239,9 @@ def test_speaker_presentation_is_generation_bound(tmp_path: Path) -> None:
     }
 
 
-def test_publish_is_deterministic_deduplicated_and_collision_safe(tmp_path: Path) -> None:
+def test_publish_is_deterministic_deduplicated_and_collision_safe(
+    tmp_path: Path,
+) -> None:
     service, digest = _service(tmp_path)
     destination = tmp_path / "exports"
     destination.mkdir()
@@ -257,7 +267,9 @@ def test_publish_is_deterministic_deduplicated_and_collision_safe(tmp_path: Path
         "[speaker-01] Hello there\n[speaker-02] Second line\n"
     )
     assert (destination / "interview.vtt").read_text().startswith("WEBVTT\n\n")
-    assert str(destination) not in " ".join(item.filename for item in result.publications)
+    assert str(destination) not in " ".join(
+        item.filename for item in result.publications
+    )
 
 
 def test_publish_rejects_empty_formats_and_missing_destination(tmp_path: Path) -> None:
@@ -292,9 +304,11 @@ def test_tampered_canonical_is_rejected_even_when_index_generation_is_stale(
 
 @given(
     st.text(min_size=0, max_size=80).filter(
-        lambda value: not (
-            len(value) == 64
-            and all(character in "0123456789abcdef" for character in value)
+        lambda value: (
+            not (
+                len(value) == 64
+                and all(character in "0123456789abcdef" for character in value)
+            )
         )
     )
 )

--- a/src/echoflow/library/tests/test_transcript_tools.py
+++ b/src/echoflow/library/tests/test_transcript_tools.py
@@ -2,8 +2,8 @@ import hashlib
 import json
 from pathlib import Path
 
-import pytest
 from hypothesis import given, strategies as st
+import pytest
 
 from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.library.errors import TranscriptToolingError

--- a/src/echoflow/library/tests/test_transcript_tools.py
+++ b/src/echoflow/library/tests/test_transcript_tools.py
@@ -1,0 +1,306 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from hypothesis import given, strategies as st
+
+from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.library.errors import TranscriptToolingError
+from echoflow.library.index import IndexedDocument
+from echoflow.library.speaker_label_service import SpeakerLabelService
+from echoflow.library.speaker_labels import SpeakerLabelStore
+from echoflow.library.speaker_presentation import SpeakerPresentationService
+from echoflow.library.transcript_tools import TranscriptToolsService
+from echoflow.transcription.export import TranscriptExportFormat
+
+
+class DocumentIndex:
+    def __init__(self, documents: tuple[IndexedDocument, ...]) -> None:
+        self._documents = documents
+
+    def documents(self) -> tuple[IndexedDocument, ...]:
+        return self._documents
+
+
+def _canonical(path: Path, *, speaker: str = "speaker-01") -> str:
+    document = {
+        "schema_version": 1,
+        "job_id": "job-1",
+        "source": {
+            "sha256": "a" * 64,
+            "size_bytes": 1234,
+            "modified_ns": 42,
+            "container_format": "mov,mp4,m4a,3gp,3g2,mj2",
+            "duration_seconds": 8.5,
+            "audio_stream_index": 2,
+        },
+        "profile": "balanced",
+        "provisional": False,
+        "decode_strategy": "ffmpeg_normalize",
+        "engine": {
+            "name": "faster-whisper",
+            "package_version": "1.2.1",
+            "model": "small",
+            "model_revision": "rev-1",
+            "device": "cpu",
+            "compute_type": "int8",
+        },
+        "detected_language": "en",
+        "detected_languages": ["en"],
+        "segments": [
+            {
+                "segment_id": "segment-000000",
+                "start_seconds": 1.0,
+                "end_seconds": 3.0,
+                "text": "Hello there",
+                "speaker_ref": speaker,
+                "words": [
+                    {
+                        "start_seconds": 1.0,
+                        "end_seconds": 1.5,
+                        "text": "Hello",
+                        "speaker_ref": speaker,
+                    },
+                    {
+                        "start_seconds": 1.6,
+                        "end_seconds": 2.2,
+                        "text": " there",
+                        "speaker_ref": speaker,
+                    },
+                ],
+            },
+            {
+                "segment_id": "segment-000001",
+                "start_seconds": 3.2,
+                "end_seconds": 5.0,
+                "text": "Second line",
+                "speaker_ref": "speaker-02",
+                "words": [],
+            },
+        ],
+        "diarization": {
+            "provider": "pyannote.audio",
+            "package_version": "4.0.0",
+            "model": "speaker-diarization-community-1",
+            "model_revision": "model-rev",
+            "mode": "anonymous_turns_v1",
+            "telemetry_enabled": False,
+        },
+        "speaker_turns": [
+            {"start_seconds": 0.9, "end_seconds": 3.1, "speaker_ref": speaker},
+            {"start_seconds": 3.2, "end_seconds": 5.0, "speaker_ref": "speaker-02"},
+        ],
+        "enhancement": {
+            "schema_version": 1,
+            "provider": "ffmpeg-afftdn",
+            "provider_version": "7.1",
+            "operation": "afftdn",
+            "parameters": {"nr": "12"},
+            "model_id": None,
+            "model_revision": None,
+        },
+    }
+    payload = json.dumps(document, sort_keys=True).encode()
+    path.write_bytes(payload)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _service(
+    tmp_path: Path, *, source_exists: bool = True
+) -> tuple[TranscriptToolsService, str]:
+    canonical = tmp_path / "interview.json"
+    digest = _canonical(canonical)
+    source = tmp_path / "interview.m4a"
+    if source_exists:
+        source.write_bytes(b"media")
+    document = IndexedDocument(
+        document_id="job-1",
+        source_sha256="a" * 64,
+        detected_language="en",
+        canonical_path=str(canonical.resolve()),
+        source_path=str(source.resolve()),
+        segment_count=2,
+        canonical_sha256=digest,
+    )
+    index = DocumentIndex((document,))
+    files = LocalFileManager()
+    labels = SpeakerLabelStore(
+        tmp_path / "speaker-labels.json", files  # type: ignore[arg-type]
+    )
+    label_service = SpeakerLabelService(
+        index=index,  # type: ignore[arg-type]
+        store=labels,
+        file_manager=files,  # type: ignore[arg-type]
+    )
+    presentation = SpeakerPresentationService(
+        index=index,  # type: ignore[arg-type]
+        label_store=labels,
+        file_manager=files,  # type: ignore[arg-type]
+    )
+    return (
+        TranscriptToolsService(
+            index=index,  # type: ignore[arg-type]
+            speaker_labels=label_service,
+            speaker_presentation=presentation,
+            file_manager=files,  # type: ignore[arg-type]
+        ),
+        digest,
+    )
+
+
+def test_inspect_returns_verified_details_and_current_roster(tmp_path: Path) -> None:
+    service, digest = _service(tmp_path)
+
+    snapshot = service.inspect("job-1", expected_canonical_sha256=digest)
+
+    assert snapshot.details.canonical_sha256 == digest
+    assert snapshot.details.source_sha256 == "a" * 64
+    assert snapshot.details.source_available
+    assert snapshot.details.audio_stream_index == 2
+    assert snapshot.details.profile == "balanced"
+    assert snapshot.details.engine.model == "small"
+    assert snapshot.details.diarization is not None
+    assert snapshot.details.enhancement is not None
+    assert snapshot.details.segment_count == 2
+    assert snapshot.details.speaker_count == 2
+    assert [speaker.speaker_ref for speaker in snapshot.speakers] == [
+        "speaker-01",
+        "speaker-02",
+    ]
+
+
+def test_inspect_reports_missing_source_without_invalidating_canonical_evidence(
+    tmp_path: Path,
+) -> None:
+    service, digest = _service(tmp_path, source_exists=False)
+
+    snapshot = service.inspect("job-1", expected_canonical_sha256=digest)
+
+    assert not snapshot.details.source_available
+    assert snapshot.details.canonical_sha256 == digest
+
+
+def test_generation_guard_rejects_stale_desktop_mutation(tmp_path: Path) -> None:
+    service, _ = _service(tmp_path)
+
+    with pytest.raises(TranscriptToolingError, match="changed since this view was opened"):
+        service.set_speaker_label(
+            "job-1",
+            expected_canonical_sha256="b" * 64,
+            speaker_ref="speaker-01",
+            label="Interviewer",
+        )
+
+
+def test_label_mutation_preserves_anonymous_ref_and_can_be_removed(tmp_path: Path) -> None:
+    service, digest = _service(tmp_path)
+
+    named = service.set_speaker_label(
+        "job-1",
+        expected_canonical_sha256=digest,
+        speaker_ref="speaker-01",
+        label=" Interviewer ",
+    )
+    snapshot = service.inspect("job-1", expected_canonical_sha256=digest)
+
+    assert named.speaker_ref == "speaker-01"
+    assert named.display_label == "Interviewer"
+    assert snapshot.speakers[0].display_name == "Interviewer (speaker-01)"
+    assert service.remove_speaker_label(
+        "job-1",
+        expected_canonical_sha256=digest,
+        speaker_ref="speaker-01",
+    )
+    assert service.inspect(
+        "job-1", expected_canonical_sha256=digest
+    ).speakers[0].display_label is None
+
+
+def test_speaker_presentation_is_generation_bound(tmp_path: Path) -> None:
+    service, digest = _service(tmp_path)
+
+    spans = service.speaker_spans("job-1", expected_canonical_sha256=digest)
+
+    assert spans
+    assert {span.canonical_sha256 for span in spans} == {digest}
+    assert {speaker.speaker_ref for span in spans for speaker in span.speakers} == {
+        "speaker-01",
+        "speaker-02",
+    }
+
+
+def test_publish_is_deterministic_deduplicated_and_collision_safe(tmp_path: Path) -> None:
+    service, digest = _service(tmp_path)
+    destination = tmp_path / "exports"
+    destination.mkdir()
+    (destination / "interview.txt").write_text("do not overwrite")
+
+    result = service.publish(
+        "job-1",
+        expected_canonical_sha256=digest,
+        destination=destination,
+        formats=(
+            TranscriptExportFormat.TEXT,
+            TranscriptExportFormat.TEXT,
+            TranscriptExportFormat.WEBVTT,
+        ),
+    )
+
+    assert [item.filename for item in result.publications] == [
+        "interview-2.txt",
+        "interview.vtt",
+    ]
+    assert (destination / "interview.txt").read_text() == "do not overwrite"
+    assert (destination / "interview-2.txt").read_text() == (
+        "[speaker-01] Hello there\n[speaker-02] Second line\n"
+    )
+    assert (destination / "interview.vtt").read_text().startswith("WEBVTT\n\n")
+    assert str(destination) not in " ".join(item.filename for item in result.publications)
+
+
+def test_publish_rejects_empty_formats_and_missing_destination(tmp_path: Path) -> None:
+    service, digest = _service(tmp_path)
+
+    with pytest.raises(ValueError, match="at least one"):
+        service.publish(
+            "job-1",
+            expected_canonical_sha256=digest,
+            destination=tmp_path,
+            formats=(),
+        )
+    with pytest.raises(TranscriptToolingError, match="not an available folder"):
+        service.publish(
+            "job-1",
+            expected_canonical_sha256=digest,
+            destination=tmp_path / "missing",
+            formats=(TranscriptExportFormat.TEXT,),
+        )
+
+
+def test_tampered_canonical_is_rejected_even_when_index_generation_is_stale(
+    tmp_path: Path,
+) -> None:
+    service, digest = _service(tmp_path)
+    canonical = tmp_path / "interview.json"
+    canonical.write_text("{}")
+
+    with pytest.raises(TranscriptToolingError, match="Canonical transcript changed"):
+        service.inspect("job-1", expected_canonical_sha256=digest)
+
+
+@given(
+    st.text(min_size=0, max_size=80).filter(
+        lambda value: not (
+            len(value) == 64
+            and all(character in "0123456789abcdef" for character in value)
+        )
+    )
+)
+def test_generation_guard_rejects_noncanonical_digest_shapes(
+    tmp_path: Path, value: str
+) -> None:
+    service, _ = _service(tmp_path)
+
+    with pytest.raises(ValueError, match="expected_canonical_sha256"):
+        service.inspect("job-1", expected_canonical_sha256=value)

--- a/src/echoflow/library/tests/test_transcript_tools.py
+++ b/src/echoflow/library/tests/test_transcript_tools.py
@@ -2,8 +2,9 @@ import hashlib
 import json
 from pathlib import Path
 
-from hypothesis import given, strategies as st
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.library.errors import TranscriptToolingError

--- a/src/echoflow/library/tests/test_transcript_tools.py
+++ b/src/echoflow/library/tests/test_transcript_tools.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 from hypothesis import given
@@ -312,10 +313,9 @@ def test_tampered_canonical_is_rejected_even_when_index_generation_is_stale(
         )
     )
 )
-def test_generation_guard_rejects_noncanonical_digest_shapes(
-    tmp_path: Path, value: str
-) -> None:
-    service, _ = _service(tmp_path)
+def test_generation_guard_rejects_noncanonical_digest_shapes(value: str) -> None:
+    with TemporaryDirectory() as directory:
+        service, _ = _service(Path(directory))
 
-    with pytest.raises(ValueError, match="expected_canonical_sha256"):
-        service.inspect("job-1", expected_canonical_sha256=value)
+        with pytest.raises(ValueError, match="expected_canonical_sha256"):
+            service.inspect("job-1", expected_canonical_sha256=value)

--- a/src/echoflow/library/transcript_tools.py
+++ b/src/echoflow/library/transcript_tools.py
@@ -14,7 +14,10 @@ from echoflow.core.errors import StorageAlreadyExistsError
 from echoflow.core.file_manager_facade import FileManagerFacade
 from echoflow.library.errors import TranscriptToolingError
 from echoflow.library.index import IndexedDocument, TranscriptIndex
-from echoflow.library.speaker_label_service import SpeakerLabelService, SpeakerRosterEntry
+from echoflow.library.speaker_label_service import (
+    SpeakerLabelService,
+    SpeakerRosterEntry,
+)
 from echoflow.library.speaker_presentation import (
     SpeakerPresentationService,
     SpeakerPresentationSpan,

--- a/src/echoflow/library/transcript_tools.py
+++ b/src/echoflow/library/transcript_tools.py
@@ -1,0 +1,507 @@
+"""Application-owned transcript inspection, speaker management, and publication."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from echoflow.core.errors import StorageAlreadyExistsError
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.errors import TranscriptToolingError
+from echoflow.library.index import IndexedDocument, TranscriptIndex
+from echoflow.library.speaker_label_service import SpeakerLabelService, SpeakerRosterEntry
+from echoflow.library.speaker_presentation import (
+    SpeakerPresentationService,
+    SpeakerPresentationSpan,
+)
+from echoflow.transcription.export import (
+    TranscriptExportFormat,
+    TranscriptRenderSegment,
+    render_transcript_parts,
+)
+
+_MAX_CANONICAL_BYTES = 256 * 1024 * 1024
+_MAX_COLLISION_ATTEMPTS = 1_000
+
+
+class _CanonicalSource(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    size_bytes: int = Field(gt=0)
+    modified_ns: int = Field(ge=0)
+    container_format: str = Field(min_length=1)
+    duration_seconds: float = Field(gt=0)
+    audio_stream_index: int = Field(ge=0)
+
+
+class _CanonicalEngine(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(min_length=1)
+    package_version: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    model_revision: str = Field(min_length=1)
+    device: str = Field(min_length=1)
+    compute_type: str = Field(min_length=1)
+
+
+class _CanonicalDiarization(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    provider: str = Field(min_length=1)
+    package_version: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    model_revision: str | None = Field(default=None, min_length=1)
+    mode: str = Field(min_length=1)
+
+
+class _CanonicalEnhancement(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    provider: str = Field(min_length=1)
+    provider_version: str = Field(min_length=1)
+    operation: str = Field(min_length=1)
+    model_id: str | None = Field(default=None, min_length=1)
+    model_revision: str | None = Field(default=None, min_length=1)
+
+
+class _CanonicalSegment(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    segment_id: str = Field(min_length=1)
+    start_seconds: float = Field(ge=0)
+    end_seconds: float = Field(ge=0)
+    text: str = Field(min_length=1)
+    speaker_ref: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def validate_timing(self) -> _CanonicalSegment:
+        if self.end_seconds < self.start_seconds:
+            raise ValueError("canonical segment timestamps must be ordered")
+        return self
+
+
+class _CanonicalSpeakerTurn(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    speaker_ref: str = Field(min_length=1)
+
+
+class _CanonicalTranscriptProjection(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    schema_version: int
+    job_id: str
+    source: _CanonicalSource
+    profile: str
+    provisional: bool
+    decode_strategy: str
+    engine: _CanonicalEngine
+    detected_language: str | None = None
+    detected_languages: list[str] = Field(default_factory=list)
+    segments: list[_CanonicalSegment]
+    diarization: _CanonicalDiarization | None = None
+    speaker_turns: list[_CanonicalSpeakerTurn] = Field(default_factory=list)
+    enhancement: _CanonicalEnhancement | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptEngineDetails:
+    name: str
+    package_version: str
+    model: str
+    model_revision: str
+    device: str
+    compute_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptDiarizationDetails:
+    provider: str
+    package_version: str
+    model: str
+    model_revision: str | None
+    mode: str
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptEnhancementDetails:
+    provider: str
+    provider_version: str
+    operation: str
+    model_id: str | None
+    model_revision: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptDetails:
+    document_id: str
+    source_sha256: str
+    canonical_sha256: str
+    source_available: bool
+    source_size_bytes: int
+    source_modified_ns: int
+    container_format: str
+    duration_seconds: float
+    audio_stream_index: int
+    profile: str
+    provisional: bool
+    decode_strategy: str
+    detected_language: str | None
+    detected_languages: tuple[str, ...]
+    segment_count: int
+    speaker_count: int
+    engine: TranscriptEngineDetails
+    diarization: TranscriptDiarizationDetails | None
+    enhancement: TranscriptEnhancementDetails | None
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptToolingSnapshot:
+    details: TranscriptDetails
+    speakers: tuple[SpeakerRosterEntry, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptPublication:
+    format: TranscriptExportFormat
+    filename: str
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptPublicationResult:
+    canonical_sha256: str
+    publications: tuple[TranscriptPublication, ...]
+
+
+class TranscriptToolsService:
+    """Keep transcript-tool policy in Python and expose only typed results to adapters."""
+
+    def __init__(
+        self,
+        *,
+        index: TranscriptIndex,
+        speaker_labels: SpeakerLabelService,
+        speaker_presentation: SpeakerPresentationService,
+        file_manager: FileManagerFacade,
+    ) -> None:
+        self.index = index
+        self.speaker_labels = speaker_labels
+        self.speaker_presentation = speaker_presentation
+        self.file_manager = file_manager
+
+    def inspect(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+    ) -> TranscriptToolingSnapshot:
+        document, projection = self._verified_projection(
+            document_id,
+            expected_canonical_sha256=expected_canonical_sha256,
+        )
+        speakers = self.speaker_labels.roster(
+            document_id, expected_canonical_sha256=expected_canonical_sha256
+        )
+        details = self._details(
+            document, expected_canonical_sha256, projection, speaker_count=len(speakers)
+        )
+        return TranscriptToolingSnapshot(details=details, speakers=speakers)
+
+    def speaker_spans(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+    ) -> tuple[SpeakerPresentationSpan, ...]:
+        self._require_generation(document_id, expected_canonical_sha256)
+        spans = self.speaker_presentation.spans(document_id)
+        if any(span.canonical_sha256 != expected_canonical_sha256 for span in spans):
+            raise TranscriptToolingError(
+                "Transcript changed while speaker presentation was being prepared; reopen it"
+            )
+        return spans
+
+    def set_speaker_label(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        speaker_ref: str,
+        label: str,
+    ) -> SpeakerRosterEntry:
+        binding = self.speaker_labels.set_label(
+            document_id,
+            speaker_ref=speaker_ref,
+            label=label,
+            expected_canonical_sha256=expected_canonical_sha256,
+        )
+        if binding.canonical_sha256 != expected_canonical_sha256:
+            raise TranscriptToolingError(
+                "Transcript changed while the speaker name was being saved; reopen it"
+            )
+        return SpeakerRosterEntry(
+            speaker_ref=binding.speaker_ref,
+            display_label=binding.label,
+        )
+
+    def remove_speaker_label(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        speaker_ref: str,
+    ) -> bool:
+        return self.speaker_labels.remove_label(
+            document_id,
+            speaker_ref=speaker_ref,
+            expected_canonical_sha256=expected_canonical_sha256,
+        )
+
+    def publish(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        destination: str | Path,
+        formats: tuple[TranscriptExportFormat, ...],
+    ) -> TranscriptPublicationResult:
+        document, projection = self._verified_projection(
+            document_id,
+            expected_canonical_sha256=expected_canonical_sha256,
+        )
+        selected = tuple(dict.fromkeys(formats))
+        if not selected:
+            raise ValueError("select at least one transcript export format")
+
+        output_dir = Path(destination).expanduser().resolve(strict=False)
+        if not output_dir.is_dir():
+            raise TranscriptToolingError(
+                "Selected export destination is not an available folder"
+            )
+
+        segments = tuple(
+            TranscriptRenderSegment(
+                segment_id=segment.segment_id,
+                start_seconds=segment.start_seconds,
+                end_seconds=segment.end_seconds,
+                text=segment.text,
+                speaker_ref=segment.speaker_ref,
+            )
+            for segment in projection.segments
+        )
+        transcript_text = " ".join(
+            segment.text.strip() for segment in projection.segments
+        )
+        payloads = tuple(
+            (
+                export_format,
+                render_transcript_parts(transcript_text, segments, export_format),
+            )
+            for export_format in selected
+        )
+
+        stem = self._publication_stem(document)
+        reserved: list[tuple[TranscriptPublication, Path, bytes]] = []
+        try:
+            for export_format, payload in payloads:
+                path = self._reserve_publication(
+                    output_dir,
+                    f"{stem}.{export_format.value}",
+                )
+                reserved.append(
+                    (
+                        TranscriptPublication(
+                            format=export_format,
+                            filename=path.name,
+                        ),
+                        path,
+                        payload,
+                    )
+                )
+            for _, path, payload in reserved:
+                self.file_manager.save_file(payload, path)
+        except BaseException:
+            for _, path, _ in reserved:
+                with suppress(Exception):
+                    self.file_manager.delete_file(path)
+            raise
+
+        return TranscriptPublicationResult(
+            canonical_sha256=expected_canonical_sha256,
+            publications=tuple(item for item, _, _ in reserved),
+        )
+
+    def _details(
+        self,
+        document: IndexedDocument,
+        canonical_sha256: str,
+        projection: _CanonicalTranscriptProjection,
+        *,
+        speaker_count: int,
+    ) -> TranscriptDetails:
+        engine = projection.engine
+        diarization = projection.diarization
+        enhancement = projection.enhancement
+        return TranscriptDetails(
+            document_id=document.document_id,
+            source_sha256=projection.source.sha256,
+            canonical_sha256=canonical_sha256,
+            source_available=(
+                document.source_path is not None
+                and self.file_manager.file_exists(Path(document.source_path))
+            ),
+            source_size_bytes=projection.source.size_bytes,
+            source_modified_ns=projection.source.modified_ns,
+            container_format=projection.source.container_format,
+            duration_seconds=projection.source.duration_seconds,
+            audio_stream_index=projection.source.audio_stream_index,
+            profile=projection.profile,
+            provisional=projection.provisional,
+            decode_strategy=projection.decode_strategy,
+            detected_language=projection.detected_language,
+            detected_languages=tuple(projection.detected_languages),
+            segment_count=len(projection.segments),
+            speaker_count=speaker_count,
+            engine=TranscriptEngineDetails(
+                name=engine.name,
+                package_version=engine.package_version,
+                model=engine.model,
+                model_revision=engine.model_revision,
+                device=engine.device,
+                compute_type=engine.compute_type,
+            ),
+            diarization=(
+                None
+                if diarization is None
+                else TranscriptDiarizationDetails(
+                    provider=diarization.provider,
+                    package_version=diarization.package_version,
+                    model=diarization.model,
+                    model_revision=diarization.model_revision,
+                    mode=diarization.mode,
+                )
+            ),
+            enhancement=(
+                None
+                if enhancement is None
+                else TranscriptEnhancementDetails(
+                    provider=enhancement.provider,
+                    provider_version=enhancement.provider_version,
+                    operation=enhancement.operation,
+                    model_id=enhancement.model_id,
+                    model_revision=enhancement.model_revision,
+                )
+            ),
+        )
+
+    def _verified_projection(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+    ) -> tuple[IndexedDocument, _CanonicalTranscriptProjection]:
+        document = self._require_generation(document_id, expected_canonical_sha256)
+        try:
+            path = Path(document.canonical_path)
+            metadata = self.file_manager.get_file_metadata(path)
+            if metadata["size"] > _MAX_CANONICAL_BYTES:
+                raise TranscriptToolingError(
+                    "Canonical transcript is too large to inspect safely in the desktop"
+                )
+            payload = self.file_manager.read_file(path)
+            if hashlib.sha256(payload).hexdigest() != expected_canonical_sha256:
+                raise TranscriptToolingError(
+                    "Canonical transcript changed; rebuild the library before using transcript tools"
+                )
+            projection = _CanonicalTranscriptProjection.model_validate(
+                json.loads(payload)
+            )
+            if projection.schema_version != 1:
+                raise TranscriptToolingError(
+                    "Canonical transcript uses an unsupported schema version"
+                )
+            if projection.source.sha256 != document.source_sha256:
+                raise TranscriptToolingError(
+                    "Canonical transcript source identity no longer matches the library index"
+                )
+            if projection.job_id != document.document_id:
+                raise TranscriptToolingError(
+                    "Canonical transcript identity no longer matches the library index"
+                )
+            if len(projection.segments) != document.segment_count:
+                raise TranscriptToolingError(
+                    "Canonical transcript segment count no longer matches the library index"
+                )
+            return document, projection
+        except TranscriptToolingError:
+            raise
+        except (
+            OSError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValidationError,
+            ValueError,
+        ) as exc:
+            raise TranscriptToolingError(
+                "Canonical transcript details could not be validated safely",
+                cause=exc,
+            ) from exc
+
+    def _require_generation(
+        self,
+        document_id: str,
+        expected_canonical_sha256: str,
+    ) -> IndexedDocument:
+        if len(expected_canonical_sha256) != 64 or any(
+            character not in "0123456789abcdef"
+            for character in expected_canonical_sha256
+        ):
+            raise ValueError(
+                "expected_canonical_sha256 must be a lowercase 64-character digest"
+            )
+        document = next(
+            (item for item in self.index.documents() if item.document_id == document_id),
+            None,
+        )
+        if document is None:
+            raise TranscriptToolingError("Transcript is not present in the local library")
+        if document.canonical_sha256 is None:
+            raise TranscriptToolingError(
+                "Transcript index predates canonical hashing; rebuild the library first"
+            )
+        if document.canonical_sha256 != expected_canonical_sha256:
+            raise TranscriptToolingError(
+                "Transcript changed since this view was opened; reopen it before making changes"
+            )
+        return document
+
+    def _publication_stem(self, document: IndexedDocument) -> str:
+        source_stem = (
+            Path(document.source_path).stem
+            if document.source_path is not None
+            else document.document_id
+        )
+        stem = self.file_manager.sanitize_filename(source_stem).strip(" .")
+        return stem or "transcript"
+
+    def _reserve_publication(self, directory: Path, filename: str) -> Path:
+        path = Path(filename)
+        for index in range(1, _MAX_COLLISION_ATTEMPTS + 1):
+            candidate = directory / (
+                filename if index == 1 else f"{path.stem}-{index}{path.suffix}"
+            )
+            try:
+                self.file_manager.reserve_file(candidate)
+            except StorageAlreadyExistsError:
+                continue
+            return candidate
+        raise TranscriptToolingError(
+            "EchoFlow could not allocate a unique transcript export filename"
+        )

--- a/src/echoflow/library/transcript_tools.py
+++ b/src/echoflow/library/transcript_tools.py
@@ -470,11 +470,17 @@ class TranscriptToolsService:
                 "expected_canonical_sha256 must be a lowercase 64-character digest"
             )
         document = next(
-            (item for item in self.index.documents() if item.document_id == document_id),
+            (
+                item
+                for item in self.index.documents()
+                if item.document_id == document_id
+            ),
             None,
         )
         if document is None:
-            raise TranscriptToolingError("Transcript is not present in the local library")
+            raise TranscriptToolingError(
+                "Transcript is not present in the local library"
+            )
         if document.canonical_sha256 is None:
             raise TranscriptToolingError(
                 "Transcript index predates canonical hashing; rebuild the library first"

--- a/src/echoflow/library/transcript_tools.py
+++ b/src/echoflow/library/transcript_tools.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 
 from echoflow.core.errors import StorageAlreadyExistsError
 from echoflow.core.file_manager_facade import FileManagerFacade
-from echoflow.library.errors import TranscriptToolingError
+from echoflow.library.errors import SpeakerLabelStateError, TranscriptToolingError
 from echoflow.library.index import IndexedDocument, TranscriptIndex
 from echoflow.library.speaker_label_service import (
     SpeakerLabelService,
@@ -209,9 +209,12 @@ class TranscriptToolsService:
             document_id,
             expected_canonical_sha256=expected_canonical_sha256,
         )
-        speakers = self.speaker_labels.roster(
-            document_id, expected_canonical_sha256=expected_canonical_sha256
-        )
+        try:
+            speakers = self.speaker_labels.roster(
+                document_id, expected_canonical_sha256=expected_canonical_sha256
+            )
+        except SpeakerLabelStateError as exc:
+            raise TranscriptToolingError(exc.public_message, cause=exc) from exc
         details = self._details(
             document, expected_canonical_sha256, projection, speaker_count=len(speakers)
         )
@@ -224,7 +227,10 @@ class TranscriptToolsService:
         expected_canonical_sha256: str,
     ) -> tuple[SpeakerPresentationSpan, ...]:
         self._require_generation(document_id, expected_canonical_sha256)
-        spans = self.speaker_presentation.spans(document_id)
+        try:
+            spans = self.speaker_presentation.spans(document_id)
+        except SpeakerLabelStateError as exc:
+            raise TranscriptToolingError(exc.public_message, cause=exc) from exc
         if any(span.canonical_sha256 != expected_canonical_sha256 for span in spans):
             raise TranscriptToolingError(
                 "Transcript changed while speaker presentation was being prepared; reopen it"
@@ -239,12 +245,16 @@ class TranscriptToolsService:
         speaker_ref: str,
         label: str,
     ) -> SpeakerRosterEntry:
-        binding = self.speaker_labels.set_label(
-            document_id,
-            speaker_ref=speaker_ref,
-            label=label,
-            expected_canonical_sha256=expected_canonical_sha256,
-        )
+        self._require_generation(document_id, expected_canonical_sha256)
+        try:
+            binding = self.speaker_labels.set_label(
+                document_id,
+                speaker_ref=speaker_ref,
+                label=label,
+                expected_canonical_sha256=expected_canonical_sha256,
+            )
+        except SpeakerLabelStateError as exc:
+            raise TranscriptToolingError(exc.public_message, cause=exc) from exc
         if binding.canonical_sha256 != expected_canonical_sha256:
             raise TranscriptToolingError(
                 "Transcript changed while the speaker name was being saved; reopen it"
@@ -261,11 +271,15 @@ class TranscriptToolsService:
         expected_canonical_sha256: str,
         speaker_ref: str,
     ) -> bool:
-        return self.speaker_labels.remove_label(
-            document_id,
-            speaker_ref=speaker_ref,
-            expected_canonical_sha256=expected_canonical_sha256,
-        )
+        self._require_generation(document_id, expected_canonical_sha256)
+        try:
+            return self.speaker_labels.remove_label(
+                document_id,
+                speaker_ref=speaker_ref,
+                expected_canonical_sha256=expected_canonical_sha256,
+            )
+        except SpeakerLabelStateError as exc:
+            raise TranscriptToolingError(exc.public_message, cause=exc) from exc
 
     def publish(
         self,

--- a/src/echoflow/transcription/export.py
+++ b/src/echoflow/transcription/export.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 
 from echoflow.core.file_manager_facade import FileManagerFacade
 from echoflow.transcription.errors import TranscriptionError
-from echoflow.transcription.models import CanonicalTranscript, RecognizedSegment
+from echoflow.transcription.models import CanonicalTranscript
 from echoflow.workspace.models import Artifact, ArtifactKind, Job
 from echoflow.workspace.service import WorkspaceService
 
@@ -38,6 +38,17 @@ class TranscriptExportResult:
         return [artifact.to_dict() for artifact in self.artifacts]
 
 
+@dataclass(frozen=True, slots=True)
+class TranscriptRenderSegment:
+    """Small stable rendering contract shared by live and stored transcript exports."""
+
+    segment_id: str
+    start_seconds: float
+    end_seconds: float
+    text: str
+    speaker_ref: str | None = None
+
+
 def _milliseconds(seconds: float, *, end: bool) -> int:
     value = Decimal(str(seconds)) * 1000
     rounding = ROUND_CEILING if end else ROUND_FLOOR
@@ -52,62 +63,109 @@ def _timestamp(seconds: float, *, separator: str, end: bool) -> str:
     return f"{hours:02d}:{minutes:02d}:{whole_seconds:02d}{separator}{milliseconds:03d}"
 
 
-def _cue_text(segment: RecognizedSegment) -> str:
-    if "\x00" in segment.text:
+def _cue_text_value(text: str) -> str:
+    if "\x00" in text:
         raise TranscriptExportError("Transcript contains text that cannot be exported")
-    normalized = segment.text.replace("\r\n", "\n").replace("\r", "\n")
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
     lines = [line.strip() for line in normalized.split("\n") if line.strip()]
     if not lines:
         raise TranscriptExportError("Transcript contains an empty subtitle cue")
     return " ".join(lines)
 
 
-def _speaker_cue_text(segment: RecognizedSegment) -> str:
-    text = _cue_text(segment)
-    if segment.speaker_ref is None:
-        return text
-    return f"[{segment.speaker_ref}] {text}"
+def _speaker_cue_text_value(text: str, speaker_ref: str | None) -> str:
+    rendered = _cue_text_value(text)
+    if speaker_ref is None:
+        return rendered
+    return f"[{speaker_ref}] {rendered}"
 
 
-def render_text(transcript: CanonicalTranscript) -> bytes:
-    if not any(segment.speaker_ref is not None for segment in transcript.segments):
-        return f"{transcript.text}\n".encode()
+def _render_segments(transcript: CanonicalTranscript) -> tuple[TranscriptRenderSegment, ...]:
+    return tuple(
+        TranscriptRenderSegment(
+            segment_id=segment.segment_id,
+            start_seconds=segment.start_seconds,
+            end_seconds=segment.end_seconds,
+            text=segment.text,
+            speaker_ref=segment.speaker_ref,
+        )
+        for segment in transcript.segments
+    )
+
+
+def render_text_parts(
+    transcript_text: str,
+    segments: tuple[TranscriptRenderSegment, ...],
+) -> bytes:
+    if not any(segment.speaker_ref is not None for segment in segments):
+        return f"{transcript_text}\n".encode()
     return (
-        "\n".join(_speaker_cue_text(segment) for segment in transcript.segments) + "\n"
+        "\n".join(
+            _speaker_cue_text_value(segment.text, segment.speaker_ref)
+            for segment in segments
+        )
+        + "\n"
     ).encode()
 
 
-def render_subrip(transcript: CanonicalTranscript) -> bytes:
+def render_subrip_parts(segments: tuple[TranscriptRenderSegment, ...]) -> bytes:
     blocks: list[str] = []
-    for cue_number, segment in enumerate(transcript.segments, start=1):
+    for cue_number, segment in enumerate(segments, start=1):
         start = _timestamp(segment.start_seconds, separator=",", end=False)
         end = _timestamp(segment.end_seconds, separator=",", end=True)
-        blocks.append(f"{cue_number}\n{start} --> {end}\n{_speaker_cue_text(segment)}")
+        blocks.append(
+            f"{cue_number}\n{start} --> {end}\n"
+            f"{_speaker_cue_text_value(segment.text, segment.speaker_ref)}"
+        )
     document = "\n\n".join(blocks)
     return (f"{document}\n\n" if document else "").encode()
 
 
-def render_webvtt(transcript: CanonicalTranscript) -> bytes:
+def render_webvtt_parts(segments: tuple[TranscriptRenderSegment, ...]) -> bytes:
     blocks: list[str] = []
-    for segment in transcript.segments:
+    for segment in segments:
         start = _timestamp(segment.start_seconds, separator=".", end=False)
         end = _timestamp(segment.end_seconds, separator=".", end=True)
         blocks.append(
-            f"{segment.segment_id}\n{start} --> {end}\n{_speaker_cue_text(segment)}"
+            f"{segment.segment_id}\n{start} --> {end}\n"
+            f"{_speaker_cue_text_value(segment.text, segment.speaker_ref)}"
         )
     body = "\n\n".join(blocks)
     return ("WEBVTT\n\n" + (f"{body}\n\n" if body else "")).encode()
 
 
+def render_transcript_parts(
+    transcript_text: str,
+    segments: tuple[TranscriptRenderSegment, ...],
+    export_format: TranscriptExportFormat,
+) -> bytes:
+    if export_format is TranscriptExportFormat.TEXT:
+        return render_text_parts(transcript_text, segments)
+    if export_format is TranscriptExportFormat.SUBRIP:
+        return render_subrip_parts(segments)
+    return render_webvtt_parts(segments)
+
+
+def render_text(transcript: CanonicalTranscript) -> bytes:
+    return render_text_parts(transcript.text, _render_segments(transcript))
+
+
+def render_subrip(transcript: CanonicalTranscript) -> bytes:
+    return render_subrip_parts(_render_segments(transcript))
+
+
+def render_webvtt(transcript: CanonicalTranscript) -> bytes:
+    return render_webvtt_parts(_render_segments(transcript))
+
+
 def render_transcript(
     transcript: CanonicalTranscript, export_format: TranscriptExportFormat
 ) -> bytes:
-    renderers = {
-        TranscriptExportFormat.TEXT: render_text,
-        TranscriptExportFormat.SUBRIP: render_subrip,
-        TranscriptExportFormat.WEBVTT: render_webvtt,
-    }
-    return renderers[export_format](transcript)
+    return render_transcript_parts(
+        transcript.text,
+        _render_segments(transcript),
+        export_format,
+    )
 
 
 class TranscriptExporter:

--- a/src/echoflow/transcription/export.py
+++ b/src/echoflow/transcription/export.py
@@ -80,7 +80,9 @@ def _speaker_cue_text_value(text: str, speaker_ref: str | None) -> str:
     return f"[{speaker_ref}] {rendered}"
 
 
-def _render_segments(transcript: CanonicalTranscript) -> tuple[TranscriptRenderSegment, ...]:
+def _render_segments(
+    transcript: CanonicalTranscript,
+) -> tuple[TranscriptRenderSegment, ...]:
     return tuple(
         TranscriptRenderSegment(
             segment_id=segment.segment_id,


### PR DESCRIPTION
## Summary

This tranche productizes transcript/speaker tooling without moving evidence or business authority into React.

- add generation-bound `TranscriptToolsService` over canonical transcript identity, speaker labels/presentation, provenance/details, and post-hoc publication
- require the expected canonical SHA-256 for inspect, speaker transcript, rename/remove, and publication so stale desktop views fail closed
- add a dedicated fixed Tauri `transcript_tools_request` command and size-bounded Python bridge allowlist; the webview cannot choose a Python module, shell command, canonical path, or source path
- add desktop transcript details, speaker-name management, explicit overlap/mixed/unattributed presentation, and TXT/SRT/WebVTT publication
- add Pride and Monochrome to the semantic-token theme registry; Pride decoration carries no semantic status and Monochrome is deliberately grayscale
- broaden frontend qualification with dedicated Processing Center, transcript-tools, presentation-contract, Pride, and Monochrome tests; the existing registry-driven theme matrix now qualifies all eight skins
- add backend positive/negative/boundary/Hypothesis coverage and a targeted manual Poodle workflow for transcript-tool decisions
- document the authority/security/performance/test seams and advance the roadmap to native playback

## Authority and custody

React submits presentation intent only. It does not parse canonical JSON, infer current speaker generations, implement subtitle timing/collision policy, or reconcile stale transcript state. Transcript-tool responses expose generation/provenance/speaker state and publication filenames, not canonical/source filesystem paths.

## Mutation strategy

Python Poodle remains targeted/manual because the decision-heavy generation, speaker, publication, and allowlist rules live there. Stryker is intentionally not added just to mutate JSX. The frontend uses strict TypeScript/build, Playwright interaction/negative/boundary tests, hostile-text/path assertions, axe, and the shared theme contrast matrix. A JavaScript mutation layer is documented as appropriate only if decision-heavy pure frontend modules later exist and are correctly presentation-owned.

## Docs

README, ROADMAP, docs index/getting-started/speaker documentation, desktop accessibility, frontend testing strategy, transcript-tools guide, development index, and frontend security boundary are synchronized. Mermaid sources with static SVG fallbacks were kept equivalent so fallback hashes remain valid.

## Next

Native local audio/video playback from verified source-relative coordinates, then lifecycle/retention UI.