### PR TITLE
feat(desktop): add generation-bound verified native playback

### DIFF
--- a/.github/workflows/mutation-playback.yml
+++ b/.github/workflows/mutation-playback.yml
@@ -1,9 +1,17 @@
 name: Playback Mutation
 
-# Playback mutation testing is a targeted qualification tool rather than a routine PR tax.
-# Run this workflow when generation/source authorization or its trusted-host bridge changes.
+# Playback mutation testing is targeted at changes to generation/source authorization and
+# its trusted-host bridge. It remains manually dispatchable for explicit requalification.
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/echoflow/library/playback.py"
+      - "src/echoflow/library/tests/test_playback*.py"
+      - "src/echoflow/desktop/playback_bridge.py"
+      - "src/echoflow/desktop/tests/test_playback_bridge.py"
+      - ".github/workflows/mutation-playback.yml"
+      - "pyproject.toml"
 
 permissions:
   contents: read

--- a/.github/workflows/mutation-playback.yml
+++ b/.github/workflows/mutation-playback.yml
@@ -40,6 +40,7 @@ jobs:
         run: >-
           uv run pytest
           src/echoflow/library/tests/test_playback.py
+          src/echoflow/library/tests/test_playback_edges.py
           src/echoflow/desktop/tests/test_playback_bridge.py
           src/echoflow/media/tests/test_probe.py
           --cov=echoflow

--- a/.github/workflows/mutation-playback.yml
+++ b/.github/workflows/mutation-playback.yml
@@ -1,0 +1,55 @@
+name: Playback Mutation
+
+# Playback mutation testing is a targeted qualification tool rather than a routine PR tax.
+# Run this workflow when generation/source authorization or its trusted-host bridge changes.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: playback-mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    name: Targeted playback Poodle mutation
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.33"
+          enable-cache: true
+
+      - name: Install locked development dependencies
+        run: uv sync --locked --all-groups --extra transcription
+
+      - name: Establish playback qualification baseline
+        run: >-
+          uv run pytest
+          src/echoflow/library/tests/test_playback.py
+          src/echoflow/desktop/tests/test_playback_bridge.py
+          src/echoflow/media/tests/test_probe.py
+          --cov=echoflow
+          --cov-context=test
+          --cov-report=
+          --cov-fail-under=0
+
+      - name: Mutate playback authorization decisions
+        run: >-
+          uv run poodle
+          -w 4
+          --only src/echoflow/library/playback.py
+          --only src/echoflow/desktop/playback_bridge.py

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Compile locked native Tauri host
         run: cargo check --locked --manifest-path src-tauri/Cargo.toml
 
+      - name: Test locked native Tauri host
+        run: cargo test --locked --manifest-path src-tauri/Cargo.toml
+
   frontend-playwright:
     needs: [static, frontend-static]
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ EchoFlow is pre-production, but the backend and desktop cover a coherent path fr
 |---|---|
 | Local transcription | faster-whisper CPU/int8 and CUDA-capable strategies with explicit managed model revisions |
 | Hardware awareness | process-visible CPU/RAM, affinity/cgroup limits, accelerator topology, engine capability negotiation, resource admission |
-| Media handling | FFprobe inspection, deterministic stream selection, FFmpeg canonicalization, exact source-relative work windows |
+| Media handling | FFprobe inspection, explicit embedded-audio-track confirmation for multi-track files, deterministic exact-stream FFmpeg canonicalization, exact source-relative work windows |
 | Reliability | private checkpoints, validated resume, contiguous checkpoint ordering, bounded accelerated prefetch |
 | Languages | multilingual decoding plus conservative local text-language attribution |
 | Speakers | optional anonymous recording-scoped diarization, word-level handoffs, generation-bound display labels, honest overlap/mixed presentation |
@@ -29,15 +29,15 @@ EchoFlow is pre-production, but the backend and desktop cover a coherent path fr
 | Transcript output | canonical JSON plus deterministic TXT, SRT, WebVTT publication views |
 | Search | private BM25 lexical retrieval, optional semantic retrieval, hybrid reciprocal-rank fusion |
 | Evidence navigation | canonical-hash verification, aligned highlights, bounded context, speaker presentation, source seek coordinates |
-| Verified playback | exact-generation/source re-verification, opaque Tauri media sessions, bounded native range streaming, current/older evidence coordinates |
+| Verified playback | exact-generation/source re-verification, opaque Tauri media sessions, bounded native range streaming, current/older evidence coordinates; multi-track sources currently fail closed for playback |
 | Research workspace | authoritative SQLite notes/tags/collections, rebuildable DuckDB projection, desktop browse/create/edit/delete/filter/anchor maintenance |
 | Unified discovery | grouped transcript/note/tag/collection query without fabricated cross-type scores |
 | Saved searches | durable typed query intent that re-resolves current evidence instead of freezing result snapshots |
 | Safe lifecycle | typed plan-bound deletion scopes plus private execution-state retention that preserves evidence/human work by default |
 | Incremental library | cheap refresh/reconciliation plus durable transcript and recording locations |
-| Processing Center | readiness, machine/model state, preflight, supervised start/cancel, resume versus retry, job-state discard, diarization/enhancement/publication intent |
+| Processing Center | readiness, machine/model state, preflight, explicit multi-track stream confirmation, supervised start/cancel, resume versus retry, job-state discard, diarization/enhancement/publication intent |
 | Transcript tools | generation-bound transcript/provenance inspection, speaker naming/removal, overlap-aware transcript view, post-hoc TXT/SRT/VTT publication |
-| Desktop guidance | persistent screen/overview help plus contextual Evidence, Playback, and Transcript explanations without duplicating backend policy |
+| Desktop guidance | persistent screen/overview help plus contextual Evidence, Playback, Transcript, and multi-track preflight explanations without duplicating backend policy |
 | Desktop presentation | Tauri + React Intake, Processing, Library, verified evidence reader/playback, Research, transcript tools, and eight semantic-token themes |
 | Accessibility | keyboard/semantic-role tests, axe, non-hover contextual help, explicit light/dark browser schemes, and an eight-skin contrast matrix |
 | Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, Playwright/axe, native Rust tests, package verification, targeted mutation qualification |
@@ -96,23 +96,25 @@ The Tauri + React desktop currently provides:
 
 - native file/folder selection and remembered-location permissions;
 - recording discovery without automatic processing side effects;
-- a Processing Center for readiness, model state, job state, preflight, launch, cancel, resume/retry distinction, and private-state discard;
+- a Processing Center for readiness, model state, job state, preflight, explicit embedded-audio-track confirmation, launch, cancel, resume/retry distinction, and private-state discard;
 - Library search across transcripts, notes, tags, and collections;
 - verified evidence context and source-relative cursor coordinates;
 - generation/source-verified local audio/video playback from that evidence cursor without exposing source paths to React;
 - Research note create/edit/delete, tag/collection navigation, saved-search lifecycle, typed retrieval controls, exact-generation evidence return, and explicit anchor review;
 - transcript details/provenance, generation-safe speaker-name management, explicit speaker-overlap presentation, and post-hoc derived publication;
-- persistent **How this screen works** and **How EchoFlow works** guidance plus local Evidence/Playback/Transcript explanations;
+- persistent **How this screen works** and **How EchoFlow works** guidance plus local Evidence/Playback/Transcript/multi-track explanations;
 - eight accessible presentation skins through one compact theme picker; and
 - persisted presentation preference without mixing theme state into evidence or research.
 
-The browser/webview does **not** receive canonical/source filesystem paths for evidence navigation, transcript tools, or playback. Rust owns native desktop capability and opened media sessions; Python owns application/evidence/custody rules; React owns presentation and explicit user intent.
+The browser/webview does **not** receive canonical/source filesystem paths for evidence navigation, transcript tools, or playback. Rust owns native desktop capability and opened media sessions; Python owns application/evidence/custody/media-selection rules; React owns presentation and explicit user intent.
+
+When a file contains several embedded audio streams, Python reports that explicit confirmation is required. The desktop shows bounded source-declared title/language/default metadata when available, accepts the user's stream choice, and sends only that exact index back to Python for a fresh preflight. Start remains disabled until the backend returns a plan bound to that stream. Canonical provenance records the exact stream index and resume restores it. See **[Audio tracks](docs/audio-tracks.md)**.
 
 Transcript tools are generation-bound. A long-lived UI cannot silently rename a speaker in a newer transcript generation: every inspect/mutation/publication request carries the exact canonical SHA-256 the user opened, and Python rejects stale identity. See **[Transcript and speaker tools](docs/transcript-tools.md)**.
 
-Playback follows the same evidence discipline. Python re-verifies the exact canonical generation, original source bytes, bounded coordinate, and audio-stream identity; Rust then turns the approved source into an opaque local media session. Multi-audio sources currently fail closed rather than risking playback of a different track than the one transcribed. See **[Verified native playback](docs/native-playback.md)**.
+Playback follows the same evidence discipline. Python re-verifies the exact canonical generation, original source bytes, bounded coordinate, and audio-stream identity; Rust then turns the approved source into an opaque local media session. Multi-track transcription is supported, but multi-track playback currently fails closed because the system WebView cannot yet prove it rendered the same embedded stream that produced the transcript. See **[Verified native playback](docs/native-playback.md)**.
 
-In-app guidance is deliberately re-openable and non-hover-only. It explains those contracts where users encounter them but carries no filesystem/database/process authority and does not recreate application policy in React. See **[In-app guidance](docs/in-app-guidance.md)**.
+In-app guidance is deliberately re-openable and non-hover-only where popovers are used, with inline help for required multi-track selection. It explains those contracts where users encounter them but carries no filesystem/database/process authority and does not recreate application policy in React. See **[In-app guidance](docs/in-app-guidance.md)**.
 
 There are still no end-user installers or Releases. The supported path remains a source build while packaging and first-run behavior are qualified.
 
@@ -147,6 +149,13 @@ uv run echoflow transcribe interview.m4a --dry-run
 uv run echoflow transcribe interview.m4a
 ```
 
+For a source with several embedded audio tracks, bind the exact FFmpeg stream index:
+
+```bash
+uv run echoflow transcribe meeting.mkv --audio-stream 3 --dry-run
+uv run echoflow transcribe meeting.mkv --audio-stream 3
+```
+
 Add derived publication formats when useful:
 
 ```bash
@@ -159,7 +168,7 @@ Resume a validated interrupted job:
 uv run echoflow transcribe interview.m4a --resume JOB_ID
 ```
 
-Model acquisition is explicit and network-bearing. Resume rechecks source identity and current resource admission rather than silently changing the execution contract.
+Model acquisition is explicit and network-bearing. Resume rechecks source identity and current resource admission rather than silently changing the execution contract, including its selected audio stream.
 
 ## Search, annotate, and name speakers
 
@@ -213,13 +222,13 @@ A database is allowed to make evidence useful. It is not allowed to become the o
 
 ## For maintainers
 
-Start with **[docs/architecture/README.md](docs/architecture/README.md)**, **[Processing Center](docs/architecture/processing-center.md)**, **[Transcript and speaker tools](docs/transcript-tools.md)**, **[Verified native playback](docs/native-playback.md)**, **[In-app guidance](docs/in-app-guidance.md)**, **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and **[frontend/SECURITY.md](frontend/SECURITY.md)**.
+Start with **[docs/architecture/README.md](docs/architecture/README.md)**, **[Processing Center](docs/architecture/processing-center.md)**, **[Audio tracks](docs/audio-tracks.md)**, **[Transcript and speaker tools](docs/transcript-tools.md)**, **[Verified native playback](docs/native-playback.md)**, **[In-app guidance](docs/in-app-guidance.md)**, **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and **[frontend/SECURITY.md](frontend/SECURITY.md)**.
 
 Normal qualification includes Ruff, strict mypy, Vulture, Radon, branch coverage, dependency audit, package verification, TypeScript/build/audit gates, native Cargo compilation/tests, Playwright/axe, the eight-theme contrast matrix, targeted Poodle mutation workflows, and Linux/macOS/Windows CI. See **[Frontend testing strategy](docs/development/frontend-testing.md)** for frontend/backend test ownership.
 
 ## Where the project goes next
 
-Research/search, Processing, desktop comprehension/themes, transcript/speaker tools, verified native playback, and contextual guidance are built. The next first-release sequence is:
+Research/search, Processing, explicit embedded-track transcription, desktop comprehension/themes, transcript/speaker tools, verified native playback, and contextual guidance are built. The next first-release sequence is:
 
 1. lifecycle and retention UI over the existing plan-bound custody backend;
 2. architecture/redundancy audit before packaging freezes seams;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 EchoFlow turns audio and video into reproducible canonical transcripts, preserves source and processing provenance, lets people search a private corpus and navigate results back to exact verified evidence, and keeps notes, tags, collections, speaker labels, and saved research questions as durable user-owned knowledge.
 
-Transcription is the engine room, not the whole product. EchoFlow also inspects the machine, chooses a safe local execution strategy, manages model custody, survives interrupted work, keeps word-level timing and anonymous-speaker evidence, publishes portable transcript views, incrementally reconciles an evolving library, and gives deletion the same explicit custody rules as creation.
+Transcription is the engine room, not the whole product. EchoFlow also inspects the machine, chooses a safe local execution strategy, manages model custody, survives interrupted work, keeps word-level timing and anonymous-speaker evidence, publishes portable transcript views, incrementally reconciles an evolving library, plays verified local source evidence, and gives deletion the same explicit custody rules as creation.
 
 Canonical transcript JSON is authoritative transcript evidence. Human-authored research state is authoritative user knowledge. DuckDB search/research projections and publication formats are rebuildable. The original recording is read-only throughout normal processing and can only be deleted through a separate explicit provenance-checked operation.
 
@@ -14,7 +14,7 @@ Start with **[docs/README.md](docs/README.md)** for human-facing documentation o
 
 ## What can it do right now?
 
-EchoFlow is pre-production, but the backend and desktop cover a coherent path from importing a recording through local processing, evidence search, durable research, and post-processing transcript/speaker management.
+EchoFlow is pre-production, but the backend and desktop cover a coherent path from importing a recording through local processing, evidence search, durable research, transcript/speaker management, and verified local playback.
 
 | Area | Current foundation |
 |---|---|
@@ -29,6 +29,7 @@ EchoFlow is pre-production, but the backend and desktop cover a coherent path fr
 | Transcript output | canonical JSON plus deterministic TXT, SRT, WebVTT publication views |
 | Search | private BM25 lexical retrieval, optional semantic retrieval, hybrid reciprocal-rank fusion |
 | Evidence navigation | canonical-hash verification, aligned highlights, bounded context, speaker presentation, source seek coordinates |
+| Verified playback | exact-generation/source re-verification, opaque Tauri media sessions, bounded native range streaming, current/older evidence coordinates |
 | Research workspace | authoritative SQLite notes/tags/collections, rebuildable DuckDB projection, desktop browse/create/edit/delete/filter/anchor maintenance |
 | Unified discovery | grouped transcript/note/tag/collection query without fabricated cross-type scores |
 | Saved searches | durable typed query intent that re-resolves current evidence instead of freezing result snapshots |
@@ -36,9 +37,9 @@ EchoFlow is pre-production, but the backend and desktop cover a coherent path fr
 | Incremental library | cheap refresh/reconciliation plus durable transcript and recording locations |
 | Processing Center | readiness, machine/model state, preflight, supervised start/cancel, resume versus retry, job-state discard, diarization/enhancement/publication intent |
 | Transcript tools | generation-bound transcript/provenance inspection, speaker naming/removal, overlap-aware transcript view, post-hoc TXT/SRT/VTT publication |
-| Desktop presentation | Tauri + React Intake, Processing, Library, verified evidence reader, Research, transcript tools, and eight semantic-token themes |
+| Desktop presentation | Tauri + React Intake, Processing, Library, verified evidence reader/playback, Research, transcript tools, and eight semantic-token themes |
 | Accessibility | keyboard/semantic-role tests, axe, explicit light/dark browser schemes, and an eight-skin contrast matrix |
-| Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, Playwright/axe, package verification, targeted mutation qualification |
+| Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, Playwright/axe, native Rust tests, package verification, targeted mutation qualification |
 
 ## From recording to useful evidence
 
@@ -97,14 +98,17 @@ The Tauri + React desktop currently provides:
 - a Processing Center for readiness, model state, job state, preflight, launch, cancel, resume/retry distinction, and private-state discard;
 - Library search across transcripts, notes, tags, and collections;
 - verified evidence context and source-relative cursor coordinates;
+- generation/source-verified local audio/video playback from that evidence cursor without exposing source paths to React;
 - Research note create/edit/delete, tag/collection navigation, saved-search lifecycle, typed retrieval controls, exact-generation evidence return, and explicit anchor review;
 - transcript details/provenance, generation-safe speaker-name management, explicit speaker-overlap presentation, and post-hoc derived publication;
 - eight accessible presentation skins through one compact theme picker; and
 - persisted presentation preference without mixing theme state into evidence or research.
 
-The browser/webview does **not** receive canonical/source filesystem paths for evidence navigation or transcript tools. Rust owns native desktop capability; Python owns application/evidence/custody rules; React owns presentation and explicit user intent.
+The browser/webview does **not** receive canonical/source filesystem paths for evidence navigation, transcript tools, or playback. Rust owns native desktop capability and opened media sessions; Python owns application/evidence/custody rules; React owns presentation and explicit user intent.
 
 Transcript tools are generation-bound. A long-lived UI cannot silently rename a speaker in a newer transcript generation: every inspect/mutation/publication request carries the exact canonical SHA-256 the user opened, and Python rejects stale identity. See **[Transcript and speaker tools](docs/transcript-tools.md)**.
+
+Playback follows the same evidence discipline. Python re-verifies the exact canonical generation, original source bytes, bounded coordinate, and audio-stream identity; Rust then turns the approved source into an opaque local media session. Multi-audio sources currently fail closed rather than risking playback of a different track than the one transcribed. See **[Verified native playback](docs/native-playback.md)**.
 
 There are still no end-user installers or Releases. The supported path remains a source build while packaging and first-run behavior are qualified.
 
@@ -205,20 +209,19 @@ A database is allowed to make evidence useful. It is not allowed to become the o
 
 ## For maintainers
 
-Start with **[docs/architecture/README.md](docs/architecture/README.md)**, **[Processing Center](docs/architecture/processing-center.md)**, **[Transcript and speaker tools](docs/transcript-tools.md)**, **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and **[frontend/SECURITY.md](frontend/SECURITY.md)**.
+Start with **[docs/architecture/README.md](docs/architecture/README.md)**, **[Processing Center](docs/architecture/processing-center.md)**, **[Transcript and speaker tools](docs/transcript-tools.md)**, **[Verified native playback](docs/native-playback.md)**, **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and **[frontend/SECURITY.md](frontend/SECURITY.md)**.
 
-Normal qualification includes Ruff, strict mypy, Vulture, Radon, branch coverage, dependency audit, package verification, TypeScript/build/audit gates, native Cargo compilation, Playwright/axe, the eight-theme contrast matrix, targeted Poodle mutation workflows, and Linux/macOS/Windows CI. See **[Frontend testing strategy](docs/development/frontend-testing.md)** for frontend/backend test ownership.
+Normal qualification includes Ruff, strict mypy, Vulture, Radon, branch coverage, dependency audit, package verification, TypeScript/build/audit gates, native Cargo compilation/tests, Playwright/axe, the eight-theme contrast matrix, targeted Poodle mutation workflows, and Linux/macOS/Windows CI. See **[Frontend testing strategy](docs/development/frontend-testing.md)** for frontend/backend test ownership.
 
 ## Where the project goes next
 
-Research/search, Processing, desktop comprehension/themes, and transcript/speaker tools are built. The next first-release sequence is:
+Research/search, Processing, desktop comprehension/themes, transcript/speaker tools, and verified native playback are built. The next first-release sequence is:
 
-1. Tauri-owned local audio/video playback from verified source-relative coordinates;
-2. lifecycle and retention UI over the existing plan-bound custody backend;
-3. architecture/redundancy audit before packaging freezes seams;
-4. packaging, first-run storage setup, signed updates, and evidence-safe uninstall;
-5. backup/restore plus selected research portability;
-6. packaged semantic-model/dependency custody; and
-7. representative-device qualification across ordinary consumer hardware and hostile path, disk, interruption, upgrade, and accessibility cases.
+1. lifecycle and retention UI over the existing plan-bound custody backend;
+2. architecture/redundancy audit before packaging freezes seams;
+3. packaging, first-run storage setup, signed updates, and evidence-safe uninstall;
+4. backup/restore plus selected research portability;
+5. packaged semantic-model/dependency custody; and
+6. representative-device qualification across ordinary consumer hardware and hostile path, disk, interruption, upgrade, and accessibility cases.
 
 See **[ROADMAP.md](ROADMAP.md)** for the capability audit and sequencing.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Canonical transcript JSON is authoritative transcript evidence. Human-authored r
 
 > **EchoFlow's product rule:** do complicated work locally, keep the evidence understandable, portable, and owned by the user.
 
-Start with **[docs/README.md](docs/README.md)** for human-facing documentation or **[Getting started](docs/getting-started.md)** for the shortest clone-to-transcript path.
+Start with **[docs/README.md](docs/README.md)** for human-facing documentation or **[Getting started](docs/getting-started.md)** for the shortest clone-to-transcript path. The desktop also keeps contextual help available inside the app so ordinary use does not depend on having repository docs open.
 
 ## What can it do right now?
 
@@ -37,8 +37,9 @@ EchoFlow is pre-production, but the backend and desktop cover a coherent path fr
 | Incremental library | cheap refresh/reconciliation plus durable transcript and recording locations |
 | Processing Center | readiness, machine/model state, preflight, supervised start/cancel, resume versus retry, job-state discard, diarization/enhancement/publication intent |
 | Transcript tools | generation-bound transcript/provenance inspection, speaker naming/removal, overlap-aware transcript view, post-hoc TXT/SRT/VTT publication |
+| Desktop guidance | persistent screen/overview help plus contextual Evidence, Playback, and Transcript explanations without duplicating backend policy |
 | Desktop presentation | Tauri + React Intake, Processing, Library, verified evidence reader/playback, Research, transcript tools, and eight semantic-token themes |
-| Accessibility | keyboard/semantic-role tests, axe, explicit light/dark browser schemes, and an eight-skin contrast matrix |
+| Accessibility | keyboard/semantic-role tests, axe, non-hover contextual help, explicit light/dark browser schemes, and an eight-skin contrast matrix |
 | Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, Playwright/axe, native Rust tests, package verification, targeted mutation qualification |
 
 ## From recording to useful evidence
@@ -101,6 +102,7 @@ The Tauri + React desktop currently provides:
 - generation/source-verified local audio/video playback from that evidence cursor without exposing source paths to React;
 - Research note create/edit/delete, tag/collection navigation, saved-search lifecycle, typed retrieval controls, exact-generation evidence return, and explicit anchor review;
 - transcript details/provenance, generation-safe speaker-name management, explicit speaker-overlap presentation, and post-hoc derived publication;
+- persistent **How this screen works** and **How EchoFlow works** guidance plus local Evidence/Playback/Transcript explanations;
 - eight accessible presentation skins through one compact theme picker; and
 - persisted presentation preference without mixing theme state into evidence or research.
 
@@ -109,6 +111,8 @@ The browser/webview does **not** receive canonical/source filesystem paths for e
 Transcript tools are generation-bound. A long-lived UI cannot silently rename a speaker in a newer transcript generation: every inspect/mutation/publication request carries the exact canonical SHA-256 the user opened, and Python rejects stale identity. See **[Transcript and speaker tools](docs/transcript-tools.md)**.
 
 Playback follows the same evidence discipline. Python re-verifies the exact canonical generation, original source bytes, bounded coordinate, and audio-stream identity; Rust then turns the approved source into an opaque local media session. Multi-audio sources currently fail closed rather than risking playback of a different track than the one transcribed. See **[Verified native playback](docs/native-playback.md)**.
+
+In-app guidance is deliberately re-openable and non-hover-only. It explains those contracts where users encounter them but carries no filesystem/database/process authority and does not recreate application policy in React. See **[In-app guidance](docs/in-app-guidance.md)**.
 
 There are still no end-user installers or Releases. The supported path remains a source build while packaging and first-run behavior are qualified.
 
@@ -209,13 +213,13 @@ A database is allowed to make evidence useful. It is not allowed to become the o
 
 ## For maintainers
 
-Start with **[docs/architecture/README.md](docs/architecture/README.md)**, **[Processing Center](docs/architecture/processing-center.md)**, **[Transcript and speaker tools](docs/transcript-tools.md)**, **[Verified native playback](docs/native-playback.md)**, **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and **[frontend/SECURITY.md](frontend/SECURITY.md)**.
+Start with **[docs/architecture/README.md](docs/architecture/README.md)**, **[Processing Center](docs/architecture/processing-center.md)**, **[Transcript and speaker tools](docs/transcript-tools.md)**, **[Verified native playback](docs/native-playback.md)**, **[In-app guidance](docs/in-app-guidance.md)**, **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and **[frontend/SECURITY.md](frontend/SECURITY.md)**.
 
 Normal qualification includes Ruff, strict mypy, Vulture, Radon, branch coverage, dependency audit, package verification, TypeScript/build/audit gates, native Cargo compilation/tests, Playwright/axe, the eight-theme contrast matrix, targeted Poodle mutation workflows, and Linux/macOS/Windows CI. See **[Frontend testing strategy](docs/development/frontend-testing.md)** for frontend/backend test ownership.
 
 ## Where the project goes next
 
-Research/search, Processing, desktop comprehension/themes, transcript/speaker tools, and verified native playback are built. The next first-release sequence is:
+Research/search, Processing, desktop comprehension/themes, transcript/speaker tools, verified native playback, and contextual guidance are built. The next first-release sequence is:
 
 1. lifecycle and retention UI over the existing plan-bound custody backend;
 2. architecture/redundancy audit before packaging freezes seams;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 EchoFlow is becoming a **private local workspace for recorded evidence**. Its job is not to out-engine every speech-recognition runtime. Its job is to make local transcription dependable, resumable, inspectable, searchable, navigable, annotatable, portable, and safe on ordinary computers while keeping source evidence and human-authored knowledge under clear custody.
 
-Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe a file?” through a substantial backend foundation into a native desktop that can import, process, search, verify, annotate, inspect speakers/provenance, publish derived transcript views, and play exact verified source evidence. This roadmap is a productization map, not a class inventory.
+Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe a file?” through a substantial backend foundation into a native desktop that can import, process, make an explicit embedded-audio-track choice, search, verify, annotate, inspect speakers/provenance, publish derived transcript views, and play exact verified source evidence. This roadmap is a productization map, not a class inventory.
 
 ```mermaid
 flowchart LR
@@ -48,17 +48,23 @@ flowchart LR
 
 </details>
 
-Text fallback: EchoFlow already spans local media, reliable transcription, canonical evidence, lexical/semantic/hybrid retrieval, verified navigation, durable research, lifecycle contracts, incremental refresh, remembered locations, native import, Processing, Library, Research, transcript/speaker tools, verified native playback, and an accessible multi-theme shell. The next first-release work is lifecycle UI, architecture cleanup, packaging, portability, packaged semantic custody, and real-device qualification.
+Text fallback: EchoFlow already spans local media, reliable transcription, explicit embedded-track selection, canonical evidence, lexical/semantic/hybrid retrieval, verified navigation, durable research, lifecycle contracts, incremental refresh, remembered locations, native import, Processing, Library, Research, transcript/speaker tools, verified native playback, and an accessible multi-theme shell. The next first-release work is lifecycle UI, architecture cleanup, packaging, portability, packaged semantic custody, and real-device qualification.
 
 # First-release foundation now
 
 “Foundation” means the authority exists in code and is protected by tests. It does not mean installers and representative-device qualification are finished.
 
-## Local processing and model custody
+## Local processing, audio tracks, and model custody
 
-EchoFlow inspects effective CPU/memory and accelerator topology before admitting a local strategy. FFprobe owns deterministic media inspection and stream selection; FFmpeg owns canonical normalization and optional deterministic enhancement. Managed model revisions are explicit, verified, and pinned before transcription.
+EchoFlow inspects effective CPU/memory and accelerator topology before admitting a local strategy. FFprobe owns bounded media inspection; `AudioStreamSelector` owns deterministic exact-stream selection; FFmpeg owns canonical normalization and optional deterministic enhancement. Managed model revisions are explicit, verified, and pinned before transcription.
 
-The Processing Center presents readiness, model state, preflight, supervised start/cancel, durable job status, checkpoint resume, fresh retry, and private execution-state discard. Python remains authoritative for planning, admission, model custody, resume compatibility, and transcript correctness. Tauri owns allowlisted long-running child-process lifetime. React submits intent and presents state.
+The Processing Center presents readiness, model state, preflight, supervised start/cancel, durable job status, checkpoint resume, fresh retry, and private execution-state discard. Python remains authoritative for planning, admission, model custody, stream-selection validation, resume compatibility, and transcript correctness. Tauri owns allowlisted long-running child-process lifetime. React submits intent and presents state.
+
+A single-audio-stream source requires no choice. If preflight discovers several embedded audio streams and no explicit index was supplied, Python marks the plan as requiring stream confirmation. The desktop promotes a semantic track chooser into the ordinary preflight surface, shows only bounded source-declared title/language/default plus basic media facts, and keeps Start disabled. Choosing a track sends its exact integer index back to Python, which re-runs preflight before the choice is considered confirmed.
+
+The source labels are clues, not recommendations or identity. Canonical provenance records the exact audio-stream index that entered transcription, and checkpoint resume restores it. This capability covers several embedded streams inside one source file; synchronized separate recording files remain a different evidence-model problem.
+
+See **[Audio tracks](docs/audio-tracks.md)** and **[Processing Center](docs/architecture/processing-center.md)**.
 
 ## Canonical evidence and transcript tools
 
@@ -82,7 +88,7 @@ The desktop can now play the original local audio/video from the same verified s
 
 Playback is generation-bound rather than path-driven. React submits `(document_id, canonical_sha256, seek_seconds)`. Python verifies canonical bytes, source identity, current source SHA-256/size, duration bounds, and audio-stream identity. Rust opens only the approved source, narrows the verification/open race with metadata checks, stores the opened file behind an opaque active-session ID, and serves bounded `GET`/`HEAD` byte ranges through a dedicated `echoflow-media` protocol.
 
-The webview never receives the source/canonical path and cannot call the private Python playback bridge. Multi-audio sources fail closed until native track selection can prove that the rendered track matches the one canonical evidence says was transcribed. Decoder availability remains an OS/WebView qualification issue, not evidence authority.
+The webview never receives the source/canonical path and cannot call the private Python playback bridge. Multi-track **transcription** is explicitly supported, but multi-track **playback** fails closed until native track selection can prove that the rendered stream matches canonical provenance. Decoder availability remains an OS/WebView qualification issue, not evidence authority.
 
 See **[Verified native playback](docs/native-playback.md)**.
 
@@ -113,7 +119,7 @@ EchoFlow Desktop
 
 The shell now has eight skins: **Archive, Midnight, Paper, Moss, Plum, Ember, Pride, and Monochrome**. All use one semantic token contract for surfaces, text, controls, focus, errors, selection, and accent foregrounds. Pride's rainbow is decorative-only; Monochrome is deliberately grayscale. Theme preference is local presentation state and never evidence/research state.
 
-Playwright iterates every registered skin through WCAG-oriented contrast pairs, real native-style controls, browser `color-scheme`, and axe. See **[Desktop themes and accessibility](docs/development/desktop-accessibility.md)**.
+Playwright iterates every registered skin through WCAG-oriented contrast pairs, real native-style controls, browser `color-scheme`, and axe. The embedded-track chooser uses native radios, visible explanatory text, semantic tokens, and the same accessibility qualification rather than a custom visual-only selector. See **[Desktop themes and accessibility](docs/development/desktop-accessibility.md)**.
 
 # Capability → desktop audit
 
@@ -123,6 +129,7 @@ Playwright iterates every registered skin through WCAG-oriented contrast pairs, 
 | Model custody | verified pinned managed revisions | implemented | progress/offline/package polish |
 | Import/locations | durable permissions/discovery | implemented | settings/forget polish |
 | Processing | plan, execute, checkpoint, resume/retry | implemented | packaging/device qualification |
+| Embedded audio tracks | Python probe/selector/planner + FFmpeg exact map | **implemented explicit desktop confirmation** | future proven multi-track playback; separate-file sync remains out of scope |
 | Enhancement/diarization intent | Python plan/execution | implemented | result polish continues through transcript view |
 | Canonical JSON | authoritative evidence | implemented consumer views | packaging/backup |
 | Speaker labels | generation-bound human state | **implemented desktop management** | optional dedicated organization polish |
@@ -136,7 +143,7 @@ Playwright iterates every registered skin through WCAG-oriented contrast pairs, 
 | Safe deletion/retention | typed plan-bound backend | backend ready | **desktop lifecycle UI next** |
 | Native source playback | generation/source authorization + Rust session | **implemented** | decoder/device qualification; future proven multi-track selection |
 | Themes/accessibility | semantic palette + browser/native controls | **8 skins qualified** | representative OS/forced-colors checks |
-| Frontend tests | strict TS/build + Playwright/axe | primary surfaces + playback covered | grow with features, avoid duplicated backend policy |
+| Frontend tests | strict TS/build + Playwright/axe | primary surfaces + playback + multitrack covered | grow with features, avoid duplicated backend policy |
 | Packaging | Python wheel + source Tauri | development only | managed runtime/installers/update/uninstall |
 | Backup/restore | authority boundaries known | none | manifest/reconcile/restore UI |
 | Representative hardware | policy contracts + platform CI | partial | real 8/16 GB, Apple/dGPU/high-DPI qualification |
@@ -149,7 +156,7 @@ The first-release Research circuit is coherent: find evidence → verify → ann
 
 ## 2. Processing Center complete
 
-The first Processing control loop exists over readiness, model state, durable jobs, preflight, launch, native supervision, cancel, resume versus retry, and private-state discard.
+The first Processing control loop exists over readiness, model state, durable jobs, preflight, explicit embedded-track confirmation, launch, native supervision, cancel, resume versus retry, and private-state discard.
 
 ## 3. Desktop comprehension + theme system complete
 
@@ -159,13 +166,13 @@ Ordinary users see human search language rather than Python/database vocabulary.
 
 The first desktop transcript-inspection loop now exists. Generation-bound backend services own speaker names, overlap-aware presentation, provenance/details, and deterministic post-hoc publication. The React layer submits intent and never becomes canonical authority.
 
-Frontend coverage explicitly spans Intake, Processing, Library/evidence, transcript tools, Research/search/anchor maintenance, themes, development mode, hostile text rendering, path non-disclosure, and accessibility. Backend decision-heavy transcript tools also have property tests and a dedicated targeted Poodle workflow. See **[Frontend testing strategy](docs/development/frontend-testing.md)**.
+Frontend coverage explicitly spans Intake, Processing including multi-track confirmation, Library/evidence, transcript tools, Research/search/anchor maintenance, themes, development mode, hostile text rendering, path non-disclosure, and accessibility. Backend decision-heavy transcript tools also have property tests and a dedicated targeted Poodle workflow. See **[Frontend testing strategy](docs/development/frontend-testing.md)**.
 
 ## 5. Native playback complete
 
 Verified source-relative evidence coordinates now drive local audio/video without giving React arbitrary path authority. Python owns generation/source/stream authorization. Rust owns the opened file handle, opaque session lifetime, and bounded local-media transport. React receives only safe playback state and coordinates.
 
-Qualification covers stale/missing/changed sources, exact word coordinates, preserved older generations, keyboard preparation, path non-disclosure, audio/video presentation, multi-audio refusal, native range parsing, session-token allowlisting, and bounded streaming. A targeted playback Poodle workflow challenges the Python authorization decisions.
+Qualification covers stale/missing/changed sources, exact word coordinates, preserved older generations, keyboard preparation, path non-disclosure, audio/video presentation, multi-audio playback refusal, native range parsing, session-token allowlisting, and bounded streaming. A targeted playback Poodle workflow challenges the Python authorization decisions.
 
 ## 6. Lifecycle + retention UI ← next
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 EchoFlow is becoming a **private local workspace for recorded evidence**. Its job is not to out-engine every speech-recognition runtime. Its job is to make local transcription dependable, resumable, inspectable, searchable, navigable, annotatable, portable, and safe on ordinary computers while keeping source evidence and human-authored knowledge under clear custody.
 
-Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe a file?” through a substantial backend foundation into a native desktop that can import, process, search, verify, annotate, inspect speakers/provenance, and publish derived transcript views. This roadmap is a productization map, not a class inventory.
+Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe a file?” through a substantial backend foundation into a native desktop that can import, process, search, verify, annotate, inspect speakers/provenance, publish derived transcript views, and play exact verified source evidence. This roadmap is a productization map, not a class inventory.
 
 ```mermaid
 flowchart LR
@@ -48,7 +48,7 @@ flowchart LR
 
 </details>
 
-Text fallback: EchoFlow already spans local media, reliable transcription, canonical evidence, lexical/semantic/hybrid retrieval, verified navigation, durable research, lifecycle contracts, incremental refresh, remembered locations, native import, Processing, Library, Research, transcript/speaker tools, and an accessible multi-theme shell. The next first-release work is native playback, lifecycle UI, architecture cleanup, packaging, portability, packaged semantic custody, and real-device qualification.
+Text fallback: EchoFlow already spans local media, reliable transcription, canonical evidence, lexical/semantic/hybrid retrieval, verified navigation, durable research, lifecycle contracts, incremental refresh, remembered locations, native import, Processing, Library, Research, transcript/speaker tools, verified native playback, and an accessible multi-theme shell. The next first-release work is lifecycle UI, architecture cleanup, packaging, portability, packaged semantic custody, and real-device qualification.
 
 # First-release foundation now
 
@@ -75,6 +75,16 @@ The desktop transcript-tools tranche is now implemented. Library results can ope
 Every transcript-tool operation carries `(document_id, canonical_sha256)`. Python refuses stale generations rather than letting a long-lived UI silently mutate newer speaker numbering. Tauri exposes a fixed transcript-tools command and Python bridge allowlist; React never parses canonical JSON or receives canonical/source paths.
 
 See **[Transcript and speaker tools](docs/transcript-tools.md)** and **[Speaker display names](docs/speaker-names.md)**.
+
+## Verified native playback
+
+The desktop can now play the original local audio/video from the same verified source-relative cursor used by evidence navigation.
+
+Playback is generation-bound rather than path-driven. React submits `(document_id, canonical_sha256, seek_seconds)`. Python verifies canonical bytes, source identity, current source SHA-256/size, duration bounds, and audio-stream identity. Rust opens only the approved source, narrows the verification/open race with metadata checks, stores the opened file behind an opaque active-session ID, and serves bounded `GET`/`HEAD` byte ranges through a dedicated `echoflow-media` protocol.
+
+The webview never receives the source/canonical path and cannot call the private Python playback bridge. Multi-audio sources fail closed until native track selection can prove that the rendered track matches the one canonical evidence says was transcribed. Decoder availability remains an OS/WebView qualification issue, not evidence authority.
+
+See **[Verified native playback](docs/native-playback.md)**.
 
 ## Retrieval and durable research
 
@@ -116,17 +126,17 @@ Playwright iterates every registered skin through WCAG-oriented contrast pairs, 
 | Enhancement/diarization intent | Python plan/execution | implemented | result polish continues through transcript view |
 | Canonical JSON | authoritative evidence | implemented consumer views | packaging/backup |
 | Speaker labels | generation-bound human state | **implemented desktop management** | optional dedicated organization polish |
-| Speaker transcript | backend derived presentation | **implemented** | playback-linked reading later |
+| Speaker transcript | backend derived presentation | **implemented** | playback-linked reading available through evidence view |
 | Provenance/details | canonical verified inspection | **implemented** | richer troubleshooting optional |
 | TXT/SRT/WebVTT | deterministic derived publication | **implemented post-hoc desktop flow** | optional export organization |
 | Lexical/semantic/hybrid search | private retrieval | implemented | packaged semantic custody |
-| Verified evidence navigation | exact generation + timing/seek | implemented | native media playback |
+| Verified evidence navigation | exact generation + timing/seek | implemented | representative-device playback qualification |
 | Notes/tags/collections | SQLite authority | implemented | optional management polish |
 | Saved searches | durable typed intent | implemented | optional organization polish |
-| Safe deletion/retention | typed plan-bound backend | backend ready | **desktop lifecycle UI** |
-| Native source playback | verified seek coordinate exists | none | **next tranche** |
+| Safe deletion/retention | typed plan-bound backend | backend ready | **desktop lifecycle UI next** |
+| Native source playback | generation/source authorization + Rust session | **implemented** | decoder/device qualification; future proven multi-track selection |
 | Themes/accessibility | semantic palette + browser/native controls | **8 skins qualified** | representative OS/forced-colors checks |
-| Frontend tests | strict TS/build + Playwright/axe | primary surfaces covered | grow with features, avoid duplicated backend policy |
+| Frontend tests | strict TS/build + Playwright/axe | primary surfaces + playback covered | grow with features, avoid duplicated backend policy |
 | Packaging | Python wheel + source Tauri | development only | managed runtime/installers/update/uninstall |
 | Backup/restore | authority boundaries known | none | manifest/reconcile/restore UI |
 | Representative hardware | policy contracts + platform CI | partial | real 8/16 GB, Apple/dGPU/high-DPI qualification |
@@ -149,21 +159,23 @@ Ordinary users see human search language rather than Python/database vocabulary.
 
 The first desktop transcript-inspection loop now exists. Generation-bound backend services own speaker names, overlap-aware presentation, provenance/details, and deterministic post-hoc publication. The React layer submits intent and never becomes canonical authority.
 
-Frontend coverage now explicitly spans Intake, Processing, Library/evidence, transcript tools, Research/search/anchor maintenance, themes, development mode, hostile text rendering, path non-disclosure, and accessibility. Backend decision-heavy transcript tools also have property tests and a dedicated targeted Poodle workflow. See **[Frontend testing strategy](docs/development/frontend-testing.md)**.
+Frontend coverage explicitly spans Intake, Processing, Library/evidence, transcript tools, Research/search/anchor maintenance, themes, development mode, hostile text rendering, path non-disclosure, and accessibility. Backend decision-heavy transcript tools also have property tests and a dedicated targeted Poodle workflow. See **[Frontend testing strategy](docs/development/frontend-testing.md)**.
 
-## 5. Native playback ← next
+## 5. Native playback complete
 
-Let the existing verified source-relative coordinate drive local audio/video without giving React arbitrary path authority. Rust should own file/media capability; Python should own source identity/evidence rules; the webview should receive playback state and safe coordinates.
+Verified source-relative evidence coordinates now drive local audio/video without giving React arbitrary path authority. Python owns generation/source/stream authorization. Rust owns the opened file handle, opaque session lifetime, and bounded local-media transport. React receives only safe playback state and coordinates.
 
-Qualification must include moved/unavailable sources, source mismatch, keyboard transport, reduced motion, long media, and seeking around exact word boundaries.
+Qualification covers stale/missing/changed sources, exact word coordinates, preserved older generations, keyboard preparation, path non-disclosure, audio/video presentation, multi-audio refusal, native range parsing, session-token allowlisting, and bounded streaming. A targeted playback Poodle workflow challenges the Python authorization decisions.
 
-## 6. Lifecycle + retention UI
+## 6. Lifecycle + retention UI ← next
 
 Productize the existing custody contracts before a packaged app invites large local corpora: dry-run plan review, plan-bound confirmation, explicit scopes, source-recording second guard, and retention preview/result state.
 
+The UI must not invent deletion semantics. Python already owns scope expansion, provenance checks, confirmation tokens, source-recording protection, and retention exclusions. The desktop tranche should expose those decisions clearly while keeping filesystem mutation out of React.
+
 ## 7. Architecture/redundancy audit
 
-Do this before packaging freezes seams. Audit bridge DTOs, Pydantic models, React client glue, serializers, service composition, fixtures, Tauri supervisor patterns, stale compatibility paths, and duplicated documentation. Refactor policy duplication or unclear ownership, not merely similar-looking files.
+Do this before packaging freezes seams. Audit bridge DTOs, Pydantic models, React client glue, serializers, service composition, fixtures, Tauri supervisor/media patterns, stale compatibility paths, and duplicated documentation. Refactor policy duplication or unclear ownership, not merely similar-looking files.
 
 ## 8. Packaging + first run + update/uninstall
 
@@ -179,10 +191,10 @@ Lock/qualify embedding dependencies, immutable model acquisition, private cache/
 
 ## 11. Representative-device qualification
 
-Qualify 8 GB Windows, 16 GB commodity systems, Apple Silicon, dGPU laptops, 32/64 GB systems, Unicode/long paths, external disks, low disk, crashes, interrupted downloads, offline use, upgrades/reinstall, scaling, native controls, keyboard use, forced colors, and accessibility.
+Qualify 8 GB Windows, 16 GB commodity systems, Apple Silicon, dGPU laptops, 32/64 GB systems, Unicode/long paths, external disks, low disk, crashes, interrupted downloads, offline use, upgrades/reinstall, scaling, native controls, media codecs, keyboard use, forced colors, and accessibility.
 
 # Later research-native work
 
 Snapshots/diffs, REFI-QDA interoperability, evidence packets, comparison workspaces, evidence-linked writing/script boards, portable research bundles, and live provisional capture remain intentionally separate from the first-release path.
 
-The sequencing rule remains simple: do not build a larger research superstructure while the ordinary desktop still lacks playback, lifecycle UI, packaging, portability, and real-device qualification.
+The sequencing rule remains simple: do not build a larger research superstructure while the ordinary desktop still lacks lifecycle UI, packaging, portability, and real-device qualification.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,9 +40,9 @@ volume, or storage responsibility today.
 
 ## Custody deletion and retention boundary
 
-Normal transcription, indexing, research, and navigation continue to treat the original
-recording as read-only source evidence. Deletion is a separate explicit custody operation,
-not a side effect of processing or library rebuild.
+Normal transcription, indexing, research, navigation, and playback preparation continue
+to treat the original recording as read-only source evidence. Deletion is a separate
+explicit custody operation, not a side effect of processing, playback, or library rebuild.
 
 `echoflow library delete` is plan-first. Without `--confirm`, it reports the exact current
 canonical generation, effective deletion scopes, concrete mutations, preserved attached
@@ -151,17 +151,29 @@ network access.
 
 ## Media inspection boundary
 
-Dry-run inspection resolves a regular local file, restricts FFprobe protocols to
-`file`, does not invoke a shell, selects bounded metadata fields, enforces timeout and
-parser-output limits, and suppresses native stderr from public errors.
+Dry-run and Processing Center inspection resolve a regular local file, restrict FFprobe
+protocols to `file`, do not invoke a shell, select bounded metadata fields, enforce timeout
+and parser-output limits, and suppress native stderr from public errors.
+
+The primary FFprobe query remains the normal inspection contract. If that bounded query
+discovers more than one audio stream, EchoFlow performs one additional bounded,
+file-protocol-only metadata query for stream index, title, language, and default disposition.
+Title and language are length-bounded before they can enter the media model or desktop DTO.
+They remain untrusted source-declared display metadata, not a recommendation or source
+identity claim.
 
 EchoFlow fingerprints the complete input with SHA-256 and rejects a file whose observed
 filesystem identity changes during inspection. `AudioStreamSelector` then selects the
-first audio stream by default or a validated explicit `--audio-stream INDEX`. The
-selected stream becomes part of source/checkpoint provenance rather than an incidental
-FFmpeg argument.
+first audio stream by low-level deterministic default or a validated explicit
+`--audio-stream INDEX`/desktop stream index. The selected stream becomes part of
+source/checkpoint provenance rather than an incidental FFmpeg argument.
 
-The output limit bounds parsed FFprobe JSON after the process returns; it is not a hard
+Processing Center does not treat the deterministic probe default as user intent when
+several embedded audio streams exist. Python marks the first preflight as requiring
+explicit stream confirmation. React can present the bounded stream metadata and return an
+integer choice, but Python validates/replans the exact stream before execution.
+
+The output limit bounds parsed FFprobe JSON after each process returns; it is not a hard
 memory cage for the native child process. FFprobe remains native media-parsing code
 operating on user-selected input.
 
@@ -169,8 +181,9 @@ operating on user-selected input.
 
 For media not already canonical mono 16 kHz PCM16 WAV, EchoFlow invokes FFmpeg without
 a shell/stdin, restricts input protocols to `file`, maps exactly the selected audio
-stream, discards video/subtitle/data streams, suppresses native diagnostics from public
-failures, and enforces a configurable process timeout.
+stream, discards video/subtitle/data and unrelated audio streams from the working path,
+suppresses native diagnostics from public failures, and enforces a configurable process
+timeout.
 
 Normalized audio is private derived state in the job workspace and is removed after the
 attempt where possible.
@@ -188,6 +201,34 @@ padding, resampling, or channel changes.
 ASR consumes enhanced audio only when enhancement succeeded. EchoFlow does not silently
 fall back to raw ASR after a requested enhancement failure. Anonymous diarization still
 consumes the unmodified canonical decode in enhancement v1.
+
+## Verified playback boundary
+
+Playback is not path-driven from React. A webview request contains only a document ID, the
+exact canonical SHA-256 already opened in the evidence view, and a finite non-negative
+source-relative seek coordinate.
+
+Python playback authorization re-reads and hashes canonical JSON, verifies source/job
+identity, probes the remembered original recording, verifies current source SHA-256 and
+size, checks duration bounds, and verifies audio-stream identity. Changed/missing source
+bytes, stale generations, invalid coordinates, and ambiguous multi-audio sources fail
+closed.
+
+The path-bearing playback grant is private to the fixed Rust host; it is not exposed as a
+general Tauri command. Rust opens the approved source, narrows the verify/open race with
+metadata checks, and stores the opened file behind an opaque active session ID. React
+receives only opaque session/media state and safe coordinates.
+
+The dedicated `echoflow-media` protocol accepts active closed-shape session IDs rather than
+paths, permits only `GET`/`HEAD`, rejects multipart/invalid ranges, caps each response body
+at 1 MiB, limits active sessions, and uses `Cache-Control: no-store`. The CSP allows this
+dedicated media protocol rather than general `file:`, `blob:`, or arbitrary localhost media.
+
+Multi-track transcription and playback intentionally have different support levels.
+Transcription owns exact FFmpeg stream extraction and can prove which stream entered ASR.
+Current system-WebView playback of the original container cannot portably prove which
+embedded audio stream was rendered, so multi-track playback remains refused instead of
+guessing.
 
 ## Resource and storage admission
 
@@ -260,7 +301,8 @@ Resume accepts only a contiguous prefix whose manifest, windows, payload integri
 source identity, engine version, and current resource admission all agree. It never
 downloads replacement ASR weights or substitutes a new model revision. Enhancement
 cannot be switched on/off or changed during resume because preprocessing identity is
-part of the contract digest.
+part of the contract digest. The selected embedded audio stream is also restored from the
+checkpointed contract rather than reselected from current container defaults.
 
 After canonical publication, checkpoint payloads are removed on a best-effort basis.
 Interrupted jobs retain them. Ordinary filesystem deletion is not secure erasure.
@@ -268,12 +310,16 @@ Interrupted jobs retain them. Ordinary filesystem deletion is not secure erasure
 ## Canonical transcript provenance
 
 Canonical JSON omits source path, source filename, and model-cache path. It retains
-source SHA-256, size, modification timestamp, container, audio stream, and duration.
+source SHA-256, size, modification timestamp, container, exact audio stream, and duration.
 
 The current transcript contract also records managed engine/model/revision and execution
 parameters, language evidence, optional anonymous speaker evidence, and optional
 enhancement provider/version/operation/parameters. Enhancement provenance explains how
 ASR input was transformed; it does not make the derived WAV authoritative or public.
+
+Source-declared track title/language/default metadata shown during multi-track preflight is
+not promoted into cryptographic identity. The exact stream index is the durable provenance
+coordinate that answers which embedded track was transcribed.
 
 Command result envelopes may include job/artifact paths because those are explicit
 command results.
@@ -312,9 +358,9 @@ guarantees.
 
 ## Risks outside the implemented boundary
 
-FFmpeg, FFprobe, ASR, optional model/native dependencies, SQLite, and DuckDB execute in
-the current process/user security context rather than an OS sandbox. EchoFlow does not
-currently provide:
+FFmpeg, FFprobe, ASR, optional model/native dependencies, SQLite, DuckDB, Tauri, and the
+system WebView execute in the current process/user security context rather than an OS
+sandbox. EchoFlow does not currently provide:
 
 - independent upstream model signatures/allowlists;
 - process-wide network egress enforcement;
@@ -325,6 +371,6 @@ currently provide:
 - malicious same-user TOCTOU protection; or
 - protection from a compromised account or local administrator.
 
-Resource admission, private-storage controls, custody-aware deletion/retention, and the
-authority/projection split are meaningful safety boundaries, but none of the stronger
-properties above should be inferred from “local-first.”
+Resource admission, private-storage controls, custody-aware deletion/retention, playback
+capability narrowing, and the authority/projection split are meaningful safety boundaries,
+but none of the stronger properties above should be inferred from “local-first.”

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 EchoFlow is a **private, local-first workspace for recorded evidence**.
 
-It can inspect a recording, choose a safe way to run on the computer you actually have, transcribe locally, survive interruptions, preserve provenance, search a private corpus, navigate results back to verified canonical evidence, keep research notes attached to that evidence, save reusable research questions, manage generation-bound speaker labels, inspect transcript provenance, and publish derived transcript views through a native desktop shell.
+It can inspect a recording, choose a safe way to run on the computer you actually have, transcribe locally, survive interruptions, preserve provenance, search a private corpus, navigate results back to verified canonical evidence, keep research notes attached to that evidence, save reusable research questions, manage generation-bound speaker labels, inspect transcript provenance, publish derived transcript views, and play verified local source evidence through a native desktop shell.
 
-You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, or desktop IPC to use the product. Those are implementation details. The desktop should speak in recordings, transcripts, searches, notes, processing, speakers, and evidence.
+You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, or desktop IPC to use the product. Those are implementation details. The desktop should speak in recordings, transcripts, searches, notes, processing, speakers, playback, and evidence.
 
 > **The short version:** your recording stays yours, canonical JSON remains inspectable evidence, your notes/speaker names/saved searches remain your knowledge, and most machinery built around those things can be thrown away and rebuilt.
 
@@ -27,6 +27,7 @@ You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, o
 | Publish useful formats | produces canonical JSON plus rebuildable TXT/SRT/WebVTT, including post-hoc desktop publication |
 | Search a private corpus | supports lexical BM25, optional semantic retrieval, hybrid RRF, and inspectable Research search options |
 | Follow a result to evidence | verifies canonical generation and returns justified segment/word/context/seek coordinates |
+| Play the cited recording | re-verifies the exact transcript generation and source before opening an opaque native audio/video session |
 | Keep durable research | stores notes/tags/collections in authoritative private SQLite anchored to exact evidence |
 | Reuse questions | stores and edits full typed saved-search intent, then re-resolves current evidence |
 | Remember libraries | persists explicit transcript/recording permissions without copying user media |
@@ -39,6 +40,7 @@ You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, o
 - **[Getting started](getting-started.md)** for the source-build path, desktop path, and first transcript.
 - **[Processing Center](architecture/processing-center.md)** for the desktop processing authority split.
 - **[Transcript and speaker tools](transcript-tools.md)** for generation-bound details, speaker management, overlap presentation, and post-hoc publication.
+- **[Verified native playback](native-playback.md)** for source re-verification, opaque media sessions, exact seek coordinates, and the multi-audio fail-closed rule.
 - **[Find things across the whole local library](library-discovery.md)** for grouped Library discovery.
 - **[Research search](research-search.md)** for Match, Search options, saved searches, and the typed backend contract beneath the ordinary UI.
 - **[Your notes should survive the machinery](research-notes.md)** for notes, tags, collections, saved research intent, and anchor maintenance.
@@ -97,7 +99,7 @@ flowchart LR
 
 </details>
 
-Text fallback: canonical evidence feeds rebuildable search; search resolves back to verified evidence; durable notes/tags/collections, speaker labels, and saved searches remain authoritative human knowledge; lifecycle and refresh reuse those identities; the desktop Processing, Library, transcript-tools, and Research surfaces consume the same application authorities.
+Text fallback: canonical evidence feeds rebuildable search; search resolves back to verified evidence; durable notes/tags/collections, speaker labels, and saved searches remain authoritative human knowledge; lifecycle and refresh reuse those identities; the desktop Processing, Library, transcript-tools, playback, and Research surfaces consume the same application authorities.
 
 ## What belongs to you, and what can the raccoon rebuild? 🦝
 
@@ -119,9 +121,9 @@ If deleting a search projection destroys unique human-authored information, some
 
 ## The desktop today
 
-Research/search, the Processing Center, desktop comprehension/themes, and transcript/speaker tools are now coherent first-release slices.
+Research/search, the Processing Center, desktop comprehension/themes, transcript/speaker tools, and verified native playback are now coherent first-release slices.
 
-Research uses ordinary product language by default. Processing presents backend planning/admission rather than duplicating it. Transcript tools pass exact generation identity into Python for details, speaker mutation, and publication. The webview does not parse canonical evidence or receive canonical/source paths.
+Research uses ordinary product language by default. Processing presents backend planning/admission rather than duplicating it. Transcript tools pass exact generation identity into Python for details, speaker mutation, and publication. Playback does the same for source authorization, then Rust owns an opaque opened-file session. The webview does not parse canonical evidence or receive canonical/source paths.
 
 Appearance remains one compact picker. All eight skins share the same semantic text/control/focus contract and the same registry-driven contrast/a11y matrix.
 
@@ -129,13 +131,12 @@ Appearance remains one compact picker. All eight skins share the same semantic t
 
 The next critical path is:
 
-1. Tauri-owned local media playback from verified source-relative coordinates;
-2. lifecycle and retention UI over the existing custody backend;
-3. architecture/redundancy audit before packaging;
-4. packaging, first run, signed updates, and evidence-safe uninstall;
-5. backup/restore and selected research portability;
-6. packaged semantic custody; and
-7. representative-device qualification.
+1. lifecycle and retention UI over the existing custody backend;
+2. architecture/redundancy audit before packaging;
+3. packaging, first run, signed updates, and evidence-safe uninstall;
+4. backup/restore and selected research portability;
+5. packaged semantic custody; and
+6. representative-device qualification.
 
 Only after the first desktop product is coherent do the deliberately separate **[post-MVP research features](post-mvp-roadmap.md)** become normal roadmap work.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ EchoFlow is a **private, local-first workspace for recorded evidence**.
 
 It can inspect a recording, choose a safe way to run on the computer you actually have, transcribe locally, survive interruptions, preserve provenance, search a private corpus, navigate results back to verified canonical evidence, keep research notes attached to that evidence, save reusable research questions, manage generation-bound speaker labels, inspect transcript provenance, publish derived transcript views, and play verified local source evidence through a native desktop shell.
 
-You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, or desktop IPC to use the product. Those are implementation details. The desktop should speak in recordings, transcripts, searches, notes, processing, speakers, playback, and evidence.
+You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, or desktop IPC to use the product. Those are implementation details. The desktop should speak in recordings, transcripts, searches, notes, processing, speakers, playback, and evidence. Persistent in-app guidance explains the unusual concepts at the point of use instead of assuming this documentation is open beside the app.
 
 > **The short version:** your recording stays yours, canonical JSON remains inspectable evidence, your notes/speaker names/saved searches remain your knowledge, and most machinery built around those things can be thrown away and rebuilt.
 
@@ -33,11 +33,13 @@ You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, o
 | Remember libraries | persists explicit transcript/recording permissions without copying user media |
 | Refresh an evolving corpus | incrementally reconciles changed canonical generations and can verify tracked evidence |
 | Remove something safely | plans typed deletion scopes before mutation and binds confirmation to the exact plan |
+| Understand an unfamiliar screen | keeps re-openable, keyboard/touch-accessible contextual help in the app instead of relying on hover-only tips |
 | Change appearance | offers Archive, Midnight, Paper, Moss, Plum, Ember, Pride, and Monochrome through one accessible Theme picker |
 
 ## Pick your doorway
 
 - **[Getting started](getting-started.md)** for the source-build path, desktop path, and first transcript.
+- **[In-app guidance](in-app-guidance.md)** for the persistent help controls and why they describe rather than duplicate backend policy.
 - **[Processing Center](architecture/processing-center.md)** for the desktop processing authority split.
 - **[Transcript and speaker tools](transcript-tools.md)** for generation-bound details, speaker management, overlap presentation, and post-hoc publication.
 - **[Verified native playback](native-playback.md)** for source re-verification, opaque media sessions, exact seek coordinates, and the multi-audio fail-closed rule.
@@ -121,9 +123,11 @@ If deleting a search projection destroys unique human-authored information, some
 
 ## The desktop today
 
-Research/search, the Processing Center, desktop comprehension/themes, transcript/speaker tools, and verified native playback are now coherent first-release slices.
+Research/search, the Processing Center, desktop comprehension/themes, transcript/speaker tools, verified native playback, and re-openable contextual guidance are now coherent first-release slices.
 
 Research uses ordinary product language by default. Processing presents backend planning/admission rather than duplicating it. Transcript tools pass exact generation identity into Python for details, speaker mutation, and publication. Playback does the same for source authorization, then Rust owns an opaque opened-file session. The webview does not parse canonical evidence or receive canonical/source paths.
+
+The sidebar keeps **How this screen works** and **How EchoFlow works** available after first use. Evidence, playback, and transcript tools add local help at the point where their evidence semantics become unusual. The help registry is presentation copy only; it never substitutes for Python application policy.
 
 Appearance remains one compact picker. All eight skins share the same semantic text/control/focus contract and the same registry-driven contrast/a11y matrix.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,8 @@ You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, o
 | Process from the desktop | provides readiness, model state, preflight, supervised start/cancel, progress, resume versus retry, and private-state discard |
 | Survive interruption | checkpoints completed work and validates the original contract on resume |
 | Keep the original intact | treats source media as read-only during normal processing and writes artifacts separately |
-| Handle audio/video | selects one audio stream deterministically and canonicalizes locally |
+| Handle audio/video | selects one audio stream deterministically, requires an explicit user choice when a file contains multiple audio tracks, and canonicalizes the chosen track locally |
+| Understand several embedded tracks | shows bounded source-declared title/language/default metadata, then re-runs backend preflight with the exact selected stream |
 | Clean noisy audio | optionally applies deterministic local suppression with provenance/timeline checks |
 | Work across languages | supports multilingual decoding plus conservative local language attribution |
 | Distinguish speakers | preserves anonymous recording-scoped speaker evidence without claiming identity |
@@ -27,7 +28,7 @@ You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, o
 | Publish useful formats | produces canonical JSON plus rebuildable TXT/SRT/WebVTT, including post-hoc desktop publication |
 | Search a private corpus | supports lexical BM25, optional semantic retrieval, hybrid RRF, and inspectable Research search options |
 | Follow a result to evidence | verifies canonical generation and returns justified segment/word/context/seek coordinates |
-| Play the cited recording | re-verifies the exact transcript generation and source before opening an opaque native audio/video session |
+| Play the cited recording | re-verifies the exact transcript generation and source before opening an opaque native audio/video session; multi-track sources currently refuse playback rather than risk the wrong embedded track |
 | Keep durable research | stores notes/tags/collections in authoritative private SQLite anchored to exact evidence |
 | Reuse questions | stores and edits full typed saved-search intent, then re-resolves current evidence |
 | Remember libraries | persists explicit transcript/recording permissions without copying user media |
@@ -39,6 +40,7 @@ You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, o
 ## Pick your doorway
 
 - **[Getting started](getting-started.md)** for the source-build path, desktop path, and first transcript.
+- **[Audio tracks](audio-tracks.md)** for single-track behavior, explicit multi-track selection, source-declared track labels, canonical stream provenance, and the current playback limitation.
 - **[In-app guidance](in-app-guidance.md)** for the persistent help controls and why they describe rather than duplicate backend policy.
 - **[Processing Center](architecture/processing-center.md)** for the desktop processing authority split.
 - **[Transcript and speaker tools](transcript-tools.md)** for generation-bound details, speaker management, overlap presentation, and post-hoc publication.
@@ -125,9 +127,9 @@ If deleting a search projection destroys unique human-authored information, some
 
 Research/search, the Processing Center, desktop comprehension/themes, transcript/speaker tools, verified native playback, and re-openable contextual guidance are now coherent first-release slices.
 
-Research uses ordinary product language by default. Processing presents backend planning/admission rather than duplicating it. Transcript tools pass exact generation identity into Python for details, speaker mutation, and publication. Playback does the same for source authorization, then Rust owns an opaque opened-file session. The webview does not parse canonical evidence or receive canonical/source paths.
+Research uses ordinary product language by default. Processing presents backend planning/admission rather than duplicating it. If a source contains several embedded audio tracks, Python tells the desktop that explicit selection is required; React presents bounded track facts and submits the chosen stream index, then Python replans before Start is enabled. Transcript tools pass exact generation identity into Python for details, speaker mutation, and publication. Playback does the same for source authorization, then Rust owns an opaque opened-file session. The webview does not parse canonical evidence or receive canonical/source paths.
 
-The sidebar keeps **How this screen works** and **How EchoFlow works** available after first use. Evidence, playback, and transcript tools add local help at the point where their evidence semantics become unusual. The help registry is presentation copy only; it never substitutes for Python application policy.
+The sidebar keeps **How this screen works** and **How EchoFlow works** available after first use. Evidence, playback, transcript tools, and multi-track preflight add local explanation at the point where their evidence semantics become unusual. The help registry and inline copy are presentation only; they never substitute for Python application policy.
 
 Appearance remains one compact picker. All eight skins share the same semantic text/control/focus contract and the same registry-driven contrast/a11y matrix.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -14,7 +14,7 @@ If you are trying to transcribe a file rather than maintain the system, use
 EchoFlow is composed from narrow local capabilities in
 `src/echoflow/app/app_container.py`. The through-line is custody: source evidence,
 canonical transcript truth, private execution state, rebuildable projections, durable human
-knowledge, native process lifetime, and desktop presentation deliberately do not share
+knowledge, native process/media lifetime, and desktop presentation deliberately do not share
 authority semantics.
 
 ```mermaid
@@ -74,16 +74,20 @@ flowchart LR
 
 Text fallback: canonical JSON is evidence; DuckDB ranks rebuildable views; canonical
 navigation verifies evidence; SQLite owns human research; `ResearchWorkspaceService`
-composes research interactions; `ProcessingCenterService` composes machine/model/job and
-preflight authority; the versioned desktop bridge feeds current Library, Research, and
-Processing presentation; `LibraryCustodyService` keeps destructive policy separate.
+composes research interactions; `ProcessingCenterService` composes machine/model/job,
+preflight, and explicit embedded-track confirmation authority; the versioned desktop bridge
+feeds current Library, Research, and Processing presentation; `LibraryCustodyService` keeps
+destructive policy separate. Verified playback adds a separate private Python-to-Rust
+authorization path without widening the general bridge.
 
 ## Where to look
 
 | Page | What question it answers |
 |---|---|
 | [Processing capabilities](processing-capabilities.md) | How does the local transcription/research system fit together? |
-| [Processing Center](processing-center.md) | How does the desktop expose readiness, preflight, jobs, and long-running native work without becoming the scheduler? |
+| [Processing Center](processing-center.md) | How does the desktop expose readiness, preflight, embedded-track choice, jobs, and long-running native work without becoming the scheduler? |
+| [Audio tracks](../audio-tracks.md) | How does EchoFlow choose among several embedded audio streams without guessing or confusing transcription with playback? |
+| [Verified native playback](../native-playback.md) | How does exact-generation evidence become a local media capability without exposing paths to React? |
 | [Adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) | How does EchoFlow decide what this machine can safely run? |
 | [Media and timeline](media-and-timeline.md) | Which source/stream did we use, and what do timestamps mean? |
 | [Word-level timestamp alignment](word-alignment.md) | How do engine timings become source-relative evidence? |
@@ -107,16 +111,16 @@ Processing presentation; `LibraryCustodyService` keeps destructive policy separa
 | `app` | Dependency-injection composition root and application-facing processing composition |
 | `core` | Configuration, errors, observability, health, measurements |
 | `interfaces` | Local filesystem/storage adapters and private-storage policy |
-| `media` | Read-only source inspection and deterministic audio-stream selection |
+| `media` | Read-only source inspection, bounded embedded-track display metadata, and deterministic audio-stream selection |
 | `runner` | Process-visible CPU/memory inspection and execution-budget policy |
 | `model_management` | Model inventory, acquisition, verification, provenance, removal |
 | `transcription` | Planning, normalization, enhancement, segmentation, ASR, checkpoints, language, alignment, diarization, assembly, exports |
 | `workspace` | Private job paths and public artifact allocation |
 | `benchmarking` | Privacy-minimized local execution measurement |
-| `library` | Retrieval, evidence navigation, research authority/projections, saved searches, discovery, refresh, locations, typed custody policy |
-| `desktop` | Versioned allowlisted Python bridge for Library/Research/Processing presentation adapters |
-| `frontend` | React/TypeScript presentation over typed desktop operations; no direct DB/filesystem authority |
-| `src-tauri` | Thin native host/capability boundary for dialogs, allowlisted long-running child processes, and later local media capability |
+| `library` | Retrieval, evidence navigation, playback authorization, research authority/projections, saved searches, discovery, refresh, locations, typed custody policy |
+| `desktop` | Versioned allowlisted Python bridges for Library/Research/Processing/transcript tools plus a private fixed playback authorization bridge |
+| `frontend` | React/TypeScript presentation over typed desktop operations; no direct DB/filesystem/media-probe authority |
+| `src-tauri` | Thin native host/capability boundary for dialogs, allowlisted long-running child processes, opened playback sessions, and bounded local media transport |
 
 ## Capability boundaries
 
@@ -134,10 +138,12 @@ The search/research/custody/processing/desktop area deliberately separates respo
 8. `ResearchWorkspaceService` composes those capabilities for CLI and presentation adapters.
 9. `LibraryLocationService` owns remembered directory permissions and cheap recording discovery without becoming a media processor.
 10. `LibraryCustodyService` owns typed deletion planning/execution and age-based private execution-state retention.
-11. `ProcessingCenterService` composes health/resource/model/job/preflight authority for the desktop without reimplementing those policies.
-12. `echoflow.desktop.bridge` exposes an allowlisted versioned IPC surface. Current Library/Research/Processing DTOs retain necessary identity without leaking general filesystem authority to React.
-13. Tauri supervises allowlisted long-running native child processes. It owns process lifetime, not strategy selection, model validity, or transcript correctness.
-14. React owns interaction and presentation only. It does not issue SQL, mutate DuckDB/SQLite directly, select canonical generations, or decide resource/custody policy.
+11. `ProcessingCenterService` composes health/resource/model/job/preflight authority, including whether multi-track preflight requires explicit user confirmation, without reimplementing lower-level media policy.
+12. `PlaybackAuthorizationService` verifies exact canonical generation, current source bytes, coordinate bounds, and stream identity before native media can open.
+13. `echoflow.desktop.bridge` exposes an allowlisted versioned IPC surface. Current Library/Research/Processing DTOs retain necessary identity without leaking general filesystem authority to React.
+14. The playback bridge is private to the fixed Rust host and is not a webview-callable Tauri command.
+15. Tauri supervises allowlisted long-running native child processes and owns opaque opened playback sessions. It owns process/file lifetime, not strategy selection, stream selection, model validity, or transcript correctness.
+16. React owns interaction and presentation only. It does not issue SQL, mutate DuckDB/SQLite directly, select canonical generations, inspect media, choose a preferred audio track by policy, or decide resource/custody policy.
 
 That split must survive future UI convenience work. Presentation convenience is not
 permission to merge custody boundaries.
@@ -167,34 +173,41 @@ research relationships.
 
 ## Desktop presentation does not rename authority
 
-The desktop now intentionally translates internal vocabulary into ordinary product
-language. For example, Research presents one **Match** choice while the backend keeps
-separate phrase/operator properties, and it calls lexical/semantic/hybrid **Wording / Meaning
-/ Wording + meaning**.
+The desktop intentionally translates internal vocabulary into ordinary product language.
+For example, Research presents one **Match** choice while the backend keeps separate
+phrase/operator properties, and it calls lexical/semantic/hybrid **Wording / Meaning /
+Wording + meaning**.
 
 That translation is presentation only. Python still validates/canonicalizes the typed
 request, derives research evidence scope, chooses retrieval behavior, and verifies evidence.
-Similarly, the six UI skins share semantic CSS tokens; theme selection cannot alter backend
-requests, evidence identity, or research state.
+Similarly, all eight UI skins share semantic CSS tokens; theme selection cannot alter
+backend requests, evidence identity, or research state.
+
+Embedded-track presentation follows the same rule. Python decides whether explicit stream
+confirmation is required and validates the requested stream. React can display bounded
+source-declared title/language/default metadata and collect a radio-button choice, but it
+cannot turn those labels into a recommendation or skip backend re-preflight.
 
 ## The custody rules 🦝
 
 1. **Original media is source evidence and read-only during normal processing.** Explicit source deletion is separate and provenance-checked.
 2. **Canonical transcript JSON is authoritative transcript evidence.**
-3. **Managed model manifests describe verified local execution dependencies.**
-4. **Lexical, semantic, and research DuckDB databases are rebuildable projections.**
-5. **Speaker labels, notes, tags, collections, and saved searches are human-authored authority and do not inherit index deletion semantics.**
-6. **Research joins include canonical generation identity, not a friendly segment ID alone.**
-7. **Precise navigation resolves to verified canonical evidence rather than trusting a stale search projection.**
-8. **Research filters apply before ranking/scoring when they define eligible evidence.**
-9. **Saved searches persist typed query intent, not a frozen derived evidence scope.**
-10. **Canonical deletion preserves attached notes and document-scoped saved searches unless their own destructive scopes are explicitly selected.**
-11. **Age-based retention can delete only private job workspaces.**
-12. **Remembered locations are permissions/pointers, not copies of user media.**
-13. **The desktop webview receives typed presentation DTOs, not arbitrary filesystem paths or database handles.**
-14. **Long-running native process supervision does not create a second job or checkpoint authority.**
-15. **Theme/presentation state is machine-local preference, not evidence or research state.**
-16. **EchoFlow does not claim secure erasure it cannot prove.**
+3. **The exact selected embedded audio-stream index is part of transcription provenance. Source-declared track labels are descriptive clues, not identity.**
+4. **Managed model manifests describe verified local execution dependencies.**
+5. **Lexical, semantic, and research DuckDB databases are rebuildable projections.**
+6. **Speaker labels, notes, tags, collections, and saved searches are human-authored authority and do not inherit index deletion semantics.**
+7. **Research joins include canonical generation identity, not a friendly segment ID alone.**
+8. **Precise navigation resolves to verified canonical evidence rather than trusting a stale search projection.**
+9. **Research filters apply before ranking/scoring when they define eligible evidence.**
+10. **Saved searches persist typed query intent, not a frozen derived evidence scope.**
+11. **Canonical deletion preserves attached notes and document-scoped saved searches unless their own destructive scopes are explicitly selected.**
+12. **Age-based retention can delete only private job workspaces.**
+13. **Remembered locations are permissions/pointers, not copies of user media.**
+14. **The desktop webview receives typed presentation DTOs and opaque playback handles, not arbitrary filesystem paths or database handles.**
+15. **Long-running native process supervision does not create a second job or checkpoint authority.**
+16. **Verified playback authorization does not turn an opaque media session into source/evidence authority.**
+17. **Theme/presentation state is machine-local preference, not evidence or research state.**
+18. **EchoFlow does not claim secure erasure it cannot prove.**
 
 Search infrastructure may disappear. User-authored knowledge may not disappear by accident.
 
@@ -206,7 +219,15 @@ verified context/word coordinates, durable Research mutation, saved search/ancho
 full Research search controls through narrow bridge methods.
 
 Processing composes through `ProcessingCenterService`; Tauri owns only the native lifetime
-of allowlisted long-running tasks. Resume/retry semantics remain Python application policy.
+of allowlisted long-running tasks. Multi-track confirmation is returned by Python preflight,
+and a user choice is rebound through Python before execution. Resume/retry semantics remain
+Python application policy.
+
+Verified playback composes through `PlaybackAuthorizationService` plus the private fixed
+playback bridge. Rust opens the approved file, retains it behind an opaque active session,
+and serves bounded byte ranges through `echoflow-media`. React does not receive the path.
+Multi-track playback deliberately fails closed until the native layer can prove the rendered
+embedded stream.
 
 Incremental corpus growth composes through `TranscriptLibraryService.refresh(...)` and
 remembered roots through `LibraryLocationService`. Full `library rebuild` is an explicit
@@ -223,10 +244,9 @@ echoflow library retention --execution-days 30
 Deletion and retention are dry-run by default. Applying a reviewed operation requires the
 plan-bound token returned by the dry run.
 
-The next native seam is local media playback. It should consume the already verified
-source-relative cursor behind a Tauri-owned media capability without giving React arbitrary
-path authority. Lifecycle/retention UI comes after playback over the existing custody
-service rather than creating a second deletion policy.
+The next product seam is lifecycle/retention UI over the existing custody service rather
+than creating a second deletion policy. After that, the architecture/redundancy audit should
+clean seams before packaging freezes them.
 
 ## New abstraction test
 
@@ -236,8 +256,8 @@ or database wrapper, ask which concrete capability or invariant it protects.
 File count is not an architectural problem. Repeated policy, unclear ownership, and
 unprovable invariants are.
 
-The same applies to frontend styling: six skins do not justify six component palettes. One
-semantic role should have one meaning and six token values.
+The same applies to frontend styling: eight skins do not justify eight component palettes.
+One semantic role should have one meaning and eight token values.
 
 ## Documentation contract
 

--- a/docs/architecture/media-and-timeline.md
+++ b/docs/architecture/media-and-timeline.md
@@ -1,9 +1,10 @@
 # Media normalization and transcript timeline 🎙️🕰️
 
 Status: canonical media timeline, word timing, verified seek coordinates, durable evidence
-anchors, and desktop evidence-cursor presentation are implemented. Local audio/video
-playback is not yet implemented.  
-Last updated: August 19, 2026
+anchors, explicit embedded-audio-track selection, desktop evidence-cursor presentation, and
+verified native playback are implemented. Multi-track playback remains deliberately
+fail-closed until the native layer can prove the rendered track.  
+Last updated: August 21, 2026
 
 EchoFlow has to answer three deceptively simple questions before recorded evidence is
 useful:
@@ -22,7 +23,8 @@ source-declared provenance when FFprobe reports them.
 Nothing rewrites the meaning of the canonical elapsed coordinate.
 
 For the plain-language guide, see
-**[Transcript time without calculator gymnastics](../time-navigation.md)**.
+**[Transcript time without calculator gymnastics](../time-navigation.md)**. For embedded
+track behavior, see **[Audio tracks](../audio-tracks.md)**.
 
 ## The human version
 
@@ -37,8 +39,8 @@ The human presentation is:
 ```
 
 That timeline survives normalization, segmentation, checkpoints, enhancement, word
-alignment, assembly, search navigation, desktop evidence-cursor movement, and durable note
-anchoring.
+alignment, assembly, search navigation, desktop evidence-cursor movement, verified
+playback, and durable note anchoring.
 
 A file may also declare something like:
 
@@ -80,8 +82,7 @@ flowchart LR
 
 Text fallback: FFprobe/source identity produces canonical elapsed time plus preserved
 source-declared clocks; canonical word/segment evidence drives transcript JSON, human
-clock display, verified seek coordinates, durable anchors, and the current desktop
-evidence cursor.
+clock display, verified seek coordinates, durable anchors, and the desktop evidence cursor.
 
 ## One input boundary for audio and video
 
@@ -100,13 +101,21 @@ normalized WAV derivative.
 ## What media inspection owns
 
 `FfprobeMediaProbe` performs read-only inspection. It does not transcode, install models,
-choose enhancement, or choose a transcription strategy.
+choose enhancement, choose an audio stream on behalf of a person, or choose a
+transcription strategy.
 
 For one local source it snapshots filesystem identity, invokes FFprobe with a file-only
 protocol whitelist, reads bounded container/stream metadata, requests format/stream
 `timecode` and `creation_time`, validates that audio exists, fingerprints the complete
 source with SHA-256, snapshots identity again, and refuses the input if the source changed
 during inspection.
+
+The primary probe contract remains stable for ordinary recordings. If that first bounded
+query discovers more than one audio stream, EchoFlow makes one additional bounded,
+file-only metadata query for stream index, title, language, and default disposition so a
+person has better clues when choosing among embedded tracks. Title and language are length
+bounded. Those declarations are presentation metadata, not a recommendation and not a new
+source-identity claim.
 
 The result is immutable `MediaInfo` evidence. Routine logs omit local paths by default
 because recording names and directory layouts may themselves be sensitive.
@@ -129,14 +138,28 @@ declarations, not trusted wall-clock facts.
 
 `AudioStreamSelector` chooses exactly one discovered audio stream.
 
-Without an override, the first audio stream is selected. With:
+At the low-level planning boundary, no override means the first audio stream is the
+deterministic probe default. That default is useful for reproducible planning, but the
+desktop does **not** treat it as user intent when a source contains several audio streams.
+
+Processing Center preflight marks a multi-track source as requiring explicit confirmation,
+shows the available tracks with bounded source-declared metadata, and keeps Start disabled.
+When the user chooses a track, React sends only that integer index back to Python and Python
+re-runs preflight with the exact stream bound into the plan.
+
+The CLI has the same explicit primitive:
 
 ```bash
 uv run echoflow transcribe meeting.mp4 --audio-stream 2
 ```
 
 EchoFlow validates that stream index `2` is audio and records that choice in the job/source
-contract. Resume restores the same selected stream.
+contract. An unavailable index fails instead of silently falling back. Resume restores the
+same selected stream.
+
+This is support for several **embedded streams inside one source file**. Several separate
+recording files that need synchronization, drift correction, and a composite evidence model
+are not this feature.
 
 ## Canonical working audio
 
@@ -204,6 +227,10 @@ source fingerprint/media identity, selected audio stream, source-declared tempor
 decode strategy, managed model revision/execution target, optional enhancement provenance,
 language/speaker evidence, and source-relative segment/word timestamps.
 
+The exact audio-stream index is evidence because it answers which embedded stream entered
+ASR. Track title, language, and default disposition are source-declared display clues and
+are not promoted into cryptographic identity.
+
 Temporal tags deliberately do **not** replace source identity. Source identity remains the
 cryptographic/file/media contract.
 
@@ -216,10 +243,10 @@ Container/device metadata may also be missing, stale, copied, or contradictory.
 EchoFlow preserves source declarations but **does not invent a mapping from canonical
 seconds to SMPTE frames** without qualified frame semantics.
 
-That limitation does not block ordinary source-relative navigation. The desktop already
-moves an evidence cursor to verified canonical word coordinates. Future media playback can
-seek the original recording to the same `seek_seconds` once a Tauri-owned playback
-capability exists.
+That limitation does not block ordinary source-relative navigation or verified playback.
+The desktop moves an evidence cursor to verified canonical word coordinates, and the native
+playback capability consumes the same `seek_seconds` after Python verifies the exact
+canonical generation and current source bytes.
 
 ## Word timing, evidence cursor, playback, and durable notes share one axis
 
@@ -232,7 +259,7 @@ These features solve different jobs but share one coordinate system:
 **Evidence cursor** answers: which verified canonical coordinate is the desktop reader
 currently pointing at?
 
-**Playback seek** answers: where should a local player jump?
+**Playback seek** answers: where should a verified local player jump?
 
 **EvidenceAnchor** answers: which exact canonical evidence does this user note refer to?
 
@@ -243,7 +270,7 @@ flowchart TD
     A --> D[EvidenceAnchor]
     D --> E[SQLite durable note]
     C --> F[Desktop evidence cursor]
-    F --> G[Future Tauri media playback]
+    F --> G[Verified native playback]
 
     classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
     classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
@@ -259,8 +286,24 @@ flowchart TD
 ```
 
 Text fallback: one canonical elapsed coordinate drives display, verified seek, durable
-research anchors, and the current desktop evidence cursor; native playback remains the
-next capability rather than a new timeline.
+research anchors, the desktop evidence cursor, and generation/source-verified native
+playback.
+
+## Why multi-track transcription and playback have different support levels
+
+Transcription owns extraction. FFmpeg receives the exact selected stream index and emits a
+private canonical working-audio representation, so EchoFlow can prove which embedded track
+entered ASR.
+
+Native playback currently gives the original container to the operating-system WebView
+media engine. EchoFlow does not yet have a portable guarantee that every supported WebView
+will render the same audio stream recorded in canonical provenance. Playing a different
+track beside the transcript would be an evidence error.
+
+Therefore multi-track **transcription** is explicit and supported, while multi-track
+**verified playback** fails closed. The playback restriction can only be relaxed after the
+native media layer can make track choice explicit and verifiable. See
+**[Verified native playback](../native-playback.md)**.
 
 ## Why the stages remain separate
 
@@ -283,8 +326,11 @@ Evidence anchoring answers **where does durable user-authored knowledge attach?*
 Desktop evidence-cursor presentation answers **which verified coordinate is the reader
 showing now?**
 
+Verified playback answers **can this exact canonical generation safely open these exact
+source bytes at this coordinate?**
+
 Keeping these responsibilities separate makes metadata discovery side-effect free, keeps
-source authority explicit, and lets search, notes, exports, desktop navigation, and future
+source authority explicit, and lets search, notes, exports, desktop navigation, and
 playback reuse the same evidence instead of inventing parallel timelines.
 
 🧜‍♀️ Multiple clocks. One transcript. No temporal soup.

--- a/docs/architecture/processing-center.md
+++ b/docs/architecture/processing-center.md
@@ -13,6 +13,7 @@ Python remains authoritative for:
 - strategy feasibility and recommendation;
 - model inventory, verification, installation provenance, and removal safety;
 - media probing and audio-stream selection;
+- whether a multi-track recording requires explicit stream confirmation;
 - transcription preflight and resource admission;
 - checkpoint compatibility and resume contracts;
 - transcription execution correctness;
@@ -34,7 +35,7 @@ Tauri therefore supervises a small allowlist of long-running task kinds:
 - model installation;
 - model removal.
 
-The native host does not decide which strategy is safe or whether a model is valid. It receives already-shaped intent, starts only allowlisted Python worker commands, owns the child handle, exposes status/cancel, rejects duplicate task identities, and terminates supervised children during desktop shutdown.
+The native host does not decide which strategy is safe, which audio stream should be used, or whether a model is valid. It receives already-shaped intent, starts only allowlisted Python worker commands, owns the child handle, exposes status/cancel, rejects duplicate task identities, and terminates supervised children during desktop shutdown.
 
 A cancelled or externally terminated transcription is recovered through Python's durable lifecycle/checkpoint rules. Tauri does not maintain a competing job database.
 
@@ -46,7 +47,11 @@ The normal Processing Center UI leads with outcome-oriented profiles:
 - **Balanced** for the ordinary default;
 - **Best locally safe** for the highest-quality feasible local strategy.
 
-Ordinary users are not required to choose Whisper model sizes, thread counts, compute types, or memory limits. Expert strategy/audio controls remain explicit advanced options and are still revalidated by Python before execution.
+Ordinary users are not required to choose Whisper model sizes, thread counts, compute types, or memory limits. Expert strategy controls remain explicit advanced options and are revalidated by Python before execution.
+
+Audio-track selection is different because it can change **which evidence is transcribed**. A single-track source needs no user decision. When Python reports more than one embedded audio stream and no stream was explicitly requested, the preflight DTO sets `audio_stream_selection_required=true`. React then presents the bounded stream facts returned by Python and keeps Start disabled. Selecting a track sends its exact integer stream index back through the existing typed preflight call; Python replans against that stream before the UI treats the choice as confirmed.
+
+React does not score or recommend tracks. Source-declared title, language, and container-default disposition are displayed as clues only. They are bounded by the backend and remain untrusted descriptive metadata. Codec, sample rate, and channel count are also presentation facts, not selection policy.
 
 Model acquisition is never silently inferred from selecting a profile. The UI shows the recommended model and whether a verified EchoFlow-managed snapshot is already installed. Installing or removing a model is an explicit long-running action.
 
@@ -57,29 +62,47 @@ Optional diarization keeps its network-consent boundary separate from transcript
 1. User selects a recording and processing intent.
 2. React asks Python for preflight.
 3. Python probes the recording, inspects current resources, assesses strategies, verifies managed model custody, and returns a minimized preflight DTO.
-4. The user reviews the resulting profile/strategy/resource plan.
-5. React asks Tauri to start an allowlisted transcription worker for the exact preflight job identity.
-6. Python owns lifecycle state and checkpoints while the native host owns child-process lifetime.
-7. The Processing Center polls bounded task status and durable job lifecycle state.
-8. Successful execution publishes canonical transcript evidence and any explicitly requested derived exports.
+4. If the source has several embedded audio streams and no explicit stream was requested, Python marks stream confirmation as required. The desktop presents the available tracks but does not treat the probe default as user intent.
+5. The user chooses one track. React submits only that stream index and Python re-runs preflight with the exact selection bound into the plan.
+6. The user reviews the resulting profile/strategy/resource plan.
+7. React asks Tauri to start an allowlisted transcription worker for the exact preflight job identity and selected stream.
+8. Python owns lifecycle state and checkpoints while the native host owns child-process lifetime.
+9. The Processing Center polls bounded task status and durable job lifecycle state.
+10. Successful execution publishes canonical transcript evidence and any explicitly requested derived exports.
 
 Private source/output/model-cache paths are not part of the general Processing Center overview DTOs. Path-bearing execution intent is kept to the narrow operation that actually needs it.
+
+The selected stream index is not merely presentation state. Planning validates it, FFmpeg maps exactly that stream during normalization, canonical source provenance records it, and checkpoint resume restores it.
+
+## Multi-track metadata inspection
+
+EchoFlow preserves the original hardened FFprobe query for normal media inspection. If that first query discovers more than one audio stream, the probe performs one additional bounded metadata-only query under the same file-only protocol whitelist and output-size limit.
+
+That extra query asks only for stream index, title, language, and default disposition. Title and language are length-bounded before they can enter `MediaStream`. The metadata helps a user identify a track but is not added to cryptographic source identity and is not trusted as an EchoFlow recommendation.
+
+This feature covers **multiple embedded audio streams inside one file**. It does not synchronize several separate source files. See **[Audio tracks](../audio-tracks.md)** for the product distinction.
 
 ## Resume, retry, cancel, and discard
 
 These operations are deliberately distinct:
 
 - **Resume** restores the interrupted job's checkpointed execution contract and re-admits it against current hardware. It does not silently change profile, strategy, audio stream, or enhancement settings.
-- **Retry** creates a new plan from the source recording. It is allowed to use current defaults or newly selected expert options.
+- **Retry** creates a new plan from the source recording. It is allowed to use current defaults or a newly selected track/strategy.
 - **Cancel** terminates the supervised child. Valid checkpoints remain subject to the normal resumability rules.
 - **Discard private job state** removes disposable lifecycle/checkpoint state only. It never deletes original recordings, published canonical transcript evidence, or human research state. The request is bound to the job's current `updated_at` value so stale UI state cannot delete a newer lifecycle generation.
 
 A job reported as `running` whose recorded process identity is no longer active is reconciled by the Python lifecycle store to `interrupted`. This makes recovery durable across application restarts without treating native in-memory task state as authoritative.
 
+## Playback is a separate guarantee
+
+Explicit multi-track transcription does not imply that verified native playback may choose among embedded tracks. Transcription owns FFmpeg extraction and can prove which stream entered ASR. Current WebView playback of the original container does not provide EchoFlow a portable guarantee that the canonical stream will be the rendered stream.
+
+For that reason multi-track transcription is supported while multi-track verified playback still fails closed. See **[Verified native playback](../native-playback.md)**.
+
 ## Failure and privacy semantics
 
 Processing Center errors crossing into the desktop are public, bounded messages. Backend exceptions, raw provider errors, and private filesystem detail are not rendered directly into the UI.
 
-Readiness and job overview responses expose only what is necessary to explain local execution state, such as platform, effective CPU count, available-memory budget, profile, model identity, progress, resumability, and safe failure categories.
+Readiness and job overview responses expose only what is necessary to explain local execution state, such as platform, effective CPU count, available-memory budget, profile, model identity, progress, resumability, and safe failure categories. Multi-track preflight adds bounded stream identity/display fields but no filesystem paths.
 
 The design preserves EchoFlow's central custody rule: recordings, canonical transcript evidence, and human research remain authoritative user-owned material; execution indexes, checkpoints, derived exports, and native task handles are supporting machinery and may be rebuilt or discarded according to their contracts.

--- a/docs/audio-tracks.md
+++ b/docs/audio-tracks.md
@@ -1,0 +1,77 @@
+# Audio tracks
+
+A recording file can contain more than one embedded audio track. A video might carry a camera microphone and a clean lavalier feed; an archive file might contain several language tracks; a recorder may preserve a mix and isolated channels as separate streams.
+
+EchoFlow treats **one file with multiple embedded audio streams** as one source recording with an explicit transcription-track choice. This is different from giving EchoFlow several separate files and asking it to synchronize them.
+
+## Single-track recordings
+
+If FFprobe finds exactly one audio stream, EchoFlow uses that stream. There is nothing useful for the user to choose.
+
+The selected stream index is still recorded in the transcription source contract so canonical evidence can explain exactly which audio produced the transcript.
+
+## Multi-track recordings in the desktop
+
+When preflight finds more than one audio stream, Processing Center does not treat the first stream as user intent.
+
+Instead it:
+
+1. presents the available audio tracks in the ordinary preflight surface;
+2. shows bounded source-declared track metadata when available, including title, language, codec, channel count, sample rate, and whether the container marked a stream as default;
+3. requires the user to choose one track explicitly;
+4. sends only that stream index back to Python;
+5. re-runs backend preflight with the exact selected index; and
+6. enables **Start local transcription** only after the backend returns a plan bound to that stream.
+
+The chooser is not an audio-quality classifier. A label such as `Lav microphone`, `eng`, or `container default` came from the source container. EchoFlow shows that information to help a person recognize the track, but it does not claim the label is accurate or recommend a stream because of it.
+
+Track title and language are bounded before they can enter the desktop DTO. They are display metadata, not filesystem authority, and they are not added to canonical source identity.
+
+## Command line selection
+
+The CLI already accepts an exact FFmpeg stream index:
+
+```bash
+uv run echoflow transcribe meeting.mkv --audio-stream 3 --dry-run
+uv run echoflow transcribe meeting.mkv --audio-stream 3
+```
+
+EchoFlow validates that the requested index exists and is an audio stream. An unavailable or non-audio index fails instead of falling back to another track.
+
+Use the dry-run plan to inspect the selected stream and other processing decisions before starting work.
+
+## What is preserved as evidence
+
+Canonical transcript source provenance records the exact `audio_stream_index` used for transcription. The stream index is part of the source/execution contract because it answers the evidentiary question: **which audio inside these source bytes produced this transcript?**
+
+The source file SHA-256 and size still identify the recording bytes. Track title, language, and default-disposition metadata are descriptive source declarations and therefore do not replace or strengthen that cryptographic identity.
+
+A checkpoint resume restores the original selected stream. It does not re-run current defaults or silently move to another track.
+
+A fresh retry is different: it creates a new plan and may choose another track explicitly.
+
+## Why multi-track transcription works while multi-track playback still refuses
+
+These are different guarantees.
+
+During transcription EchoFlow owns extraction. FFmpeg receives an explicit mapping for the selected stream and drops unrelated video, subtitle, data, and other audio streams from the canonical working-audio path. EchoFlow can therefore prove which track entered ASR.
+
+Verified native playback currently hands the original container to the operating-system WebView media engine. EchoFlow does not yet have a portable native guarantee that every platform will render the same embedded audio stream recorded in canonical provenance.
+
+Playing track 1 while displaying a transcript produced from track 3 would be an evidence error. For that reason verified playback currently refuses sources with multiple audio streams instead of guessing. See **[Verified native playback](native-playback.md)**.
+
+A future relaxation must make native playback track selection explicit and verifiable. The desktop transcription chooser does not weaken that requirement.
+
+## What this does not support
+
+EchoFlow does **not** currently treat several separate files as synchronized tracks of one evidence object, for example:
+
+```text
+camera.wav
+lav.wav
+interpreter.wav
+```
+
+That would require a different evidence model covering source identity for every file, alignment offsets, clock drift, missing spans, resampling, and how one transcript cites several originals. It should be designed explicitly rather than hidden inside the embedded-stream feature.
+
+For the underlying media/timeline model, see **[Media normalization and transcript timeline](architecture/media-and-timeline.md)**. For Processing Center ownership, see **[Processing Center](architecture/processing-center.md)**.

--- a/docs/development/desktop-accessibility.md
+++ b/docs/development/desktop-accessibility.md
@@ -59,13 +59,32 @@ Inputs, selects, textareas, checkboxes, radios, options, placeholders, disabled 
 
 The verified playback surface also deliberately uses native `<audio>`/`<video>` controls rather than rebuilding transport widgets in React. Playback never autoplays after verification. The separate **Prepare playback** and **Play from evidence cursor** actions remain ordinary keyboard-reachable buttons, status/error messages use semantic roles, and surrounding presentation honors `prefers-reduced-motion`.
 
-Do not fix contrast with a component-local `#666`, `#fff`, or platform gray. Fix the semantic role. The same repair should work in Intake, Processing, Library, Research, transcript tools, and playback.
+Do not fix contrast with a component-local `#666`, `#fff`, or platform gray. Fix the semantic role. The same repair should work in Intake, Processing, Library, Research, transcript tools, playback, and in-app help.
 
 Browser automation cannot fully prove how opened native menus or media controls are painted by every Windows/macOS/Linux stack. Representative-device qualification still includes opened controls, media transport, forced/high-contrast modes, scaling, keyboard traversal, and platform focus treatment.
 
+## Help must work without hover
+
+EchoFlow's in-app guidance is progressive disclosure, not a collection of mouse-only tooltips.
+
+The reusable `InfoPopover` contract requires:
+
+- an ordinary focusable button with a visible text label;
+- programmatic expanded state through `aria-expanded` and `aria-controls`;
+- pointer, touch, and keyboard activation;
+- **Escape** to close an open panel;
+- focus restoration to the trigger after Escape or the explicit close action;
+- an explicit close control inside the panel;
+- semantic-token styling rather than theme-specific colors; and
+- a narrow-screen layout that remains reachable without hover.
+
+Sidebar help stays available after first use, while Evidence reader, Playback, and Transcript tools add local explanations at the point of use. A user should never have to remember what a one-time onboarding tour said three months ago.
+
+Help copy is also subject to the architecture boundary: it may describe a backend rule, but it may not recreate or enforce that rule in React. See **[In-app guidance](../in-app-guidance.md)**.
+
 ## Color cannot be the only signal
 
-Status, errors, selection, processing readiness, current/older evidence, speaker overlap, playback verification/failure, disabled actions, and destructive scope all require text or semantic structure in addition to color. The transcript-tools overlap view, for example, says **Overlap** and lists both evidence refs; border treatment is secondary decoration. Playback similarly reports missing, changed, ambiguous-track, and decoder states in text rather than relying on media-control appearance.
+Status, errors, selection, processing readiness, current/older evidence, speaker overlap, playback verification/failure, help expanded state, disabled actions, and destructive scope all require text or semantic structure in addition to color. The transcript-tools overlap view, for example, says **Overlap** and lists both evidence refs; border treatment is secondary decoration. Playback similarly reports missing, changed, ambiguous-track, and decoder states in text rather than relying on media-control appearance.
 
 ## Adding a skin
 
@@ -76,7 +95,7 @@ A new skin is acceptable only when it:
 3. declares an explicit light or dark `color-scheme`;
 4. passes the shared contrast matrix and axe checks;
 5. does not add component-specific palette overrides;
-6. remains legible for focused, selected, disabled, error, and native-control states; and
+6. remains legible for focused, selected, disabled, error, help, and native-control states; and
 7. does not use color as the only carrier of product meaning.
 
 This is intentionally more restrictive than “the screenshot looks good.” Unreadable UI should be difficult to commit.

--- a/docs/development/desktop-accessibility.md
+++ b/docs/development/desktop-accessibility.md
@@ -1,6 +1,6 @@
 # Desktop themes and accessibility
 
-EchoFlow themes are presentation, not application state. A skin may change color and visual tone; it may not change evidence, research, processing behavior, or what an interaction means.
+EchoFlow themes are presentation, not application state. A skin may change color and visual tone; it may not change evidence, research, processing, playback authorization, or what an interaction means.
 
 ## One semantic token contract
 
@@ -35,7 +35,7 @@ EchoFlow ships eight skins through one compact **Theme** picker:
 - **Pride**: a high-contrast plum/paper interface with a decorative rainbow edge; and
 - **Monochrome**: deliberately grayscale near-black surfaces with white interaction emphasis.
 
-Pride's rainbow is decoration only. Status, selection, errors, readiness, speaker overlap, and destructive actions remain understandable without it. Monochrome is not merely another blue-black dark theme: all semantic color tokens are grayscale, which is separately asserted in browser tests.
+Pride's rainbow is decoration only. Status, selection, errors, readiness, speaker overlap, playback state, and destructive actions remain understandable without it. Monochrome is not merely another blue-black dark theme: all semantic color tokens are grayscale, which is separately asserted in browser tests.
 
 Theme choice is browser-local presentation preference. Failure to read or write it falls back to Archive and must never block the evidence workspace.
 
@@ -57,13 +57,15 @@ Do not tune a palette to a screenshot and then add exceptions until it passes. I
 
 Inputs, selects, textareas, checkboxes, radios, options, placeholders, disabled states, selection, and focus are normalized centrally. Every theme declares `color-scheme`, so browser/OS controls receive the correct native light/dark context.
 
-Do not fix contrast with a component-local `#666`, `#fff`, or platform gray. Fix the semantic role. The same repair should work in Intake, Processing, Library, Research, and transcript tools.
+The verified playback surface also deliberately uses native `<audio>`/`<video>` controls rather than rebuilding transport widgets in React. Playback never autoplays after verification. The separate **Prepare playback** and **Play from evidence cursor** actions remain ordinary keyboard-reachable buttons, status/error messages use semantic roles, and surrounding presentation honors `prefers-reduced-motion`.
 
-Browser automation cannot fully prove how an opened native menu is painted by every Windows/macOS/Linux stack. Representative-device qualification still includes opened controls, forced/high-contrast modes, scaling, keyboard traversal, and platform focus treatment.
+Do not fix contrast with a component-local `#666`, `#fff`, or platform gray. Fix the semantic role. The same repair should work in Intake, Processing, Library, Research, transcript tools, and playback.
+
+Browser automation cannot fully prove how opened native menus or media controls are painted by every Windows/macOS/Linux stack. Representative-device qualification still includes opened controls, media transport, forced/high-contrast modes, scaling, keyboard traversal, and platform focus treatment.
 
 ## Color cannot be the only signal
 
-Status, errors, selection, processing readiness, current/older evidence, speaker overlap, disabled actions, and destructive scope all require text or semantic structure in addition to color. The transcript-tools overlap view, for example, says **Overlap** and lists both evidence refs; border treatment is secondary decoration.
+Status, errors, selection, processing readiness, current/older evidence, speaker overlap, playback verification/failure, disabled actions, and destructive scope all require text or semantic structure in addition to color. The transcript-tools overlap view, for example, says **Overlap** and lists both evidence refs; border treatment is secondary decoration. Playback similarly reports missing, changed, ambiguous-track, and decoder states in text rather than relying on media-control appearance.
 
 ## Adding a skin
 

--- a/docs/development/frontend-testing.md
+++ b/docs/development/frontend-testing.md
@@ -30,10 +30,13 @@ Playwright exercises every primary desktop surface:
 - Library search and verified evidence navigation;
 - verified local playback from current and preserved older evidence generations;
 - Transcript and speaker tools;
-- Research notes, filtering, saved searches, typed search, and anchor maintenance; and
+- Research notes, filtering, saved searches, typed search, and anchor maintenance;
+- persistent and contextual in-app guidance; and
 - development-mode behavior.
 
 Playback browser qualification covers exact ranked and word-level coordinates, missing and changed sources, deliberate multi-audio refusal, audio/video presentation, keyboard preparation, and path non-disclosure. The browser mock does not reimplement source verification; it exposes already-decided backend outcomes so React tests can verify presentation of success/refusal states.
+
+`frontend/tests/in-app-help.spec.ts` treats guidance as an interaction/accessibility feature, not as backend policy. It proves that screen help follows the active workspace, overall help remains reachable, Escape closes a panel and restores focus, contextual Evidence/Playback/Transcript guidance is discoverable, sensitive paths do not appear, and axe stays clean while help is open.
 
 Tests use semantic roles and accessible names where possible. A selector that depends on implementation-only class names should have a specific reason.
 
@@ -45,15 +48,19 @@ Pride has a dedicated assertion that its rainbow remains decorative. Monochrome 
 
 Native playback does not autoplay. Its prepare/re-verify action is keyboard reachable, the system media controls remain native semantic controls, and the surrounding presentation honors reduced-motion preferences.
 
+In-app guidance is never hover-only. Triggers are ordinary buttons usable by keyboard, pointer, and touch. Expanded state is programmatic, Escape closes the panel, focus returns to the trigger, and every panel has an explicit close control. The responsive layout keeps the explanation reachable on narrow/touch viewports.
+
 ### Security-oriented browser assertions
 
 Frontend tests explicitly check that:
 
 - transcript/research strings containing HTML remain inert text;
-- evidence, transcript-tool, and playback views do not expose canonical/source filesystem paths;
+- evidence, transcript-tool, playback, and help views do not expose canonical/source filesystem paths;
 - playback failure does not create a media element/session in the view;
 - speaker display labels do not erase anonymous evidence refs; and
 - post-hoc publication reports safe filenames instead of rendering the selected destination path.
+
+Help content is static local presentation text. It must not become a remote-document embed, analytics surface, or a second executable copy of backend rules.
 
 ## Native Rust qualification
 
@@ -84,7 +91,7 @@ The important mutants in current desktop policy are questions such as:
 - can an ambiguous audio track be guessed?; and
 - can an unallowlisted desktop method execute?
 
-Those decisions live in Python, so Poodle is the meaningful mutation tool for them. Installing Stryker solely to mutate JSX branches would increase dependency/runtime surface without improving evidence-policy assurance.
+Those decisions live in Python, so Poodle is the meaningful mutation tool for them. Installing Stryker solely to mutate JSX branches or static guidance copy would increase dependency/runtime surface without improving evidence-policy assurance.
 
 This is not a permanent ban. Add a frontend mutation layer when all of the following are true:
 
@@ -108,8 +115,9 @@ A new interactive slice should normally ship with:
 - at least one meaningful negative/boundary case;
 - keyboard/semantic-role coverage where interactive;
 - axe on the rendered slice;
+- contextual guidance when the user must understand a non-obvious EchoFlow concept;
 - explicit path/capability assertions if sensitive local state is involved;
 - native tests when Rust gains a new privileged capability; and
 - backend property/mutation tests when the feature changes decision-heavy application policy.
 
-If writing the browser test requires recreating a backend rule in the mock or component, inspect the architecture first. The better fix may be moving that rule back behind the Python service boundary.
+If writing the browser test or help copy requires recreating a backend rule in the component, inspect the architecture first. The better fix may be moving that rule back behind the Python service boundary and letting the frontend describe its outcome.

--- a/docs/development/frontend-testing.md
+++ b/docs/development/frontend-testing.md
@@ -1,6 +1,6 @@
 # Frontend testing strategy
 
-EchoFlow tests the desktop according to its architecture: React proves presentation and human interaction; Python proves application, evidence, custody, resource, and playback-authorization decisions; Rust proves narrow native capability wiring, process lifetime, and local media transport.
+EchoFlow tests the desktop according to its architecture: React proves presentation and human interaction; Python proves application, evidence, custody, resource, media-selection, and playback-authorization decisions; Rust proves narrow native capability wiring, process lifetime, and local media transport.
 
 The goal is not equal tool counts in every language. The goal is to place each behavioral oracle beside the authority it can actually judge.
 
@@ -26,7 +26,7 @@ These tests are deliberately small. A pure frontend helper belongs here only whe
 Playwright exercises every primary desktop surface:
 
 - Intake and remembered locations;
-- Processing readiness, preflight, supervised start, resume, and fresh retry;
+- Processing readiness, preflight, explicit embedded-track confirmation, supervised start, resume, and fresh retry;
 - Library search and verified evidence navigation;
 - verified local playback from current and preserved older evidence generations;
 - Transcript and speaker tools;
@@ -35,6 +35,17 @@ Playwright exercises every primary desktop surface:
 - development-mode behavior.
 
 Playback browser qualification covers exact ranked and word-level coordinates, missing and changed sources, deliberate multi-audio refusal, audio/video presentation, keyboard preparation, and path non-disclosure. The browser mock does not reimplement source verification; it exposes already-decided backend outcomes so React tests can verify presentation of success/refusal states.
+
+Processing has a separate multi-track presentation contract. Under the E2E multitrack fixture, Python-shaped mock data reports two embedded audio streams plus `audio_stream_selection_required=true`. The browser test proves that:
+
+- both tracks and their bounded source-declared metadata are visible;
+- neither track is silently treated as confirmed;
+- **Start local transcription** remains disabled;
+- selecting a track causes a new preflight request with that exact integer stream index;
+- the resulting backend-bound plan becomes startable; and
+- axe remains clean in the multi-track state.
+
+The mock deliberately does not score microphones or choose a preferred track. That decision does not belong in React.
 
 `frontend/tests/in-app-help.spec.ts` treats guidance as an interaction/accessibility feature, not as backend policy. It proves that screen help follows the active workspace, overall help remains reachable, Escape closes a panel and restores focus, contextual Evidence/Playback/Transcript guidance is discoverable, sensitive paths do not appear, and axe stays clean while help is open.
 
@@ -50,6 +61,8 @@ Native playback does not autoplay. Its prepare/re-verify action is keyboard reac
 
 In-app guidance is never hover-only. Triggers are ordinary buttons usable by keyboard, pointer, and touch. Expanded state is programmatic, Escape closes the panel, focus returns to the trigger, and every panel has an explicit close control. The responsive layout keeps the explanation reachable on narrow/touch viewports.
 
+The multi-track chooser is a semantic fieldset with radio inputs, a visible legend, and inline explanatory text. It remains usable by keyboard and touch and uses the same semantic theme tokens as the rest of Processing Center.
+
 ### Security-oriented browser assertions
 
 Frontend tests explicitly check that:
@@ -57,6 +70,7 @@ Frontend tests explicitly check that:
 - transcript/research strings containing HTML remain inert text;
 - evidence, transcript-tool, playback, and help views do not expose canonical/source filesystem paths;
 - playback failure does not create a media element/session in the view;
+- multi-track preflight receives only bounded display metadata and stream indices rather than a new path/media-inspection capability;
 - speaker display labels do not erase anonymous evidence refs; and
 - post-hoc publication reports safe filenames instead of rendering the selected destination path.
 
@@ -88,7 +102,8 @@ The important mutants in current desktop policy are questions such as:
 - does publication skip canonical verification?;
 - can collision policy overwrite a file?;
 - can playback proceed after the source bytes change?;
-- can an ambiguous audio track be guessed?; and
+- can an ambiguous playback audio track be guessed?;
+- does multi-track preflight require explicit user confirmation rather than treating a probe default as intent?; and
 - can an unallowlisted desktop method execute?
 
 Those decisions live in Python, so Poodle is the meaningful mutation tool for them. Installing Stryker solely to mutate JSX branches or static guidance copy would increase dependency/runtime surface without improving evidence-policy assurance.
@@ -104,7 +119,9 @@ This is not a permanent ban. Add a frontend mutation layer when all of the follo
 
 Poodle workflows are targeted by design. Routine PR CI already runs static analysis, branch coverage, package checks, browser tests, native compilation/tests, dependency audit, and platform smoke. Mutation should follow decision-heavy backend changes rather than becoming a mandatory tax on unrelated presentation or documentation edits.
 
-Transcript tools retain a manually dispatchable mutation workflow covering generation, speaker, and publication decisions. Playback is stricter because it introduces a privileged evidence-to-native-media boundary: its workflow runs automatically on pull requests that change playback authorization, its trusted-host bridge, their dedicated tests, Poodle configuration, or the workflow itself. It also remains manually dispatchable for explicit requalification. The broader transcript-library mutation workflow continues to cover retrieval/semantic decisions.
+Transcript tools retain a manually dispatchable mutation workflow covering generation, speaker, and publication decisions. Playback is stricter because it introduces a privileged evidence-to-native-media boundary: its workflow runs automatically on pull requests that change playback authorization, its trusted-host bridge, their dedicated tests, Poodle configuration, or the workflow itself. Its baseline also includes the hardened media-probe tests used by playback authorization, so an incompatible probe refactor fails before mutation begins. It remains manually dispatchable for explicit requalification. The broader transcript-library mutation workflow continues to cover retrieval/semantic decisions.
+
+Multi-track display metadata and confirmation policy are qualified by the normal repository-wide Python coverage gate plus dedicated media/Processing tests. The Poodle target remains playback authorization/bridge policy rather than expanding mutation scope merely because playback shares the hardened probe.
 
 ## Adding a desktop feature
 

--- a/docs/development/frontend-testing.md
+++ b/docs/development/frontend-testing.md
@@ -1,6 +1,6 @@
 # Frontend testing strategy
 
-EchoFlow tests the desktop according to its architecture: React proves presentation and human interaction; Python proves application, evidence, custody, and resource decisions; Rust proves narrow native capability wiring and process lifetime.
+EchoFlow tests the desktop according to its architecture: React proves presentation and human interaction; Python proves application, evidence, custody, resource, and playback-authorization decisions; Rust proves narrow native capability wiring, process lifetime, and local media transport.
 
 The goal is not equal tool counts in every language. The goal is to place each behavioral oracle beside the authority it can actually judge.
 
@@ -28,9 +28,12 @@ Playwright exercises every primary desktop surface:
 - Intake and remembered locations;
 - Processing readiness, preflight, supervised start, resume, and fresh retry;
 - Library search and verified evidence navigation;
+- verified local playback from current and preserved older evidence generations;
 - Transcript and speaker tools;
 - Research notes, filtering, saved searches, typed search, and anchor maintenance; and
 - development-mode behavior.
+
+Playback browser qualification covers exact ranked and word-level coordinates, missing and changed sources, deliberate multi-audio refusal, audio/video presentation, keyboard preparation, and path non-disclosure. The browser mock does not reimplement source verification; it exposes already-decided backend outcomes so React tests can verify presentation of success/refusal states.
 
 Tests use semantic roles and accessible names where possible. A selector that depends on implementation-only class names should have a specific reason.
 
@@ -40,26 +43,45 @@ Axe runs on representative rendered workflows. Theme qualification iterates the 
 
 Pride has a dedicated assertion that its rainbow remains decorative. Monochrome has a dedicated assertion that its semantic palette is actually grayscale. Neither special test replaces the shared contrast matrix.
 
+Native playback does not autoplay. Its prepare/re-verify action is keyboard reachable, the system media controls remain native semantic controls, and the surrounding presentation honors reduced-motion preferences.
+
 ### Security-oriented browser assertions
 
 Frontend tests explicitly check that:
 
 - transcript/research strings containing HTML remain inert text;
-- evidence and transcript-tool views do not expose canonical/source filesystem paths;
+- evidence, transcript-tool, and playback views do not expose canonical/source filesystem paths;
+- playback failure does not create a media element/session in the view;
 - speaker display labels do not erase anonymous evidence refs; and
 - post-hoc publication reports safe filenames instead of rendering the selected destination path.
+
+## Native Rust qualification
+
+Rust owns the opened playback file handle, opaque session lifetime, and `echoflow-media` byte-range transport. Those are not browser-policy questions, so they are covered beside the native implementation.
+
+`cargo test --locked` runs in the normal `native-tauri` CI lane and covers:
+
+- closed opaque session-token shape;
+- rejection of path-like/unknown tokens;
+- single-range parsing including open and suffix ranges;
+- rejection of multipart/invalid ranges; and
+- the 1 MiB response bound for local media transport.
+
+`cargo check --locked` remains a separate compilation gate.
 
 ## Why there is no Stryker gate today
 
 Stryker is useful when JavaScript/TypeScript contains decision-heavy pure logic whose tests should kill semantic mutations. EchoFlow deliberately keeps those decisions out of React.
 
-The important mutants in the current transcript-tools tranche are questions such as:
+The important mutants in current desktop policy are questions such as:
 
 - does a stale canonical digest get accepted?;
 - can a label cross transcript generations?;
 - can an unknown speaker ref be named?;
 - does publication skip canonical verification?;
-- can collision policy overwrite a file?; and
+- can collision policy overwrite a file?;
+- can playback proceed after the source bytes change?;
+- can an ambiguous audio track be guessed?; and
 - can an unallowlisted desktop method execute?
 
 Those decisions live in Python, so Poodle is the meaningful mutation tool for them. Installing Stryker solely to mutate JSX branches would increase dependency/runtime surface without improving evidence-policy assurance.
@@ -73,9 +95,9 @@ This is not a permanent ban. Add a frontend mutation layer when all of the follo
 
 ## Backend mutation qualification
 
-Poodle workflows are manual/targeted by design. Routine PR CI already runs static analysis, branch coverage, package checks, browser tests, native compilation, dependency audit, and platform smoke. Full mutation runs are qualification jobs for changed decision-heavy surfaces, not a mandatory tax on every typo.
+Poodle workflows are manual/targeted by design. Routine PR CI already runs static analysis, branch coverage, package checks, browser tests, native compilation/tests, dependency audit, and platform smoke. Full mutation runs are qualification jobs for changed decision-heavy surfaces, not a mandatory tax on every typo.
 
-Transcript tools have a dedicated mutation workflow covering generation, speaker, and publication decisions. The broader transcript-library mutation workflow continues to cover retrieval/semantic decisions.
+Transcript tools have a dedicated mutation workflow covering generation, speaker, and publication decisions. Playback has a dedicated workflow covering exact-generation/source authorization and the private trusted-host bridge. The broader transcript-library mutation workflow continues to cover retrieval/semantic decisions.
 
 ## Adding a desktop feature
 
@@ -86,7 +108,8 @@ A new interactive slice should normally ship with:
 - at least one meaningful negative/boundary case;
 - keyboard/semantic-role coverage where interactive;
 - axe on the rendered slice;
-- explicit path/capability assertions if sensitive local state is involved; and
+- explicit path/capability assertions if sensitive local state is involved;
+- native tests when Rust gains a new privileged capability; and
 - backend property/mutation tests when the feature changes decision-heavy application policy.
 
 If writing the browser test requires recreating a backend rule in the mock or component, inspect the architecture first. The better fix may be moving that rule back behind the Python service boundary.

--- a/docs/development/frontend-testing.md
+++ b/docs/development/frontend-testing.md
@@ -102,9 +102,9 @@ This is not a permanent ban. Add a frontend mutation layer when all of the follo
 
 ## Backend mutation qualification
 
-Poodle workflows are manual/targeted by design. Routine PR CI already runs static analysis, branch coverage, package checks, browser tests, native compilation/tests, dependency audit, and platform smoke. Full mutation runs are qualification jobs for changed decision-heavy surfaces, not a mandatory tax on every typo.
+Poodle workflows are targeted by design. Routine PR CI already runs static analysis, branch coverage, package checks, browser tests, native compilation/tests, dependency audit, and platform smoke. Mutation should follow decision-heavy backend changes rather than becoming a mandatory tax on unrelated presentation or documentation edits.
 
-Transcript tools have a dedicated mutation workflow covering generation, speaker, and publication decisions. Playback has a dedicated workflow covering exact-generation/source authorization and the private trusted-host bridge. The broader transcript-library mutation workflow continues to cover retrieval/semantic decisions.
+Transcript tools retain a manually dispatchable mutation workflow covering generation, speaker, and publication decisions. Playback is stricter because it introduces a privileged evidence-to-native-media boundary: its workflow runs automatically on pull requests that change playback authorization, its trusted-host bridge, their dedicated tests, Poodle configuration, or the workflow itself. It also remains manually dispatchable for explicit requalification. The broader transcript-library mutation workflow continues to cover retrieval/semantic decisions.
 
 ## Adding a desktop feature
 

--- a/docs/evidence-navigation.md
+++ b/docs/evidence-navigation.md
@@ -32,7 +32,7 @@ flowchart LR
 ```
 
 Text fallback: retrieval ranks a passage, canonical navigation verifies it, and the same
-verified evidence coordinates feed the desktop reader and durable research notes.
+verified evidence coordinates feed the desktop reader, native playback, and durable research notes.
 
 🦝 Search may know the neighborhood. The canonical transcript still owns the street
 address.
@@ -96,9 +96,9 @@ thing.
 
 The desktop Evidence reader renders that verified context directly.
 
-## Can this jump to the original audio or video?
+## Jump to the original audio or video
 
-The application contract exposes the coordinate a player needs.
+The same application contract now drives verified native playback.
 
 If an exact aligned lexical match begins at `4788.370` seconds, that can render as
 `01:19:48.370` and become the preferred seek point. If a result has no justified exact-word
@@ -108,9 +108,15 @@ The desktop Evidence reader exposes this as an interactive **evidence cursor**. 
 canonical timed word moves the cursor to that verified source-relative coordinate;
 **Return to match** restores the backend-selected match coordinate.
 
-EchoFlow does not yet ship local audio/video playback. Playback belongs behind a
-Tauri-owned capability so React can consume safe playback state and verified coordinates
-without receiving arbitrary raw source paths.
+**Prepare playback** submits only `(document_id, canonical_sha256, seek_seconds)` to the
+native playback boundary. Python re-verifies the exact canonical generation and original
+source bytes, and Rust opens that approved file behind an opaque local media session. React
+receives the safe session URL, duration, media kind, and seek coordinate, not the source or
+canonical filesystem path.
+
+Playback is intentionally fail-closed for stale generations, missing/changed sources,
+out-of-range coordinates, and multi-audio sources whose browser track cannot be proven to
+match the stream that was transcribed. See **[Verified native playback](native-playback.md)**.
 
 ## Durable research uses the same coordinate system 📝
 
@@ -145,7 +151,7 @@ flowchart TD
     D --> E[SQLite note]
     E --> F[Rebuildable DuckDB research projection]
     B --> G[Desktop evidence cursor]
-    G --> H[Future Tauri media capability]
+    G --> H[Verified Tauri media capability]
 
     classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
     classDef source fill:#F9D5E5,stroke:#7B2E52,stroke-width:2px,color:#22151B
@@ -161,8 +167,8 @@ flowchart TD
 ```
 
 Text fallback: verified canonical coordinates drive result presentation, durable SQLite
-research anchors, rebuildable research projection, and the current desktop evidence cursor;
-native media playback is a later capability.
+research anchors, rebuildable research projection, the desktop evidence cursor, and
+verified native playback without exposing raw source paths to React.
 
 ## Research metadata can constrain later retrieval
 
@@ -177,15 +183,17 @@ echoflow library search \
   --with-notes
 ```
 
-Saved searches persist that typed intent and re-resolve current evidence later. A dedicated
-desktop Research workspace over this existing authority is the next UI tranche.
+Saved searches persist that typed intent and re-resolve current evidence later. Research
+can reopen either current evidence or the exact older canonical generation cited by a
+preserved note; playback uses whichever verified generation the reader actually opened.
 
 ## What this deliberately does not do
 
 Evidence navigation still does not change ranking, claim an exact word for semantic-only
 relevance, rewrite canonical JSON, bake display names into diarization evidence,
 automatically re-anchor notes across changed generations, expose arbitrary raw
-source/canonical paths to React, or ship graphical audio/video playback yet.
+source/canonical paths to React, guess an audio track in a multi-track container, or
+silently transcode media that the system WebView cannot decode.
 
 For the retrieval internals, open **[Evidence-first corpus search](architecture/corpus-search.md)**.
 For durable notebook custody, see **[Your notes should survive the machinery](research-notes.md)**.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,14 @@ npm run tauri dev
 
 The debug Tauri host prefers the repository `.venv` for local backend calls.
 
+## Help is built into the desktop
+
+You do not need to keep this guide open beside EchoFlow. The sidebar always offers **How this screen works** for the active workspace and **How EchoFlow works** for the overall evidence model.
+
+Evidence reader, Playback, and Transcript tools also expose local help beside their unfamiliar controls. These explanations are re-openable, work with keyboard/touch, close with **Escape**, and do not rely on hover. They describe existing backend rules without recreating those rules in React.
+
+See **[In-app guidance](in-app-guidance.md)** for the interaction and architecture contract.
+
 ## 1. Add or remember recordings
 
 Use **Add evidence** to select recordings, existing transcript JSON, or folders you want EchoFlow to remember. Remembered locations are explicit permissions, not media custody.
@@ -189,6 +197,8 @@ The desktop WebView does not receive arbitrary SQL, shell, subprocess, database,
 
 Ordinary desktop calls go through a fixed Python bridge. Transcript tools use a separate fixed Tauri command/Python module with an explicit allowlist. Playback is narrower still: its path-bearing Python grant is private to Rust, which opens the file and returns only an opaque session to React. Python remains application/evidence authority.
 
+The in-app help layer is static local presentation copy. It has no extra filesystem, process, database, model, media, or network capability.
+
 See **[frontend/SECURITY.md](../frontend/SECURITY.md)**.
 
 ## 10. Optional semantic/hybrid search
@@ -205,7 +215,7 @@ Original media and canonical JSON are evidence. Notes/tags/collections, saved se
 
 ## What comes next?
 
-Research/search, Processing, desktop comprehension/themes, transcript/speaker tools, and verified native playback are foundation. Next:
+Research/search, Processing, desktop comprehension/themes, transcript/speaker tools, verified native playback, and contextual guidance are foundation. Next:
 
 1. lifecycle and retention UI;
 2. architecture/redundancy audit before packaging;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 This is the **use-the-thing** guide.
 
-EchoFlow is a private, local-first workspace for recorded evidence. You do not need to understand CUDA, DuckDB, SQLite, model revisions, or desktop IPC to use it. Python owns those application/evidence decisions so the desktop can speak in recordings, transcripts, speakers, searches, notes, and evidence.
+EchoFlow is a private, local-first workspace for recorded evidence. You do not need to understand CUDA, DuckDB, SQLite, model revisions, or desktop IPC to use it. Python owns those application/evidence decisions so the desktop can speak in recordings, transcripts, speakers, searches, notes, playback, and evidence.
 
 EchoFlow is still pre-production. There is no polished signed installer yet, so the supported path is a source/developer checkout.
 
@@ -106,10 +106,22 @@ uv run echoflow library find "housing affordability" --context-segments 1
 
 In the desktop **Library**, search transcripts, notes, tags, and collections. A transcript result can open either:
 
-- **Open transcript passage** for exact verified context and the source-relative cursor; or
+- **Open transcript passage** for exact verified context, the source-relative cursor, and verified playback; or
 - **Transcript tools** for transcript/speaker management on that exact canonical generation.
 
-## 5. Use transcript and speaker tools
+## 5. Play the verified source
+
+Open a transcript passage and choose **Prepare playback**.
+
+EchoFlow does not hand the recording path to React. The request carries only the exact transcript generation and current source-relative cursor. Python re-verifies the canonical bytes, original source fingerprint, duration bounds, and selected audio stream. Rust opens only that approved file and gives the webview an opaque local media session.
+
+After preparation you can use the system audio/video controls or **Play from evidence cursor**. Clicking a timed word moves the same cursor, and preparing/replaying from that cursor uses the verified source-relative coordinate.
+
+Playback is refused when the original recording is missing, its bytes changed, the transcript view is stale, the requested coordinate is invalid, or the source has multiple audio tracks that EchoFlow cannot yet prove the WebView will select correctly. A verified source can also be unsupported by the local system decoder; that is reported as a codec/container limitation rather than silently transcoding the evidence.
+
+See **[Verified native playback](native-playback.md)**.
+
+## 6. Use transcript and speaker tools
 
 From a transcript result, choose **Transcript tools**. EchoFlow verifies `(document_id, canonical_sha256)` before returning details or accepting mutations.
 
@@ -137,7 +149,7 @@ uv run echoflow library speakers name JOB_ID speaker-02 "Dr. Chen"
 uv run echoflow library speakers transcript JOB_ID
 ```
 
-## 6. Keep durable research
+## 7. Keep durable research
 
 Notes, tags, collections, anchors, and saved searches are authoritative local user state.
 
@@ -150,9 +162,11 @@ uv run echoflow library notes add JOB_ID segment-000042 \
 
 The desktop Research search uses one **Match** choice: Any of these words, All of these words, or Exact phrase. Retrieval, ordering, transcript/speaker/language constraints, research filters, result count, and context live under **Search options**. Technical retrieval provenance stays under **Technical details**.
 
+Research can reopen the exact older canonical generation cited by a durable note. Playback uses that opened generation identity rather than silently substituting the current transcript.
+
 See **[Research search](research-search.md)** and **[Research notes](research-notes.md)**.
 
-## 7. Change the appearance
+## 8. Change the appearance
 
 The header has one **Theme** dropdown with:
 
@@ -169,15 +183,15 @@ The choice is local presentation preference only. All eight skins use the same s
 
 See **[Desktop themes and accessibility](development/desktop-accessibility.md)**.
 
-## 8. Know the trust boundary
+## 9. Know the trust boundary
 
 The desktop WebView does not receive arbitrary SQL, shell, subprocess, database, or raw canonical/source filesystem authority.
 
-Ordinary desktop calls go through a fixed Python bridge. Transcript tools use a separate fixed Tauri command/Python module with an explicit allowlist. React submits typed intent; Python remains application/evidence authority.
+Ordinary desktop calls go through a fixed Python bridge. Transcript tools use a separate fixed Tauri command/Python module with an explicit allowlist. Playback is narrower still: its path-bearing Python grant is private to Rust, which opens the file and returns only an opaque session to React. Python remains application/evidence authority.
 
 See **[frontend/SECURITY.md](../frontend/SECURITY.md)**.
 
-## 9. Optional semantic/hybrid search
+## 10. Optional semantic/hybrid search
 
 Lexical search is the dependency-light default. Semantic search helps when you remember the idea but not the wording; hybrid retrieval combines lexical/semantic ranking using reciprocal rank fusion.
 
@@ -187,18 +201,17 @@ See **[Semantic search](semantic-search.md)**.
 
 ## What EchoFlow stores
 
-Original media and canonical JSON are evidence. Notes/tags/collections, saved searches, and speaker names are durable human knowledge. Search/research projections and TXT/SRT/WebVTT are derived/rebuildable. Remembered locations and theme selection are machine-local preferences with different custody semantics from evidence.
+Original media and canonical JSON are evidence. Notes/tags/collections, saved searches, and speaker names are durable human knowledge. Search/research projections and TXT/SRT/WebVTT are derived/rebuildable. Remembered locations and theme selection are machine-local preferences with different custody semantics from evidence. Playback sessions are temporary native capabilities and are not evidence or durable state.
 
 ## What comes next?
 
-Research/search, Processing, desktop comprehension/themes, and transcript/speaker tools are foundation. Next:
+Research/search, Processing, desktop comprehension/themes, transcript/speaker tools, and verified native playback are foundation. Next:
 
-1. Tauri-owned local audio/video playback from verified source-relative coordinates;
-2. lifecycle and retention UI;
-3. architecture/redundancy audit before packaging;
-4. packaging/first run/update/uninstall;
-5. backup/restore and research portability;
-6. packaged semantic custody; and
-7. representative-device qualification.
+1. lifecycle and retention UI;
+2. architecture/redundancy audit before packaging;
+3. packaging/first run/update/uninstall;
+4. backup/restore and research portability;
+5. packaged semantic custody; and
+6. representative-device qualification.
 
 For the detailed first-release sequence, see **[ROADMAP.md](../ROADMAP.md)**.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ The debug Tauri host prefers the repository `.venv` for local backend calls.
 
 You do not need to keep this guide open beside EchoFlow. The sidebar always offers **How this screen works** for the active workspace and **How EchoFlow works** for the overall evidence model.
 
-Evidence reader, Playback, and Transcript tools also expose local help beside their unfamiliar controls. These explanations are re-openable, work with keyboard/touch, close with **Escape**, and do not rely on hover. They describe existing backend rules without recreating those rules in React.
+Evidence reader, Playback, Transcript tools, and multi-track preflight also expose local explanation beside unfamiliar controls. These explanations are re-openable where appropriate, work with keyboard/touch, and do not rely on hover. They describe existing backend rules without recreating those rules in React.
 
 See **[In-app guidance](in-app-guidance.md)** for the interaction and architecture contract.
 
@@ -65,6 +65,7 @@ Choose **Processing**. The current control loop includes:
 - managed model state;
 - outcome-oriented processing profile;
 - backend preflight before execution;
+- explicit embedded-audio-track confirmation when a source contains more than one audio stream;
 - optional deterministic enhancement;
 - optional anonymous diarization;
 - derived publication intent;
@@ -73,9 +74,13 @@ Choose **Processing**. The current control loop includes:
 - checkpoint resume versus fresh retry; and
 - private execution-state discard that does not delete source media, canonical transcript evidence, or research.
 
+For a normal single-track recording, there is no track choice to make. If preflight finds several embedded audio tracks, Processing Center shows the available tracks and bounded source-declared metadata such as title, language, codec, sample rate, channel count, and container-default status. **Start local transcription** remains disabled until you choose one. EchoFlow then sends that exact index back to Python and re-runs preflight before enabling Start.
+
+Those labels are clues from the source file, not EchoFlow recommendations. A container can call something `Lav microphone` or mark it default without proving that the label is correct.
+
 Long transcription is not an hour-long WebView request. Python plans/admisses/executes; Tauri supervises allowlisted child processes; React presents status and user intent.
 
-See **[Processing Center](architecture/processing-center.md)**.
+See **[Processing Center](architecture/processing-center.md)** and **[Audio tracks](audio-tracks.md)**.
 
 ## 3. Process from the CLI when useful
 
@@ -88,6 +93,15 @@ uv run echoflow models install small
 uv run echoflow transcribe interview.m4a --dry-run
 uv run echoflow transcribe interview.m4a
 ```
+
+For a file with several embedded audio tracks, bind an exact FFmpeg stream index explicitly:
+
+```bash
+uv run echoflow transcribe meeting.mkv --audio-stream 3 --dry-run
+uv run echoflow transcribe meeting.mkv --audio-stream 3
+```
+
+An unavailable or non-audio index fails instead of silently falling back. The selected stream is preserved in canonical source provenance and restored on checkpoint resume.
 
 Publication views can be requested with:
 
@@ -125,9 +139,9 @@ EchoFlow does not hand the recording path to React. The request carries only the
 
 After preparation you can use the system audio/video controls or **Play from evidence cursor**. Clicking a timed word moves the same cursor, and preparing/replaying from that cursor uses the verified source-relative coordinate.
 
-Playback is refused when the original recording is missing, its bytes changed, the transcript view is stale, the requested coordinate is invalid, or the source has multiple audio tracks that EchoFlow cannot yet prove the WebView will select correctly. A verified source can also be unsupported by the local system decoder; that is reported as a codec/container limitation rather than silently transcoding the evidence.
+Playback is refused when the original recording is missing, its bytes changed, the transcript view is stale, the requested coordinate is invalid, or the source has multiple audio tracks that EchoFlow cannot yet prove the WebView will select correctly. This playback restriction does **not** prevent multi-track transcription: transcription explicitly extracts the user-selected track, while current WebView playback cannot yet prove its rendered embedded track. A verified source can also be unsupported by the local system decoder; that is reported as a codec/container limitation rather than silently transcoding the evidence.
 
-See **[Verified native playback](native-playback.md)**.
+See **[Verified native playback](native-playback.md)** and **[Audio tracks](audio-tracks.md)**.
 
 ## 6. Use transcript and speaker tools
 
@@ -197,6 +211,8 @@ The desktop WebView does not receive arbitrary SQL, shell, subprocess, database,
 
 Ordinary desktop calls go through a fixed Python bridge. Transcript tools use a separate fixed Tauri command/Python module with an explicit allowlist. Playback is narrower still: its path-bearing Python grant is private to Rust, which opens the file and returns only an opaque session to React. Python remains application/evidence authority.
 
+Multi-track preflight follows the same rule. Python discovers streams and decides whether explicit confirmation is required. React only presents bounded track metadata and submits the user's chosen index; it does not infer the best track or inspect media itself.
+
 The in-app help layer is static local presentation copy. It has no extra filesystem, process, database, model, media, or network capability.
 
 See **[frontend/SECURITY.md](../frontend/SECURITY.md)**.
@@ -215,7 +231,7 @@ Original media and canonical JSON are evidence. Notes/tags/collections, saved se
 
 ## What comes next?
 
-Research/search, Processing, desktop comprehension/themes, transcript/speaker tools, verified native playback, and contextual guidance are foundation. Next:
+Research/search, Processing, desktop comprehension/themes, transcript/speaker tools, explicit embedded-track transcription, verified native playback, and contextual guidance are foundation. Next:
 
 1. lifecycle and retention UI;
 2. architecture/redundancy audit before packaging;

--- a/docs/in-app-guidance.md
+++ b/docs/in-app-guidance.md
@@ -1,0 +1,75 @@
+# In-app guidance without a mystery tour
+
+EchoFlow has enough moving parts that the desktop cannot assume somebody read the repository documentation first. The product therefore carries a small, persistent guidance layer inside the same local UI.
+
+The goal is **progressive disclosure**: explain a concept where it matters, keep the explanation available later, and avoid turning every screen into an onboarding slideshow.
+
+## Where help lives
+
+The sidebar always exposes two controls:
+
+- **How this screen works** explains the active Add evidence, Processing, Library, or Research workspace.
+- **How EchoFlow works** explains the overall recording → processing → canonical evidence → search → research model.
+
+More specific controls appear where EchoFlow has unusual semantics:
+
+- **How to use this** in the Evidence reader explains verified context, timed words, the evidence cursor, note anchoring, and Return to match.
+- **Why verify?** beside Playback explains why playback is prepared before the recording opens and why a source-integrity failure is different from a codec failure.
+- **How these work** in Transcript tools explains exact-generation binding, anonymous speaker refs, overlap presentation, and derived publication.
+
+These are not hover-only tooltips. They open on an ordinary button click or keyboard activation, work on touch, close with **Escape**, return focus to the trigger, and have an explicit close control.
+
+## What the guidance is allowed to explain
+
+In-app guidance is presentation copy. It describes existing product contracts but does not become a second implementation of them.
+
+For example, the Playback guide can explain that EchoFlow refuses a multi-audio recording rather than guessing which track matches the transcript. The guide does **not** decide whether a recording has multiple audio streams. Python playback authorization still owns that rule.
+
+Likewise:
+
+- the Processing guide can explain preflight, resume, and fresh retry, but Python owns admission and checkpoint compatibility;
+- the Library guide can explain that search rank is not evidence authority, but canonical verification owns that distinction;
+- the Research guide can explain exact-generation anchors, but SQLite/application services own durable research state; and
+- the Transcript tools guide can explain speaker refs and publication, but React does not parse canonical JSON or render authoritative subtitle timing.
+
+If help copy and backend behavior ever disagree, fix the copy or the application contract. Do not add frontend policy to make the explanation true.
+
+## Why there is no forced first-run tour yet
+
+A forced tour is useful when a sequence itself is hard to discover. It is less useful when the difficult part is understanding concepts that recur months later.
+
+EchoFlow currently favors persistent contextual help because:
+
+1. it remains available after first use;
+2. it does not block somebody who already knows what they are doing;
+3. it works on keyboard and touch without relying on hover;
+4. it can grow one topic at a time as features become real; and
+5. it avoids teaching interactions that do not exist.
+
+A first-run walkthrough can be added later if usability testing shows that people still cannot find the primary workflow. It should reuse the same help-topic registry rather than create a competing body of product copy.
+
+## Evidence interaction is taught literally
+
+The Evidence reader currently supports canonical timed-word buttons plus a bounded range control. Selecting a timed word moves the source-relative evidence cursor. **Return to match** restores the coordinate chosen by evidence navigation. Verified playback consumes that same cursor.
+
+The help does not tell users to drag arbitrary transcript text because EchoFlow does not yet have a durable arbitrary-text-selection anchor contract. A future selection model should be designed around canonical evidence coordinates first, then taught in the UI.
+
+## Privacy and security boundary
+
+Guidance content is static application copy. It contains no transcript text, source paths, canonical paths, research contents, analytics hooks, or remote documentation embeds.
+
+The help layer has no filesystem, database, process, model, or network capability. It renders through ordinary React text nodes under the same Content Security Policy as the rest of the desktop.
+
+## Testing the guidance
+
+`frontend/tests/in-app-help.spec.ts` protects the interaction contract. It checks that:
+
+- screen help follows the active workspace;
+- help exposes `aria-expanded` state;
+- Escape closes the panel and returns focus to its trigger;
+- the overall EchoFlow explanation is always reachable;
+- Evidence reader, Playback, and Transcript tools expose their local explanations;
+- help does not introduce canonical/source path disclosure; and
+- axe sees no accessibility violations while guidance is open.
+
+The broader theme/accessibility suite still qualifies the semantic colors used by help triggers and panels. The guidance layer should never require a theme-specific CSS exception.

--- a/docs/in-app-guidance.md
+++ b/docs/in-app-guidance.md
@@ -11,13 +11,14 @@ The sidebar always exposes two controls:
 - **How this screen works** explains the active Add evidence, Processing, Library, or Research workspace.
 - **How EchoFlow works** explains the overall recording → processing → canonical evidence → search → research model.
 
-More specific controls appear where EchoFlow has unusual semantics:
+More specific guidance appears where EchoFlow has unusual semantics:
 
 - **How to use this** in the Evidence reader explains verified context, timed words, the evidence cursor, note anchoring, and Return to match.
 - **Why verify?** beside Playback explains why playback is prepared before the recording opens and why a source-integrity failure is different from a codec failure.
 - **How these work** in Transcript tools explains exact-generation binding, anonymous speaker refs, overlap presentation, and derived publication.
+- the Processing preflight inserts an inline **Choose the audio track to transcribe** explanation when Python discovers several embedded audio streams, because choosing a track changes which evidence enters transcription.
 
-These are not hover-only tooltips. They open on an ordinary button click or keyboard activation, work on touch, close with **Escape**, return focus to the trigger, and have an explicit close control.
+Popover help is not hover-only. It opens on an ordinary button click or keyboard activation, works on touch, closes with **Escape**, returns focus to the trigger, and has an explicit close control. The multi-track explanation is inline beside its radio group so the required decision and its meaning remain visible while the user chooses.
 
 ## What the guidance is allowed to explain
 
@@ -27,7 +28,8 @@ For example, the Playback guide can explain that EchoFlow refuses a multi-audio 
 
 Likewise:
 
-- the Processing guide can explain preflight, resume, and fresh retry, but Python owns admission and checkpoint compatibility;
+- the Processing guide can explain preflight, resume, fresh retry, and why a multi-track source needs an explicit choice, but Python owns admission, checkpoint compatibility, stream discovery, and the `audio_stream_selection_required` decision;
+- the multi-track chooser may show bounded source-declared title/language/default metadata, but React does not score those values or infer a preferred stream;
 - the Library guide can explain that search rank is not evidence authority, but canonical verification owns that distinction;
 - the Research guide can explain exact-generation anchors, but SQLite/application services own durable research state; and
 - the Transcript tools guide can explain speaker refs and publication, but React does not parse canonical JSON or render authoritative subtitle timing.
@@ -54,15 +56,17 @@ The Evidence reader currently supports canonical timed-word buttons plus a bound
 
 The help does not tell users to drag arbitrary transcript text because EchoFlow does not yet have a durable arbitrary-text-selection anchor contract. A future selection model should be designed around canonical evidence coordinates first, then taught in the UI.
 
+Multi-track help follows the same rule. It says to choose an embedded track because that action exists and causes a fresh backend preflight. It does not promise audio preview, automatic microphone quality ranking, separate-file synchronization, or multi-track verified playback, because those capabilities do not exist yet.
+
 ## Privacy and security boundary
 
-Guidance content is static application copy. It contains no transcript text, source paths, canonical paths, research contents, analytics hooks, or remote documentation embeds.
+Guidance content is static application copy plus bounded source-declared display metadata already returned by preflight. It contains no canonical/source filesystem paths, research contents, analytics hooks, or remote documentation embeds.
 
 The help layer has no filesystem, database, process, model, or network capability. It renders through ordinary React text nodes under the same Content Security Policy as the rest of the desktop.
 
 ## Testing the guidance
 
-`frontend/tests/in-app-help.spec.ts` protects the interaction contract. It checks that:
+`frontend/tests/in-app-help.spec.ts` protects the popover interaction contract. It checks that:
 
 - screen help follows the active workspace;
 - help exposes `aria-expanded` state;
@@ -72,4 +76,6 @@ The help layer has no filesystem, database, process, model, or network capabilit
 - help does not introduce canonical/source path disclosure; and
 - axe sees no accessibility violations while guidance is open.
 
-The broader theme/accessibility suite still qualifies the semantic colors used by help triggers and panels. The guidance layer should never require a theme-specific CSS exception.
+`frontend/tests/processing.spec.ts` separately protects the required multi-track guidance/choice flow: both tracks are presented with their source metadata, neither is silently pre-confirmed, Start remains disabled, selecting one track causes backend re-preflight, and the confirmed plan becomes startable. Axe runs on that state too.
+
+The broader theme/accessibility suite still qualifies the semantic colors used by help triggers, panels, and the multi-track chooser. Guidance should never require a theme-specific CSS exception.

--- a/docs/native-playback.md
+++ b/docs/native-playback.md
@@ -29,7 +29,11 @@ A stale view, changed file, missing file, incompatible canonical generation, inv
 
 Canonical evidence records which audio stream EchoFlow transcribed. A generic WebView media element does not give EchoFlow a portable guarantee that it will render that same audio track from every multi-track container.
 
-Playing a different track while presenting transcript evidence would be a provenance error, not merely a UX inconvenience. Therefore first-release playback rejects sources with more than one audio stream instead of guessing. A future multi-track implementation must make track selection explicit and verifiable at the native media layer before this restriction can be relaxed.
+Playing a different track while presenting transcript evidence would be a provenance error, not merely a UX inconvenience. Therefore first-release playback rejects sources with more than one audio stream instead of guessing. A future multi-track playback implementation must make track selection explicit and verifiable at the native media layer before this restriction can be relaxed.
+
+This restriction is **playback-specific**. EchoFlow already supports transcription from a file with several embedded audio streams. Processing Center requires an explicit user choice when preflight discovers multiple tracks, Python re-plans with that exact stream index, FFmpeg maps only that stream into canonical working audio, canonical source provenance records the index, and resume restores it. See **[Audio tracks](audio-tracks.md)**.
+
+The distinction is intentional: transcription owns extraction and can prove which stream entered ASR; current WebView playback of the original container cannot yet prove which embedded stream the platform media engine rendered.
 
 ## Authority split
 
@@ -106,7 +110,9 @@ Playback is covered at multiple layers:
 - Python positive, negative, boundary, tamper, stale-generation, source-mismatch, stream-ambiguity, and Hypothesis seek tests;
 - Python trusted-bridge allowlist, invalid JSON, extra-field, error-redaction, and request-size tests;
 - Rust range-parser, token-allowlist, unknown-session, and bounded-stream tests executed in CI;
-- Playwright current/older generation, exact word-coordinate, missing/changed/multi-audio, audio/video, keyboard, path-nondisclosure, and axe tests;
-- a targeted manual Poodle workflow for playback authorization and bridge decisions.
+- Playwright current/older generation, exact word-coordinate, missing/changed/multi-audio, audio/video, keyboard, path-nondisclosure, and axe tests; and
+- a targeted Poodle workflow that runs when playback authorization/bridge policy changes.
+
+Multi-track transcription has separate backend probe/serialization/confirmation tests plus a Processing Center Playwright/axe flow that proves Start stays disabled until the backend-bound stream choice is confirmed.
 
 The normal quality pipeline still enforces strict TypeScript, frontend build/audit, Ruff, mypy, Vulture, complexity reporting, dependency audit, Python branch coverage, Rust compilation/tests, platform smoke tests, packaging checks, and Playwright.

--- a/docs/native-playback.md
+++ b/docs/native-playback.md
@@ -1,0 +1,112 @@
+# Verified native playback
+
+EchoFlow can play the original local audio or video from a verified transcript coordinate without turning the webview into a filesystem client.
+
+Playback is deliberately evidence-bound. A browser media element is not allowed to decide that a path, transcript generation, source file, or audio track is trustworthy. Python verifies those facts first, Rust opens the authorized file and owns the resulting native capability, and React receives only an opaque session plus safe playback coordinates.
+
+## What playback proves
+
+A playback request carries only:
+
+- `document_id`;
+- the exact `canonical_sha256` already attached to the evidence view; and
+- a finite non-negative source-relative seek coordinate.
+
+Before granting playback, Python verifies that:
+
+1. the requested transcript generation is still the indexed generation;
+2. the canonical JSON bytes still hash to that generation;
+3. canonical job/source identity still agrees with the library index;
+4. the remembered original source still exists;
+5. FFprobe can inspect the source using EchoFlow's file-only media policy;
+6. the current source SHA-256 and size still match canonical provenance;
+7. the requested coordinate is inside the verified recording duration; and
+8. the source has exactly one audio stream and that stream is the one recorded by canonical evidence.
+
+A stale view, changed file, missing file, incompatible canonical generation, invalid coordinate, or ambiguous audio-track situation fails closed.
+
+## Why multi-audio playback is refused for now
+
+Canonical evidence records which audio stream EchoFlow transcribed. A generic WebView media element does not give EchoFlow a portable guarantee that it will render that same audio track from every multi-track container.
+
+Playing a different track while presenting transcript evidence would be a provenance error, not merely a UX inconvenience. Therefore first-release playback rejects sources with more than one audio stream instead of guessing. A future multi-track implementation must make track selection explicit and verifiable at the native media layer before this restriction can be relaxed.
+
+## Authority split
+
+```text
+Evidence view
+    │ document_id + canonical_sha256 + seek_seconds
+    ▼
+Python PlaybackAuthorizationService
+    │ verifies canonical generation + source bytes + stream identity
+    │ trusted grant includes source path
+    ▼
+Rust/Tauri native host
+    │ opens file immediately and rechecks size/mtime
+    │ stores opened File behind opaque active session ID
+    ▼
+echoflow-media protocol
+    │ GET/HEAD only, active session IDs only, bounded byte ranges
+    ▼
+React <audio>/<video>
+    safe URL token + duration + seek + media kind only
+```
+
+The Python playback bridge is intentionally not registered as a Tauri command. Only the fixed Rust playback command can call it. The raw trusted grant contains the local source path so Rust can open the file, but that object never crosses into the webview.
+
+## Native media sessions
+
+Rust turns an authorized source into an in-memory session backed by an already-open file handle.
+
+The session contract is intentionally narrow:
+
+- opaque IDs use a closed token shape, not paths;
+- at most eight sessions may be active at once;
+- only `GET` and `HEAD` are accepted by the media protocol;
+- random, expired, malformed, or path-like tokens return no media;
+- multipart ranges are rejected;
+- each response body is capped at 1 MiB;
+- responses use `Cache-Control: no-store`;
+- release removes the session and closes the capability when no references remain.
+
+The webview CSP allows media only from EchoFlow's dedicated `echoflow-media` protocol (including its platform-specific localhost representation). It does not add general `file:`, `blob:`, or arbitrary localhost media access.
+
+## Time coordinates
+
+Playback uses the same source-relative coordinate already produced by verified evidence navigation. Word buttons, the evidence-position control, and native media time all update one presentation cursor. React does not calculate transcript/source alignment.
+
+Preparing playback verifies the source at the current cursor. There is no re-hash on every seek. This keeps ordinary scrubbing and native media transport lightweight while preserving a strong authorization boundary at session creation.
+
+Older research anchors use the same rule. If a note cites an older canonical generation, playback authorization receives that exact generation identity. EchoFlow never silently substitutes the current transcript.
+
+## Missing, moved, or changed recordings
+
+Canonical transcript evidence remains valid when the original media is temporarily unavailable. Playback is a separate capability and fails with an explicit message.
+
+If a recording has moved, refresh/reconnect the library location so the indexed source path points to the same verified bytes. EchoFlow does not search the machine heuristically during playback. If bytes changed at the remembered path, playback refuses the source even when the filename is unchanged.
+
+## Codec support
+
+Authorization proves identity, not decoder availability. The operating-system WebView ultimately decodes the authorized media container/codecs. A source can therefore be verified correctly but still be unplayable on a particular system media engine.
+
+EchoFlow reports that as a decoder limitation. It does not transcode or replace the source silently during playback, because doing so would introduce another derived-media/provenance contract that should be designed explicitly.
+
+## Performance
+
+Playback authorization hashes and probes one source once when a session is prepared or explicitly re-verified. For very large recordings this can be visible I/O, but it is intentionally outside the high-frequency seek path.
+
+The native protocol then serves bounded byte ranges from the already-open file. React does not read canonical JSON, stream files through Python, or poll Python during playback.
+
+If representative-device profiling later shows authorization hashing to be a material bottleneck, the correct optimization is a generation/source-keyed verified backend cache with explicit invalidation. The webview must not become the cache authority.
+
+## Qualification
+
+Playback is covered at multiple layers:
+
+- Python positive, negative, boundary, tamper, stale-generation, source-mismatch, stream-ambiguity, and Hypothesis seek tests;
+- Python trusted-bridge allowlist, invalid JSON, extra-field, error-redaction, and request-size tests;
+- Rust range-parser, token-allowlist, unknown-session, and bounded-stream tests executed in CI;
+- Playwright current/older generation, exact word-coordinate, missing/changed/multi-audio, audio/video, keyboard, path-nondisclosure, and axe tests;
+- a targeted manual Poodle workflow for playback authorization and bridge decisions.
+
+The normal quality pipeline still enforces strict TypeScript, frontend build/audit, Ruff, mypy, Vulture, complexity reporting, dependency audit, Python branch coverage, Rust compilation/tests, platform smoke tests, packaging checks, and Playwright.

--- a/docs/time-navigation.md
+++ b/docs/time-navigation.md
@@ -31,7 +31,7 @@ flowchart LR
     A --> C[Verified search seek coordinate]
     A --> D[Durable note anchor]
     A --> E[Desktop evidence cursor]
-    E --> F[Future Tauri media playback]
+    E --> F[Verified Tauri media playback]
 
     classDef evidence fill:#FFF0B8,stroke:#8A6B18,stroke-width:2px,color:#2C260F
     classDef view fill:#DDF5E3,stroke:#347A46,stroke-width:2px,color:#142719
@@ -47,8 +47,8 @@ flowchart LR
 ```
 
 Text fallback: one canonical numeric time drives human clock display, verified search
-navigation, durable research anchors, and the current desktop evidence cursor. Actual
-local media playback remains a separate native capability.
+navigation, durable research anchors, the desktop evidence cursor, and verified local
+media playback through the native host.
 
 ## Can search find the exact place now?
 
@@ -65,19 +65,22 @@ passage and its start time rather than fabricating a word highlight.
 
 ## Can I click a word and jump around now?
 
-**The desktop evidence cursor can. The media player cannot yet.**
+**Yes. The evidence cursor and verified native player now share the same source-relative coordinate.**
 
 The Library screen can open a verified Evidence reader. Canonical timed words are
 interactive: selecting one moves the reader's evidence cursor to that exact
 source-relative coordinate, while **Return to match** restores the backend-selected seek
 position.
 
-That is deliberately not the same thing as playing the recording. The current React
-surface does not receive an arbitrary source path or open local media itself.
+Preparing playback submits that current coordinate with the exact canonical generation.
+Python re-verifies the original source and transcript identity, then Rust opens the source
+behind an opaque local media session. React receives playback state and coordinates, not a
+raw source path or general filesystem authority.
 
-The next native media step is a Tauri-owned playback capability that consumes a verified
-coordinate and safe source capability. React should receive playback state and coordinates,
-not general filesystem authority.
+Normal media transport and seeking stay in the native/WebView media layer after the
+session is authorized. EchoFlow does not re-hash a multi-gigabyte source on every seek.
+See **[Verified native playback](native-playback.md)** for the authorization and range-stream
+contract.
 
 ## What about notes and annotations? 📝
 
@@ -99,9 +102,10 @@ echoflow library notes add JOB_ID segment-000042 \
   --body "Compare this with the 2024 survey."
 ```
 
-The desktop Evidence reader already exposes the verified segment/word coordinate system.
-The next **Research workspace UI** should browse those durable anchors and create/edit notes
-from verified selections without inventing a UI-only coordinate model.
+The desktop Evidence reader and Research workspace both consume the verified
+segment/word coordinate system. Current evidence can accept a new durable note; older
+research anchors can reopen the exact preserved canonical generation without silently
+rebinding it to the current transcript.
 
 A note should not anchor only to a rendered clock such as `01:19:48.370`, because that is
 presentation. It also should not anchor only to a semantic-search chunk ID because chunks
@@ -179,7 +183,8 @@ yet qualify**.
 | Neighboring reading context | bounded canonical segment expansion after ranking |
 | Desktop word interaction | canonical timed words move the evidence cursor; Return to match restores backend seek |
 | Durable notes/annotations | verified evidence anchors stored with authoritative user state |
-| Play original audio/video | not yet; Tauri media capability is next |
+| Play original audio/video | generation/source-verified Tauri session from the same evidence cursor |
+| Multi-audio playback | intentionally refused until native track selection can prove the transcribed stream |
 | SMPTE frame arithmetic | intentionally not inferred without qualified frame semantics |
 
 ## The small rule underneath all of this
@@ -190,5 +195,6 @@ the three.** ✨
 For the exact implementation contract, see
 **[Media normalization and transcript timeline](architecture/media-and-timeline.md)**,
 **[Word-level timestamp alignment](architecture/word-alignment.md)**,
-**[Evidence-first corpus search](architecture/corpus-search.md)**, and
+**[Evidence-first corpus search](architecture/corpus-search.md)**,
+**[Verified native playback](native-playback.md)**, and
 **[Your notes should survive the machinery](research-notes.md)**.

--- a/frontend/SECURITY.md
+++ b/frontend/SECURITY.md
@@ -10,6 +10,8 @@ The frontend does not receive arbitrary SQL, shell, database, model-provider, or
 
 The ordinary desktop bridge is fixed to `python -m echoflow.desktop.bridge`. Transcript inspection and speaker management use the separate fixed `python -m echoflow.desktop.transcript_tools_bridge` entry point through Tauri's `transcript_tools_request` command. The webview cannot choose either Python module, substitute a shell command, or provide an arbitrary backend method. The transcript-tools bridge currently allowlists only inspect, speaker presentation, speaker-label set/remove, and deterministic publication operations.
 
+Verified playback has a stricter split. The Python `echoflow.desktop.playback_bridge` is **not** exposed as a Tauri command. Only Rust's fixed `playback_prepare` implementation may call it. That private bridge returns the verified source path to Rust so Rust can open the file, but the raw grant never crosses into the webview.
+
 Adding a desktop capability requires all three layers to agree deliberately:
 
 1. a typed frontend request/response contract;
@@ -18,11 +20,30 @@ Adding a desktop capability requires all three layers to agree deliberately:
 
 React must not recreate application policy by opening DuckDB, SQLite, canonical JSON, arbitrary local files, or subprocesses directly.
 
-## Generation-bound transcript mutations
+## Generation-bound transcript mutations and playback
 
 A long-lived desktop view can become stale while the library changes. Speaker numbering is meaningful only inside the canonical transcript generation that produced it. Every transcript-tools inspect, speaker presentation, label mutation, and publication request therefore carries `(document_id, canonical_sha256)`.
 
-Python verifies that generation at the service boundary. A stale desktop view is rejected rather than silently applying a human label or publication request to a newer generation that happens to reuse `speaker-02` or a segment identifier. React may present the rejection and ask the user to reopen the transcript; it may not reconcile generations itself.
+Playback carries the same exact generation identity plus a finite non-negative source-relative coordinate. Python verifies canonical bytes, source identity, current source SHA-256/size, duration bounds, and audio-stream identity before playback can be granted. A stale desktop view or changed source is rejected rather than reconciled in React.
+
+Multi-audio sources currently fail closed. Canonical evidence records which audio stream was transcribed, but the system WebView cannot portably guarantee that it will render that exact track from every multi-track container. EchoFlow therefore refuses ambiguous playback instead of presenting one track as evidence for another.
+
+## Opaque native media capability
+
+Rust immediately opens the source authorized by Python and rechecks its size and modification timestamp to narrow the verification/open race. The opened `File` is stored behind an opaque active-session token.
+
+The `echoflow-media` protocol accepts only active closed-format session IDs. It does not accept paths. Its transport boundary is deliberately narrow:
+
+- `GET` and `HEAD` only;
+- no arbitrary path lookup or filesystem scope;
+- malformed, random, expired, or path-like tokens return no media;
+- multipart ranges are rejected;
+- each response body is capped at 1 MiB;
+- at most eight playback sessions may be active;
+- media responses use `Cache-Control: no-store`; and
+- `playback_release` revokes the session.
+
+Session IDs are opaque handles, not independent evidence authority. Creating a session still requires Python's generation/source authorization.
 
 ## Rendering untrusted local content
 
@@ -34,9 +55,11 @@ The packaged frontend uses no remote fonts, scripts, stylesheets, analytics, or 
 
 ## Path and evidence disclosure
 
-Local paths are sensitive. Intake may intentionally show paths the user has just selected because reviewing that selection is part of the requested action. Evidence navigation and transcript tooling are narrower.
+Local paths are sensitive. Intake may intentionally show paths the user has just selected because reviewing that selection is part of the requested action. Evidence navigation, transcript tooling, and playback are narrower.
 
 Search/discovery responses return evidence identity, verified segment/word coordinates, seek time, speaker display state, and research metadata without canonical/source filesystem paths. Transcript-tools responses return generation identity, source availability/provenance, speaker state, and publication **filenames**, not canonical/source paths or the selected publication directory. The native folder dialog returns a destination only to the local client so it can submit that explicit intent to Python.
+
+Playback responses to React contain only an opaque session/token, media kind, verified duration, and safe seek coordinate. The source path exists only inside the private Python-to-Rust authorization hop and the Rust session. React never receives it and cannot choose an arbitrary playback file.
 
 The frontend must not copy path-bearing values into routine logs. EchoFlow currently has no application telemetry.
 
@@ -47,6 +70,8 @@ TXT, SRT, and WebVTT are derived views, not transcript authority. React chooses 
 ## Content Security Policy and Tauri capabilities
 
 Production and development Content Security Policies are separate. Production does not permit the Vite development WebSocket endpoint. Development may allow the local HMR WebSocket required by Vite. Script execution remains restricted to the application origin.
+
+Media is restricted to the application origin and EchoFlow's dedicated `echoflow-media` protocol, including the localhost representation Tauri uses on platforms that require it. EchoFlow does not add general `file:`, `blob:`, or arbitrary localhost media access.
 
 The main window capability grants Tauri's core defaults plus the native open dialog and explicit EchoFlow commands. New permissions should be added one at a time with a concrete user workflow and security rationale. Broad shell, filesystem, process, or database permissions are not acceptable substitutes for a typed application method.
 
@@ -60,8 +85,10 @@ Do not hand-edit lockfile integrity hashes.
 
 ## What current tests prove
 
-Python tests cover allowlists, schema validation, stale-generation rejection, error masking, speaker authority, deterministic publication, collision behavior, and other application semantics. Hypothesis exercises generation-bound input invariants. Targeted Poodle mutation workflows challenge decision-heavy backend code without making every pull request pay the full mutation cost.
+Python tests cover allowlists, schema validation, stale-generation rejection, error masking, speaker authority, deterministic publication, playback generation/source verification, stream ambiguity, and other application semantics. Hypothesis exercises generation-bound and bounded-seek invariants. Targeted Poodle mutation workflows challenge decision-heavy backend code without making every pull request pay the full mutation cost.
 
-Frontend tests cover each primary workspace, transcript-tool interactions, hostile-text rendering, keyboard paths, path/capability boundaries, theme persistence/contrast, and axe. Pride and Monochrome use the same semantic-token qualification as every other skin.
+Rust tests cover playback session-token validation, range parsing, unknown sessions, and bounded protocol responses. CI runs both `cargo check --locked` and `cargo test --locked` for the native host.
 
-These checks do not prove that the host OS, system WebView, Tauri runtime, registry infrastructure, native dependencies, or a compromised same-user process are trustworthy. Packaging, signing, update integrity, managed Python runtime custody, and representative-device WebView qualification remain separate release milestones.
+Frontend tests cover each primary workspace, transcript-tool interactions, verified playback, hostile-text rendering, keyboard paths, path/capability boundaries, theme persistence/contrast, and axe. Playback qualification includes current and preserved older generations, exact word coordinates, missing/changed/multi-audio failures, audio/video presentation, keyboard preparation, and path non-disclosure. Pride and Monochrome use the same semantic-token qualification as every other skin.
+
+These checks do not prove that the host OS, system WebView, Tauri runtime, registry infrastructure, native dependencies, or a compromised same-user process are trustworthy. Native codec availability also varies by operating-system media engine. Packaging, signing, update integrity, managed Python runtime custody, and representative-device WebView qualification remain separate release milestones.

--- a/frontend/SECURITY.md
+++ b/frontend/SECURITY.md
@@ -53,6 +53,14 @@ Search snippets, note bodies, participant-provided text, filenames, speaker labe
 
 The packaged frontend uses no remote fonts, scripts, stylesheets, analytics, or application telemetry. Network-bearing product behavior must be explicit and separately designed rather than smuggled through presentation code.
 
+## In-app guidance is presentation only
+
+`frontend/src/help.ts` contains static local explanatory copy. `InfoPopover` renders that copy through ordinary React text nodes. The guidance layer has no filesystem, database, subprocess, model, media, or network capability and does not load remote documentation.
+
+Help may explain an application rule, such as generation binding or deliberate multi-audio playback refusal, but it does not evaluate or enforce that rule. Python remains authoritative. Treating help copy as executable policy would create exactly the duplicate frontend business logic this boundary is designed to avoid.
+
+Guidance must not interpolate source/canonical paths, transcript contents, research contents, or other sensitive state into reusable help text. Tests assert path non-disclosure while help is open.
+
 ## Path and evidence disclosure
 
 Local paths are sensitive. Intake may intentionally show paths the user has just selected because reviewing that selection is part of the requested action. Evidence navigation, transcript tooling, and playback are narrower.
@@ -89,6 +97,6 @@ Python tests cover allowlists, schema validation, stale-generation rejection, er
 
 Rust tests cover playback session-token validation, range parsing, unknown sessions, and bounded protocol responses. CI runs both `cargo check --locked` and `cargo test --locked` for the native host.
 
-Frontend tests cover each primary workspace, transcript-tool interactions, verified playback, hostile-text rendering, keyboard paths, path/capability boundaries, theme persistence/contrast, and axe. Playback qualification includes current and preserved older generations, exact word coordinates, missing/changed/multi-audio failures, audio/video presentation, keyboard preparation, and path non-disclosure. Pride and Monochrome use the same semantic-token qualification as every other skin.
+Frontend tests cover each primary workspace, transcript-tool interactions, verified playback, contextual help, hostile-text rendering, keyboard paths, path/capability boundaries, theme persistence/contrast, and axe. Playback qualification includes current and preserved older generations, exact word coordinates, missing/changed/multi-audio failures, audio/video presentation, keyboard preparation, and path non-disclosure. Guidance qualification includes keyboard dismissal/focus return, screen-sensitive topics, contextual evidence/playback/transcript help, axe with an open panel, and path non-disclosure. Pride and Monochrome use the same semantic-token qualification as every other skin.
 
 These checks do not prove that the host OS, system WebView, Tauri runtime, registry infrastructure, native dependencies, or a compromised same-user process are trustworthy. Native codec availability also varies by operating-system media engine. Packaging, signing, update integrity, managed Python runtime custody, and representative-device WebView qualification remain separate release milestones.

--- a/frontend/SECURITY.md
+++ b/frontend/SECURITY.md
@@ -4,9 +4,9 @@ The desktop client is a presentation and native-host boundary over EchoFlow's lo
 
 ## Trust boundary
 
-The React/WebView layer may display sensitive transcript text, research notes, tags, collection names, speaker labels, and paths the user has explicitly selected. Those values are data. They must never become trusted markup or executable content.
+The React/WebView layer may display sensitive transcript text, research notes, tags, collection names, speaker labels, paths the user has explicitly selected, and bounded source-declared audio-track labels returned by preflight. Those values are data. They must never become trusted markup or executable content.
 
-The frontend does not receive arbitrary SQL, shell, database, model-provider, or filesystem capabilities. Tauri exposes narrow commands for specific human workflows. Python validates versioned, size-bounded requests with closed schemas before application services run.
+The frontend does not receive arbitrary SQL, shell, database, model-provider, media-probe, or filesystem capabilities. Tauri exposes narrow commands for specific human workflows. Python validates versioned, size-bounded requests with closed schemas before application services run.
 
 The ordinary desktop bridge is fixed to `python -m echoflow.desktop.bridge`. Transcript inspection and speaker management use the separate fixed `python -m echoflow.desktop.transcript_tools_bridge` entry point through Tauri's `transcript_tools_request` command. The webview cannot choose either Python module, substitute a shell command, or provide an arbitrary backend method. The transcript-tools bridge currently allowlists only inspect, speaker presentation, speaker-label set/remove, and deterministic publication operations.
 
@@ -18,7 +18,25 @@ Adding a desktop capability requires all three layers to agree deliberately:
 2. an explicit Tauri/native capability when native privilege is required; and
 3. a validated Python bridge method that delegates to an application service.
 
-React must not recreate application policy by opening DuckDB, SQLite, canonical JSON, arbitrary local files, or subprocesses directly.
+React must not recreate application policy by opening DuckDB, SQLite, canonical JSON, arbitrary local files, FFprobe, or subprocesses directly.
+
+## Explicit embedded-audio-track selection
+
+A source file may contain several audio streams. The low-level planner has a deterministic primary stream so probing/planning remains reproducible, but Processing Center must not silently reinterpret that default as user intent.
+
+Python owns the decision. A preflight with multiple audio streams and no requested stream returns `audio_stream_selection_required=true`. The frontend then:
+
+- presents the bounded stream facts returned by Python;
+- keeps **Start local transcription** disabled;
+- accepts a human radio-button choice;
+- sends only the selected integer stream index back to the existing typed preflight operation; and
+- enables Start only after Python returns a new plan bound to that stream.
+
+React does not infer the best microphone, prefer the container default, inspect audio quality, or validate whether an index exists. Those would be duplicated media/business policy.
+
+For multi-track files, Python may expose bounded source-declared `title`, `language`, and `is_default` display fields plus codec/sample-rate/channel facts. Title and language are length-bounded before crossing the desktop DTO. They remain untrusted text and are not source identity. No source path is added to the multi-track response.
+
+A new recording selection clears any previously selected stream in the presentation state so a choice from one source cannot leak into another source's initial preflight. Fresh retry likewise begins without inheriting an unrelated presentation choice; checkpoint resume restores the stream from its backend checkpoint contract.
 
 ## Generation-bound transcript mutations and playback
 
@@ -26,7 +44,9 @@ A long-lived desktop view can become stale while the library changes. Speaker nu
 
 Playback carries the same exact generation identity plus a finite non-negative source-relative coordinate. Python verifies canonical bytes, source identity, current source SHA-256/size, duration bounds, and audio-stream identity before playback can be granted. A stale desktop view or changed source is rejected rather than reconciled in React.
 
-Multi-audio sources currently fail closed. Canonical evidence records which audio stream was transcribed, but the system WebView cannot portably guarantee that it will render that exact track from every multi-track container. EchoFlow therefore refuses ambiguous playback instead of presenting one track as evidence for another.
+Multi-audio **playback** currently fails closed. Canonical evidence records which audio stream was transcribed, but the system WebView cannot portably guarantee that it will render that exact track from every multi-track container. EchoFlow therefore refuses ambiguous playback instead of presenting one track as evidence for another.
+
+This does not conflict with multi-track transcription. Transcription owns explicit FFmpeg extraction and can prove which selected stream entered ASR; current WebView playback cannot yet prove its rendered embedded track.
 
 ## Opaque native media capability
 
@@ -47,9 +67,9 @@ Session IDs are opaque handles, not independent evidence authority. Creating a s
 
 ## Rendering untrusted local content
 
-React's normal text rendering is the default boundary for transcript and research content. `dangerouslySetInnerHTML` is prohibited unless a future security review adds an explicit sanitizer and a narrowly documented use case. CI rejects its use today.
+React's normal text rendering is the default boundary for transcript, research, filename, speaker, and audio-track metadata. `dangerouslySetInnerHTML` is prohibited unless a future security review adds an explicit sanitizer and a narrowly documented use case. CI rejects its use today.
 
-Search snippets, note bodies, participant-provided text, filenames, speaker labels, and metadata remain text. A malicious recording filename or transcript containing HTML/script syntax must remain inert in the WebView.
+Search snippets, note bodies, participant-provided text, filenames, speaker labels, source-declared track titles/languages, and metadata remain text. A malicious recording filename, track title, or transcript containing HTML/script syntax must remain inert in the WebView.
 
 The packaged frontend uses no remote fonts, scripts, stylesheets, analytics, or application telemetry. Network-bearing product behavior must be explicit and separately designed rather than smuggled through presentation code.
 
@@ -57,15 +77,17 @@ The packaged frontend uses no remote fonts, scripts, stylesheets, analytics, or 
 
 `frontend/src/help.ts` contains static local explanatory copy. `InfoPopover` renders that copy through ordinary React text nodes. The guidance layer has no filesystem, database, subprocess, model, media, or network capability and does not load remote documentation.
 
-Help may explain an application rule, such as generation binding or deliberate multi-audio playback refusal, but it does not evaluate or enforce that rule. Python remains authoritative. Treating help copy as executable policy would create exactly the duplicate frontend business logic this boundary is designed to avoid.
+Help may explain an application rule, such as generation binding, deliberate multi-audio playback refusal, or the need to choose among embedded tracks, but it does not evaluate or enforce those rules. Python remains authoritative. Treating help copy as executable policy would create exactly the duplicate frontend business logic this boundary is designed to avoid.
 
-Guidance must not interpolate source/canonical paths, transcript contents, research contents, or other sensitive state into reusable help text. Tests assert path non-disclosure while help is open.
+Guidance must not interpolate source/canonical paths, transcript contents, research contents, or other sensitive state into reusable help text. The multi-track chooser is a special inline case: it renders only bounded stream display facts already returned by backend preflight. Tests assert path non-disclosure while help is open.
 
 ## Path and evidence disclosure
 
-Local paths are sensitive. Intake may intentionally show paths the user has just selected because reviewing that selection is part of the requested action. Evidence navigation, transcript tooling, and playback are narrower.
+Local paths are sensitive. Intake may intentionally show paths the user has just selected because reviewing that selection is part of the requested action. Evidence navigation, transcript tooling, playback, and multi-track metadata presentation are narrower.
 
 Search/discovery responses return evidence identity, verified segment/word coordinates, seek time, speaker display state, and research metadata without canonical/source filesystem paths. Transcript-tools responses return generation identity, source availability/provenance, speaker state, and publication **filenames**, not canonical/source paths or the selected publication directory. The native folder dialog returns a destination only to the local client so it can submit that explicit intent to Python.
+
+Processing preflight may already operate on a path the user selected, but its returned multi-track DTO exposes only stream index plus bounded descriptive media facts. It does not add another filesystem disclosure surface.
 
 Playback responses to React contain only an opaque session/token, media kind, verified duration, and safe seek coordinate. The source path exists only inside the private Python-to-Rust authorization hop and the Rust session. React never receives it and cannot choose an arbitrary playback file.
 
@@ -93,10 +115,10 @@ Do not hand-edit lockfile integrity hashes.
 
 ## What current tests prove
 
-Python tests cover allowlists, schema validation, stale-generation rejection, error masking, speaker authority, deterministic publication, playback generation/source verification, stream ambiguity, and other application semantics. Hypothesis exercises generation-bound and bounded-seek invariants. Targeted Poodle mutation workflows challenge decision-heavy backend code without making every pull request pay the full mutation cost.
+Python tests cover allowlists, schema validation, stale-generation rejection, error masking, speaker authority, deterministic publication, playback generation/source verification, stream ambiguity, media-probe bounds, embedded-track display metadata, and explicit multi-track confirmation policy. Hypothesis exercises generation-bound and bounded-seek invariants. Targeted Poodle mutation workflows challenge decision-heavy backend code without making every pull request pay the full mutation cost.
 
 Rust tests cover playback session-token validation, range parsing, unknown sessions, and bounded protocol responses. CI runs both `cargo check --locked` and `cargo test --locked` for the native host.
 
-Frontend tests cover each primary workspace, transcript-tool interactions, verified playback, contextual help, hostile-text rendering, keyboard paths, path/capability boundaries, theme persistence/contrast, and axe. Playback qualification includes current and preserved older generations, exact word coordinates, missing/changed/multi-audio failures, audio/video presentation, keyboard preparation, and path non-disclosure. Guidance qualification includes keyboard dismissal/focus return, screen-sensitive topics, contextual evidence/playback/transcript help, axe with an open panel, and path non-disclosure. Pride and Monochrome use the same semantic-token qualification as every other skin.
+Frontend tests cover each primary workspace, transcript-tool interactions, verified playback, multi-track Processing preflight, contextual help, hostile-text rendering, keyboard paths, path/capability boundaries, theme persistence/contrast, and axe. Playback qualification includes current and preserved older generations, exact word coordinates, missing/changed/multi-audio failures, audio/video presentation, keyboard preparation, and path non-disclosure. Multi-track Processing qualification proves that no stream is pre-confirmed, Start is blocked until explicit choice, a chosen index is rebound through preflight, and axe remains clean. Guidance qualification includes keyboard dismissal/focus return, screen-sensitive topics, contextual evidence/playback/transcript help, axe with an open panel, and path non-disclosure. Pride and Monochrome use the same semantic-token qualification as every other skin.
 
 These checks do not prove that the host OS, system WebView, Tauri runtime, registry infrastructure, native dependencies, or a compromised same-user process are trustworthy. Native codec availability also varies by operating-system media engine. Packaging, signing, update integrity, managed Python runtime custody, and representative-device WebView qualification remain separate release milestones.

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -87,6 +87,10 @@ async fn request_module(module: &'static str, request: Value) -> Result<Value, S
         .map_err(|_| "EchoFlow's local service task could not be completed".to_string())?
 }
 
+pub(crate) async fn playback_authorization_request(request: Value) -> Result<Value, String> {
+    request_module("echoflow.desktop.playback_bridge", request).await
+}
+
 #[tauri::command]
 pub async fn desktop_request(request: Value) -> Result<Value, String> {
     request_module("echoflow.desktop.bridge", request).await

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -1,18 +1,31 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod backend;
+mod playback;
 mod processing;
 
 fn main() {
+    let playback_sessions = playback::PlaybackSessions::default();
+    let playback_protocol = playback_sessions.clone();
+
     tauri::Builder::default()
         .manage(processing::ProcessingProcesses::default())
+        .manage(playback_sessions)
         .plugin(tauri_plugin_dialog::init())
+        .register_asynchronous_uri_scheme_protocol(
+            "echoflow-media",
+            move |_context, request, responder| {
+                responder.respond(playback_protocol.protocol_response(request));
+            },
+        )
         .invoke_handler(tauri::generate_handler![
             backend::desktop_request,
             backend::transcript_tools_request,
             processing::processing_start_task,
             processing::processing_task_status,
             processing::processing_cancel_task,
+            playback::playback_prepare,
+            playback::playback_release,
         ])
         .run(tauri::generate_context!())
         .expect("EchoFlow desktop host could not start");

--- a/frontend/src-tauri/src/playback.rs
+++ b/frontend/src-tauri/src/playback.rs
@@ -1,0 +1,429 @@
+use crate::backend;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+use std::fs::{File, Metadata};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::UNIX_EPOCH;
+use tauri::http::{self, header};
+use tauri::State;
+
+const MAX_ACTIVE_SESSIONS: usize = 8;
+const MAX_RANGE_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+pub struct PlaybackPrepareRequest {
+    document_id: String,
+    canonical_sha256: String,
+    seek_seconds: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PlaybackPrepared {
+    session_id: String,
+    media_token: String,
+    duration_seconds: f64,
+    seek_seconds: f64,
+    media_kind: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PlaybackReleased {
+    released: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct BridgeError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TrustedGrant {
+    source_path: String,
+    source_size_bytes: u64,
+    source_modified_ns: u64,
+    duration_seconds: f64,
+    seek_seconds: f64,
+    media_kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BridgeResponse {
+    ok: bool,
+    result: Option<TrustedGrant>,
+    error: Option<BridgeError>,
+}
+
+struct PlaybackSession {
+    file: Arc<File>,
+    length: u64,
+    content_type: &'static str,
+}
+
+#[derive(Clone, Default)]
+pub struct PlaybackSessions {
+    inner: Arc<Mutex<HashMap<String, PlaybackSession>>>,
+    counter: Arc<AtomicU64>,
+}
+
+impl PlaybackSessions {
+    fn insert(&self, session: PlaybackSession) -> Result<String, String> {
+        let mut sessions = self
+            .inner
+            .lock()
+            .map_err(|_| "Playback session state is unavailable".to_string())?;
+        if sessions.len() >= MAX_ACTIVE_SESSIONS {
+            return Err(
+                "Too many playback sessions are open; close another evidence player and retry"
+                    .to_string(),
+            );
+        }
+        let id = self.counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let session_id = format!("p{id:016x}");
+        sessions.insert(session_id.clone(), session);
+        Ok(session_id)
+    }
+
+    fn remove(&self, session_id: &str) -> Result<bool, String> {
+        if !valid_session_id(session_id) {
+            return Ok(false);
+        }
+        self.inner
+            .lock()
+            .map(|mut sessions| sessions.remove(session_id).is_some())
+            .map_err(|_| "Playback session state is unavailable".to_string())
+    }
+
+    fn session(&self, session_id: &str) -> Option<(Arc<File>, u64, &'static str)> {
+        if !valid_session_id(session_id) {
+            return None;
+        }
+        let sessions = self.inner.lock().ok()?;
+        let session = sessions.get(session_id)?;
+        Some((
+            Arc::clone(&session.file),
+            session.length,
+            session.content_type,
+        ))
+    }
+
+    pub fn protocol_response(
+        &self,
+        request: http::Request<Vec<u8>>,
+    ) -> http::Response<Vec<u8>> {
+        let method = request.method().clone();
+        if method != http::Method::GET && method != http::Method::HEAD {
+            return response_with_status(http::StatusCode::METHOD_NOT_ALLOWED);
+        }
+        let session_id = request.uri().path().trim_start_matches('/');
+        let Some((file, length, content_type)) = self.session(session_id) else {
+            return response_with_status(http::StatusCode::NOT_FOUND);
+        };
+        if length == 0 {
+            return response_with_status(http::StatusCode::NOT_FOUND);
+        }
+
+        let mut builder = http::Response::builder()
+            .header(header::CONTENT_TYPE, content_type)
+            .header(header::ACCEPT_RANGES, "bytes")
+            .header(header::CACHE_CONTROL, "no-store");
+
+        if method == http::Method::HEAD {
+            return builder
+                .header(header::CONTENT_LENGTH, length)
+                .status(http::StatusCode::OK)
+                .body(Vec::new())
+                .unwrap_or_else(|_| response_with_status(http::StatusCode::INTERNAL_SERVER_ERROR));
+        }
+
+        let requested = request
+            .headers()
+            .get(header::RANGE)
+            .and_then(|value| value.to_str().ok());
+        let range = match requested {
+            Some(value) => match parse_single_range(value, length) {
+                Some(range) => range,
+                None => return range_not_satisfiable(length),
+            },
+            None if length > MAX_RANGE_BYTES => (0, MAX_RANGE_BYTES - 1),
+            None => (0, length - 1),
+        };
+        let (start, requested_end) = range;
+        let end = requested_end.min(start.saturating_add(MAX_RANGE_BYTES - 1));
+        let bytes_to_read = end + 1 - start;
+
+        let mut local_file = match file.try_clone() {
+            Ok(file) => file,
+            Err(_) => return response_with_status(http::StatusCode::INTERNAL_SERVER_ERROR),
+        };
+        if local_file.seek(SeekFrom::Start(start)).is_err() {
+            return response_with_status(http::StatusCode::INTERNAL_SERVER_ERROR);
+        }
+        let mut body = Vec::with_capacity(bytes_to_read as usize);
+        if local_file
+            .take(bytes_to_read)
+            .read_to_end(&mut body)
+            .is_err()
+        {
+            return response_with_status(http::StatusCode::INTERNAL_SERVER_ERROR);
+        }
+
+        let partial = requested.is_some() || start != 0 || end + 1 != length;
+        if partial {
+            builder = builder
+                .status(http::StatusCode::PARTIAL_CONTENT)
+                .header(header::CONTENT_RANGE, format!("bytes {start}-{end}/{length}"));
+        } else {
+            builder = builder.status(http::StatusCode::OK);
+        }
+        builder
+            .header(header::CONTENT_LENGTH, body.len())
+            .body(body)
+            .unwrap_or_else(|_| response_with_status(http::StatusCode::INTERNAL_SERVER_ERROR))
+    }
+}
+
+fn response_with_status(status: http::StatusCode) -> http::Response<Vec<u8>> {
+    http::Response::builder()
+        .status(status)
+        .header(header::CACHE_CONTROL, "no-store")
+        .body(Vec::new())
+        .unwrap_or_else(|_| http::Response::new(Vec::new()))
+}
+
+fn range_not_satisfiable(length: u64) -> http::Response<Vec<u8>> {
+    http::Response::builder()
+        .status(http::StatusCode::RANGE_NOT_SATISFIABLE)
+        .header(header::CONTENT_RANGE, format!("bytes */{length}"))
+        .header(header::CACHE_CONTROL, "no-store")
+        .body(Vec::new())
+        .unwrap_or_else(|_| response_with_status(http::StatusCode::RANGE_NOT_SATISFIABLE))
+}
+
+fn valid_session_id(value: &str) -> bool {
+    value.len() == 17
+        && value.starts_with('p')
+        && value[1..].bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn parse_single_range(value: &str, length: u64) -> Option<(u64, u64)> {
+    let value = value.strip_prefix("bytes=")?;
+    if value.contains(',') || length == 0 {
+        return None;
+    }
+    let (start_text, end_text) = value.split_once('-')?;
+    if start_text.is_empty() {
+        let suffix = end_text.parse::<u64>().ok()?;
+        if suffix == 0 {
+            return None;
+        }
+        let start = length.saturating_sub(suffix.min(length));
+        return Some((start, length - 1));
+    }
+
+    let start = start_text.parse::<u64>().ok()?;
+    if start >= length {
+        return None;
+    }
+    let end = if end_text.is_empty() {
+        length - 1
+    } else {
+        end_text.parse::<u64>().ok()?.min(length - 1)
+    };
+    if end < start {
+        return None;
+    }
+    Some((start, end))
+}
+
+fn modified_ns(metadata: &Metadata) -> Option<u128> {
+    metadata
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_nanos())
+}
+
+fn content_type(path: &Path, media_kind: &str) -> &'static str {
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match extension.as_str() {
+        "aac" => "audio/aac",
+        "aiff" => "audio/aiff",
+        "flac" => "audio/flac",
+        "m4a" => "audio/mp4",
+        "mp3" => "audio/mpeg",
+        "ogg" | "opus" => "audio/ogg",
+        "wav" => "audio/wav",
+        "wma" => "audio/x-ms-wma",
+        "avi" => "video/x-msvideo",
+        "m4v" | "mp4" if media_kind == "video" => "video/mp4",
+        "m4v" | "mp4" => "audio/mp4",
+        "mkv" => "video/x-matroska",
+        "mov" => "video/quicktime",
+        "mpeg" | "mpg" => "video/mpeg",
+        "webm" if media_kind == "video" => "video/webm",
+        "webm" => "audio/webm",
+        _ => "application/octet-stream",
+    }
+}
+
+fn bridge_error(response: &BridgeResponse) -> String {
+    response
+        .error
+        .as_ref()
+        .map(|error| error.message.clone())
+        .unwrap_or_else(|| "EchoFlow could not authorize local playback".to_string())
+}
+
+#[tauri::command]
+pub async fn playback_prepare(
+    request: PlaybackPrepareRequest,
+    sessions: State<'_, PlaybackSessions>,
+) -> Result<PlaybackPrepared, String> {
+    let payload = json!({
+        "protocol_version": 1,
+        "request_id": "native-playback",
+        "method": "playback.authorize",
+        "params": {
+            "document_id": request.document_id,
+            "canonical_sha256": request.canonical_sha256,
+            "seek_seconds": request.seek_seconds,
+        }
+    });
+    let raw = backend::playback_authorization_request(payload).await?;
+    let response: BridgeResponse = serde_json::from_value(raw)
+        .map_err(|_| "EchoFlow's playback authorization response was invalid".to_string())?;
+    if !response.ok {
+        return Err(bridge_error(&response));
+    }
+    let grant = response
+        .result
+        .ok_or_else(|| "EchoFlow's playback authorization response was incomplete".to_string())?;
+    if !grant.duration_seconds.is_finite()
+        || !grant.seek_seconds.is_finite()
+        || grant.seek_seconds < 0.0
+        || grant.seek_seconds > grant.duration_seconds
+        || !matches!(grant.media_kind.as_str(), "audio" | "video")
+    {
+        return Err("EchoFlow's playback authorization response was invalid".to_string());
+    }
+
+    let source_path = PathBuf::from(&grant.source_path);
+    let file = File::open(&source_path)
+        .map_err(|_| "The verified recording could not be opened for local playback".to_string())?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| "The verified recording could not be inspected for local playback".to_string())?;
+    if metadata.len() != grant.source_size_bytes
+        || modified_ns(&metadata) != Some(u128::from(grant.source_modified_ns))
+    {
+        return Err(
+            "The recording changed between verification and native playback; retry from the evidence view"
+                .to_string(),
+        );
+    }
+
+    let kind = grant.media_kind.clone();
+    let session_id = sessions.insert(PlaybackSession {
+        file: Arc::new(file),
+        length: metadata.len(),
+        content_type: content_type(&source_path, &kind),
+    })?;
+    Ok(PlaybackPrepared {
+        media_token: session_id.clone(),
+        session_id,
+        duration_seconds: grant.duration_seconds,
+        seek_seconds: grant.seek_seconds,
+        media_kind: kind,
+    })
+}
+
+#[tauri::command]
+pub fn playback_release(
+    session_id: String,
+    sessions: State<'_, PlaybackSessions>,
+) -> Result<PlaybackReleased, String> {
+    Ok(PlaybackReleased {
+        released: sessions.remove(&session_id)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn range_parser_accepts_bounded_open_and_suffix_ranges() {
+        assert_eq!(parse_single_range("bytes=0-99", 1_000), Some((0, 99)));
+        assert_eq!(parse_single_range("bytes=900-", 1_000), Some((900, 999)));
+        assert_eq!(parse_single_range("bytes=-100", 1_000), Some((900, 999)));
+        assert_eq!(parse_single_range("bytes=100-9999", 1_000), Some((100, 999)));
+    }
+
+    #[test]
+    fn range_parser_rejects_multipart_and_invalid_bounds() {
+        assert_eq!(parse_single_range("bytes=0-1,4-5", 100), None);
+        assert_eq!(parse_single_range("bytes=100-", 100), None);
+        assert_eq!(parse_single_range("bytes=9-3", 100), None);
+        assert_eq!(parse_single_range("items=0-3", 100), None);
+        assert_eq!(parse_single_range("bytes=-0", 100), None);
+    }
+
+    #[test]
+    fn session_ids_are_closed_tokens_not_paths() {
+        assert!(valid_session_id("p0000000000000001"));
+        assert!(!valid_session_id("../secret.mp4"));
+        assert!(!valid_session_id("p000000000000000g"));
+    }
+
+    #[test]
+    fn protocol_caps_large_reads_and_rejects_unknown_tokens() {
+        let temp = std::env::temp_dir().join(format!(
+            "echoflow-playback-test-{}-{}",
+            std::process::id(),
+            1
+        ));
+        let mut file = File::create(&temp).expect("create temp media");
+        file.write_all(&vec![7_u8; (MAX_RANGE_BYTES + 64) as usize])
+            .expect("write temp media");
+        drop(file);
+        let source = File::open(&temp).expect("open temp media");
+        let sessions = PlaybackSessions::default();
+        let token = sessions
+            .insert(PlaybackSession {
+                file: Arc::new(source),
+                length: MAX_RANGE_BYTES + 64,
+                content_type: "audio/wav",
+            })
+            .expect("insert session");
+
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(format!("http://echoflow-media.localhost/{token}"))
+            .body(Vec::new())
+            .expect("build request");
+        let response = sessions.protocol_response(request);
+        assert_eq!(response.status(), http::StatusCode::PARTIAL_CONTENT);
+        assert_eq!(response.body().len(), MAX_RANGE_BYTES as usize);
+
+        let missing = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("http://echoflow-media.localhost/p00000000000000ff")
+            .body(Vec::new())
+            .expect("build missing request");
+        assert_eq!(
+            sessions.protocol_response(missing).status(),
+            http::StatusCode::NOT_FOUND
+        );
+        let _ = std::fs::remove_file(temp);
+    }
+}

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -22,8 +22,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost data:; style-src 'self' 'unsafe-inline'; script-src 'self'",
-      "devCsp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost ws://localhost:5173; img-src 'self' asset: http://asset.localhost data:; style-src 'self' 'unsafe-inline'; script-src 'self'",
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost data:; media-src 'self' echoflow-media: http://echoflow-media.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'",
+      "devCsp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost ws://localhost:5173; img-src 'self' asset: http://asset.localhost data:; media-src 'self' echoflow-media: http://echoflow-media.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'",
       "freezePrototype": true
     }
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { createDesktopClient } from "./api/desktop";
+import { createPlaybackClient } from "./api/playback";
 import { createProcessingClient } from "./api/processing";
 import { createTranscriptToolsClient } from "./api/transcriptTools";
 import { type Theme } from "./components/WorkspaceHeader";
 import { IntakeWorkspace } from "./IntakeWorkspace";
+import { PlaybackProvider } from "./PlaybackContext";
 import { ProcessingCenter } from "./ProcessingCenter";
 import { ResearchWorkspaceWithAnchorReview } from "./ResearchWorkspaceWithAnchorReview";
 import { SearchWorkspace } from "./SearchWorkspace";
@@ -13,6 +15,7 @@ import "./processing-center.css";
 import "./theme-extras.css";
 
 const client = createDesktopClient();
+const playback = createPlaybackClient();
 const processing = createProcessingClient();
 const transcriptTools = createTranscriptToolsClient();
 
@@ -132,7 +135,9 @@ export function App() {
         </div>
       </aside>
 
-      <main className="workspace">{workspace}</main>
+      <PlaybackProvider client={playback}>
+        <main className="workspace">{workspace}</main>
+      </PlaybackProvider>
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,13 +4,16 @@ import { createDesktopClient } from "./api/desktop";
 import { createPlaybackClient } from "./api/playback";
 import { createProcessingClient } from "./api/processing";
 import { createTranscriptToolsClient } from "./api/transcriptTools";
+import { InfoPopover } from "./components/InfoPopover";
 import { type Theme } from "./components/WorkspaceHeader";
+import type { HelpTopicId } from "./help";
 import { IntakeWorkspace } from "./IntakeWorkspace";
 import { PlaybackProvider } from "./PlaybackContext";
 import { ProcessingCenter } from "./ProcessingCenter";
 import { ResearchWorkspaceWithAnchorReview } from "./ResearchWorkspaceWithAnchorReview";
 import { SearchWorkspace } from "./SearchWorkspace";
 import { DEFAULT_THEME, isTheme, THEME_STORAGE_KEY } from "./themes";
+import "./help.css";
 import "./processing-center.css";
 import "./theme-extras.css";
 
@@ -20,6 +23,13 @@ const processing = createProcessingClient();
 const transcriptTools = createTranscriptToolsClient();
 
 type View = "intake" | "processing" | "library" | "research";
+
+const VIEW_HELP_TOPIC: Record<View, HelpTopicId> = {
+  intake: "intake",
+  processing: "processing",
+  library: "library",
+  research: "research",
+};
 
 function initialTheme(): Theme {
   try {
@@ -125,6 +135,21 @@ export function App() {
             <span aria-hidden="true">✦</span> Research
           </button>
         </nav>
+
+        <div className="sidebar-guides" aria-label="In-app help">
+          <InfoPopover
+            topic={VIEW_HELP_TOPIC[view]}
+            label="How this screen works"
+            align="start"
+            className="sidebar-help"
+          />
+          <InfoPopover
+            topic="overview"
+            label="How EchoFlow works"
+            align="start"
+            className="sidebar-help"
+          />
+        </div>
 
         <div className="privacy-note">
           <span className="privacy-dot" aria-hidden="true" />

--- a/frontend/src/EvidencePlayback.tsx
+++ b/frontend/src/EvidencePlayback.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 
 import type { PlaybackClient, PlaybackSession } from "./api/playback";
 import type { TranscriptGenerationRef } from "./api/transcriptTools";
+import { InfoPopover } from "./components/InfoPopover";
 import { formatEvidenceTime } from "./format";
 import "./playback.css";
 
@@ -103,9 +104,22 @@ export function EvidencePlayback({
           <p className="mini-label">Verified local source</p>
           <h3 id="evidence-playback-title">Playback</h3>
         </div>
-        <button type="button" className="quiet-button" disabled={preparing} onClick={() => void prepare()}>
-          {preparing ? "Verifying…" : session ? "Re-verify source" : "Prepare playback"}
-        </button>
+        <div className="context-help-actions">
+          <InfoPopover
+            topic="playback"
+            label="Why verify?"
+            align="end"
+            className="context-help"
+          />
+          <button
+            type="button"
+            className="quiet-button"
+            disabled={preparing}
+            onClick={() => void prepare()}
+          >
+            {preparing ? "Verifying…" : session ? "Re-verify source" : "Prepare playback"}
+          </button>
+        </div>
       </div>
 
       <p className="evidence-playback-copy">

--- a/frontend/src/EvidencePlayback.tsx
+++ b/frontend/src/EvidencePlayback.tsx
@@ -82,7 +82,6 @@ export function EvidencePlayback({
   }
 
   const mediaProps = {
-    ref: mediaRef,
     src: session?.media_url,
     controls: true,
     preload: "metadata" as const,
@@ -117,11 +116,27 @@ export function EvidencePlayback({
       {error && <p className="error-banner evidence-playback-error" role="alert">{error}</p>}
 
       {session && (
-        <div className="evidence-playback-player">
+        <div
+          className="evidence-playback-player"
+          data-session-seek-seconds={session.seek_seconds}
+          data-media-kind={session.media_kind}
+        >
           {session.media_kind === "video" ? (
-            <video {...mediaProps} aria-label="Verified evidence video" />
+            <video
+              {...mediaProps}
+              ref={(node) => {
+                mediaRef.current = node;
+              }}
+              aria-label="Verified evidence video"
+            />
           ) : (
-            <audio {...mediaProps} aria-label="Verified evidence audio" />
+            <audio
+              {...mediaProps}
+              ref={(node) => {
+                mediaRef.current = node;
+              }}
+              aria-label="Verified evidence audio"
+            />
           )}
           <div className="evidence-playback-actions">
             <button type="button" className="secondary-action" onClick={() => void playFromCursor()}>

--- a/frontend/src/EvidencePlayback.tsx
+++ b/frontend/src/EvidencePlayback.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { PlaybackClient, PlaybackSession } from "./api/playback";
+import type { TranscriptGenerationRef } from "./api/transcriptTools";
+import { formatEvidenceTime } from "./format";
+import "./playback.css";
+
+interface EvidencePlaybackProps {
+  client: PlaybackClient;
+  generation: TranscriptGenerationRef;
+  cursorSeconds: number;
+  onPositionChange: (seconds: number) => void;
+}
+
+export function EvidencePlayback({
+  client,
+  generation,
+  cursorSeconds,
+  onPositionChange,
+}: EvidencePlaybackProps) {
+  const mediaRef = useRef<HTMLMediaElement | null>(null);
+  const [session, setSession] = useState<PlaybackSession | null>(null);
+  const [preparing, setPreparing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    const current = session;
+    return () => {
+      if (current) void client.release(current.session_id);
+    };
+  }, [client, session]);
+
+  useEffect(() => {
+    const media = mediaRef.current;
+    if (!media || !session) return;
+    const bounded = Math.min(session.duration_seconds, Math.max(0, cursorSeconds));
+    if (Math.abs(media.currentTime - bounded) > 0.05) {
+      media.currentTime = bounded;
+    }
+  }, [cursorSeconds, session]);
+
+  async function prepare() {
+    setPreparing(true);
+    setError(null);
+    setStatus(null);
+    const previous = session;
+    try {
+      if (previous) {
+        await client.release(previous.session_id);
+        setSession(null);
+      }
+      const prepared = await client.prepare(generation, cursorSeconds);
+      setSession(prepared);
+      setStatus(`Verified local playback prepared at ${formatEvidenceTime(prepared.seek_seconds)}.`);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "EchoFlow could not prepare verified local playback.",
+      );
+    } finally {
+      setPreparing(false);
+    }
+  }
+
+  async function playFromCursor() {
+    const media = mediaRef.current;
+    if (!media || !session) return;
+    media.currentTime = Math.min(session.duration_seconds, Math.max(0, cursorSeconds));
+    try {
+      await media.play();
+    } catch {
+      setError("The system media engine could not start this recording.");
+    }
+  }
+
+  function mediaError() {
+    setError(
+      "The verified recording is available, but this system media engine cannot decode its container or codec.",
+    );
+  }
+
+  const mediaProps = {
+    ref: mediaRef,
+    src: session?.media_url,
+    controls: true,
+    preload: "metadata" as const,
+    onLoadedMetadata: () => {
+      const media = mediaRef.current;
+      if (media && session) media.currentTime = session.seek_seconds;
+    },
+    onTimeUpdate: () => {
+      const media = mediaRef.current;
+      if (media && Number.isFinite(media.currentTime)) onPositionChange(media.currentTime);
+    },
+    onError: mediaError,
+  };
+
+  return (
+    <section className="evidence-playback" aria-labelledby="evidence-playback-title">
+      <div className="evidence-playback-heading">
+        <div>
+          <p className="mini-label">Verified local source</p>
+          <h3 id="evidence-playback-title">Playback</h3>
+        </div>
+        <button type="button" className="quiet-button" disabled={preparing} onClick={() => void prepare()}>
+          {preparing ? "Verifying…" : session ? "Re-verify source" : "Prepare playback"}
+        </button>
+      </div>
+
+      <p className="evidence-playback-copy">
+        EchoFlow verifies the exact transcript generation and original recording before opening a native media session. The recording path is never sent to this view.
+      </p>
+
+      {status && <p className="evidence-playback-status" role="status">{status}</p>}
+      {error && <p className="error-banner evidence-playback-error" role="alert">{error}</p>}
+
+      {session && (
+        <div className="evidence-playback-player">
+          {session.media_kind === "video" ? (
+            <video {...mediaProps} aria-label="Verified evidence video" />
+          ) : (
+            <audio {...mediaProps} aria-label="Verified evidence audio" />
+          )}
+          <div className="evidence-playback-actions">
+            <button type="button" className="secondary-action" onClick={() => void playFromCursor()}>
+              Play from evidence cursor
+            </button>
+            <span>
+              Verified source · {formatEvidenceTime(session.duration_seconds)}
+            </span>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/EvidenceReader.tsx
+++ b/frontend/src/EvidenceReader.tsx
@@ -6,7 +6,9 @@ import type {
   WorkspaceEvidenceResult,
   WorkspaceMatchedWord,
 } from "./api/desktop";
+import { EvidencePlayback } from "./EvidencePlayback";
 import { formatEvidenceTime } from "./format";
+import { usePlaybackClient } from "./PlaybackContext";
 import "./evidence-reader.css";
 
 interface EvidenceReaderProps {
@@ -55,6 +57,7 @@ export function EvidenceReader({
   generationState = "current",
   resultLabel = "Search result",
 }: EvidenceReaderProps) {
+  const playback = usePlaybackClient();
   const [cursorSeconds, setCursorSeconds] = useState(evidence.seek_seconds);
   const [noteBody, setNoteBody] = useState("");
   const [savingNote, setSavingNote] = useState(false);
@@ -225,6 +228,16 @@ export function EvidenceReader({
         </section>
       )}
 
+      <EvidencePlayback
+        client={playback}
+        generation={{
+          document_id: evidence.document_id,
+          canonical_sha256: evidence.canonical_sha256,
+        }}
+        cursorSeconds={cursorSeconds}
+        onPositionChange={setCursorSeconds}
+      />
+
       <footer className="evidence-seek" data-seek-seconds={evidence.seek_seconds}>
         <div>
           <span className="mini-label">Source-relative evidence cursor</span>
@@ -250,9 +263,8 @@ export function EvidenceReader({
             onChange={(event) => setCursorSeconds(Number(event.target.value))}
           />
           <p>
-            This source-relative coordinate is verified against canonical evidence. Media
-            playback can consume it without exposing source or canonical filesystem paths to
-            the webview.
+            This source-relative coordinate is verified against canonical evidence. Native playback
+            consumes it without exposing source or canonical filesystem paths to the webview.
           </p>
         </div>
       </footer>

--- a/frontend/src/EvidenceReader.tsx
+++ b/frontend/src/EvidenceReader.tsx
@@ -6,6 +6,7 @@ import type {
   WorkspaceEvidenceResult,
   WorkspaceMatchedWord,
 } from "./api/desktop";
+import { InfoPopover } from "./components/InfoPopover";
 import { EvidencePlayback } from "./EvidencePlayback";
 import { formatEvidenceTime } from "./format";
 import { usePlaybackClient } from "./PlaybackContext";
@@ -119,9 +120,17 @@ export function EvidenceReader({
           <p className="mini-label">Verified canonical window</p>
           <h2 id="evidence-reader-title">Evidence reader</h2>
         </div>
-        <button type="button" className="quiet-button" onClick={onClose}>
-          Close
-        </button>
+        <div className="context-help-actions">
+          <InfoPopover
+            topic="evidence"
+            label="How to use this"
+            align="end"
+            className="context-help"
+          />
+          <button type="button" className="quiet-button" onClick={onClose}>
+            Close
+          </button>
+        </div>
       </header>
 
       <p

--- a/frontend/src/PlaybackContext.tsx
+++ b/frontend/src/PlaybackContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, type ReactNode, useContext } from "react";
+
+import type { PlaybackClient } from "./api/playback";
+
+const PlaybackContext = createContext<PlaybackClient | null>(null);
+
+export function PlaybackProvider({
+  client,
+  children,
+}: {
+  client: PlaybackClient;
+  children: ReactNode;
+}) {
+  return <PlaybackContext.Provider value={client}>{children}</PlaybackContext.Provider>;
+}
+
+export function usePlaybackClient(): PlaybackClient {
+  const client = useContext(PlaybackContext);
+  if (!client) {
+    throw new Error("EchoFlow playback client is not configured");
+  }
+  return client;
+}

--- a/frontend/src/ProcessingCenter.tsx
+++ b/frontend/src/ProcessingCenter.tsx
@@ -13,6 +13,7 @@ import type {
   ProcessingReadiness,
   ProcessingTaskStatus,
 } from "./api/processing";
+import { AudioTrackChooser } from "./components/AudioTrackChooser";
 import { WorkspaceHeader, type Theme } from "./components/WorkspaceHeader";
 
 interface ProcessingCenterProps {
@@ -198,6 +199,7 @@ export function ProcessingCenter({
     if (!path) return;
     setSelectedPath(path);
     setRetrySourceJobId(null);
+    setAudioStreamIndex(null);
     setPreflight(null);
     setStatus(`${basename(path)} selected. Run preflight before starting.`);
   }
@@ -209,10 +211,14 @@ export function ProcessingCenter({
     try {
       const plan = await processing.preflight(path, preflightOptions);
       setPreflight(plan);
-      setAudioStreamIndex(plan.selected_audio_stream_index);
+      setAudioStreamIndex(
+        plan.audio_stream_selection_required ? null : plan.selected_audio_stream_index,
+      );
       setRetrySourceJobId(null);
       setStatus(
-        `Preflight complete. EchoFlow admitted ${plan.model} on ${plan.device}/${plan.compute_type}.`,
+        plan.audio_stream_selection_required
+          ? `Preflight found ${plan.audio_streams.length} audio tracks. Choose the track EchoFlow should transcribe.`
+          : `Preflight complete. EchoFlow admitted ${plan.model} on ${plan.device}/${plan.compute_type}.`,
       );
     } catch (caught) {
       setPreflight(null);
@@ -226,17 +232,27 @@ export function ProcessingCenter({
     }
   }
 
-  async function prepareRetry(job: ProcessingJob) {
+  async function prepareRetry(
+    job: ProcessingJob,
+    requestedAudioStreamIndex = audioStreamIndex,
+  ) {
     setBusy(true);
     setError(null);
     try {
-      const plan = await processing.retryPreflight(job.job_id, preflightOptions);
+      const plan = await processing.retryPreflight(job.job_id, {
+        ...preflightOptions,
+        audioStreamIndex: requestedAudioStreamIndex,
+      });
       setPreflight(plan);
       setSelectedPath(null);
       setRetrySourceJobId(job.job_id);
-      setAudioStreamIndex(plan.selected_audio_stream_index);
+      setAudioStreamIndex(
+        plan.audio_stream_selection_required ? null : plan.selected_audio_stream_index,
+      );
       setStatus(
-        `Fresh retry preflight complete for ${job.recording_name}. The interrupted job was not changed.`,
+        plan.audio_stream_selection_required
+          ? `Fresh retry preflight found ${plan.audio_streams.length} audio tracks. Choose the track EchoFlow should transcribe.`
+          : `Fresh retry preflight complete for ${job.recording_name}. The interrupted job was not changed.`,
       );
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "EchoFlow could not plan a fresh retry.");
@@ -245,8 +261,37 @@ export function ProcessingCenter({
     }
   }
 
-  async function startPlannedJob() {
+  async function chooseAudioStream(index: number) {
     if (!preflight) return;
+    if (!selectedPath && !retrySourceJobId) return;
+    setBusy(true);
+    setError(null);
+    const previousIndex = audioStreamIndex;
+    setAudioStreamIndex(index);
+    try {
+      const options = { ...preflightOptions, audioStreamIndex: index };
+      const plan = retrySourceJobId
+        ? await processing.retryPreflight(retrySourceJobId, options)
+        : await processing.preflight(selectedPath ?? "", options);
+      setPreflight(plan);
+      setAudioStreamIndex(plan.selected_audio_stream_index);
+      setStatus(
+        `Audio track #${plan.selected_audio_stream_index} confirmed. EchoFlow re-ran backend preflight with that exact stream.`,
+      );
+    } catch (caught) {
+      setAudioStreamIndex(previousIndex);
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "EchoFlow could not safely bind that audio track.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function startPlannedJob() {
+    if (!preflight || preflight.audio_stream_selection_required) return;
     if (!retrySourceJobId && !selectedPath) return;
     setBusy(true);
     setError(null);
@@ -538,6 +583,7 @@ export function ProcessingCenter({
                 onClick={() => {
                   setSelectedPath(recording.path);
                   setRetrySourceJobId(null);
+                  setAudioStreamIndex(null);
                   setPreflight(null);
                 }}
               >
@@ -581,6 +627,13 @@ export function ProcessingCenter({
               <div><dt>Disk estimate</dt><dd>{formatBytes(preflight.estimated_disk_bytes)}</dd></div>
               <div><dt>Audio stream</dt><dd>#{preflight.selected_audio_stream_index}</dd></div>
             </dl>
+            <AudioTrackChooser
+              streams={preflight.audio_streams}
+              selectedIndex={audioStreamIndex}
+              selectionRequired={preflight.audio_stream_selection_required}
+              busy={busy}
+              onSelect={(index) => void chooseAudioStream(index)}
+            />
             <details className="advanced-card processing-advanced">
               <summary>Expert controls and optional processing</summary>
               <div className="advanced-processing-grid">
@@ -596,20 +649,6 @@ export function ProcessingCenter({
                     <option value="">Automatic recommendation</option>
                     {feasibleStrategies.map((strategy) => (
                       <option key={strategy.strategy_id} value={strategy.strategy_id}>{strategy.strategy_id}</option>
-                    ))}
-                  </select>
-                </label>
-                <label>
-                  <span>Audio stream</span>
-                  <select
-                    value={audioStreamIndex ?? preflight.selected_audio_stream_index}
-                    onChange={(event) => {
-                      setAudioStreamIndex(Number(event.target.value));
-                      setPreflight(null);
-                    }}
-                  >
-                    {preflight.audio_streams.map((stream) => (
-                      <option key={stream.index} value={stream.index}>#{stream.index} · {stream.codec} · {stream.channels ?? "?"} ch</option>
                     ))}
                   </select>
                 </label>
@@ -645,9 +684,20 @@ export function ProcessingCenter({
             </details>
             <div className="launch-row">
               <p>
-                Start re-runs backend admission immediately before execution. A changed machine, model, source, or strategy fails closed instead of trusting this displayed plan.
+                {preflight.audio_stream_selection_required
+                  ? "Choose an audio track above before starting. EchoFlow will not treat the container's first track as user intent."
+                  : "Start re-runs backend admission immediately before execution. A changed machine, model, source, or strategy fails closed instead of trusting this displayed plan."}
               </p>
-              <button type="button" className="primary-action" disabled={busy || !preflight.fits_memory_budget} onClick={() => void startPlannedJob()}>
+              <button
+                type="button"
+                className="primary-action"
+                disabled={
+                  busy ||
+                  !preflight.fits_memory_budget ||
+                  preflight.audio_stream_selection_required
+                }
+                onClick={() => void startPlannedJob()}
+              >
                 Start local transcription
               </button>
             </div>
@@ -696,7 +746,7 @@ export function ProcessingCenter({
                   <button type="button" className="primary-action compact-action" onClick={() => void resumeJob(job)}>Resume checkpoint</button>
                 )}
                 {job.status !== "running" && (
-                  <button type="button" onClick={() => void prepareRetry(job)}>Plan fresh retry</button>
+                  <button type="button" onClick={() => void prepareRetry(job, null)}>Plan fresh retry</button>
                 )}
                 {job.status !== "running" && (
                   <button type="button" className="danger-link" onClick={() => setPendingDiscard(job)}>Discard private state</button>

--- a/frontend/src/TranscriptToolsPanel.tsx
+++ b/frontend/src/TranscriptToolsPanel.tsx
@@ -9,6 +9,7 @@ import type {
   TranscriptToolsClient,
   TranscriptToolsSnapshot,
 } from "./api/transcriptTools";
+import { InfoPopover } from "./components/InfoPopover";
 import { formatEvidenceTime } from "./format";
 import "./transcript-tools.css";
 
@@ -190,9 +191,17 @@ export function TranscriptToolsPanel({
           <p className="mini-label">Transcript</p>
           <h2 id="transcript-tools-title">Transcript tools</h2>
         </div>
-        <button type="button" className="quiet-button" onClick={onClose}>
-          Close
-        </button>
+        <div className="context-help-actions">
+          <InfoPopover
+            topic="transcript-tools"
+            label="How these work"
+            align="end"
+            className="context-help"
+          />
+          <button type="button" className="quiet-button" onClick={onClose}>
+            Close
+          </button>
+        </div>
       </header>
 
       <p className="transcript-tools-status" role="status">{status}</p>

--- a/frontend/src/api/playback.ts
+++ b/frontend/src/api/playback.ts
@@ -1,0 +1,126 @@
+import type { TranscriptGenerationRef } from "./transcriptTools";
+
+export type PlaybackMediaKind = "audio" | "video";
+
+export interface PlaybackSession {
+  session_id: string;
+  media_url: string;
+  duration_seconds: number;
+  seek_seconds: number;
+  media_kind: PlaybackMediaKind;
+}
+
+interface NativePlaybackPrepared {
+  session_id: string;
+  media_token: string;
+  duration_seconds: number;
+  seek_seconds: number;
+  media_kind: PlaybackMediaKind;
+}
+
+interface NativePlaybackReleased {
+  released: boolean;
+}
+
+export interface PlaybackClient {
+  prepare(ref: TranscriptGenerationRef, seekSeconds: number): Promise<PlaybackSession>;
+  release(sessionId: string): Promise<boolean>;
+}
+
+function assertPrepared(value: unknown): NativePlaybackPrepared {
+  if (!value || typeof value !== "object") {
+    throw new Error("EchoFlow playback returned an invalid native session");
+  }
+  const candidate = value as Partial<NativePlaybackPrepared>;
+  if (
+    typeof candidate.session_id !== "string" ||
+    typeof candidate.media_token !== "string" ||
+    typeof candidate.duration_seconds !== "number" ||
+    !Number.isFinite(candidate.duration_seconds) ||
+    candidate.duration_seconds <= 0 ||
+    typeof candidate.seek_seconds !== "number" ||
+    !Number.isFinite(candidate.seek_seconds) ||
+    candidate.seek_seconds < 0 ||
+    candidate.seek_seconds > candidate.duration_seconds ||
+    (candidate.media_kind !== "audio" && candidate.media_kind !== "video")
+  ) {
+    throw new Error("EchoFlow playback returned an incompatible native session");
+  }
+  return candidate as NativePlaybackPrepared;
+}
+
+class TauriPlaybackClient implements PlaybackClient {
+  async prepare(
+    ref: TranscriptGenerationRef,
+    seekSeconds: number,
+  ): Promise<PlaybackSession> {
+    const { convertFileSrc, invoke } = await import("@tauri-apps/api/core");
+    const prepared = assertPrepared(
+      await invoke<unknown>("playback_prepare", {
+        request: {
+          document_id: ref.document_id,
+          canonical_sha256: ref.canonical_sha256,
+          seek_seconds: seekSeconds,
+        },
+      }),
+    );
+    return {
+      session_id: prepared.session_id,
+      media_url: convertFileSrc(prepared.media_token, "echoflow-media"),
+      duration_seconds: prepared.duration_seconds,
+      seek_seconds: prepared.seek_seconds,
+      media_kind: prepared.media_kind,
+    };
+  }
+
+  async release(sessionId: string): Promise<boolean> {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const released = await invoke<NativePlaybackReleased>("playback_release", {
+      sessionId,
+    });
+    return released.released;
+  }
+}
+
+class MockPlaybackClient implements PlaybackClient {
+  private nextId = 1;
+
+  async prepare(
+    ref: TranscriptGenerationRef,
+    seekSeconds: number,
+  ): Promise<PlaybackSession> {
+    const params = new URLSearchParams(window.location.search);
+    const failure = params.get("playback");
+    if (failure === "missing") {
+      throw new Error("Original recording is unavailable at its recorded location");
+    }
+    if (failure === "changed") {
+      throw new Error("Original recording no longer matches the source used for this transcript");
+    }
+    if (failure === "multi-audio") {
+      throw new Error(
+        "Playback for recordings with multiple audio streams is not enabled yet; EchoFlow will not guess which track matches this transcript",
+      );
+    }
+    if (!Number.isFinite(seekSeconds) || seekSeconds < 0 || seekSeconds > 1460.4) {
+      throw new Error("Playback position is outside the verified recording duration");
+    }
+    const sessionId = `e2e-playback-${this.nextId++}`;
+    return {
+      session_id: sessionId,
+      media_url: `mock-media://${sessionId}`,
+      duration_seconds: 1460.4,
+      seek_seconds: seekSeconds,
+      media_kind: params.get("media") === "video" ? "video" : "audio",
+    };
+  }
+
+  async release(_sessionId: string): Promise<boolean> {
+    return true;
+  }
+}
+
+export function createPlaybackClient(): PlaybackClient {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("e2e") === "1" ? new MockPlaybackClient() : new TauriPlaybackClient();
+}

--- a/frontend/src/api/processing.ts
+++ b/frontend/src/api/processing.ts
@@ -79,6 +79,9 @@ export interface ProcessingAudioStream {
   duration_seconds: number | null;
   sample_rate_hz: number | null;
   channels: number | null;
+  title: string | null;
+  language: string | null;
+  is_default: boolean;
 }
 
 export interface ProcessingPreflight {
@@ -89,6 +92,7 @@ export interface ProcessingPreflight {
   duration_seconds: number;
   audio_streams: ProcessingAudioStream[];
   selected_audio_stream_index: number;
+  audio_stream_selection_required: boolean;
   profile: ProcessingProfile;
   provisional: boolean;
   strategy_id: string;
@@ -578,14 +582,51 @@ class MockProcessingClient implements ProcessingClient {
   private plan(recordingName: string, options: PreflightOptions): ProcessingPreflight {
     const model = options.profile === "screening" ? "tiny" : options.profile === "accuracy" ? "medium" : "small";
     const strategy = options.strategyId ?? `${model}-cpu-int8`;
+    const multitrack = new URLSearchParams(window.location.search).get("multitrack") === "1";
+    const audioStreams: ProcessingAudioStream[] = multitrack
+      ? [
+          {
+            index: 1,
+            codec: "aac",
+            duration_seconds: 3_642.5,
+            sample_rate_hz: 48_000,
+            channels: 2,
+            title: "Camera scratch",
+            language: "eng",
+            is_default: false,
+          },
+          {
+            index: 3,
+            codec: "pcm_s16le",
+            duration_seconds: 3_642.5,
+            sample_rate_hz: 48_000,
+            channels: 1,
+            title: "Lav microphone",
+            language: "eng",
+            is_default: true,
+          },
+        ]
+      : [
+          {
+            index: 1,
+            codec: "aac",
+            duration_seconds: 3_642.5,
+            sample_rate_hz: 48_000,
+            channels: 2,
+            title: null,
+            language: null,
+            is_default: false,
+          },
+        ];
     return {
       job_id: `job-planned-${this.jobMutation + 10}`,
       recording_name: recordingName,
       source_sha256: "e".repeat(64),
       container_format: "mov,mp4,m4a,3gp,3g2,mj2",
       duration_seconds: 3_642.5,
-      audio_streams: [{ index: 1, codec: "aac", duration_seconds: 3_642.5, sample_rate_hz: 48_000, channels: 2 }],
-      selected_audio_stream_index: options.audioStreamIndex ?? 1,
+      audio_streams: audioStreams,
+      selected_audio_stream_index: options.audioStreamIndex ?? audioStreams[0]!.index,
+      audio_stream_selection_required: multitrack && options.audioStreamIndex == null,
       profile: options.profile,
       provisional: options.profile === "screening",
       strategy_id: strategy,

--- a/frontend/src/components/AudioTrackChooser.tsx
+++ b/frontend/src/components/AudioTrackChooser.tsx
@@ -1,0 +1,70 @@
+import type { ProcessingAudioStream } from "../api/processing";
+
+interface AudioTrackChooserProps {
+  streams: ProcessingAudioStream[];
+  selectedIndex: number | null;
+  selectionRequired: boolean;
+  busy: boolean;
+  onSelect: (index: number) => void;
+}
+
+function trackDetails(stream: ProcessingAudioStream): string {
+  const details = [stream.language, stream.codec];
+  if (stream.sample_rate_hz !== null) {
+    details.push(`${Math.round(stream.sample_rate_hz / 1000)} kHz`);
+  }
+  details.push(`${stream.channels ?? "?"} ch`);
+  if (stream.is_default) details.push("container default");
+  return details.filter(Boolean).join(" · ");
+}
+
+export function AudioTrackChooser({
+  streams,
+  selectedIndex,
+  selectionRequired,
+  busy,
+  onSelect,
+}: AudioTrackChooserProps) {
+  if (streams.length < 2) return null;
+
+  return (
+    <fieldset className="audio-track-chooser" aria-describedby="audio-track-help">
+      <legend>Choose the audio track to transcribe</legend>
+      <p id="audio-track-help">
+        EchoFlow found {streams.length} audio tracks in this recording. Choose the track that
+        contains the evidence you want transcribed. Container titles, languages, and default
+        flags are descriptive source metadata, not an EchoFlow recommendation.
+      </p>
+      {selectionRequired && (
+        <p className="audio-track-required" role="status">
+          Confirm one track before starting. EchoFlow will re-run backend preflight with that
+          exact stream bound into the transcription plan.
+        </p>
+      )}
+      <div className="audio-track-options">
+        {streams.map((stream) => {
+          const confirmed = !selectionRequired && selectedIndex === stream.index;
+          return (
+            <label
+              key={stream.index}
+              className={confirmed ? "audio-track-option audio-track-option-active" : "audio-track-option"}
+            >
+              <input
+                type="radio"
+                name="transcription-audio-track"
+                value={stream.index}
+                checked={confirmed}
+                disabled={busy}
+                onChange={() => onSelect(stream.index)}
+              />
+              <span>
+                <strong>{stream.title ?? `Track #${stream.index}`}</strong>
+                <small>#{stream.index} · {trackDetails(stream)}</small>
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/frontend/src/components/InfoPopover.tsx
+++ b/frontend/src/components/InfoPopover.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useId, useRef, useState } from "react";
+
+import { HELP_TOPICS, type HelpTopicId } from "../help";
+
+interface InfoPopoverProps {
+  topic: HelpTopicId;
+  label?: string;
+  align?: "start" | "end";
+  className?: string;
+}
+
+export function InfoPopover({
+  topic,
+  label = "What is this?",
+  align = "end",
+  className,
+}: InfoPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const shellRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelId = useId();
+  const titleId = useId();
+  const content = HELP_TOPICS[topic];
+
+  useEffect(() => {
+    setOpen(false);
+  }, [topic]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    function closeOnOutsidePointer(event: PointerEvent) {
+      const target = event.target;
+      if (target instanceof Node && !shellRef.current?.contains(target)) {
+        setOpen(false);
+      }
+    }
+
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      setOpen(false);
+      triggerRef.current?.focus();
+    }
+
+    document.addEventListener("pointerdown", closeOnOutsidePointer);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnOutsidePointer);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  const shellClass = ["info-popover", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={shellClass} ref={shellRef} data-align={align}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="info-popover-trigger"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="info-popover-glyph" aria-hidden="true">
+          ?
+        </span>
+        <span>{label}</span>
+      </button>
+
+      {open && (
+        <div
+          id={panelId}
+          className="info-popover-panel"
+          role="note"
+          aria-labelledby={titleId}
+        >
+          <div className="info-popover-heading">
+            <div>
+              <p className="mini-label">In-app guide</p>
+              <h3 id={titleId}>{content.title}</h3>
+            </div>
+            <button
+              type="button"
+              className="info-popover-close"
+              aria-label={`Close ${content.title}`}
+              onClick={() => {
+                setOpen(false);
+                triggerRef.current?.focus();
+              }}
+            >
+              ×
+            </button>
+          </div>
+          <p className="info-popover-summary">{content.summary}</p>
+          <ul>
+            {content.points.map((point) => (
+              <li key={point}>{point}</li>
+            ))}
+          </ul>
+          {content.note && <p className="info-popover-note">{content.note}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/help.css
+++ b/frontend/src/help.css
@@ -125,6 +125,14 @@
   border-radius: 12px;
 }
 
+.context-help-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .context-help .info-popover-trigger {
   min-height: 32px;
   padding-block: 5px;

--- a/frontend/src/help.css
+++ b/frontend/src/help.css
@@ -110,6 +110,11 @@
   padding-top: 12px;
 }
 
+.sidebar-guides {
+  display: grid;
+  gap: 6px;
+}
+
 .sidebar-help {
   width: 100%;
 }

--- a/frontend/src/help.css
+++ b/frontend/src/help.css
@@ -1,0 +1,135 @@
+.info-popover {
+  position: relative;
+  display: inline-flex;
+  max-width: 100%;
+}
+
+.info-popover-trigger {
+  border: 1px solid var(--control-border);
+  border-radius: 999px;
+  background: var(--control-bg);
+  color: var(--control-ink);
+  min-height: 36px;
+  padding: 7px 11px 7px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.74rem;
+  font-weight: 680;
+  text-align: left;
+}
+
+.info-popover-trigger:hover,
+.info-popover-trigger[aria-expanded="true"] {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.info-popover-glyph {
+  width: 21px;
+  height: 21px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  flex: none;
+  background: var(--accent);
+  color: var(--on-accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.info-popover-panel {
+  position: absolute;
+  z-index: 80;
+  top: calc(100% + 10px);
+  width: min(390px, calc(100vw - 32px));
+  max-height: min(620px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 18px;
+  background: var(--surface-raised);
+  color: var(--ink);
+  box-shadow: var(--shadow);
+}
+
+.info-popover[data-align="start"] .info-popover-panel {
+  left: 0;
+}
+
+.info-popover[data-align="end"] .info-popover-panel {
+  right: 0;
+}
+
+.info-popover-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.info-popover-heading h3 {
+  margin: 6px 0 0;
+  font-size: 1.05rem;
+  line-height: 1.2;
+  letter-spacing: -0.025em;
+}
+
+.info-popover-close {
+  width: 32px;
+  height: 32px;
+  flex: none;
+  border: 1px solid var(--control-border);
+  border-radius: 10px;
+  background: var(--control-bg);
+  color: var(--control-ink);
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+.info-popover-summary,
+.info-popover-note {
+  margin: 14px 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.info-popover-panel ul {
+  margin: 14px 0 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 9px;
+  color: var(--ink);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.info-popover-note {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.sidebar-help {
+  width: 100%;
+}
+
+.sidebar-help .info-popover-trigger {
+  width: 100%;
+  justify-content: flex-start;
+  border-radius: 12px;
+}
+
+.context-help .info-popover-trigger {
+  min-height: 32px;
+  padding-block: 5px;
+}
+
+@media (max-width: 760px) {
+  .info-popover-panel {
+    position: fixed;
+    inset: auto 16px 16px;
+    width: auto;
+    max-height: min(70vh, 620px);
+  }
+}

--- a/frontend/src/help.ts
+++ b/frontend/src/help.ts
@@ -1,0 +1,110 @@
+export type HelpTopicId =
+  | "overview"
+  | "intake"
+  | "processing"
+  | "library"
+  | "research"
+  | "evidence"
+  | "playback"
+  | "transcript-tools";
+
+export interface HelpTopic {
+  title: string;
+  summary: string;
+  points: readonly string[];
+  note?: string;
+}
+
+export const HELP_TOPICS: Record<HelpTopicId, HelpTopic> = {
+  overview: {
+    title: "How EchoFlow works",
+    summary:
+      "EchoFlow turns local recordings into searchable, verifiable evidence without making the app database or search index the source of truth.",
+    points: [
+      "Add recordings or existing canonical transcript folders without moving your originals into a hidden vault.",
+      "Process locally. EchoFlow inspects the recording and this computer before choosing an execution strategy.",
+      "Search rebuildable indexes, then reopen the exact canonical transcript evidence behind a result.",
+      "Keep notes, tags, collections, speaker names, and saved searches as durable human-owned research state.",
+    ],
+    note: "Original recordings and canonical transcript JSON are durable evidence. Search indexes and derived exports can be rebuilt.",
+  },
+  intake: {
+    title: "Adding evidence",
+    summary:
+      "This screen decides what local material EchoFlow may use. Selecting something does not silently copy, transcribe, or delete it.",
+    points: [
+      "Choose files for a one-time action, or choose a folder if you may want EchoFlow to remember that location.",
+      "Remembering a folder stores a local permission so future refreshes can discover material there.",
+      "Discovery and processing are separate. Automatic processing requires its own explicit opt-in.",
+    ],
+    note: "Forgetting a remembered folder removes EchoFlow's permission record. It does not delete files inside the folder.",
+  },
+  processing: {
+    title: "Processing recordings",
+    summary:
+      "Processing starts with a preflight. Python inspects source media, available hardware, memory, models, and requested outcome before EchoFlow admits a local job.",
+    points: [
+      "Choose an outcome profile rather than manually guessing thread counts or memory limits.",
+      "Run preflight before starting so EchoFlow can verify the selected source, model, stream, and resource fit.",
+      "Resume continues a compatible checkpointed job. Fresh retry creates a new plan without rewriting the interrupted job.",
+      "Closing the view does not turn transcription into a browser request. Tauri supervises the local process.",
+    ],
+    note: "Model installation is network-bearing and explicit. Transcription itself does not require a hosted transcription service.",
+  },
+  library: {
+    title: "Searching the Library",
+    summary:
+      "Library search finds useful passages in rebuildable local indexes. Opening a passage is a separate verification step against canonical transcript evidence.",
+    points: [
+      "Open transcript passage to read verified context, move the evidence cursor, create a note, or prepare playback.",
+      "Transcript tools manage speaker display names, provenance details, and derived transcript publication for one exact generation.",
+      "Search rank is not evidence authority. EchoFlow verifies the canonical generation before precise navigation.",
+    ],
+    note: "The webview does not receive canonical or original-recording filesystem paths for evidence navigation.",
+  },
+  research: {
+    title: "Keeping research attached to evidence",
+    summary:
+      "Notes, tags, collections, anchors, and saved searches are durable human research. They are not disposable search-index rows.",
+    points: [
+      "A note cites an exact canonical transcript generation and evidence span.",
+      "Saved searches store the question and search options, then resolve current results when you run them again.",
+      "If an older note cites an older transcript generation, EchoFlow can reopen that exact preserved evidence instead of silently moving the citation.",
+      "Re-anchoring is deliberate maintenance, not an automatic rewrite of your research history.",
+    ],
+  },
+  evidence: {
+    title: "Using the Evidence reader",
+    summary:
+      "The Evidence reader is a verified window onto canonical transcript timing. The cursor is a source-relative coordinate, not a decorative progress marker.",
+    points: [
+      "Select a timed transcript word to move the evidence cursor to that exact source-relative position.",
+      "Use the range control for fine movement inside the verified context window, then Return to match to restore the ranked result coordinate.",
+      "A new note is anchored to the exact canonical generation shown here.",
+      "Playback consumes the same cursor after the original source is re-verified.",
+    ],
+  },
+  playback: {
+    title: "Verified local playback",
+    summary:
+      "Prepare playback first so EchoFlow can re-check the exact transcript generation and original recording before a native media session opens.",
+    points: [
+      "Prepare playback verifies source identity and the evidence coordinate. It does not autoplay.",
+      "Play from evidence cursor starts from the same coordinate used by the transcript reader.",
+      "The source path stays behind the native boundary. React receives only an opaque media session and safe timing state.",
+      "Recordings with multiple audio streams are refused for now rather than risking playback of a track that was not transcribed.",
+    ],
+    note: "If verification succeeds but the operating system cannot decode the media codec, EchoFlow reports that separately from an evidence-integrity failure.",
+  },
+  "transcript-tools": {
+    title: "Transcript and speaker tools",
+    summary:
+      "These tools are bound to one exact canonical transcript generation so a long-lived desktop view cannot silently edit a newer transcript.",
+    points: [
+      "Speaker names are your private display labels. Anonymous speaker refs remain visible as machine-produced evidence.",
+      "The speaker transcript preserves overlap, mixed, and unattributed states instead of inventing a single speaker.",
+      "Technical details show verified processing provenance without exposing source or canonical filesystem paths.",
+      "TXT, SRT, and WebVTT publications are derived copies. They do not replace canonical JSON evidence.",
+    ],
+  },
+};

--- a/frontend/src/playback.css
+++ b/frontend/src/playback.css
@@ -1,0 +1,54 @@
+.evidence-playback {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+}
+
+.evidence-playback-heading,
+.evidence-playback-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.evidence-playback-heading h3,
+.evidence-playback-heading p,
+.evidence-playback-copy,
+.evidence-playback-status,
+.evidence-playback-error,
+.evidence-playback-actions span {
+  margin: 0;
+}
+
+.evidence-playback-copy,
+.evidence-playback-actions span {
+  color: var(--text-muted);
+}
+
+.evidence-playback-player {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.evidence-playback-player audio,
+.evidence-playback-player video {
+  width: 100%;
+  max-height: min(52vh, 34rem);
+  border-radius: var(--radius-md);
+  background: var(--surface-sunken);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .evidence-playback,
+  .evidence-playback * {
+    scroll-behavior: auto;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/frontend/src/processing-center.css
+++ b/frontend/src/processing-center.css
@@ -161,6 +161,31 @@
 .preflight-hero strong { display: block; margin-top: 5px; font-size: 1.06rem; }
 .preflight-hero p { margin: 5px 0 0; font-size: 0.78rem; }
 .preflight-metrics { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.audio-track-chooser {
+  margin: 18px 0 0;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface-raised);
+  padding: 16px;
+}
+.audio-track-chooser legend { padding: 0 6px; font-weight: 720; }
+.audio-track-chooser > p { margin: 0; max-width: 820px; color: var(--muted); font-size: 0.78rem; line-height: 1.5; }
+.audio-track-chooser .audio-track-required { margin-top: 8px; color: var(--accent-strong); font-weight: 650; }
+.audio-track-options { margin-top: 12px; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px; }
+.audio-track-option {
+  display: flex;
+  gap: 11px;
+  align-items: flex-start;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  padding: 12px;
+}
+.audio-track-option-active { border-color: var(--accent); background: var(--accent-soft); }
+.audio-track-option input { margin-top: 4px; accent-color: var(--accent); }
+.audio-track-option span { min-width: 0; display: grid; gap: 3px; }
+.audio-track-option strong { overflow-wrap: anywhere; }
+.audio-track-option small { color: var(--muted); line-height: 1.4; }
 .processing-advanced { margin: 18px 0 0; }
 .advanced-processing-grid { padding: 0 17px 16px; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .advanced-processing-grid label { display: grid; gap: 6px; font-size: 0.78rem; font-weight: 650; }
@@ -191,7 +216,8 @@
   .processing-intro,
   .processing-grid { grid-template-columns: 1fr; gap: 14px; }
   .processing-intro { margin-top: 48px; }
-  .recording-choices { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .recording-choices,
+  .audio-track-options { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .preflight-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
@@ -207,6 +233,7 @@
   .processing-metrics,
   .recording-choices,
   .preflight-metrics,
+  .audio-track-options,
   .advanced-processing-grid { grid-template-columns: 1fr; }
   .model-actions,
   .job-actions,

--- a/frontend/tests/in-app-help.spec.ts
+++ b/frontend/tests/in-app-help.spec.ts
@@ -1,0 +1,76 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+async function openLibraryResult(page: import("@playwright/test").Page) {
+  await page.goto("/?e2e=1");
+  await page.getByRole("button", { name: "Library" }).click();
+  await page.getByRole("searchbox", { name: "Search EchoFlow" }).fill("ABC");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+}
+
+test("workspace help remains discoverable and follows the current screen", async ({
+  page,
+}) => {
+  await page.goto("/?e2e=1");
+  const screenHelp = page.getByRole("button", { name: "How this screen works" });
+
+  await expect(screenHelp).toHaveAttribute("aria-expanded", "false");
+  await screenHelp.click();
+  await expect(page.getByRole("heading", { name: "Adding evidence" })).toBeVisible();
+  await expect(page.getByText(/Selecting something does not silently copy/)).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(screenHelp).toHaveAttribute("aria-expanded", "false");
+  await expect(screenHelp).toBeFocused();
+
+  await page.getByRole("button", { name: "Processing" }).click();
+  await screenHelp.click();
+  await expect(page.getByRole("heading", { name: "Processing recordings" })).toBeVisible();
+  await expect(page.getByText(/Resume continues a compatible checkpointed job/)).toBeVisible();
+});
+
+test("global help explains the evidence model without exposing implementation paths", async ({
+  page,
+}) => {
+  await page.goto("/?e2e=1");
+  await page.getByRole("button", { name: "How EchoFlow works" }).click();
+
+  await expect(page.getByRole("heading", { name: "How EchoFlow works" })).toBeVisible();
+  await expect(page.getByText(/Original recordings and canonical transcript JSON/)).toBeVisible();
+  await expect(page.getByText("source_path")).toHaveCount(0);
+  await expect(page.getByText("canonical_path")).toHaveCount(0);
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations).toEqual([]);
+});
+
+test("evidence playback and transcript tools carry help at the point of use", async ({
+  page,
+}) => {
+  await openLibraryResult(page);
+  await page
+    .getByRole("button", { name: /Open transcript passage from interview-42/ })
+    .click();
+
+  const reader = page.getByRole("complementary", { name: "Evidence reader" });
+  await reader.getByRole("button", { name: "How to use this" }).click();
+  await expect(page.getByRole("heading", { name: "Using the Evidence reader" })).toBeVisible();
+  await expect(page.getByText(/Select a timed transcript word/)).toBeVisible();
+
+  const playback = reader.getByRole("region", { name: "Playback" });
+  await playback.getByRole("button", { name: "Why verify?" }).click();
+  await expect(page.getByRole("heading", { name: "Verified local playback" })).toBeVisible();
+  await expect(page.getByText(/Recordings with multiple audio streams are refused/)).toBeVisible();
+
+  await reader.getByRole("button", { name: "Close" }).click();
+  await page.getByRole("button", { name: /Open transcript tools for interview-42/ }).click();
+  const tools = page.getByRole("complementary", { name: "Transcript tools" });
+  await tools.getByRole("button", { name: "How these work" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Transcript and speaker tools" }),
+  ).toBeVisible();
+  await expect(page.getByText(/Speaker names are your private display labels/)).toBeVisible();
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations).toEqual([]);
+});

--- a/frontend/tests/in-app-help.spec.ts
+++ b/frontend/tests/in-app-help.spec.ts
@@ -62,7 +62,7 @@ test("evidence playback and transcript tools carry help at the point of use", as
   await expect(page.getByRole("heading", { name: "Verified local playback" })).toBeVisible();
   await expect(page.getByText(/Recordings with multiple audio streams are refused/)).toBeVisible();
 
-  await reader.getByRole("button", { name: "Close" }).click();
+  await reader.getByRole("button", { name: "Close", exact: true }).click();
   await page.getByRole("button", { name: /Open transcript tools for interview-42/ }).click();
   const tools = page.getByRole("complementary", { name: "Transcript tools" });
   await tools.getByRole("button", { name: "How these work" }).click();

--- a/frontend/tests/playback.spec.ts
+++ b/frontend/tests/playback.spec.ts
@@ -1,0 +1,114 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+async function openLibraryEvidence(
+  page: import("@playwright/test").Page,
+  query = "?e2e=1",
+) {
+  await page.goto(`/${query}`);
+  await page.getByRole("button", { name: "Library" }).click();
+  await page.getByRole("searchbox", { name: "Search EchoFlow" }).fill("ABC");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  await page.getByRole("button", { name: /Open transcript passage from interview-42/ }).click();
+  return page.getByRole("complementary", { name: "Evidence reader" });
+}
+
+test("verified playback starts from the ranked evidence coordinate without path disclosure", async ({
+  page,
+}) => {
+  const reader = await openLibraryEvidence(page);
+  const playback = reader.getByRole("region", { name: "Playback" });
+
+  await expect(playback.getByText(/recording path is never sent to this view/)).toBeVisible();
+  await playback.getByRole("button", { name: "Prepare playback" }).click();
+
+  await expect(playback.getByRole("status")).toHaveText(
+    "Verified local playback prepared at 14:22.",
+  );
+  await expect(playback.locator("[data-session-seek-seconds='862.43']")).toBeVisible();
+  await expect(playback.getByLabel("Verified evidence audio")).toBeVisible();
+  await expect(reader.getByText("/Users/")).toHaveCount(0);
+  await expect(reader.getByText("source_path")).toHaveCount(0);
+  await expect(reader.getByText("canonical_path")).toHaveCount(0);
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations).toEqual([]);
+});
+
+test("word-level evidence cursor is the coordinate submitted to playback authorization", async ({
+  page,
+}) => {
+  const reader = await openLibraryEvidence(page);
+  await reader
+    .getByRole("button", { name: /Move evidence cursor to 14:22 at started/ })
+    .click();
+  const playback = reader.getByRole("region", { name: "Playback" });
+
+  await playback.getByRole("button", { name: "Prepare playback" }).click();
+
+  await expect(playback.locator("[data-session-seek-seconds='862.35']")).toBeVisible();
+  await expect(reader.locator("[data-playhead-seconds='862.35']")).toBeVisible();
+});
+
+for (const [mode, expected] of [
+  ["missing", "Original recording is unavailable at its recorded location"],
+  ["changed", "Original recording no longer matches the source used for this transcript"],
+  [
+    "multi-audio",
+    "Playback for recordings with multiple audio streams is not enabled yet; EchoFlow will not guess which track matches this transcript",
+  ],
+] as const) {
+  test(`playback ${mode} failure is explicit and never creates a media session`, async ({
+    page,
+  }) => {
+    const reader = await openLibraryEvidence(page, `?e2e=1&playback=${mode}`);
+    const playback = reader.getByRole("region", { name: "Playback" });
+
+    await playback.getByRole("button", { name: "Prepare playback" }).click();
+
+    await expect(playback.getByRole("alert")).toHaveText(expected);
+    await expect(playback.locator("audio, video")).toHaveCount(0);
+    await expect(reader.getByText("/Users/")).toHaveCount(0);
+  });
+}
+
+test("video evidence uses the same verified playback contract", async ({ page }) => {
+  const reader = await openLibraryEvidence(page, "?e2e=1&media=video");
+  const playback = reader.getByRole("region", { name: "Playback" });
+
+  await playback.getByRole("button", { name: "Prepare playback" }).click();
+
+  await expect(playback.getByLabel("Verified evidence video")).toBeVisible();
+  await expect(playback.locator("[data-media-kind='video']")).toBeVisible();
+});
+
+test("older anchored evidence can request playback for its exact preserved generation", async ({
+  page,
+}) => {
+  await page.goto("/?e2e=1");
+  await page.getByRole("button", { name: "Research" }).click();
+  await expect(page.getByRole("heading", { name: "Research", exact: true })).toBeVisible();
+  const oldNote = page.locator(".research-note-card").filter({ hasText: "interview-11" });
+  await oldNote.getByRole("button", { name: "Open verified evidence" }).click();
+  const reader = page.getByRole("complementary", { name: "Evidence reader" });
+  await expect(reader.getByText(/Older verified canonical generation/)).toBeVisible();
+
+  const playback = reader.getByRole("region", { name: "Playback" });
+  await playback.getByRole("button", { name: "Prepare playback" }).click();
+
+  await expect(playback.getByRole("status")).toContainText("Verified local playback prepared");
+  await expect(reader.getByText("cccccccccccc…")).toBeVisible();
+  await expect(reader.getByText("source_path")).toHaveCount(0);
+});
+
+test("playback preparation remains keyboard reachable", async ({ page }) => {
+  const reader = await openLibraryEvidence(page);
+  const prepare = reader.getByRole("button", { name: "Prepare playback" });
+
+  await prepare.focus();
+  await page.keyboard.press("Enter");
+
+  await expect(reader.getByRole("region", { name: "Playback" }).getByRole("status")).toContainText(
+    "Verified local playback prepared",
+  );
+});

--- a/frontend/tests/processing.spec.ts
+++ b/frontend/tests/processing.spec.ts
@@ -1,8 +1,11 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
 
-async function openProcessing(page: import("@playwright/test").Page) {
-  await page.goto("/?e2e=1");
+async function openProcessing(
+  page: import("@playwright/test").Page,
+  querySuffix = "",
+) {
+  await page.goto(`/?e2e=1${querySuffix}`);
   await page.getByRole("button", { name: "Processing" }).click();
   await expect(
     page.getByRole("heading", { name: "Turn recordings into durable evidence." }),
@@ -34,6 +37,35 @@ test("Susan can choose a recording and obtain a backend preflight before start",
   await expect(preflight).toBeVisible();
   await expect(page.getByRole("status")).toContainText("Preflight complete");
   await expect(page.getByRole("button", { name: "Start local transcription" })).toBeEnabled();
+  await expect(page.getByRole("group", { name: "Choose the audio track to transcribe" })).toHaveCount(0);
+});
+
+test("multiple embedded audio tracks require an explicit backend-bound choice", async ({ page }) => {
+  await openProcessing(page, "&multitrack=1");
+
+  await page.getByRole("button", { name: "Choose recording" }).click();
+  await page.getByRole("button", { name: "Run preflight" }).click();
+
+  const chooser = page.getByRole("group", { name: "Choose the audio track to transcribe" });
+  await expect(chooser).toBeVisible();
+  await expect(chooser).toContainText("Camera scratch");
+  await expect(chooser).toContainText("Lav microphone");
+  await expect(chooser).toContainText("eng");
+  await expect(chooser).toContainText("container default");
+  await expect(chooser.getByRole("radio")).toHaveCount(2);
+  await expect(chooser.getByRole("radio").first()).not.toBeChecked();
+  await expect(chooser.getByRole("radio").last()).not.toBeChecked();
+
+  const start = page.getByRole("button", { name: "Start local transcription" });
+  await expect(start).toBeDisabled();
+
+  await chooser.getByRole("radio", { name: /Lav microphone/ }).check();
+  await expect(page.getByRole("status")).toContainText("Audio track #3 confirmed");
+  await expect(chooser.getByRole("radio", { name: /Lav microphone/ })).toBeChecked();
+  await expect(start).toBeEnabled();
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations).toEqual([]);
 });
 
 test("starting work uses the supervised local-task path", async ({ page }) => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ only_files = [
     "src/echoflow/library/service.py",
     "src/echoflow/library/speaker_label_service.py",
     "src/echoflow/library/transcript_tools.py",
+    "src/echoflow/library/playback.py",
     "src/echoflow/media/models.py",
     "src/echoflow/media/probe.py",
     "src/echoflow/model_management/catalog.py",
@@ -165,6 +166,7 @@ only_files = [
     "src/echoflow/transcription/speaker_models.py",
     "src/echoflow/transcription/strategy.py",
     "src/echoflow/desktop/transcript_tools_bridge.py",
+    "src/echoflow/desktop/playback_bridge.py",
     "src/echoflow/workspace/models.py",
     "src/echoflow/workspace/service.py",
 ]

--- a/src/echoflow/app/processing_center.py
+++ b/src/echoflow/app/processing_center.py
@@ -81,7 +81,11 @@ def _serialize_job(record: JobLifecycleRecord, *, resumable: bool) -> dict[str, 
     }
 
 
-def _serialize_preflight(plan: TranscriptionJobPlan) -> dict[str, object]:
+def _serialize_preflight(
+    plan: TranscriptionJobPlan,
+    *,
+    audio_stream_selection_required: bool = False,
+) -> dict[str, object]:
     audio_streams = tuple(
         {
             "index": stream.index,
@@ -104,6 +108,7 @@ def _serialize_preflight(plan: TranscriptionJobPlan) -> dict[str, object]:
         "duration_seconds": plan.media.duration_seconds,
         "audio_streams": list(audio_streams),
         "selected_audio_stream_index": plan.media.primary_audio_stream.index,
+        "audio_stream_selection_required": audio_stream_selection_required,
         "profile": plan.policy.profile.value,
         "provisional": plan.policy.provisional,
         "strategy_id": _strategy_id(plan),
@@ -131,6 +136,15 @@ def _strategy_id(plan: TranscriptionJobPlan) -> str:
             plan.engine.compute_type.replace("_", "-"),
         )
     )
+
+
+def _requires_audio_stream_confirmation(
+    plan: TranscriptionJobPlan,
+    requested_index: int | None,
+) -> bool:
+    if requested_index is not None:
+        return False
+    return sum(stream.kind.value == "audio" for stream in plan.media.streams) > 1
 
 
 class ProcessingCenterService:
@@ -250,7 +264,13 @@ class ProcessingCenterService:
             audio_stream_index=audio_stream_index,
             enhance=enhance,
         )
-        return _serialize_preflight(plan)
+        return _serialize_preflight(
+            plan,
+            audio_stream_selection_required=_requires_audio_stream_confirmation(
+                plan,
+                audio_stream_index,
+            ),
+        )
 
     def retry_preflight(
         self,

--- a/src/echoflow/app/processing_center.py
+++ b/src/echoflow/app/processing_center.py
@@ -89,6 +89,9 @@ def _serialize_preflight(plan: TranscriptionJobPlan) -> dict[str, object]:
             "duration_seconds": stream.duration_seconds,
             "sample_rate_hz": stream.sample_rate_hz,
             "channels": stream.channels,
+            "title": stream.title,
+            "language": stream.language,
+            "is_default": stream.is_default,
         }
         for stream in plan.media.streams
         if stream.kind.value == "audio"

--- a/src/echoflow/app/processing_center.py
+++ b/src/echoflow/app/processing_center.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from echoflow.core.errors import ErrorCode
 from echoflow.core.health_check import HealthCheck
+from echoflow.media.models import MediaStream
 from echoflow.model_management.models import ModelInventoryItem
 from echoflow.model_management.service import ModelManager
 from echoflow.runner.inspector import RunnerInspector
@@ -81,22 +82,33 @@ def _serialize_job(record: JobLifecycleRecord, *, resumable: bool) -> dict[str, 
     }
 
 
+def _serialize_audio_stream(stream: MediaStream) -> dict[str, object]:
+    document: dict[str, object] = {
+        "index": stream.index,
+        "codec": stream.codec,
+        "duration_seconds": stream.duration_seconds,
+        "sample_rate_hz": stream.sample_rate_hz,
+        "channels": stream.channels,
+    }
+    title = getattr(stream, "title", None)
+    language = getattr(stream, "language", None)
+    is_default = getattr(stream, "is_default", False)
+    if title is not None:
+        document["title"] = title
+    if language is not None:
+        document["language"] = language
+    if is_default is True:
+        document["is_default"] = True
+    return document
+
+
 def _serialize_preflight(
     plan: TranscriptionJobPlan,
     *,
     audio_stream_selection_required: bool = False,
 ) -> dict[str, object]:
     audio_streams = tuple(
-        {
-            "index": stream.index,
-            "codec": stream.codec,
-            "duration_seconds": stream.duration_seconds,
-            "sample_rate_hz": stream.sample_rate_hz,
-            "channels": stream.channels,
-            "title": stream.title,
-            "language": stream.language,
-            "is_default": stream.is_default,
-        }
+        _serialize_audio_stream(stream)
         for stream in plan.media.streams
         if stream.kind.value == "audio"
     )

--- a/src/echoflow/app/tests/test_multitrack_preflight.py
+++ b/src/echoflow/app/tests/test_multitrack_preflight.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+from echoflow.app.processing_center import (
+    _requires_audio_stream_confirmation,
+    _serialize_preflight,
+)
+from echoflow.media.models import MediaStream, StreamKind
+from echoflow.runner.models import ProcessingProfile
+from echoflow.workspace.models import JobId
+
+
+def _plan():
+    camera = MediaStream(
+        index=1,
+        kind=StreamKind.AUDIO,
+        codec="aac",
+        duration_seconds=42.0,
+        sample_rate_hz=48_000,
+        channels=2,
+        title="Camera scratch",
+        language="eng",
+    )
+    lav = MediaStream(
+        index=3,
+        kind=StreamKind.AUDIO,
+        codec="pcm_s16le",
+        duration_seconds=42.0,
+        sample_rate_hz=48_000,
+        channels=1,
+        title="Lav microphone",
+        language="eng",
+        is_default=True,
+    )
+    video = MediaStream(index=0, kind=StreamKind.VIDEO, codec="h264")
+    return SimpleNamespace(
+        job=SimpleNamespace(
+            job_id=JobId("planned-job"),
+            input_path=Path("/private/recording.mkv"),
+        ),
+        media=SimpleNamespace(
+            input=SimpleNamespace(sha256="a" * 64),
+            container_format="matroska",
+            duration_seconds=42.0,
+            streams=(video, camera, lav),
+            primary_audio_stream=camera,
+        ),
+        policy=SimpleNamespace(
+            profile=ProcessingProfile.BALANCED,
+            provisional=False,
+            memory_budget_bytes=8_000,
+        ),
+        engine=SimpleNamespace(
+            engine="faster-whisper",
+            model="small",
+            model_revision="revision-small",
+            device="cpu",
+            compute_type="int8",
+            cpu_threads=4,
+        ),
+        decoder=SimpleNamespace(strategy=SimpleNamespace(value="ffmpeg-normalize")),
+        enhancement=SimpleNamespace(enabled=False),
+        resources=SimpleNamespace(
+            total_disk_bytes=12_000,
+            estimated_peak_memory_bytes=2_000,
+            fits_memory_budget=True,
+        ),
+        warnings=(),
+    )
+
+
+def test_multitrack_preflight_requires_explicit_stream_until_index_is_requested():
+    plan = cast(Any, _plan())
+
+    assert _requires_audio_stream_confirmation(plan, None) is True
+    assert _requires_audio_stream_confirmation(plan, 1) is False
+    assert _requires_audio_stream_confirmation(plan, 3) is False
+
+
+def test_preflight_serializes_bounded_human_track_metadata_without_paths():
+    plan = cast(Any, _plan())
+
+    result = _serialize_preflight(plan, audio_stream_selection_required=True)
+
+    assert result["audio_stream_selection_required"] is True
+    assert result["selected_audio_stream_index"] == 1
+    assert result["audio_streams"] == [
+        {
+            "index": 1,
+            "codec": "aac",
+            "duration_seconds": 42.0,
+            "sample_rate_hz": 48_000,
+            "channels": 2,
+            "title": "Camera scratch",
+            "language": "eng",
+        },
+        {
+            "index": 3,
+            "codec": "pcm_s16le",
+            "duration_seconds": 42.0,
+            "sample_rate_hz": 48_000,
+            "channels": 1,
+            "title": "Lav microphone",
+            "language": "eng",
+            "is_default": True,
+        },
+    ]
+    assert "/private" not in str(result)

--- a/src/echoflow/desktop/playback_bridge.py
+++ b/src/echoflow/desktop/playback_bridge.py
@@ -1,0 +1,173 @@
+"""Trusted-host bridge for generation-bound local playback authorization.
+
+This adapter returns a source path only to EchoFlow's fixed Rust host command. The Rust
+host must convert it to an opaque media session before returning anything to the webview.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import redirect_stdout
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from echoflow.app.app_container import AppContainer
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.playback import PlaybackAuthorizationService, PlaybackGrant
+
+_PROTOCOL_VERSION = 1
+_MAX_REQUEST_BYTES = 128 * 1024
+PlaybackMethod = Literal["playback.authorize"]
+
+
+class _Request(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    protocol_version: Literal[1]
+    request_id: str = Field(min_length=1, max_length=128)
+    method: PlaybackMethod
+    params: dict[str, object] = Field(default_factory=dict)
+
+
+class _AuthorizeParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    document_id: str = Field(min_length=1, max_length=1_024)
+    canonical_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    seek_seconds: float = Field(ge=0)
+
+    @field_validator("document_id")
+    @classmethod
+    def strip_document_id(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("document_id cannot be blank")
+        return stripped
+
+
+def _serialize_grant(grant: PlaybackGrant) -> dict[str, object]:
+    """Serialize the trusted-host grant. Never forward this object to React."""
+    return {
+        "document_id": grant.document_id,
+        "canonical_sha256": grant.canonical_sha256,
+        "source_sha256": grant.source_sha256,
+        "source_path": grant.source_path,
+        "source_size_bytes": grant.source_size_bytes,
+        "source_modified_ns": grant.source_modified_ns,
+        "duration_seconds": grant.duration_seconds,
+        "seek_seconds": grant.seek_seconds,
+        "audio_stream_index": grant.audio_stream_index,
+        "media_kind": grant.media_kind,
+        "container_format": grant.container_format,
+    }
+
+
+def dispatch_playback(
+    method: str,
+    params: dict[str, object],
+    service: PlaybackAuthorizationService,
+) -> object:
+    if method != "playback.authorize":
+        raise ValueError("Unsupported playback method")
+    parsed = _AuthorizeParams.model_validate(params)
+    return _serialize_grant(
+        service.authorize(
+            parsed.document_id,
+            expected_canonical_sha256=parsed.canonical_sha256,
+            seek_seconds=parsed.seek_seconds,
+        )
+    )
+
+
+def _success(request_id: str, result: object) -> dict[str, object]:
+    return {
+        "protocol_version": _PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": True,
+        "result": result,
+        "error": None,
+    }
+
+
+def _failure(request_id: str, *, code: str, message: str) -> dict[str, object]:
+    return {
+        "protocol_version": _PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": False,
+        "result": None,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _service(container: AppContainer) -> PlaybackAuthorizationService:
+    return PlaybackAuthorizationService(
+        index=container.transcript_index(),
+        file_manager=container.file_manager(),
+        media_probe=container.media_probe(),
+    )
+
+
+def handle_request(
+    payload: object,
+    service: PlaybackAuthorizationService,
+) -> dict[str, object]:
+    request_id = "unknown"
+    try:
+        request = _Request.model_validate(payload)
+        request_id = request.request_id
+        return _success(
+            request_id,
+            dispatch_playback(request.method, request.params, service),
+        )
+    except ValidationError:
+        return _failure(
+            request_id,
+            code="invalid_request",
+            message="Playback authorization request is invalid",
+        )
+    except EchoFlowError as exc:
+        return _failure(
+            request_id,
+            code=exc.code.value,
+            message=exc.public_message,
+        )
+    except ValueError as exc:
+        return _failure(request_id, code="invalid_request", message=str(exc))
+    except Exception:
+        return _failure(
+            request_id,
+            code="internal_error",
+            message="EchoFlow could not authorize local playback",
+        )
+
+
+def main() -> int:
+    raw = sys.stdin.buffer.read(_MAX_REQUEST_BYTES + 1)
+    if len(raw) > _MAX_REQUEST_BYTES:
+        response = _failure(
+            "unknown",
+            code="invalid_request",
+            message="Playback authorization request exceeded the safe size limit",
+        )
+    else:
+        try:
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            response = _failure(
+                "unknown",
+                code="invalid_request",
+                message="Playback authorization request was not valid JSON",
+            )
+        else:
+            with redirect_stdout(sys.stderr):
+                container = AppContainer()
+                response = handle_request(payload, _service(container))
+    sys.stdout.write(json.dumps(response, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/echoflow/desktop/tests/test_playback_bridge.py
+++ b/src/echoflow/desktop/tests/test_playback_bridge.py
@@ -1,0 +1,190 @@
+import io
+import json
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+from echoflow.desktop.playback_bridge import dispatch_playback, handle_request, main
+from echoflow.library.errors import PlaybackAuthorizationError
+from echoflow.library.playback import PlaybackGrant
+
+
+class PlaybackStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, float]] = []
+
+    def authorize(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        seek_seconds: float,
+    ) -> PlaybackGrant:
+        self.calls.append(
+            (document_id, expected_canonical_sha256, seek_seconds)
+        )
+        return PlaybackGrant(
+            document_id=document_id,
+            canonical_sha256=expected_canonical_sha256,
+            source_sha256="b" * 64,
+            source_path="/private/evidence/interview.m4a",
+            source_size_bytes=1234,
+            source_modified_ns=42,
+            duration_seconds=120.0,
+            seek_seconds=seek_seconds,
+            audio_stream_index=0,
+            media_kind="audio",
+            container_format="mov,mp4,m4a,3gp,3g2,mj2",
+        )
+
+
+class PlaybackFailureStub(PlaybackStub):
+    def authorize(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        seek_seconds: float,
+    ) -> PlaybackGrant:
+        raise PlaybackAuthorizationError("Original recording does not match")
+
+
+class UnexpectedFailureStub(PlaybackStub):
+    def authorize(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        seek_seconds: float,
+    ) -> PlaybackGrant:
+        raise RuntimeError("private source path detail")
+
+
+class BinaryInput:
+    def __init__(self, payload: bytes) -> None:
+        self.buffer = io.BytesIO(payload)
+
+
+def _valid_request() -> dict[str, object]:
+    return {
+        "protocol_version": 1,
+        "request_id": "playback-1",
+        "method": "playback.authorize",
+        "params": {
+            "document_id": "interview-1",
+            "canonical_sha256": "a" * 64,
+            "seek_seconds": 12.5,
+        },
+    }
+
+
+def test_dispatch_serializes_trusted_host_grant() -> None:
+    stub = PlaybackStub()
+
+    result = dispatch_playback(
+        "playback.authorize",
+        {
+            "document_id": " interview-1 ",
+            "canonical_sha256": "a" * 64,
+            "seek_seconds": 12.5,
+        },
+        stub,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(result, dict)
+    assert result["source_path"] == "/private/evidence/interview.m4a"
+    assert result["seek_seconds"] == 12.5
+    assert result["media_kind"] == "audio"
+    assert stub.calls == [("interview-1", "a" * 64, 12.5)]
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"document_id": "x", "canonical_sha256": "A" * 64, "seek_seconds": 1.0},
+        {"document_id": "x", "canonical_sha256": "a" * 63, "seek_seconds": 1.0},
+        {"document_id": "   ", "canonical_sha256": "a" * 64, "seek_seconds": 1.0},
+        {"document_id": "x", "canonical_sha256": "a" * 64, "seek_seconds": -1.0},
+        {
+            "document_id": "x",
+            "canonical_sha256": "a" * 64,
+            "seek_seconds": 1.0,
+            "source_path": "/attacker/chosen/path",
+        },
+    ],
+)
+def test_dispatch_rejects_invalid_or_extra_values(params: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        dispatch_playback(
+            "playback.authorize",
+            params,
+            PlaybackStub(),  # type: ignore[arg-type]
+        )
+
+
+def test_unknown_method_is_denied_before_service_dispatch() -> None:
+    stub = PlaybackStub()
+    response = handle_request(
+        {
+            "protocol_version": 1,
+            "request_id": "playback-1",
+            "method": "playback.open-path",
+            "params": {"path": "/tmp/secret"},
+        },
+        stub,  # type: ignore[arg-type]
+    )
+
+    assert response["ok"] is False
+    assert response["error"] == {
+        "code": "invalid_request",
+        "message": "Playback authorization request is invalid",
+    }
+    assert stub.calls == []
+
+
+def test_handle_request_translates_application_and_unexpected_failures() -> None:
+    application = handle_request(
+        _valid_request(),
+        PlaybackFailureStub(),  # type: ignore[arg-type]
+    )
+    unexpected = handle_request(
+        _valid_request(),
+        UnexpectedFailureStub(),  # type: ignore[arg-type]
+    )
+
+    assert application["error"] == {
+        "code": "internal_error",
+        "message": "Original recording does not match",
+    }
+    assert unexpected["error"] == {
+        "code": "internal_error",
+        "message": "EchoFlow could not authorize local playback",
+    }
+    assert "private source path detail" not in str(unexpected)
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, payload: bytes) -> dict[str, object]:
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdin", BinaryInput(payload))
+    monkeypatch.setattr(sys, "stdout", stdout)
+    main()
+    return json.loads(stdout.getvalue())
+
+
+def test_main_rejects_invalid_json_without_constructing_services(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _run_main(monkeypatch, b"not-json")
+
+    assert response["ok"] is False
+    assert response["error"]["message"] == "Playback authorization request was not valid JSON"
+
+
+def test_main_rejects_oversized_request_before_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _run_main(monkeypatch, b"x" * (128 * 1024 + 1))
+
+    assert response["ok"] is False
+    assert "safe size limit" in response["error"]["message"]

--- a/src/echoflow/desktop/tests/test_playback_bridge.py
+++ b/src/echoflow/desktop/tests/test_playback_bridge.py
@@ -21,9 +21,7 @@ class PlaybackStub:
         expected_canonical_sha256: str,
         seek_seconds: float,
     ) -> PlaybackGrant:
-        self.calls.append(
-            (document_id, expected_canonical_sha256, seek_seconds)
-        )
+        self.calls.append((document_id, expected_canonical_sha256, seek_seconds))
         return PlaybackGrant(
             document_id=document_id,
             canonical_sha256=expected_canonical_sha256,
@@ -130,7 +128,7 @@ def test_unknown_method_is_denied_before_service_dispatch() -> None:
             "protocol_version": 1,
             "request_id": "playback-1",
             "method": "playback.open-path",
-            "params": {"path": "/tmp/secret"},
+            "params": {"path": "attacker-chosen-secret"},
         },
         stub,  # type: ignore[arg-type]
     )

--- a/src/echoflow/desktop/tests/test_playback_bridge.py
+++ b/src/echoflow/desktop/tests/test_playback_bridge.py
@@ -176,7 +176,10 @@ def test_main_rejects_invalid_json_without_constructing_services(
     response = _run_main(monkeypatch, b"not-json")
 
     assert response["ok"] is False
-    assert response["error"]["message"] == "Playback authorization request was not valid JSON"
+    assert (
+        response["error"]["message"]
+        == "Playback authorization request was not valid JSON"
+    )
 
 
 def test_main_rejects_oversized_request_before_parsing(

--- a/src/echoflow/library/errors.py
+++ b/src/echoflow/library/errors.py
@@ -31,6 +31,12 @@ class TranscriptToolingError(TranscriptLibraryError):
     exit_code = 2
 
 
+class PlaybackAuthorizationError(TranscriptLibraryError):
+    """Verified local-source playback could not be authorized safely."""
+
+    exit_code = 2
+
+
 class EvidenceNavigationError(TranscriptLibraryError):
     """A ranked result cannot be reconciled safely with canonical evidence."""
 

--- a/src/echoflow/library/playback.py
+++ b/src/echoflow/library/playback.py
@@ -1,0 +1,266 @@
+"""Generation-bound authorization for native playback of verified local source evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from echoflow.core.errors import EchoFlowError
+from echoflow.core.file_manager_facade import FileManagerFacade
+from echoflow.library.errors import PlaybackAuthorizationError
+from echoflow.library.index import IndexedDocument, TranscriptIndex
+from echoflow.media.models import MediaInfo, StreamKind
+
+_MAX_CANONICAL_BYTES = 256 * 1024 * 1024
+
+
+class _CanonicalSource(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    size_bytes: int = Field(gt=0)
+    modified_ns: int = Field(ge=0)
+    container_format: str = Field(min_length=1)
+    duration_seconds: float = Field(gt=0)
+    audio_stream_index: int = Field(ge=0)
+
+
+class _CanonicalPlaybackProjection(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    schema_version: int
+    job_id: str = Field(min_length=1)
+    source: _CanonicalSource
+
+
+class MediaProbe(Protocol):
+    """Read-only media inspection needed by playback authorization."""
+
+    def probe(self, input_path: str | Path) -> MediaInfo: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PlaybackGrant:
+    """Trusted-host grant. ``source_path`` must never cross into the webview DTO."""
+
+    document_id: str
+    canonical_sha256: str
+    source_sha256: str
+    source_path: str
+    source_size_bytes: int
+    source_modified_ns: int
+    duration_seconds: float
+    seek_seconds: float
+    audio_stream_index: int
+    media_kind: str
+    container_format: str
+
+    def __post_init__(self) -> None:
+        if self.media_kind not in {"audio", "video"}:
+            raise ValueError("media_kind must be audio or video")
+        if not math.isfinite(self.seek_seconds) or not (
+            0 <= self.seek_seconds <= self.duration_seconds
+        ):
+            raise ValueError("seek_seconds must remain inside source duration")
+
+
+class PlaybackAuthorizationService:
+    """Authorize playback only when canonical generation and source bytes still agree."""
+
+    def __init__(
+        self,
+        *,
+        index: TranscriptIndex,
+        file_manager: FileManagerFacade,
+        media_probe: MediaProbe,
+    ) -> None:
+        self.index = index
+        self.file_manager = file_manager
+        self.media_probe = media_probe
+
+    def authorize(
+        self,
+        document_id: str,
+        *,
+        expected_canonical_sha256: str,
+        seek_seconds: float,
+    ) -> PlaybackGrant:
+        self._validate_seek_shape(seek_seconds)
+        document = self._require_generation(document_id, expected_canonical_sha256)
+        projection = self._verified_projection(document, expected_canonical_sha256)
+        source_path = self._require_source_path(document)
+        media = self._verified_source(source_path, projection, document)
+
+        if seek_seconds > projection.source.duration_seconds:
+            raise PlaybackAuthorizationError(
+                "Playback position is outside the verified recording duration"
+            )
+
+        audio_streams = tuple(
+            stream for stream in media.streams if stream.kind is StreamKind.AUDIO
+        )
+        if len(audio_streams) != 1:
+            raise PlaybackAuthorizationError(
+                "Playback for recordings with multiple audio streams is not enabled yet; "
+                "EchoFlow will not guess which track matches this transcript"
+            )
+        if audio_streams[0].index != projection.source.audio_stream_index:
+            raise PlaybackAuthorizationError(
+                "The verified source audio stream no longer matches this transcript"
+            )
+
+        return PlaybackGrant(
+            document_id=document.document_id,
+            canonical_sha256=expected_canonical_sha256,
+            source_sha256=projection.source.sha256,
+            source_path=str(media.input.path),
+            source_size_bytes=media.input.size_bytes,
+            source_modified_ns=media.input.modified_ns,
+            duration_seconds=projection.source.duration_seconds,
+            seek_seconds=seek_seconds,
+            audio_stream_index=projection.source.audio_stream_index,
+            media_kind=(
+                "video"
+                if any(stream.kind is StreamKind.VIDEO for stream in media.streams)
+                else "audio"
+            ),
+            container_format=projection.source.container_format,
+        )
+
+    @staticmethod
+    def _validate_seek_shape(seek_seconds: float) -> None:
+        if not math.isfinite(seek_seconds) or seek_seconds < 0:
+            raise ValueError("seek_seconds must be finite and non-negative")
+
+    def _require_generation(
+        self, document_id: str, expected_canonical_sha256: str
+    ) -> IndexedDocument:
+        if len(expected_canonical_sha256) != 64 or any(
+            character not in "0123456789abcdef"
+            for character in expected_canonical_sha256
+        ):
+            raise ValueError(
+                "expected_canonical_sha256 must be a lowercase 64-character digest"
+            )
+        normalized_id = document_id.strip()
+        if not normalized_id:
+            raise ValueError("document_id cannot be blank")
+        document = next(
+            (
+                item
+                for item in self.index.documents()
+                if item.document_id == normalized_id
+            ),
+            None,
+        )
+        if document is None:
+            raise PlaybackAuthorizationError(
+                "Transcript is not present in the local library"
+            )
+        if document.canonical_sha256 is None:
+            raise PlaybackAuthorizationError(
+                "Transcript index predates canonical hashing; rebuild the library first"
+            )
+        if document.canonical_sha256 != expected_canonical_sha256:
+            raise PlaybackAuthorizationError(
+                "Transcript changed since this evidence view was opened; reopen it before playback"
+            )
+        return document
+
+    def _verified_projection(
+        self, document: IndexedDocument, expected_canonical_sha256: str
+    ) -> _CanonicalPlaybackProjection:
+        try:
+            path = Path(document.canonical_path)
+            metadata = self.file_manager.get_file_metadata(path)
+            if metadata["size"] > _MAX_CANONICAL_BYTES:
+                raise PlaybackAuthorizationError(
+                    "Canonical transcript is too large to authorize playback safely"
+                )
+            payload = self.file_manager.read_file(path)
+            if hashlib.sha256(payload).hexdigest() != expected_canonical_sha256:
+                raise PlaybackAuthorizationError(
+                    "Canonical transcript changed; rebuild the library before playback"
+                )
+            projection = _CanonicalPlaybackProjection.model_validate(json.loads(payload))
+            if projection.schema_version != 1:
+                raise PlaybackAuthorizationError(
+                    "Canonical transcript uses an unsupported schema version"
+                )
+            if projection.job_id != document.document_id:
+                raise PlaybackAuthorizationError(
+                    "Canonical transcript identity no longer matches the library index"
+                )
+            if projection.source.sha256 != document.source_sha256:
+                raise PlaybackAuthorizationError(
+                    "Canonical transcript source identity no longer matches the library index"
+                )
+            if not math.isfinite(projection.source.duration_seconds):
+                raise PlaybackAuthorizationError(
+                    "Canonical recording duration is not valid for playback"
+                )
+            return projection
+        except PlaybackAuthorizationError:
+            raise
+        except (
+            OSError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            ValidationError,
+            ValueError,
+        ) as exc:
+            raise PlaybackAuthorizationError(
+                "Canonical transcript could not be validated safely for playback",
+                cause=exc,
+            ) from exc
+
+    @staticmethod
+    def _require_source_path(document: IndexedDocument) -> Path:
+        if document.source_path is None:
+            raise PlaybackAuthorizationError(
+                "Original recording location is unavailable; reconnect the source before playback"
+            )
+        source = Path(document.source_path).expanduser().resolve(strict=False)
+        if not source.is_file():
+            raise PlaybackAuthorizationError(
+                "Original recording is unavailable at its recorded location"
+            )
+        return source
+
+    def _verified_source(
+        self,
+        source_path: Path,
+        projection: _CanonicalPlaybackProjection,
+        document: IndexedDocument,
+    ) -> MediaInfo:
+        try:
+            media = self.media_probe.probe(source_path)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except EchoFlowError as exc:
+            raise PlaybackAuthorizationError(
+                "Original recording could not be verified safely for playback",
+                cause=exc,
+            ) from exc
+        except Exception as exc:
+            raise PlaybackAuthorizationError(
+                "Original recording could not be verified safely for playback",
+                cause=exc,
+            ) from exc
+
+        expected_sha = projection.source.sha256
+        if media.input.sha256 != expected_sha or media.input.sha256 != document.source_sha256:
+            raise PlaybackAuthorizationError(
+                "Original recording no longer matches the source used for this transcript"
+            )
+        if media.input.size_bytes != projection.source.size_bytes:
+            raise PlaybackAuthorizationError(
+                "Original recording size no longer matches canonical source provenance"
+            )
+        return media

--- a/src/echoflow/library/playback.py
+++ b/src/echoflow/library/playback.py
@@ -188,7 +188,9 @@ class PlaybackAuthorizationService:
                 raise PlaybackAuthorizationError(
                     "Canonical transcript changed; rebuild the library before playback"
                 )
-            projection = _CanonicalPlaybackProjection.model_validate(json.loads(payload))
+            projection = _CanonicalPlaybackProjection.model_validate(
+                json.loads(payload)
+            )
             if projection.schema_version != 1:
                 raise PlaybackAuthorizationError(
                     "Canonical transcript uses an unsupported schema version"
@@ -255,7 +257,10 @@ class PlaybackAuthorizationService:
             ) from exc
 
         expected_sha = projection.source.sha256
-        if media.input.sha256 != expected_sha or media.input.sha256 != document.source_sha256:
+        if (
+            media.input.sha256 != expected_sha
+            or media.input.sha256 != document.source_sha256
+        ):
             raise PlaybackAuthorizationError(
                 "Original recording no longer matches the source used for this transcript"
             )

--- a/src/echoflow/library/tests/test_playback.py
+++ b/src/echoflow/library/tests/test_playback.py
@@ -183,20 +183,16 @@ def test_authorize_rejects_stale_generation_before_source_probe(tmp_path: Path) 
     assert probe.paths == []
 
 
-def test_authorize_rejects_missing_or_unknown_source_path(tmp_path: Path) -> None:
-    missing, probe, digest, _, _ = _service(tmp_path, source_exists=False)
-    with pytest.raises(PlaybackAuthorizationError, match="unavailable at its recorded location"):
-        missing.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
-    assert probe.paths == []
+def test_authorize_rejects_missing_source_path(tmp_path: Path) -> None:
+    service, probe, digest, _, _ = _service(tmp_path, source_exists=False)
 
-    unknown, _, digest, _, _ = _service(
-        tmp_path / "unknown",
-        source_path_known=False,
-    ) if False else (None, None, None, None, None)
+    with pytest.raises(PlaybackAuthorizationError, match="unavailable at its recorded location"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+    assert probe.paths == []
 
 
 def test_authorize_rejects_unknown_source_location(tmp_path: Path) -> None:
-    tmp_path.mkdir(exist_ok=True)
     service, probe, digest, _, _ = _service(tmp_path, source_path_known=False)
 
     with pytest.raises(PlaybackAuthorizationError, match="location is unavailable"):

--- a/src/echoflow/library/tests/test_playback.py
+++ b/src/echoflow/library/tests/test_playback.py
@@ -1,0 +1,259 @@
+import hashlib
+import json
+import math
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from echoflow.interfaces.local_file_manager import LocalFileManager
+from echoflow.library.errors import PlaybackAuthorizationError
+from echoflow.library.index import IndexedDocument
+from echoflow.library.playback import PlaybackAuthorizationService
+from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
+
+
+class DocumentIndex:
+    def __init__(self, documents: tuple[IndexedDocument, ...]) -> None:
+        self._documents = documents
+
+    def documents(self) -> tuple[IndexedDocument, ...]:
+        return self._documents
+
+
+class StaticMediaProbe:
+    def __init__(self, media: MediaInfo | Exception) -> None:
+        self.media = media
+        self.paths: list[Path] = []
+
+    def probe(self, input_path: str | Path) -> MediaInfo:
+        self.paths.append(Path(input_path))
+        if isinstance(self.media, Exception):
+            raise self.media
+        return self.media
+
+
+def _canonical(path: Path, *, source_sha256: str, source_size: int) -> str:
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "job_id": "job-1",
+            "source": {
+                "sha256": source_sha256,
+                "size_bytes": source_size,
+                "modified_ns": 42,
+                "container_format": "mov,mp4,m4a,3gp,3g2,mj2",
+                "duration_seconds": 8.5,
+                "audio_stream_index": 2,
+            },
+            "segments": [],
+        },
+        sort_keys=True,
+    ).encode()
+    path.write_bytes(payload)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _media(
+    source: Path,
+    *,
+    source_sha256: str,
+    source_size: int,
+    audio_indices: tuple[int, ...] = (2,),
+    video: bool = False,
+) -> MediaInfo:
+    streams = [
+        MediaStream(index=index, kind=StreamKind.AUDIO, codec="aac")
+        for index in audio_indices
+    ]
+    if video:
+        streams.append(MediaStream(index=0, kind=StreamKind.VIDEO, codec="h264"))
+    return MediaInfo(
+        input=InputIdentity(
+            path=source,
+            size_bytes=source_size,
+            modified_ns=42,
+            sha256=source_sha256,
+        ),
+        container_format="mov,mp4,m4a,3gp,3g2,mj2",
+        duration_seconds=8.5,
+        streams=tuple(streams),
+        primary_audio_stream_index=audio_indices[0],
+    )
+
+
+def _service(
+    tmp_path: Path,
+    *,
+    source_exists: bool = True,
+    probe_sha256: str | None = None,
+    probe_size: int | None = None,
+    audio_indices: tuple[int, ...] = (2,),
+    video: bool = False,
+    source_path_known: bool = True,
+) -> tuple[PlaybackAuthorizationService, StaticMediaProbe, str, Path, str]:
+    source = tmp_path / "interview.mp4"
+    source_bytes = b"verified local recording bytes"
+    source_sha256 = hashlib.sha256(source_bytes).hexdigest()
+    if source_exists:
+        source.write_bytes(source_bytes)
+    source_size = len(source_bytes)
+    canonical = tmp_path / "interview.json"
+    canonical_sha256 = _canonical(
+        canonical,
+        source_sha256=source_sha256,
+        source_size=source_size,
+    )
+    document = IndexedDocument(
+        document_id="job-1",
+        source_sha256=source_sha256,
+        detected_language="en",
+        canonical_path=str(canonical.resolve()),
+        source_path=str(source.resolve()) if source_path_known else None,
+        segment_count=0,
+        canonical_sha256=canonical_sha256,
+    )
+    probe = StaticMediaProbe(
+        _media(
+            source,
+            source_sha256=probe_sha256 or source_sha256,
+            source_size=source_size if probe_size is None else probe_size,
+            audio_indices=audio_indices,
+            video=video,
+        )
+    )
+    return (
+        PlaybackAuthorizationService(
+            index=DocumentIndex((document,)),  # type: ignore[arg-type]
+            file_manager=LocalFileManager(),  # type: ignore[arg-type]
+            media_probe=probe,
+        ),
+        probe,
+        canonical_sha256,
+        source,
+        source_sha256,
+    )
+
+
+def test_authorize_binds_exact_generation_source_and_seek(tmp_path: Path) -> None:
+    service, probe, canonical_sha256, source, source_sha256 = _service(tmp_path)
+
+    grant = service.authorize(
+        "job-1",
+        expected_canonical_sha256=canonical_sha256,
+        seek_seconds=3.25,
+    )
+
+    assert grant.document_id == "job-1"
+    assert grant.canonical_sha256 == canonical_sha256
+    assert grant.source_sha256 == source_sha256
+    assert grant.source_path == str(source.resolve())
+    assert grant.seek_seconds == 3.25
+    assert grant.duration_seconds == 8.5
+    assert grant.audio_stream_index == 2
+    assert grant.media_kind == "audio"
+    assert probe.paths == [source.resolve()]
+
+
+def test_authorize_detects_video_without_changing_audio_evidence(tmp_path: Path) -> None:
+    service, _, canonical_sha256, _, _ = _service(tmp_path, video=True)
+
+    grant = service.authorize(
+        "job-1",
+        expected_canonical_sha256=canonical_sha256,
+        seek_seconds=0.0,
+    )
+
+    assert grant.media_kind == "video"
+    assert grant.audio_stream_index == 2
+
+
+def test_authorize_rejects_stale_generation_before_source_probe(tmp_path: Path) -> None:
+    service, probe, _, _, _ = _service(tmp_path)
+
+    with pytest.raises(PlaybackAuthorizationError, match="changed since this evidence view"):
+        service.authorize(
+            "job-1",
+            expected_canonical_sha256="b" * 64,
+            seek_seconds=1.0,
+        )
+
+    assert probe.paths == []
+
+
+def test_authorize_rejects_missing_or_unknown_source_path(tmp_path: Path) -> None:
+    missing, probe, digest, _, _ = _service(tmp_path, source_exists=False)
+    with pytest.raises(PlaybackAuthorizationError, match="unavailable at its recorded location"):
+        missing.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+    assert probe.paths == []
+
+    unknown, _, digest, _, _ = _service(
+        tmp_path / "unknown",
+        source_path_known=False,
+    ) if False else (None, None, None, None, None)
+
+
+def test_authorize_rejects_unknown_source_location(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    service, probe, digest, _, _ = _service(tmp_path, source_path_known=False)
+
+    with pytest.raises(PlaybackAuthorizationError, match="location is unavailable"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+    assert probe.paths == []
+
+
+def test_authorize_rejects_source_hash_or_size_mismatch(tmp_path: Path) -> None:
+    service, _, digest, _, _ = _service(tmp_path, probe_sha256="b" * 64)
+    with pytest.raises(PlaybackAuthorizationError, match="no longer matches the source"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+    service, _, digest, _, _ = _service(tmp_path, probe_size=999)
+    with pytest.raises(PlaybackAuthorizationError, match="size no longer matches"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+
+def test_authorize_rejects_multi_audio_instead_of_guessing_track(tmp_path: Path) -> None:
+    service, _, digest, _, _ = _service(tmp_path, audio_indices=(2, 4))
+
+    with pytest.raises(PlaybackAuthorizationError, match="multiple audio streams"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+
+def test_authorize_rejects_tampered_canonical_and_out_of_range_seek(tmp_path: Path) -> None:
+    service, probe, digest, _, _ = _service(tmp_path)
+    (tmp_path / "interview.json").write_text("{}")
+
+    with pytest.raises(PlaybackAuthorizationError, match="Canonical transcript changed"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+    assert probe.paths == []
+
+    service, _, digest, _, _ = _service(tmp_path)
+    with pytest.raises(PlaybackAuthorizationError, match="outside the verified recording"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=8.5001)
+
+
+@pytest.mark.parametrize("seek", [-1.0, math.inf, -math.inf, math.nan])
+def test_authorize_rejects_invalid_seek_shapes(tmp_path: Path, seek: float) -> None:
+    service, probe, digest, _, _ = _service(tmp_path)
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=seek)
+
+    assert probe.paths == []
+
+
+@given(st.floats(min_value=0.0, max_value=8.5, allow_nan=False, allow_infinity=False))
+def test_all_finite_seeks_inside_verified_duration_are_preserved(seek: float) -> None:
+    with TemporaryDirectory() as directory:
+        service, _, digest, _, _ = _service(Path(directory))
+
+        grant = service.authorize(
+            "job-1",
+            expected_canonical_sha256=digest,
+            seek_seconds=seek,
+        )
+
+        assert grant.seek_seconds == seek

--- a/src/echoflow/library/tests/test_playback.py
+++ b/src/echoflow/library/tests/test_playback.py
@@ -157,7 +157,9 @@ def test_authorize_binds_exact_generation_source_and_seek(tmp_path: Path) -> Non
     assert probe.paths == [source.resolve()]
 
 
-def test_authorize_detects_video_without_changing_audio_evidence(tmp_path: Path) -> None:
+def test_authorize_detects_video_without_changing_audio_evidence(
+    tmp_path: Path,
+) -> None:
     service, _, canonical_sha256, _, _ = _service(tmp_path, video=True)
 
     grant = service.authorize(
@@ -173,7 +175,9 @@ def test_authorize_detects_video_without_changing_audio_evidence(tmp_path: Path)
 def test_authorize_rejects_stale_generation_before_source_probe(tmp_path: Path) -> None:
     service, probe, _, _, _ = _service(tmp_path)
 
-    with pytest.raises(PlaybackAuthorizationError, match="changed since this evidence view"):
+    with pytest.raises(
+        PlaybackAuthorizationError, match="changed since this evidence view"
+    ):
         service.authorize(
             "job-1",
             expected_canonical_sha256="b" * 64,
@@ -186,7 +190,9 @@ def test_authorize_rejects_stale_generation_before_source_probe(tmp_path: Path) 
 def test_authorize_rejects_missing_source_path(tmp_path: Path) -> None:
     service, probe, digest, _, _ = _service(tmp_path, source_exists=False)
 
-    with pytest.raises(PlaybackAuthorizationError, match="unavailable at its recorded location"):
+    with pytest.raises(
+        PlaybackAuthorizationError, match="unavailable at its recorded location"
+    ):
         service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
 
     assert probe.paths == []
@@ -203,7 +209,9 @@ def test_authorize_rejects_unknown_source_location(tmp_path: Path) -> None:
 
 def test_authorize_rejects_source_hash_or_size_mismatch(tmp_path: Path) -> None:
     service, _, digest, _, _ = _service(tmp_path, probe_sha256="b" * 64)
-    with pytest.raises(PlaybackAuthorizationError, match="no longer matches the source"):
+    with pytest.raises(
+        PlaybackAuthorizationError, match="no longer matches the source"
+    ):
         service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
 
     service, _, digest, _, _ = _service(tmp_path, probe_size=999)
@@ -211,24 +219,34 @@ def test_authorize_rejects_source_hash_or_size_mismatch(tmp_path: Path) -> None:
         service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
 
 
-def test_authorize_rejects_multi_audio_instead_of_guessing_track(tmp_path: Path) -> None:
+def test_authorize_rejects_multi_audio_instead_of_guessing_track(
+    tmp_path: Path,
+) -> None:
     service, _, digest, _, _ = _service(tmp_path, audio_indices=(2, 4))
 
     with pytest.raises(PlaybackAuthorizationError, match="multiple audio streams"):
         service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
 
 
-def test_authorize_rejects_tampered_canonical_and_out_of_range_seek(tmp_path: Path) -> None:
+def test_authorize_rejects_tampered_canonical_and_out_of_range_seek(
+    tmp_path: Path,
+) -> None:
     service, probe, digest, _, _ = _service(tmp_path)
     (tmp_path / "interview.json").write_text("{}")
 
-    with pytest.raises(PlaybackAuthorizationError, match="Canonical transcript changed"):
+    with pytest.raises(
+        PlaybackAuthorizationError, match="Canonical transcript changed"
+    ):
         service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
     assert probe.paths == []
 
     service, _, digest, _, _ = _service(tmp_path)
-    with pytest.raises(PlaybackAuthorizationError, match="outside the verified recording"):
-        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=8.5001)
+    with pytest.raises(
+        PlaybackAuthorizationError, match="outside the verified recording"
+    ):
+        service.authorize(
+            "job-1", expected_canonical_sha256=digest, seek_seconds=8.5001
+        )
 
 
 @pytest.mark.parametrize("seek", [-1.0, math.inf, -math.inf, math.nan])

--- a/src/echoflow/library/tests/test_playback_edges.py
+++ b/src/echoflow/library/tests/test_playback_edges.py
@@ -114,7 +114,7 @@ def _service(
     tmp_path: Path,
     *,
     payload: bytes | None = None,
-    indexed_digest: str | None | object = ..., 
+    indexed_digest: str | None | object = ...,
     documents: bool = True,
     probe: MediaInfo | BaseException | None = None,
     reported_size: int | None = None,
@@ -168,7 +168,9 @@ def test_playback_grant_rejects_invalid_kind_and_seek() -> None:
         PlaybackGrant(**{**values, "seek_seconds": 11.0})
 
 
-def test_authorize_rejects_invalid_digest_blank_id_and_missing_document(tmp_path: Path) -> None:
+def test_authorize_rejects_invalid_digest_blank_id_and_missing_document(
+    tmp_path: Path,
+) -> None:
     service, digest = _service(tmp_path)
 
     with pytest.raises(ValueError, match="lowercase 64-character"):
@@ -177,7 +179,9 @@ def test_authorize_rejects_invalid_digest_blank_id_and_missing_document(tmp_path
         service.authorize("   ", expected_canonical_sha256=digest, seek_seconds=1.0)
 
     missing, _ = _service(tmp_path, documents=False)
-    with pytest.raises(PlaybackAuthorizationError, match="not present in the local library"):
+    with pytest.raises(
+        PlaybackAuthorizationError, match="not present in the local library"
+    ):
         missing.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
 
 
@@ -210,9 +214,7 @@ def test_authorize_rejects_canonical_identity_drift(
     source = tmp_path / "source.mp4"
     source.write_bytes(b"source evidence")
     source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
-    base = json.loads(
-        _canonical_payload(source_sha256, source.stat().st_size).decode()
-    )
+    base = json.loads(_canonical_payload(source_sha256, source.stat().st_size).decode())
     mutated = payload_mutation(base)  # type: ignore[operator]
     payload = json.dumps(mutated, sort_keys=True).encode()
     service, digest = _service(tmp_path, payload=payload)
@@ -225,7 +227,9 @@ def test_authorize_normalizes_invalid_canonical_json(tmp_path: Path) -> None:
     payload = b"not-json"
     service, digest = _service(tmp_path, payload=payload)
 
-    with pytest.raises(PlaybackAuthorizationError, match="could not be validated safely"):
+    with pytest.raises(
+        PlaybackAuthorizationError, match="could not be validated safely"
+    ):
         service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
 
 
@@ -243,11 +247,15 @@ def test_authorize_rejects_single_audio_stream_with_wrong_index(tmp_path: Path) 
     wrong_media = _media(source, source_sha256, source.stat().st_size, audio_index=3)
     service, digest = _service(tmp_path, probe=wrong_media)
 
-    with pytest.raises(PlaybackAuthorizationError, match="audio stream no longer matches"):
+    with pytest.raises(
+        PlaybackAuthorizationError, match="audio stream no longer matches"
+    ):
         service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
 
 
-def test_authorize_normalizes_probe_failures_without_private_detail(tmp_path: Path) -> None:
+def test_authorize_normalizes_probe_failures_without_private_detail(
+    tmp_path: Path,
+) -> None:
     for failure in (
         ProbeFailure("private probe detail"),
         RuntimeError("private runtime detail"),
@@ -257,7 +265,9 @@ def test_authorize_normalizes_probe_failures_without_private_detail(tmp_path: Pa
             PlaybackAuthorizationError,
             match="could not be verified safely for playback",
         ) as caught:
-            service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+            service.authorize(
+                "job-1", expected_canonical_sha256=digest, seek_seconds=1.0
+            )
         assert "private" not in caught.value.public_message
 
 

--- a/src/echoflow/library/tests/test_playback_edges.py
+++ b/src/echoflow/library/tests/test_playback_edges.py
@@ -1,0 +1,271 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from echoflow.core.errors import EchoFlowError
+from echoflow.library.errors import PlaybackAuthorizationError
+from echoflow.library.index import IndexedDocument
+from echoflow.library.playback import PlaybackAuthorizationService, PlaybackGrant
+from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
+
+
+class DocumentIndex:
+    def __init__(self, documents: tuple[IndexedDocument, ...]) -> None:
+        self._documents = documents
+
+    def documents(self) -> tuple[IndexedDocument, ...]:
+        return self._documents
+
+
+class MemoryFiles:
+    def __init__(self, canonical: bytes, *, reported_size: int | None = None) -> None:
+        self.canonical = canonical
+        self.reported_size = reported_size
+
+    def get_file_metadata(self, _path: str | Path) -> dict[str, int]:
+        return {"size": self.reported_size or len(self.canonical)}
+
+    def read_file(self, _path: str | Path) -> bytes:
+        return self.canonical
+
+
+class StaticProbe:
+    def __init__(self, media: MediaInfo | BaseException) -> None:
+        self.media = media
+
+    def probe(self, _path: str | Path) -> MediaInfo:
+        if isinstance(self.media, BaseException):
+            raise self.media
+        return self.media
+
+
+class ProbeFailure(EchoFlowError):
+    pass
+
+
+def _canonical_payload(
+    source_sha256: str,
+    source_size: int,
+    *,
+    schema_version: int = 1,
+    job_id: str = "job-1",
+    canonical_source_sha256: str | None = None,
+    duration_seconds: float = 8.5,
+    audio_stream_index: int = 2,
+) -> bytes:
+    return json.dumps(
+        {
+            "schema_version": schema_version,
+            "job_id": job_id,
+            "source": {
+                "sha256": canonical_source_sha256 or source_sha256,
+                "size_bytes": source_size,
+                "modified_ns": 42,
+                "container_format": "mp4",
+                "duration_seconds": duration_seconds,
+                "audio_stream_index": audio_stream_index,
+            },
+        },
+        sort_keys=True,
+    ).encode()
+
+
+def _document(
+    canonical_path: Path,
+    source_path: Path | None,
+    source_sha256: str,
+    canonical_sha256: str | None,
+) -> IndexedDocument:
+    return IndexedDocument(
+        document_id="job-1",
+        source_sha256=source_sha256,
+        detected_language="en",
+        canonical_path=str(canonical_path),
+        source_path=str(source_path) if source_path else None,
+        segment_count=0,
+        canonical_sha256=canonical_sha256,
+    )
+
+
+def _media(
+    source: Path,
+    source_sha256: str,
+    source_size: int,
+    *,
+    audio_index: int = 2,
+) -> MediaInfo:
+    return MediaInfo(
+        input=InputIdentity(
+            path=source,
+            size_bytes=source_size,
+            modified_ns=42,
+            sha256=source_sha256,
+        ),
+        container_format="mp4",
+        duration_seconds=8.5,
+        streams=(MediaStream(index=audio_index, kind=StreamKind.AUDIO, codec="aac"),),
+        primary_audio_stream_index=audio_index,
+    )
+
+
+def _service(
+    tmp_path: Path,
+    *,
+    payload: bytes | None = None,
+    indexed_digest: str | None | object = ..., 
+    documents: bool = True,
+    probe: MediaInfo | BaseException | None = None,
+    reported_size: int | None = None,
+) -> tuple[PlaybackAuthorizationService, str]:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"source evidence")
+    source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+    canonical = tmp_path / "canonical.json"
+    canonical_payload = payload or _canonical_payload(
+        source_sha256,
+        source.stat().st_size,
+    )
+    canonical.write_bytes(canonical_payload)
+    digest = hashlib.sha256(canonical_payload).hexdigest()
+    canonical_digest = digest if indexed_digest is ... else indexed_digest
+    document = _document(
+        canonical,
+        source,
+        source_sha256,
+        canonical_digest if isinstance(canonical_digest, str) else None,
+    )
+    media = probe or _media(source, source_sha256, source.stat().st_size)
+    service = PlaybackAuthorizationService(
+        index=DocumentIndex((document,) if documents else ()),  # type: ignore[arg-type]
+        file_manager=MemoryFiles(  # type: ignore[arg-type]
+            canonical_payload,
+            reported_size=reported_size,
+        ),
+        media_probe=StaticProbe(media),
+    )
+    return service, digest
+
+
+def test_playback_grant_rejects_invalid_kind_and_seek() -> None:
+    values = dict(
+        document_id="job-1",
+        canonical_sha256="a" * 64,
+        source_sha256="b" * 64,
+        source_path="source.mp4",
+        source_size_bytes=10,
+        source_modified_ns=42,
+        duration_seconds=10.0,
+        seek_seconds=2.0,
+        audio_stream_index=0,
+        media_kind="audio",
+        container_format="mp4",
+    )
+    with pytest.raises(ValueError, match="media_kind"):
+        PlaybackGrant(**{**values, "media_kind": "document"})
+    with pytest.raises(ValueError, match="inside source duration"):
+        PlaybackGrant(**{**values, "seek_seconds": 11.0})
+
+
+def test_authorize_rejects_invalid_digest_blank_id_and_missing_document(tmp_path: Path) -> None:
+    service, digest = _service(tmp_path)
+
+    with pytest.raises(ValueError, match="lowercase 64-character"):
+        service.authorize("job-1", expected_canonical_sha256="A" * 64, seek_seconds=1.0)
+    with pytest.raises(ValueError, match="document_id cannot be blank"):
+        service.authorize("   ", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+    missing, _ = _service(tmp_path, documents=False)
+    with pytest.raises(PlaybackAuthorizationError, match="not present in the local library"):
+        missing.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+
+def test_authorize_rejects_legacy_index_without_canonical_hash(tmp_path: Path) -> None:
+    service, digest = _service(tmp_path, indexed_digest=None)
+
+    with pytest.raises(PlaybackAuthorizationError, match="predates canonical hashing"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+
+@pytest.mark.parametrize(
+    ("payload_mutation", "message"),
+    [
+        (lambda data: {**data, "schema_version": 2}, "unsupported schema version"),
+        (lambda data: {**data, "job_id": "other-job"}, "identity no longer matches"),
+        (
+            lambda data: {
+                **data,
+                "source": {**data["source"], "sha256": "c" * 64},
+            },
+            "source identity no longer matches",
+        ),
+    ],
+)
+def test_authorize_rejects_canonical_identity_drift(
+    tmp_path: Path,
+    payload_mutation: object,
+    message: str,
+) -> None:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"source evidence")
+    source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+    base = json.loads(
+        _canonical_payload(source_sha256, source.stat().st_size).decode()
+    )
+    mutated = payload_mutation(base)  # type: ignore[operator]
+    payload = json.dumps(mutated, sort_keys=True).encode()
+    service, digest = _service(tmp_path, payload=payload)
+
+    with pytest.raises(PlaybackAuthorizationError, match=message):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+
+def test_authorize_normalizes_invalid_canonical_json(tmp_path: Path) -> None:
+    payload = b"not-json"
+    service, digest = _service(tmp_path, payload=payload)
+
+    with pytest.raises(PlaybackAuthorizationError, match="could not be validated safely"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+
+def test_authorize_rejects_canonical_size_guard_before_read(tmp_path: Path) -> None:
+    service, digest = _service(tmp_path, reported_size=256 * 1024 * 1024 + 1)
+
+    with pytest.raises(PlaybackAuthorizationError, match="too large"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+
+def test_authorize_rejects_single_audio_stream_with_wrong_index(tmp_path: Path) -> None:
+    source = tmp_path / "source.mp4"
+    source.write_bytes(b"source evidence")
+    source_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+    wrong_media = _media(source, source_sha256, source.stat().st_size, audio_index=3)
+    service, digest = _service(tmp_path, probe=wrong_media)
+
+    with pytest.raises(PlaybackAuthorizationError, match="audio stream no longer matches"):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+
+def test_authorize_normalizes_probe_failures_without_private_detail(tmp_path: Path) -> None:
+    for failure in (
+        ProbeFailure("private probe detail"),
+        RuntimeError("private runtime detail"),
+    ):
+        service, digest = _service(tmp_path, probe=failure)
+        with pytest.raises(
+            PlaybackAuthorizationError,
+            match="could not be verified safely for playback",
+        ) as caught:
+            service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+        assert "private" not in caught.value.public_message
+
+
+def test_authorize_preserves_process_interrupts(tmp_path: Path) -> None:
+    service, digest = _service(tmp_path, probe=KeyboardInterrupt())
+    with pytest.raises(KeyboardInterrupt):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)
+
+    service, digest = _service(tmp_path, probe=SystemExit())
+    with pytest.raises(SystemExit):
+        service.authorize("job-1", expected_canonical_sha256=digest, seek_seconds=1.0)

--- a/src/echoflow/media/models.py
+++ b/src/echoflow/media/models.py
@@ -9,6 +9,22 @@ _STREAM_TITLE_MAX_LENGTH = 200
 _STREAM_LANGUAGE_MAX_LENGTH = 64
 
 
+def _normalize_optional_display_text(
+    value: str | None,
+    *,
+    field_name: str,
+    maximum: int,
+) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if len(normalized) > maximum:
+        raise ValueError(f"{field_name} exceeds safe display length")
+    return normalized
+
+
 class StreamKind(StrEnum):
     AUDIO = "audio"
     VIDEO = "video"
@@ -114,20 +130,24 @@ class MediaStream:
             value = getattr(self, name)
             if value is not None and value < 1:
                 raise ValueError(f"{name} must be positive")
-        for name, maximum in (
-            ("title", _STREAM_TITLE_MAX_LENGTH),
-            ("language", _STREAM_LANGUAGE_MAX_LENGTH),
-        ):
-            value = getattr(self, name)
-            if value is None:
-                continue
-            normalized = value.strip()
-            if not normalized:
-                object.__setattr__(self, name, None)
-                continue
-            if len(normalized) > maximum:
-                raise ValueError(f"{name} exceeds safe display length")
-            object.__setattr__(self, name, normalized)
+        object.__setattr__(
+            self,
+            "title",
+            _normalize_optional_display_text(
+                self.title,
+                field_name="title",
+                maximum=_STREAM_TITLE_MAX_LENGTH,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "language",
+            _normalize_optional_display_text(
+                self.language,
+                field_name="language",
+                maximum=_STREAM_LANGUAGE_MAX_LENGTH,
+            ),
+        )
         if not isinstance(self.is_default, bool):
             raise ValueError("is_default must be boolean")
 

--- a/src/echoflow/media/models.py
+++ b/src/echoflow/media/models.py
@@ -5,6 +5,8 @@ from enum import StrEnum
 from pathlib import Path
 
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_STREAM_TITLE_MAX_LENGTH = 200
+_STREAM_LANGUAGE_MAX_LENGTH = 64
 
 
 class StreamKind(StrEnum):
@@ -95,6 +97,9 @@ class MediaStream:
     channels: int | None = None
     channel_layout: str | None = None
     bit_rate_bps: int | None = None
+    title: str | None = None
+    language: str | None = None
+    is_default: bool = False
 
     def __post_init__(self) -> None:
         if self.index < 0:
@@ -109,9 +114,25 @@ class MediaStream:
             value = getattr(self, name)
             if value is not None and value < 1:
                 raise ValueError(f"{name} must be positive")
+        for name, maximum in (
+            ("title", _STREAM_TITLE_MAX_LENGTH),
+            ("language", _STREAM_LANGUAGE_MAX_LENGTH),
+        ):
+            value = getattr(self, name)
+            if value is None:
+                continue
+            normalized = value.strip()
+            if not normalized:
+                object.__setattr__(self, name, None)
+                continue
+            if len(normalized) > maximum:
+                raise ValueError(f"{name} exceeds safe display length")
+            object.__setattr__(self, name, normalized)
+        if not isinstance(self.is_default, bool):
+            raise ValueError("is_default must be boolean")
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        document: dict[str, object] = {
             "index": self.index,
             "kind": self.kind.value,
             "codec": self.codec,
@@ -121,6 +142,13 @@ class MediaStream:
             "channel_layout": self.channel_layout,
             "bit_rate_bps": self.bit_rate_bps,
         }
+        if self.title is not None:
+            document["title"] = self.title
+        if self.language is not None:
+            document["language"] = self.language
+        if self.is_default:
+            document["is_default"] = True
+        return document
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/echoflow/media/probe.py
+++ b/src/echoflow/media/probe.py
@@ -94,7 +94,13 @@ def _default_disposition(raw_disposition: object) -> bool:
     if not isinstance(raw_disposition, dict):
         return False
     value = raw_disposition.get("default")
-    return value is True or value == 1 or value == "1"
+    if value is True:
+        return True
+    if isinstance(value, int):
+        return value == 1
+    if isinstance(value, str):
+        return value == "1"
+    return False
 
 
 def _raw_stream_index(raw_stream: object) -> int | None:

--- a/src/echoflow/media/probe.py
+++ b/src/echoflow/media/probe.py
@@ -30,8 +30,10 @@ _MAX_STREAM_LANGUAGE_LENGTH = 64
 _FFPROBE_ENTRIES = (
     "format=format_name,duration:format_tags=timecode,creation_time:"
     "stream=index,codec_type,codec_name,duration,sample_rate,channels,"
-    "channel_layout,bit_rate:stream_tags=timecode,creation_time,title,language:"
-    "stream_disposition=default"
+    "channel_layout,bit_rate:stream_tags=timecode,creation_time"
+)
+_FFPROBE_TRACK_DISPLAY_ENTRIES = (
+    "stream=index:stream_tags=title,language:stream_disposition=default"
 )
 
 
@@ -95,7 +97,47 @@ def _default_disposition(raw_disposition: object) -> bool:
     return value is True or value == 1 or value == "1"
 
 
-def _parse_stream(raw_stream: object) -> MediaStream:
+def _raw_stream_index(raw_stream: object) -> int | None:
+    if not isinstance(raw_stream, dict):
+        return None
+    index = raw_stream.get("index")
+    if isinstance(index, bool):
+        return None
+    try:
+        return int(str(index))
+    except (TypeError, ValueError):
+        return None
+
+
+def _multiple_audio_streams(payload: Mapping[str, Any]) -> bool:
+    raw_streams = payload.get("streams")
+    if not isinstance(raw_streams, list):
+        return False
+    return (
+        sum(
+            isinstance(stream, dict) and stream.get("codec_type") == "audio"
+            for stream in raw_streams
+        )
+        > 1
+    )
+
+
+def _display_stream_lookup(payload: Mapping[str, Any]) -> dict[int, Mapping[str, Any]]:
+    raw_streams = payload.get("streams")
+    if not isinstance(raw_streams, list):
+        return {}
+    lookup: dict[int, Mapping[str, Any]] = {}
+    for stream in raw_streams:
+        index = _raw_stream_index(stream)
+        if index is not None and isinstance(stream, dict):
+            lookup[index] = stream
+    return lookup
+
+
+def _parse_stream(
+    raw_stream: object,
+    display_stream: Mapping[str, Any] | None = None,
+) -> MediaStream:
     if not isinstance(raw_stream, dict):
         raise MediaProbeError("FFprobe stream metadata is invalid")
     index = raw_stream.get("index")
@@ -105,7 +147,8 @@ def _parse_stream(raw_stream: object) -> MediaStream:
         parsed_index = int(str(index))
     except (TypeError, ValueError) as exc:
         raise MediaProbeError("FFprobe stream index is invalid", cause=exc) from exc
-    tags = raw_stream.get("tags")
+    display_source = display_stream if display_stream is not None else raw_stream
+    tags = display_source.get("tags")
     try:
         return MediaStream(
             index=parsed_index,
@@ -122,7 +165,7 @@ def _parse_stream(raw_stream: object) -> MediaStream:
             bit_rate_bps=_optional_int(raw_stream.get("bit_rate")),
             title=_display_tag(tags, "title", _MAX_STREAM_TITLE_LENGTH),
             language=_display_tag(tags, "language", _MAX_STREAM_LANGUAGE_LENGTH),
-            is_default=_default_disposition(raw_stream.get("disposition")),
+            is_default=_default_disposition(display_source.get("disposition")),
         )
     except ValueError as exc:
         raise MediaProbeError(
@@ -220,7 +263,15 @@ class FfprobeMediaProbe:
                 "FFprobe is required to inspect audio input"
             )
 
-        payload = self._run(executable, source)
+        payload = self._run(executable, source, entries=_FFPROBE_ENTRIES)
+        display_lookup: Mapping[int, Mapping[str, Any]] = {}
+        if _multiple_audio_streams(payload):
+            display_payload = self._run(
+                executable,
+                source,
+                entries=_FFPROBE_TRACK_DISPLAY_ENTRIES,
+            )
+            display_lookup = _display_stream_lookup(display_payload)
         try:
             sha256 = _fingerprint(source)
             after = _snapshot(source)
@@ -239,9 +290,16 @@ class FfprobeMediaProbe:
                 modified_ns=after[1],
                 sha256=sha256,
             ),
+            display_lookup=display_lookup,
         )
 
-    def _run(self, executable: str, source: Path) -> Mapping[str, Any]:
+    def _run(
+        self,
+        executable: str,
+        source: Path,
+        *,
+        entries: str,
+    ) -> Mapping[str, Any]:
         command = [
             executable,
             "-v",
@@ -249,7 +307,7 @@ class FfprobeMediaProbe:
             "-protocol_whitelist",
             "file",
             "-show_entries",
-            _FFPROBE_ENTRIES,
+            entries,
             "-of",
             "json",
             str(source),
@@ -289,13 +347,25 @@ class FfprobeMediaProbe:
         return payload
 
     @staticmethod
-    def _parse(payload: Mapping[str, Any], identity: InputIdentity) -> MediaInfo:
+    def _parse(
+        payload: Mapping[str, Any],
+        identity: InputIdentity,
+        *,
+        display_lookup: Mapping[int, Mapping[str, Any]] | None = None,
+    ) -> MediaInfo:
         raw_streams = payload.get("streams")
         raw_format = payload.get("format")
         if not isinstance(raw_streams, list) or not isinstance(raw_format, dict):
             raise MediaProbeError("FFprobe metadata is incomplete")
 
-        streams = [_parse_stream(raw_stream) for raw_stream in raw_streams]
+        track_display = display_lookup or {}
+        streams = [
+            _parse_stream(
+                raw_stream,
+                track_display.get(_raw_stream_index(raw_stream) or -1),
+            )
+            for raw_stream in raw_streams
+        ]
 
         audio_streams = [
             stream for stream in streams if stream.kind is StreamKind.AUDIO

--- a/src/echoflow/media/probe.py
+++ b/src/echoflow/media/probe.py
@@ -119,13 +119,16 @@ def _multiple_audio_streams(payload: Mapping[str, Any]) -> bool:
     raw_streams = payload.get("streams")
     if not isinstance(raw_streams, list):
         return False
-    return (
-        sum(
-            isinstance(stream, dict) and stream.get("codec_type") == "audio"
-            for stream in raw_streams
-        )
-        > 1
-    )
+    audio_count = 0
+    for stream in raw_streams:
+        if not isinstance(stream, dict):
+            continue
+        codec_type = stream.get("codec_type")
+        if isinstance(codec_type, str) and codec_type == "audio":
+            audio_count += 1
+            if audio_count > 1:
+                return True
+    return False
 
 
 def _display_stream_lookup(payload: Mapping[str, Any]) -> dict[int, Mapping[str, Any]]:

--- a/src/echoflow/media/probe.py
+++ b/src/echoflow/media/probe.py
@@ -25,10 +25,13 @@ from echoflow.media.models import (
 
 _HASH_BLOCK_SIZE = 1024 * 1024
 _MAX_PROBE_OUTPUT_BYTES = 1024 * 1024
+_MAX_STREAM_TITLE_LENGTH = 200
+_MAX_STREAM_LANGUAGE_LENGTH = 64
 _FFPROBE_ENTRIES = (
     "format=format_name,duration:format_tags=timecode,creation_time:"
     "stream=index,codec_type,codec_name,duration,sample_rate,channels,"
-    "channel_layout,bit_rate:stream_tags=timecode,creation_time"
+    "channel_layout,bit_rate:stream_tags=timecode,creation_time,title,language:"
+    "stream_disposition=default"
 )
 
 
@@ -68,6 +71,30 @@ def _snapshot(path: Path) -> tuple[int, int, int, int]:
     return details.st_size, details.st_mtime_ns, details.st_dev, details.st_ino
 
 
+def _tag_value(raw_tags: object, key: str) -> str | None:
+    if not isinstance(raw_tags, dict):
+        return None
+    value = raw_tags.get(key)
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _display_tag(raw_tags: object, key: str, maximum: int) -> str | None:
+    value = _tag_value(raw_tags, key)
+    if value is None:
+        return None
+    return value[:maximum]
+
+
+def _default_disposition(raw_disposition: object) -> bool:
+    if not isinstance(raw_disposition, dict):
+        return False
+    value = raw_disposition.get("default")
+    return value is True or value == 1 or value == "1"
+
+
 def _parse_stream(raw_stream: object) -> MediaStream:
     if not isinstance(raw_stream, dict):
         raise MediaProbeError("FFprobe stream metadata is invalid")
@@ -78,6 +105,7 @@ def _parse_stream(raw_stream: object) -> MediaStream:
         parsed_index = int(str(index))
     except (TypeError, ValueError) as exc:
         raise MediaProbeError("FFprobe stream index is invalid", cause=exc) from exc
+    tags = raw_stream.get("tags")
     try:
         return MediaStream(
             index=parsed_index,
@@ -92,6 +120,9 @@ def _parse_stream(raw_stream: object) -> MediaStream:
                 else None
             ),
             bit_rate_bps=_optional_int(raw_stream.get("bit_rate")),
+            title=_display_tag(tags, "title", _MAX_STREAM_TITLE_LENGTH),
+            language=_display_tag(tags, "language", _MAX_STREAM_LANGUAGE_LENGTH),
+            is_default=_default_disposition(raw_stream.get("disposition")),
         )
     except ValueError as exc:
         raise MediaProbeError(
@@ -113,16 +144,6 @@ def _audio_duration(
     if duration <= 0:
         raise UnsupportedMediaError("Input audio duration could not be determined")
     return duration
-
-
-def _tag_value(raw_tags: object, key: str) -> str | None:
-    if not isinstance(raw_tags, dict):
-        return None
-    value = raw_tags.get(key)
-    if not isinstance(value, str):
-        return None
-    normalized = value.strip()
-    return normalized or None
 
 
 def _temporal_tags(

--- a/src/echoflow/media/probe.py
+++ b/src/echoflow/media/probe.py
@@ -359,13 +359,13 @@ class FfprobeMediaProbe:
             raise MediaProbeError("FFprobe metadata is incomplete")
 
         track_display = display_lookup or {}
-        streams = [
-            _parse_stream(
-                raw_stream,
-                track_display.get(_raw_stream_index(raw_stream) or -1),
+        streams: list[MediaStream] = []
+        for raw_stream in raw_streams:
+            stream_index = _raw_stream_index(raw_stream)
+            display_stream = (
+                track_display.get(stream_index) if stream_index is not None else None
             )
-            for raw_stream in raw_streams
-        ]
+            streams.append(_parse_stream(raw_stream, display_stream))
 
         audio_streams = [
             stream for stream in streams if stream.kind is StreamKind.AUDIO

--- a/src/echoflow/media/probe.py
+++ b/src/echoflow/media/probe.py
@@ -298,7 +298,7 @@ class FfprobeMediaProbe:
         executable: str,
         source: Path,
         *,
-        entries: str,
+        entries: str = _FFPROBE_ENTRIES,
     ) -> Mapping[str, Any]:
         command = [
             executable,

--- a/src/echoflow/media/tests/test_track_display_metadata.py
+++ b/src/echoflow/media/tests/test_track_display_metadata.py
@@ -1,0 +1,157 @@
+import pytest
+
+from echoflow.media import probe as probe_module
+from echoflow.media.models import InputIdentity, MediaStream, StreamKind
+from echoflow.media.probe import FfprobeMediaProbe
+
+
+def _identity(tmp_path) -> InputIdentity:
+    return InputIdentity(tmp_path / "recording.mkv", 5, 0, "a" * 64)
+
+
+def _base_payload(*, multitrack: bool = True) -> dict[str, object]:
+    streams: list[dict[str, object]] = [
+        {
+            "index": 0,
+            "codec_type": "audio",
+            "codec_name": "aac",
+            "duration": "10.0",
+            "sample_rate": "48000",
+            "channels": 2,
+        }
+    ]
+    if multitrack:
+        streams.append(
+            {
+                "index": 3,
+                "codec_type": "audio",
+                "codec_name": "pcm_s16le",
+                "duration": "10.0",
+                "sample_rate": "48000",
+                "channels": 1,
+            }
+        )
+    return {
+        "streams": streams,
+        "format": {"format_name": "matroska", "duration": "10.0"},
+    }
+
+
+def _display_payload() -> dict[str, object]:
+    return {
+        "streams": [
+            {
+                "index": 0,
+                "tags": {"title": "  Camera scratch  ", "language": "eng"},
+                "disposition": {"default": 0},
+            },
+            {
+                "index": 3,
+                "tags": {"title": "Lav microphone", "language": "eng"},
+                "disposition": {"default": 1},
+            },
+        ]
+    }
+
+
+def test_parse_binds_display_metadata_by_exact_stream_index_including_zero(tmp_path):
+    display = probe_module._display_stream_lookup(_display_payload())
+
+    media = FfprobeMediaProbe._parse(
+        _base_payload(),
+        _identity(tmp_path),
+        display_lookup=display,
+    )
+
+    first, second = media.streams
+    assert first.index == 0
+    assert first.title == "Camera scratch"
+    assert first.language == "eng"
+    assert first.is_default is False
+    assert second.index == 3
+    assert second.title == "Lav microphone"
+    assert second.language == "eng"
+    assert second.is_default is True
+    assert second.to_dict()["is_default"] is True
+
+
+def test_multitrack_probe_runs_one_extra_bounded_display_query(monkeypatch, tmp_path):
+    source = tmp_path / "recording.mkv"
+    source.write_bytes(b"media")
+    calls: list[str] = []
+
+    def fake_run(self, executable, path, *, entries):
+        del self, executable
+        assert path == source.resolve()
+        calls.append(entries)
+        if entries == probe_module._FFPROBE_TRACK_DISPLAY_ENTRIES:
+            return _display_payload()
+        return _base_payload()
+
+    monkeypatch.setattr(probe_module.shutil, "which", lambda name: "/tools/ffprobe")
+    monkeypatch.setattr(FfprobeMediaProbe, "_run", fake_run)
+
+    media = FfprobeMediaProbe().probe(source)
+
+    assert calls == [
+        probe_module._FFPROBE_ENTRIES,
+        probe_module._FFPROBE_TRACK_DISPLAY_ENTRIES,
+    ]
+    assert media.streams[1].title == "Lav microphone"
+
+
+def test_single_track_probe_does_not_request_display_metadata(monkeypatch, tmp_path):
+    source = tmp_path / "recording.m4a"
+    source.write_bytes(b"media")
+    calls: list[str] = []
+
+    def fake_run(self, executable, path, *, entries):
+        del self, executable
+        assert path == source.resolve()
+        calls.append(entries)
+        return _base_payload(multitrack=False)
+
+    monkeypatch.setattr(probe_module.shutil, "which", lambda name: "/tools/ffprobe")
+    monkeypatch.setattr(FfprobeMediaProbe, "_run", fake_run)
+
+    FfprobeMediaProbe().probe(source)
+
+    assert calls == [probe_module._FFPROBE_ENTRIES]
+
+
+def test_display_lookup_and_multitrack_detection_fail_closed_on_malformed_values():
+    assert probe_module._display_stream_lookup({"streams": "not-a-list"}) == {}
+    assert probe_module._display_stream_lookup(
+        {"streams": [{"index": True}, {"index": "bad"}, {"index": 2}]}
+    ) == {2: {"index": 2}}
+    assert probe_module._multiple_audio_streams({"streams": []}) is False
+    assert probe_module._multiple_audio_streams(
+        {
+            "streams": [
+                {"codec_type": "audio"},
+                {"codec_type": "video"},
+                {"codec_type": "audio"},
+            ]
+        }
+    ) is True
+
+
+def test_stream_display_metadata_is_normalized_bounded_and_typed():
+    stream = MediaStream(
+        1,
+        StreamKind.AUDIO,
+        "aac",
+        title="  Interview microphone  ",
+        language=" eng ",
+        is_default=True,
+    )
+    assert stream.title == "Interview microphone"
+    assert stream.language == "eng"
+    assert stream.is_default is True
+
+    with pytest.raises(ValueError, match="^title exceeds safe display length$"):
+        MediaStream(1, StreamKind.AUDIO, "aac", title="x" * 201)
+    with pytest.raises(ValueError, match="^language exceeds safe display length$"):
+        MediaStream(1, StreamKind.AUDIO, "aac", language="x" * 65)
+    with pytest.raises(ValueError, match="^is_default must be boolean$"):
+        MediaStream(1, StreamKind.AUDIO, "aac", is_default=1)  # type: ignore[arg-type]

--- a/src/echoflow/media/tests/test_track_display_metadata.py
+++ b/src/echoflow/media/tests/test_track_display_metadata.py
@@ -125,15 +125,18 @@ def test_display_lookup_and_multitrack_detection_fail_closed_on_malformed_values
         {"streams": [{"index": True}, {"index": "bad"}, {"index": 2}]}
     ) == {2: {"index": 2}}
     assert probe_module._multiple_audio_streams({"streams": []}) is False
-    assert probe_module._multiple_audio_streams(
-        {
-            "streams": [
-                {"codec_type": "audio"},
-                {"codec_type": "video"},
-                {"codec_type": "audio"},
-            ]
-        }
-    ) is True
+    assert (
+        probe_module._multiple_audio_streams(
+            {
+                "streams": [
+                    {"codec_type": "audio"},
+                    {"codec_type": "video"},
+                    {"codec_type": "audio"},
+                ]
+            }
+        )
+        is True
+    )
 
 
 def test_stream_display_metadata_is_normalized_bounded_and_typed():


### PR DESCRIPTION
## Summary

Add native local audio/video playback from verified source-relative evidence coordinates without giving React filesystem authority.

- authorize playback in Python against the exact canonical generation and current source fingerprint
- fail closed for stale/missing/changed sources and multi-audio recordings rather than guessing which track matches transcript evidence
- keep the Python playback bridge private to the fixed Rust host
- bind authorized sources to opaque native sessions and serve bounded byte ranges through a dedicated `echoflow-media` protocol
- expose only session IDs, media kind, duration, and safe source-relative coordinates to React
- connect playback to the existing Evidence Reader cursor for both current and preserved older evidence generations
- restrict CSP media access to the dedicated local protocol

## Security boundary

React never receives source or canonical filesystem paths and cannot choose a Python module or local file. Python owns generation/source/evidence policy. Rust owns the opened file handle, opaque session lifetime, protocol allowlist, and bounded range transport.

## Qualification in progress

Backend negative/boundary/property coverage, Rust protocol tests, Playwright interaction/accessibility tests, docs/roadmap sync, and full CI are being completed in this draft before review.
