### PR TITLE
feat(desktop): add custody-aware Storage controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Start with **[docs/README.md](docs/README.md)** for human-facing documentation o
 
 ## What can it do right now?
 
-EchoFlow is pre-production, but the backend and desktop cover a coherent path from importing a recording through local processing, evidence search, durable research, transcript/speaker management, and verified local playback.
+EchoFlow is pre-production, but the backend and desktop cover a coherent path from importing a recording through local processing, evidence search, durable research, transcript/speaker management, verified local playback, and custody-aware storage management.
 
 | Area | Current foundation |
 |---|---|
@@ -33,12 +33,12 @@ EchoFlow is pre-production, but the backend and desktop cover a coherent path fr
 | Research workspace | authoritative SQLite notes/tags/collections, rebuildable DuckDB projection, desktop browse/create/edit/delete/filter/anchor maintenance |
 | Unified discovery | grouped transcript/note/tag/collection query without fabricated cross-type scores |
 | Saved searches | durable typed query intent that re-resolves current evidence instead of freezing result snapshots |
-| Safe lifecycle | typed plan-bound deletion scopes plus private execution-state retention that preserves evidence/human work by default |
+| Safe lifecycle | typed plan-bound deletion scopes plus private execution-state retention, now exposed through a native Storage workspace with plan review, source second guard, and resume-loss warnings |
 | Incremental library | cheap refresh/reconciliation plus durable transcript and recording locations |
 | Processing Center | readiness, machine/model state, preflight, explicit multi-track stream confirmation, supervised start/cancel, resume versus retry, job-state discard, diarization/enhancement/publication intent |
 | Transcript tools | generation-bound transcript/provenance inspection, speaker naming/removal, overlap-aware transcript view, post-hoc TXT/SRT/VTT publication |
-| Desktop guidance | persistent screen/overview help plus contextual Evidence, Playback, Transcript, and multi-track preflight explanations without duplicating backend policy |
-| Desktop presentation | Tauri + React Intake, Processing, Library, verified evidence reader/playback, Research, transcript tools, and eight semantic-token themes |
+| Desktop guidance | persistent screen/overview help plus contextual Evidence, Playback, Transcript, multi-track preflight, and Storage explanations without duplicating backend policy |
+| Desktop presentation | Tauri + React Intake, Processing, Library, verified evidence reader/playback, Research, Storage, transcript tools, and eight semantic-token themes |
 | Accessibility | keyboard/semantic-role tests, axe, non-hover contextual help, explicit light/dark browser schemes, and an eight-skin contrast matrix |
 | Quality | Linux/macOS/Windows CI, strict typing, lint/format/security, complexity/dead-code, branch coverage, dependency audit, Playwright/axe, native Rust tests, package verification, targeted mutation qualification |
 
@@ -102,11 +102,12 @@ The Tauri + React desktop currently provides:
 - generation/source-verified local audio/video playback from that evidence cursor without exposing source paths to React;
 - Research note create/edit/delete, tag/collection navigation, saved-search lifecycle, typed retrieval controls, exact-generation evidence return, and explicit anchor review;
 - transcript details/provenance, generation-safe speaker-name management, explicit speaker-overlap presentation, and post-hoc derived publication;
-- persistent **How this screen works** and **How EchoFlow works** guidance plus local Evidence/Playback/Transcript/multi-track explanations;
+- a Storage workspace for backend-planned transcript custody changes, explicit source protection, and previewed old-processing cleanup;
+- persistent **How this screen works** and **How EchoFlow works** guidance plus local Evidence/Playback/Transcript/multi-track/Storage explanations;
 - eight accessible presentation skins through one compact theme picker; and
 - persisted presentation preference without mixing theme state into evidence or research.
 
-The browser/webview does **not** receive canonical/source filesystem paths for evidence navigation, transcript tools, or playback. Rust owns native desktop capability and opened media sessions; Python owns application/evidence/custody/media-selection rules; React owns presentation and explicit user intent.
+The browser/webview does **not** receive canonical/source filesystem paths for evidence navigation, transcript tools, playback, or lifecycle plans. Rust owns native desktop capability and opened media sessions; Python owns application/evidence/custody/media-selection rules; React owns presentation and explicit user intent.
 
 When a file contains several embedded audio streams, Python reports that explicit confirmation is required. The desktop shows bounded source-declared title/language/default metadata when available, accepts the user's stream choice, and sends only that exact index back to Python for a fresh preflight. Start remains disabled until the backend returns a plan bound to that stream. Canonical provenance records the exact stream index and resume restores it. See **[Audio tracks](docs/audio-tracks.md)**.
 
@@ -114,7 +115,9 @@ Transcript tools are generation-bound. A long-lived UI cannot silently rename a 
 
 Playback follows the same evidence discipline. Python re-verifies the exact canonical generation, original source bytes, bounded coordinate, and audio-stream identity; Rust then turns the approved source into an opaque local media session. Multi-track transcription is supported, but multi-track playback currently fails closed because the system WebView cannot yet prove it rendered the same embedded stream that produced the transcript. See **[Verified native playback](docs/native-playback.md)**.
 
-In-app guidance is deliberately re-openable and non-hover-only where popovers are used, with inline help for required multi-track selection. It explains those contracts where users encounter them but carries no filesystem/database/process authority and does not recreate application policy in React. See **[In-app guidance](docs/in-app-guidance.md)**.
+Storage follows the same authority split. React requests a plan and renders the backend's effective scopes/actions; a separate fixed Tauri command can invoke only the custody bridge; Python recalculates the plan at execution and refuses stale confirmation tokens. Source and canonical paths are stripped before the response reaches React. See **[Storage and lifecycle controls](docs/storage-lifecycle.md)**.
+
+In-app guidance is deliberately re-openable and non-hover-only where popovers are used, with inline help for required multi-track selection and storage/custody review. It explains those contracts where users encounter them but carries no filesystem/database/process authority and does not recreate application policy in React. See **[In-app guidance](docs/in-app-guidance.md)**.
 
 There are still no end-user installers or Releases. The supported path remains a source build while packaging and first-run behavior are qualified.
 
@@ -187,7 +190,7 @@ Research metadata can constrain retrieval, and saved searches persist the questi
 
 ## Delete exactly what you mean
 
-Deletion is dry-run first:
+Deletion remains dry-run first from the CLI:
 
 ```bash
 uv run echoflow library delete JOB_ID --scope library-view
@@ -195,13 +198,17 @@ uv run echoflow library delete JOB_ID --scope library-view
 
 The plan prints actions and a confirmation token. Nothing changes until the same request is repeated with that token. `canonical-transcript` does **not** imply `research-notes`, `saved-searches`, or `source-recording`.
 
+The native desktop exposes the same contract under **Storage**: select explicit scopes, preview the backend-calculated plan, review any scope expansion/preservation consequences, then apply that exact plan. Source recording removal requires an additional acknowledgment and provenance check.
+
 Age-based retention is narrower:
 
 ```bash
 uv run echoflow library retention --execution-days 30
 ```
 
-It can delete old private execution work while preserving canonical transcripts, human research, source media, and lightweight lifecycle manifests. Read **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)** for the exact contract.
+The Storage workspace can preview the same private-state cleanup and marks interrupted/failed candidates whose resume capability would be lost. Retention preserves canonical transcripts, human research, source media, and lightweight lifecycle manifests.
+
+Read **[Storage and lifecycle controls](docs/storage-lifecycle.md)** and **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)** for the exact contract.
 
 ## What belongs to you?
 
@@ -222,19 +229,20 @@ A database is allowed to make evidence useful. It is not allowed to become the o
 
 ## For maintainers
 
-Start with **[docs/architecture/README.md](docs/architecture/README.md)**, **[Processing Center](docs/architecture/processing-center.md)**, **[Audio tracks](docs/audio-tracks.md)**, **[Transcript and speaker tools](docs/transcript-tools.md)**, **[Verified native playback](docs/native-playback.md)**, **[In-app guidance](docs/in-app-guidance.md)**, **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and **[frontend/SECURITY.md](frontend/SECURITY.md)**.
+Start with **[docs/architecture/README.md](docs/architecture/README.md)**, **[Processing Center](docs/architecture/processing-center.md)**, **[Audio tracks](docs/audio-tracks.md)**, **[Transcript and speaker tools](docs/transcript-tools.md)**, **[Verified native playback](docs/native-playback.md)**, **[Storage and lifecycle controls](docs/storage-lifecycle.md)**, **[In-app guidance](docs/in-app-guidance.md)**, **[Safe deletion and retention](docs/architecture/safe-deletion-retention.md)**, and **[frontend/SECURITY.md](frontend/SECURITY.md)**.
 
 Normal qualification includes Ruff, strict mypy, Vulture, Radon, branch coverage, dependency audit, package verification, TypeScript/build/audit gates, native Cargo compilation/tests, Playwright/axe, the eight-theme contrast matrix, targeted Poodle mutation workflows, and Linux/macOS/Windows CI. See **[Frontend testing strategy](docs/development/frontend-testing.md)** for frontend/backend test ownership.
 
 ## Where the project goes next
 
-Research/search, Processing, explicit embedded-track transcription, desktop comprehension/themes, transcript/speaker tools, verified native playback, and contextual guidance are built. The next first-release sequence is:
+Research/search, Processing, explicit embedded-track transcription, desktop comprehension/themes, transcript/speaker tools, verified native playback, contextual guidance, and desktop lifecycle/retention controls are built. The next first-release sequence is:
 
-1. lifecycle and retention UI over the existing plan-bound custody backend;
-2. architecture/redundancy audit before packaging freezes seams;
-3. packaging, first-run storage setup, signed updates, and evidence-safe uninstall;
-4. backup/restore plus selected research portability;
-5. packaged semantic-model/dependency custody; and
-6. representative-device qualification across ordinary consumer hardware and hostile path, disk, interruption, upgrade, and accessibility cases.
+1. architecture/redundancy audit before packaging freezes seams;
+2. packaging, first-run storage setup, signed updates, and evidence-safe uninstall;
+3. backup/restore plus selected research portability;
+4. packaged semantic-model/dependency custody; and
+5. representative-device qualification across ordinary consumer hardware and hostile path, disk, interruption, upgrade, and accessibility cases.
+
+A product-name decision should be made before packaging/signing fixes bundle identifiers, app-data paths, update channels, and migration semantics. Freeform research notebook pages are a useful later research-native feature, but they are intentionally separate from evidence-anchored notes and are not on the first-release critical path.
 
 See **[ROADMAP.md](ROADMAP.md)** for the capability audit and sequencing.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 EchoFlow is becoming a **private local workspace for recorded evidence**. Its job is not to out-engine every speech-recognition runtime. Its job is to make local transcription dependable, resumable, inspectable, searchable, navigable, annotatable, portable, and safe on ordinary computers while keeping source evidence and human-authored knowledge under clear custody.
 
-Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe a file?” through a substantial backend foundation into a native desktop that can import, process, make an explicit embedded-audio-track choice, search, verify, annotate, inspect speakers/provenance, publish derived transcript views, and play exact verified source evidence. This roadmap is a productization map, not a class inventory.
+Modern EchoFlow restarted on August 2, 2026. The project has moved from “can we transcribe a file?” through a substantial backend foundation into a native desktop that can import, process, make an explicit embedded-audio-track choice, search, verify, annotate, inspect speakers/provenance, publish derived transcript views, play exact verified source evidence, and review/apply custody-aware storage changes. This roadmap is a productization map, not a class inventory.
 
 ```mermaid
 flowchart LR
@@ -48,7 +48,7 @@ flowchart LR
 
 </details>
 
-Text fallback: EchoFlow already spans local media, reliable transcription, explicit embedded-track selection, canonical evidence, lexical/semantic/hybrid retrieval, verified navigation, durable research, lifecycle contracts, incremental refresh, remembered locations, native import, Processing, Library, Research, transcript/speaker tools, verified native playback, and an accessible multi-theme shell. The next first-release work is lifecycle UI, architecture cleanup, packaging, portability, packaged semantic custody, and real-device qualification.
+Text fallback: EchoFlow already spans local media, reliable transcription, explicit embedded-track selection, canonical evidence, lexical/semantic/hybrid retrieval, verified navigation, durable research, lifecycle contracts and desktop controls, incremental refresh, remembered locations, native import, Processing, Library, Research, transcript/speaker tools, verified native playback, and an accessible multi-theme shell. The next first-release work is architecture/redundancy cleanup, a product-identity checkpoint before packaging, packaging, portability, packaged semantic custody, and real-device qualification.
 
 # First-release foundation now
 
@@ -98,11 +98,17 @@ The library has a database-neutral retrieval contract, DuckDB lexical projection
 
 Search ranking and evidence navigation remain separate. A ranked passage becomes precise evidence only after EchoFlow verifies canonical generation and resolves exact segment/word coordinates.
 
-Authoritative SQLite owns notes, tags, collections, anchor history, and saved-search intent. DuckDB research/search state is rebuildable. The desktop supports note create/edit/delete, tag/collection navigation, saved-search lifecycle, typed Research search, exact-generation return, and explicit stale-anchor review/re-anchor.
+Authoritative SQLite owns evidence notes, tags, collections, anchor history, and saved-search intent. DuckDB research/search state is rebuildable. The desktop supports note create/edit/delete, tag/collection navigation, saved-search lifecycle, typed Research search, exact-generation return, and explicit stale-anchor review/re-anchor.
+
+Today's `ResearchNote` always has an exact evidence anchor. A future freeform notebook/memo should be a separate authoritative research-document class with optional explicit evidence references rather than weakening that invariant with nullable provenance. See **[Research notes](docs/research-notes.md)**.
 
 ## Safe lifecycle and locations
 
-Deletion is dry-run-first and plan-bound. Source-recording deletion requires its own explicit guard and provenance verification. Retention is intentionally narrower and may remove old private execution work without silently deleting canonical transcripts, source media, or human research.
+Deletion is preview-first and plan-bound. The native Storage workspace presents backend-computed requested/effective scopes, concrete action descriptions, preserved-note counts, affected saved-search counts, and the exact reviewed confirmation flow. Source-recording deletion requires its own scope, a second UI guard, and provenance verification.
+
+Retention is intentionally narrower. Storage can preview old private processing workspaces, identify interrupted/failed candidates whose resume capability would be lost, and apply the exact plan. It does not age-delete canonical transcripts, source media, published transcripts, human research, or lightweight lifecycle manifests.
+
+The destructive path remains Python-owned: `LibraryCustodyService` computes policy, a dedicated fixed custody bridge strips action/workspace paths, Tauri exposes only `lifecycle_request`, and React presents typed intent/consequences. See **[Storage and lifecycle controls](docs/storage-lifecycle.md)**.
 
 Remembered recording/transcript locations are durable permissions. Recording discovery itself does not hash, probe, copy, or transcribe candidate media. Automatic processing remains a separate explicit policy.
 
@@ -119,7 +125,7 @@ EchoFlow Desktop
 
 The shell now has eight skins: **Archive, Midnight, Paper, Moss, Plum, Ember, Pride, and Monochrome**. All use one semantic token contract for surfaces, text, controls, focus, errors, selection, and accent foregrounds. Pride's rainbow is decorative-only; Monochrome is deliberately grayscale. Theme preference is local presentation state and never evidence/research state.
 
-Playwright iterates every registered skin through WCAG-oriented contrast pairs, real native-style controls, browser `color-scheme`, and axe. The embedded-track chooser uses native radios, visible explanatory text, semantic tokens, and the same accessibility qualification rather than a custom visual-only selector. See **[Desktop themes and accessibility](docs/development/desktop-accessibility.md)**.
+Playwright iterates every registered skin through WCAG-oriented contrast pairs, real native-style controls, browser `color-scheme`, and axe. The embedded-track chooser uses native radios, visible explanatory text, semantic tokens, and the same accessibility qualification rather than a custom visual-only selector. Storage uses native controls and semantic danger presentation, and axe covers an open destructive plan. See **[Desktop themes and accessibility](docs/development/desktop-accessibility.md)**.
 
 # Capability → desktop audit
 
@@ -138,12 +144,12 @@ Playwright iterates every registered skin through WCAG-oriented contrast pairs, 
 | TXT/SRT/WebVTT | deterministic derived publication | **implemented post-hoc desktop flow** | optional export organization |
 | Lexical/semantic/hybrid search | private retrieval | implemented | packaged semantic custody |
 | Verified evidence navigation | exact generation + timing/seek | implemented | representative-device playback qualification |
-| Notes/tags/collections | SQLite authority | implemented | optional management polish |
+| Notes/tags/collections | SQLite authority | implemented | optional management polish; freeform memos later as separate object type |
 | Saved searches | durable typed intent | implemented | optional organization polish |
-| Safe deletion/retention | typed plan-bound backend | backend ready | **desktop lifecycle UI next** |
+| Safe deletion/retention | typed plan-bound Python custody | **implemented desktop Storage plan/apply** | representative-device/path qualification |
 | Native source playback | generation/source authorization + Rust session | **implemented** | decoder/device qualification; future proven multi-track selection |
 | Themes/accessibility | semantic palette + browser/native controls | **8 skins qualified** | representative OS/forced-colors checks |
-| Frontend tests | strict TS/build + Playwright/axe | primary surfaces + playback + multitrack covered | grow with features, avoid duplicated backend policy |
+| Frontend tests | strict TS/build + Playwright/axe | primary surfaces + playback + multitrack + lifecycle covered | grow with features, avoid duplicated backend policy |
 | Packaging | Python wheel + source Tauri | development only | managed runtime/installers/update/uninstall |
 | Backup/restore | authority boundaries known | none | manifest/reconcile/restore UI |
 | Representative hardware | policy contracts + platform CI | partial | real 8/16 GB, Apple/dGPU/high-DPI qualification |
@@ -174,34 +180,62 @@ Verified source-relative evidence coordinates now drive local audio/video withou
 
 Qualification covers stale/missing/changed sources, exact word coordinates, preserved older generations, keyboard preparation, path non-disclosure, audio/video presentation, multi-audio playback refusal, native range parsing, session-token allowlisting, and bounded streaming. A targeted playback Poodle workflow challenges the Python authorization decisions.
 
-## 6. Lifecycle + retention UI ← next
+## 6. Lifecycle + retention UI complete
 
-Productize the existing custody contracts before a packaged app invites large local corpora: dry-run plan review, plan-bound confirmation, explicit scopes, source-recording second guard, and retention preview/result state.
+The Storage workspace now productizes the existing custody contracts without creating a second deletion policy. Users can choose explicit transcript custody scopes, preview backend-calculated scope expansion/actions/preservation effects, and apply only the exact reviewed plan. Source recording removal has a second guard and backend provenance verification.
 
-The UI must not invent deletion semantics. Python already owns scope expansion, provenance checks, confirmation tokens, source-recording protection, and retention exclusions. The desktop tranche should expose those decisions clearly while keeping filesystem mutation out of React.
+Private retention exposes age policy, completed-only defaults, optional failed/interrupted inclusion, explicit resume-loss warnings, preview, and plan-bound application. Running jobs remain backend-ineligible. React never receives destructive action paths or private workspace paths.
 
-## 7. Architecture/redundancy audit
+The dedicated `custody_bridge` and fixed Tauri `lifecycle_request` keep destructive authority separate from the ordinary desktop bridge. Ordinary quality, boundary tests, existing custody-service tests, Playwright, and axe qualify this tranche. Poodle is not added merely because there is a new screen; mutation testing remains targeted to files containing decision-heavy policy.
 
-Do this before packaging freezes seams. Audit bridge DTOs, Pydantic models, React client glue, serializers, service composition, fixtures, Tauri supervisor/media patterns, stale compatibility paths, and duplicated documentation. Refactor policy duplication or unclear ownership, not merely similar-looking files.
+## 7. Architecture/redundancy audit ← next
 
-## 8. Packaging + first run + update/uninstall
+Do this before packaging freezes seams. Audit bridge DTOs, Pydantic models, React client glue, serializers, service composition, fixtures, Tauri supervisor/media/custody patterns, stale compatibility paths, and duplicated documentation. Refactor policy duplication or unclear ownership, not merely similar-looking files.
+
+Specific questions to answer include whether fixed desktop bridges share enough trusted-host transport mechanics to justify one narrow helper without merging their authority, whether mock/E2E DTO fixtures can be generated or centralized without hiding product contracts, and whether any compatibility layer still exists only because the product evolved quickly.
+
+## 8. Product identity checkpoint
+
+Make the final first-release naming decision **before** packaging/signing turns identity into a migration contract.
+
+A rename affects more than the GitHub repository label. Audit and intentionally migrate:
+
+- product/CLI/module/package/display names;
+- Tauri bundle identifiers and executable names;
+- app-data/cache/model/output directory names;
+- installer/update-channel/signing identities;
+- documentation/examples and generated artifacts;
+- environment variables and integration points; and
+- migration/compatibility behavior for existing local EchoFlow workspaces.
+
+Do not rename speculatively. Choose the actual replacement name first, verify pronunciation/searchability/legal/package-namespace collisions, then perform one deliberate identity migration before installers exist. If EchoFlow remains the name, record that decision and freeze the identity surface.
+
+## 9. Packaging + first run + update/uninstall
 
 Ship a managed Python runtime/sidecar, FFmpeg/native dependencies, Windows/macOS/Linux delivery, storage onboarding/repair, signed updates, and evidence-safe uninstall semantics.
 
-## 9. Backup/restore + research portability
+Packaging must not silently move/delete user evidence. Uninstall should remove application/runtime/cache state according to explicit rules while preserving original recordings, canonical transcript evidence, and authoritative research unless the user separately requests destruction.
+
+## 10. Backup/restore + research portability
 
 Back up canonical evidence and authoritative research, rebuild projections on restore, reconcile machine-local paths, and export selected research with stable evidence identity.
 
-## 10. Packaged semantic custody
+Design the authority manifest so a later freeform `ResearchDocument`/memo class can be added without pretending current evidence notes are unanchored. Export formats are derived views; the backup manifest is about stable authority and relationships.
+
+## 11. Packaged semantic custody
 
 Lock/qualify embedding dependencies, immutable model acquisition, private cache/offline behavior, corpus compatibility, and upgrade semantics as an ordinary product feature.
 
-## 11. Representative-device qualification
+## 12. Representative-device qualification
 
 Qualify 8 GB Windows, 16 GB commodity systems, Apple Silicon, dGPU laptops, 32/64 GB systems, Unicode/long paths, external disks, low disk, crashes, interrupted downloads, offline use, upgrades/reinstall, scaling, native controls, media codecs, keyboard use, forced colors, and accessibility.
 
+This is where “my friend can put a random video in and it works” becomes an evidence-backed claim rather than an architectural expectation.
+
 # Later research-native work
 
-Snapshots/diffs, REFI-QDA interoperability, evidence packets, comparison workspaces, evidence-linked writing/script boards, portable research bundles, and live provisional capture remain intentionally separate from the first-release path.
+Freeform research memos/notebook pages, snapshots/diffs, REFI-QDA interoperability, evidence packets, comparison workspaces, evidence-linked writing/script boards, portable research bundles, and live provisional capture remain intentionally separate from the first-release path.
 
-The sequencing rule remains simple: do not build a larger research superstructure while the ordinary desktop still lacks lifecycle UI, packaging, portability, and real-device qualification.
+A future notebook page should live in authoritative SQLite as its own research-document type with optional explicit references to evidence notes/anchors. It should not weaken the current `ResearchNote` invariant by making its evidence anchor optional. DuckDB can later project memo text/relationships for search, and Markdown/plain-text/HTML/research-bundle exports can remain derived views.
+
+The sequencing rule remains simple: do not build a larger research superstructure while the ordinary desktop still needs architecture cleanup, identity freeze, packaging, portability, and real-device qualification.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 EchoFlow is a **private, local-first workspace for recorded evidence**.
 
-It can inspect a recording, choose a safe way to run on the computer you actually have, transcribe locally, survive interruptions, preserve provenance, search a private corpus, navigate results back to verified canonical evidence, keep research notes attached to that evidence, save reusable research questions, manage generation-bound speaker labels, inspect transcript provenance, publish derived transcript views, and play verified local source evidence through a native desktop shell.
+It can inspect a recording, choose a safe way to run on the computer you actually have, transcribe locally, survive interruptions, preserve provenance, search a private corpus, navigate results back to verified canonical evidence, keep research notes attached to that evidence, save reusable research questions, manage generation-bound speaker labels, inspect transcript provenance, publish derived transcript views, play verified local source evidence, and manage storage through reviewed custody plans in a native desktop shell.
 
-You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, or desktop IPC to use the product. Those are implementation details. The desktop should speak in recordings, transcripts, searches, notes, processing, speakers, playback, and evidence. Persistent in-app guidance explains the unusual concepts at the point of use instead of assuming this documentation is open beside the app.
+You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, or desktop IPC to use the product. Those are implementation details. The desktop should speak in recordings, transcripts, searches, notes, processing, speakers, playback, storage, and evidence. Persistent in-app guidance explains the unusual concepts at the point of use instead of assuming this documentation is open beside the app.
 
 > **The short version:** your recording stays yours, canonical JSON remains inspectable evidence, your notes/speaker names/saved searches remain your knowledge, and most machinery built around those things can be thrown away and rebuilt.
 
@@ -29,11 +29,12 @@ You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, o
 | Search a private corpus | supports lexical BM25, optional semantic retrieval, hybrid RRF, and inspectable Research search options |
 | Follow a result to evidence | verifies canonical generation and returns justified segment/word/context/seek coordinates |
 | Play the cited recording | re-verifies the exact transcript generation and source before opening an opaque native audio/video session; multi-track sources currently refuse playback rather than risk the wrong embedded track |
-| Keep durable research | stores notes/tags/collections in authoritative private SQLite anchored to exact evidence |
+| Keep durable research | stores evidence-anchored notes/tags/collections in authoritative private SQLite |
 | Reuse questions | stores and edits full typed saved-search intent, then re-resolves current evidence |
 | Remember libraries | persists explicit transcript/recording permissions without copying user media |
 | Refresh an evolving corpus | incrementally reconciles changed canonical generations and can verify tracked evidence |
-| Remove something safely | plans typed deletion scopes before mutation and binds confirmation to the exact plan |
+| Remove something safely | previews backend-calculated custody scopes/actions, requires an exact plan-bound confirmation, and gives source media its own second guard |
+| Clean old processing state | previews eligible private workspaces and marks resumable interrupted/failed jobs before cleanup |
 | Understand an unfamiliar screen | keeps re-openable, keyboard/touch-accessible contextual help in the app instead of relying on hover-only tips |
 | Change appearance | offers Archive, Midnight, Paper, Moss, Plum, Ember, Pride, and Monochrome through one accessible Theme picker |
 
@@ -45,16 +46,17 @@ You do **not** need to understand CUDA, DuckDB, SQLite, BM25, model revisions, o
 - **[Processing Center](architecture/processing-center.md)** for the desktop processing authority split.
 - **[Transcript and speaker tools](transcript-tools.md)** for generation-bound details, speaker management, overlap presentation, and post-hoc publication.
 - **[Verified native playback](native-playback.md)** for source re-verification, opaque media sessions, exact seek coordinates, and the multi-audio fail-closed rule.
+- **[Storage and lifecycle controls](storage-lifecycle.md)** for plan-first transcript custody, source protection, private-state retention, and native boundary details.
 - **[Find things across the whole local library](library-discovery.md)** for grouped Library discovery.
 - **[Research search](research-search.md)** for Match, Search options, saved searches, and the typed backend contract beneath the ordinary UI.
-- **[Your notes should survive the machinery](research-notes.md)** for notes, tags, collections, saved research intent, and anchor maintenance.
+- **[Your notes should survive the machinery](research-notes.md)** for evidence notes, tags, collections, saved research intent, anchor maintenance, and the future freeform-notebook distinction.
 - **[From search result to the exact evidence](evidence-navigation.md)** for verified canonical navigation and the evidence reader/cursor.
 - **[Transcript time without calculator gymnastics](time-navigation.md)** for timeline and source-relative coordinates.
 - **[Give the anonymous speakers names](speaker-names.md)** for human-authored display labels and generation semantics.
 - **[Semantic search, without the mystery box](semantic-search.md)** for local semantic/hybrid retrieval.
 - **[Desktop themes and accessibility](development/desktop-accessibility.md)** for the eight-skin semantic token system and contrast qualification.
 - **[Frontend testing strategy](development/frontend-testing.md)** for frontend/backend test ownership and mutation policy.
-- **[Safe deletion and retention](architecture/safe-deletion-retention.md)** for custody-aware deletion.
+- **[Safe deletion and retention](architecture/safe-deletion-retention.md)** for the underlying custody contract.
 - **[Post-MVP research roadmap](post-mvp-roadmap.md)** for later research-native workflows.
 - **[SECURITY.md](../SECURITY.md)** for the repository security boundary.
 - **[Architecture](architecture/README.md)** and **[Development docs](development/)** for maintainers.
@@ -103,7 +105,7 @@ flowchart LR
 
 </details>
 
-Text fallback: canonical evidence feeds rebuildable search; search resolves back to verified evidence; durable notes/tags/collections, speaker labels, and saved searches remain authoritative human knowledge; lifecycle and refresh reuse those identities; the desktop Processing, Library, transcript-tools, playback, and Research surfaces consume the same application authorities.
+Text fallback: canonical evidence feeds rebuildable search; search resolves back to verified evidence; durable notes/tags/collections, speaker labels, and saved searches remain authoritative human knowledge; lifecycle and refresh reuse those identities; the desktop Processing, Library, transcript-tools, playback, Research, and Storage surfaces consume the same application authorities.
 
 ## What belongs to you, and what can the raccoon rebuild? 🦝
 
@@ -125,11 +127,13 @@ If deleting a search projection destroys unique human-authored information, some
 
 ## The desktop today
 
-Research/search, the Processing Center, desktop comprehension/themes, transcript/speaker tools, verified native playback, and re-openable contextual guidance are now coherent first-release slices.
+Research/search, the Processing Center, desktop comprehension/themes, transcript/speaker tools, verified native playback, re-openable contextual guidance, and custody-aware Storage are now coherent first-release slices.
 
-Research uses ordinary product language by default. Processing presents backend planning/admission rather than duplicating it. If a source contains several embedded audio tracks, Python tells the desktop that explicit selection is required; React presents bounded track facts and submits the chosen stream index, then Python replans before Start is enabled. Transcript tools pass exact generation identity into Python for details, speaker mutation, and publication. Playback does the same for source authorization, then Rust owns an opaque opened-file session. The webview does not parse canonical evidence or receive canonical/source paths.
+Research uses ordinary product language by default. Processing presents backend planning/admission rather than duplicating it. If a source contains several embedded audio tracks, Python tells the desktop that explicit selection is required; React presents bounded track facts and submits the chosen stream index, then Python replans before Start is enabled. Transcript tools pass exact generation identity into Python for details, speaker mutation, and publication. Playback does the same for source authorization, then Rust owns an opaque opened-file session.
 
-The sidebar keeps **How this screen works** and **How EchoFlow works** available after first use. Evidence, playback, transcript tools, and multi-track preflight add local explanation at the point where their evidence semantics become unusual. The help registry and inline copy are presentation only; they never substitute for Python application policy.
+Storage follows the same rule. React sends only typed lifecycle intent and renders a plan calculated by `LibraryCustodyService`. A dedicated Tauri command invokes only the fixed custody bridge. Action paths and private workspace paths are removed before responses reach the webview. Applying a plan sends the exact reviewed token back to Python, which recalculates and refuses stale state.
+
+The sidebar keeps **How this screen works** and **How EchoFlow works** available after first use. Evidence, playback, transcript tools, multi-track preflight, and Storage add local explanation at the point where their semantics become unusual. The help registry and inline copy are presentation only; they never substitute for Python application policy.
 
 Appearance remains one compact picker. All eight skins share the same semantic text/control/focus contract and the same registry-driven contrast/a11y matrix.
 
@@ -137,12 +141,14 @@ Appearance remains one compact picker. All eight skins share the same semantic t
 
 The next critical path is:
 
-1. lifecycle and retention UI over the existing custody backend;
-2. architecture/redundancy audit before packaging;
+1. architecture/redundancy audit before packaging freezes seams;
+2. product-identity decision before package IDs/app-data/update channels become migration contracts;
 3. packaging, first run, signed updates, and evidence-safe uninstall;
 4. backup/restore and selected research portability;
 5. packaged semantic custody; and
 6. representative-device qualification.
+
+A future freeform notebook/memo capability belongs in later Research work as a second durable research-object class, not as evidence notes with optional/missing provenance.
 
 Only after the first desktop product is coherent do the deliberately separate **[post-MVP research features](post-mvp-roadmap.md)** become normal roadmap work.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -77,8 +77,8 @@ navigation verifies evidence; SQLite owns human research; `ResearchWorkspaceServ
 composes research interactions; `ProcessingCenterService` composes machine/model/job,
 preflight, and explicit embedded-track confirmation authority; the versioned desktop bridge
 feeds current Library, Research, and Processing presentation; `LibraryCustodyService` keeps
-destructive policy separate. Verified playback adds a separate private Python-to-Rust
-authorization path without widening the general bridge.
+destructive policy separate. Verified playback and lifecycle Storage each use separate fixed
+Python-to-Rust paths rather than widening the general bridge.
 
 ## Where to look
 
@@ -88,6 +88,7 @@ authorization path without widening the general bridge.
 | [Processing Center](processing-center.md) | How does the desktop expose readiness, preflight, embedded-track choice, jobs, and long-running native work without becoming the scheduler? |
 | [Audio tracks](../audio-tracks.md) | How does EchoFlow choose among several embedded audio streams without guessing or confusing transcription with playback? |
 | [Verified native playback](../native-playback.md) | How does exact-generation evidence become a local media capability without exposing paths to React? |
+| [Storage and lifecycle controls](../storage-lifecycle.md) | How does the desktop expose plan-bound custody and retention without giving React filesystem authority? |
 | [Adaptive heterogeneous execution](adaptive-heterogeneous-execution.md) | How does EchoFlow decide what this machine can safely run? |
 | [Media and timeline](media-and-timeline.md) | Which source/stream did we use, and what do timestamps mean? |
 | [Word-level timestamp alignment](word-alignment.md) | How do engine timings become source-relative evidence? |
@@ -118,9 +119,9 @@ authorization path without widening the general bridge.
 | `workspace` | Private job paths and public artifact allocation |
 | `benchmarking` | Privacy-minimized local execution measurement |
 | `library` | Retrieval, evidence navigation, playback authorization, research authority/projections, saved searches, discovery, refresh, locations, typed custody policy |
-| `desktop` | Versioned allowlisted Python bridges for Library/Research/Processing/transcript tools plus a private fixed playback authorization bridge |
-| `frontend` | React/TypeScript presentation over typed desktop operations; no direct DB/filesystem/media-probe authority |
-| `src-tauri` | Thin native host/capability boundary for dialogs, allowlisted long-running child processes, opened playback sessions, and bounded local media transport |
+| `desktop` | Versioned allowlisted Python bridges plus fixed private playback and lifecycle custody bridges |
+| `frontend` | React/TypeScript presentation over typed desktop operations; no direct DB/filesystem/media-probe/custody authority |
+| `src-tauri` | Thin native host/capability boundary for dialogs, allowlisted long-running child processes, fixed Python bridge commands, opened playback sessions, and bounded local media transport |
 
 ## Capability boundaries
 
@@ -131,7 +132,7 @@ The search/research/custody/processing/desktop area deliberately separates respo
 1. `TranscriptLibraryService` discovers and ranks rebuildable transcript passages.
 2. `EvidenceLocator` verifies ranked passages against canonical evidence.
 3. `SpeakerLabelService` owns durable recording-scoped human display names without rewriting diarization evidence.
-4. `ResearchStateStore` owns durable notes, tags, collections, and exact evidence anchors.
+4. `ResearchStateStore` owns durable evidence notes, tags, collections, and exact evidence anchors.
 5. `ResearchStateProjector` converges authoritative SQLite state into a disposable DuckDB research projection.
 6. `ResearchProjectionIndex` owns fast derived research constraints and summaries.
 7. `WorkspaceMetadataStore` owns durable saved-search intent and computes disposable navigation views.
@@ -140,10 +141,11 @@ The search/research/custody/processing/desktop area deliberately separates respo
 10. `LibraryCustodyService` owns typed deletion planning/execution and age-based private execution-state retention.
 11. `ProcessingCenterService` composes health/resource/model/job/preflight authority, including whether multi-track preflight requires explicit user confirmation, without reimplementing lower-level media policy.
 12. `PlaybackAuthorizationService` verifies exact canonical generation, current source bytes, coordinate bounds, and stream identity before native media can open.
-13. `echoflow.desktop.bridge` exposes an allowlisted versioned IPC surface. Current Library/Research/Processing DTOs retain necessary identity without leaking general filesystem authority to React.
-14. The playback bridge is private to the fixed Rust host and is not a webview-callable Tauri command.
-15. Tauri supervises allowlisted long-running native child processes and owns opaque opened playback sessions. It owns process/file lifetime, not strategy selection, stream selection, model validity, or transcript correctness.
-16. React owns interaction and presentation only. It does not issue SQL, mutate DuckDB/SQLite directly, select canonical generations, inspect media, choose a preferred audio track by policy, or decide resource/custody policy.
+13. `echoflow.desktop.bridge` exposes the ordinary allowlisted versioned IPC surface for Library/Research/Processing.
+14. The playback bridge is private to a fixed Rust host path and cannot be redirected to an arbitrary Python module.
+15. `echoflow.desktop.custody_bridge` exposes only document listing, deletion plan/apply, and retention plan/apply through a dedicated fixed Tauri command; it strips action/workspace paths before serialization.
+16. Tauri supervises allowlisted long-running native child processes, owns opaque opened playback sessions, and invokes fixed Python modules. It owns process/file lifetime, not strategy selection, stream selection, model validity, transcript correctness, or custody policy.
+17. React owns interaction and presentation only. It does not issue SQL, mutate DuckDB/SQLite directly, select canonical generations, inspect media, choose a preferred audio track by policy, or decide effective deletion/retention policy.
 
 That split must survive future UI convenience work. Presentation convenience is not
 permission to merge custody boundaries.
@@ -171,6 +173,11 @@ Saved searches live in authoritative SQLite because they are authored intent. Th
 evidence scope does not. Replaying a saved search re-resolves the current corpus and current
 research relationships.
 
+A future freeform research memo/notebook should also be authoritative SQLite state, but as a
+separate research-document class rather than an evidence note with a nullable anchor. That
+keeps “this is my synthesis” distinct from “this prose is attached to these exact canonical
+coordinates.”
+
 ## Desktop presentation does not rename authority
 
 The desktop intentionally translates internal vocabulary into ordinary product language.
@@ -188,6 +195,11 @@ confirmation is required and validates the requested stream. React can display b
 source-declared title/language/default metadata and collect a radio-button choice, but it
 cannot turn those labels into a recommendation or skip backend re-preflight.
 
+Storage follows the same principle. React offers understandable custody scope labels and a
+second source acknowledgment, but `LibraryCustodyService` computes scope expansion, action
+sets, note preservation, saved-search effects, source provenance checks, retention
+eligibility, resume-loss flags, and the plan-bound confirmation token.
+
 ## The custody rules 🦝
 
 1. **Original media is source evidence and read-only during normal processing.** Explicit source deletion is separate and provenance-checked.
@@ -204,10 +216,11 @@ cannot turn those labels into a recommendation or skip backend re-preflight.
 12. **Age-based retention can delete only private job workspaces.**
 13. **Remembered locations are permissions/pointers, not copies of user media.**
 14. **The desktop webview receives typed presentation DTOs and opaque playback handles, not arbitrary filesystem paths or database handles.**
-15. **Long-running native process supervision does not create a second job or checkpoint authority.**
-16. **Verified playback authorization does not turn an opaque media session into source/evidence authority.**
-17. **Theme/presentation state is machine-local preference, not evidence or research state.**
-18. **EchoFlow does not claim secure erasure it cannot prove.**
+15. **Lifecycle plan DTOs omit deletion paths and private workspace paths.**
+16. **Long-running native process supervision does not create a second job or checkpoint authority.**
+17. **Verified playback authorization does not turn an opaque media session into source/evidence authority.**
+18. **Theme/presentation state is machine-local preference, not evidence or research state.**
+19. **EchoFlow does not claim secure erasure it cannot prove.**
 
 Search infrastructure may disappear. User-authored knowledge may not disappear by accident.
 
@@ -241,12 +254,15 @@ echoflow library delete TRANSCRIPT_ID --scope canonical-transcript
 echoflow library retention --execution-days 30
 ```
 
-Deletion and retention are dry-run by default. Applying a reviewed operation requires the
-plan-bound token returned by the dry run.
+The native Storage workspace exposes the same plan/apply contract through the dedicated
+custody bridge. Deletion and retention remain preview-first. Applying a reviewed operation
+requires the exact plan-bound token; execution recalculates the plan and refuses changed
+state. React never receives the destructive filesystem paths.
 
-The next product seam is lifecycle/retention UI over the existing custody service rather
-than creating a second deletion policy. After that, the architecture/redundancy audit should
-clean seams before packaging freezes them.
+The **next product seam is the architecture/redundancy audit**. It should remove duplicated
+policy/glue and clarify ownership before packaging freezes bundle IDs, app-data locations,
+sidecar contracts, and update/uninstall behavior. The product-name/identity decision belongs
+before that packaging freeze as well.
 
 ## New abstraction test
 

--- a/docs/architecture/safe-deletion-retention.md
+++ b/docs/architecture/safe-deletion-retention.md
@@ -13,6 +13,43 @@ This design protects the central library invariant:
 > **Removing evidence from search must never silently erase canonical transcript evidence,
 > user-authored research knowledge, or an original recording.**
 
+## Desktop Storage workspace
+
+The native desktop now exposes these existing contracts through **Storage & deletion**.
+The desktop does not create a second deletion policy.
+
+For transcript custody, the user:
+
+1. chooses an indexed transcript;
+2. selects explicit custody scopes;
+3. previews a backend-calculated plan;
+4. reviews effective scope expansion, planned actions, preserved-note count, and affected
+   saved-search count; and
+5. applies that exact reviewed plan.
+
+Source-recording removal adds a second explicit acknowledgment before the backend
+`allow_source` safety switch can be submitted.
+
+Private processing cleanup exposes retention age plus an optional failed/interrupted-job
+switch. The preview marks any candidate whose resume capability would be lost. Running jobs
+remain backend-ineligible.
+
+The desktop path is intentionally narrow:
+
+```text
+React Storage
+    -> fixed Tauri lifecycle_request
+    -> python -m echoflow.desktop.custody_bridge
+    -> LibraryCustodyService
+```
+
+The bridge does not serialize `DeletionAction.path`, `RetentionCandidate.workspace_path`,
+canonical paths, or full source paths. React renders typed intent and backend consequences;
+Python remains the authority for scope expansion, provenance checks, retention eligibility,
+confirmation tokens, and execution.
+
+See **[Storage and lifecycle controls](../storage-lifecycle.md)** for the user/native contract.
+
 ## CLI
 
 Plan an operation:
@@ -101,8 +138,10 @@ over:
 canonical deletion cascades into silent loss of human work
 ```
 
-A later UI can present this as an "evidence unavailable" note while still showing the
-recorded document/generation identity.
+The Research workspace already represents older/unavailable anchor states without silently
+moving the note to a different generation. Storage therefore reports how many anchored notes
+will be preserved by the reviewed deletion plan rather than implying that canonical deletion
+owns those notes.
 
 ## Saved searches are preserved unless their own scope is selected
 
@@ -153,7 +192,8 @@ Original recordings are treated read-only throughout normal EchoFlow processing.
 A source recording can be deleted only when all of the following are true:
 
 1. `source-recording` is an explicitly requested scope;
-2. `--allow-source` is supplied;
+2. `--allow-source` is supplied, or the desktop's equivalent second acknowledgment enables
+   that explicit safety switch;
 3. a source path is available;
 4. the source still exists; and
 5. current source integrity is `matches-recorded-source`.
@@ -179,7 +219,7 @@ state/
 It never age-deletes:
 
 - canonical JSON;
-- TXT/SRT/VTT;
+- TXT/SRT/WebVTT;
 - source recordings;
 - notes/tags/collections;
 - speaker labels;
@@ -194,7 +234,7 @@ valid evidence harder to rediscover.
 
 ## Retention defaults
 
-The default CLI policy is:
+The default CLI and desktop policy is:
 
 ```text
 execution_days = 30
@@ -204,7 +244,8 @@ include_incomplete = false
 A completed workspace older than the cutoff is eligible.
 
 Failed/interrupted workspaces remain available for resume unless the user explicitly opts
-into `--include-incomplete`. Running jobs are never eligible, regardless of age.
+into `--include-incomplete`. Running jobs are never eligible, regardless of age. The desktop
+shows backend-provided `resume_capability_lost` state before a reviewed plan can be applied.
 
 Retention plans are recalculated at execution time. If candidates changed, the old token
 no longer matches and EchoFlow refuses to apply the stale plan.
@@ -249,11 +290,11 @@ It does **not** mean EchoFlow can prove the bytes are unrecoverable from:
 - storage-controller caches; or
 - forensic recovery outside the active filesystem namespace.
 
-Both human and JSON CLI output therefore state that secure erasure is not guaranteed.
+CLI output and desktop guidance therefore avoid claiming secure erasure.
 
 ## Test contract
 
-The custody tests cover:
+The custody service tests cover:
 
 - canonical scope expansion;
 - preservation of notes by default;
@@ -274,6 +315,18 @@ The custody tests cover:
 - human and JSON CLI behavior; and
 - safe public/internal error presentation.
 
-Additional saved-search tests added alongside this work cover value-object validation,
-storage bounds, corrupt persisted JSON/enums, missing mutation targets, closed navigation
-dispatch, and human rendering paths that were under-covered in the merged saved-search PR.
+Desktop custody tests add:
+
+- closed lifecycle protocol and bounded parameters;
+- path stripping from deletion/retention DTOs;
+- exact confirmation-token forwarding;
+- explicit source-gate forwarding;
+- plan-first canonical deletion presentation;
+- source second-guard presentation;
+- retention completed/incomplete distinction and resume-loss warning;
+- DOM path non-disclosure; and
+- axe with an open destructive plan.
+
+The desktop tranche does not modify `LibraryCustodyService` decision logic, so no broad new
+mutation workflow is added. Mutation testing remains targeted to decision-heavy policy files
+rather than becoming a cost paid by every UI/docs change.

--- a/docs/development/frontend-testing.md
+++ b/docs/development/frontend-testing.md
@@ -31,6 +31,7 @@ Playwright exercises every primary desktop surface:
 - verified local playback from current and preserved older evidence generations;
 - Transcript and speaker tools;
 - Research notes, filtering, saved searches, typed search, and anchor maintenance;
+- Storage custody planning/application and private-retention previews;
 - persistent and contextual in-app guidance; and
 - development-mode behavior.
 
@@ -47,7 +48,18 @@ Processing has a separate multi-track presentation contract. Under the E2E multi
 
 The mock deliberately does not score microphones or choose a preferred track. That decision does not belong in React.
 
-`frontend/tests/in-app-help.spec.ts` treats guidance as an interaction/accessibility feature, not as backend policy. It proves that screen help follows the active workspace, overall help remains reachable, Escape closes a panel and restores focus, contextual Evidence/Playback/Transcript guidance is discoverable, sensitive paths do not appear, and axe stays clean while help is open.
+`frontend/tests/lifecycle.spec.ts` treats Storage as a presentation surface over the existing Python custody service. It proves that:
+
+- canonical transcript removal is previewed before application and backend scope expansion is visible;
+- source recording removal cannot even be previewed until the second user guard is enabled;
+- source/canonical/private workspace paths do not enter the DOM;
+- default retention shows only completed old work while optional incomplete retention exposes resumable interrupted state and a backend-provided resume-loss warning;
+- applying a reviewed mock plan produces the expected presentation result; and
+- Storage guidance plus an open destructive plan remain axe-clean.
+
+The lifecycle mock may mirror DTO shape and deterministic backend outcomes for browser interaction. It must not become a second implementation of `LibraryCustodyService` policy. Scope expansion/provenance/retention/stale-token correctness are Python-test responsibilities.
+
+`frontend/tests/in-app-help.spec.ts` treats guidance as an interaction/accessibility feature, not as backend policy. It proves that screen help follows the active workspace, overall help remains reachable, Escape closes a panel and restores focus, contextual Evidence/Playback/Transcript guidance is discoverable, sensitive paths do not appear, and axe stays clean while help is open. Lifecycle-specific help is additionally exercised from `lifecycle.spec.ts`.
 
 Tests use semantic roles and accessible names where possible. A selector that depends on implementation-only class names should have a specific reason.
 
@@ -63,14 +75,17 @@ In-app guidance is never hover-only. Triggers are ordinary buttons usable by key
 
 The multi-track chooser is a semantic fieldset with radio inputs, a visible legend, and inline explanatory text. It remains usable by keyboard and touch and uses the same semantic theme tokens as the rest of Processing Center.
 
+Storage uses native checkboxes/select/number controls and plan-first buttons. Danger is conveyed through wording, structure, and semantic tokens rather than color alone. The second source guard is an ordinary labeled checkbox, not a hover affordance or modal-only trap.
+
 ### Security-oriented browser assertions
 
 Frontend tests explicitly check that:
 
 - transcript/research strings containing HTML remain inert text;
-- evidence, transcript-tool, playback, and help views do not expose canonical/source filesystem paths;
+- evidence, transcript-tool, playback, lifecycle, and help views do not expose canonical/source/private-workspace filesystem paths;
 - playback failure does not create a media element/session in the view;
 - multi-track preflight receives only bounded display metadata and stream indices rather than a new path/media-inspection capability;
+- lifecycle DTOs expose backend descriptions/counts/typed targets rather than destructive action paths;
 - speaker display labels do not erase anonymous evidence refs; and
 - post-hoc publication reports safe filenames instead of rendering the selected destination path.
 
@@ -88,7 +103,7 @@ Rust owns the opened playback file handle, opaque session lifetime, and `echoflo
 - rejection of multipart/invalid ranges; and
 - the 1 MiB response bound for local media transport.
 
-`cargo check --locked` remains a separate compilation gate.
+`cargo check --locked` remains a separate compilation gate. The Storage tranche adds no new Rust policy object; native qualification compiles the fixed `lifecycle_request` command that maps to the fixed Python custody module.
 
 ## Why there is no Stryker gate today
 
@@ -103,7 +118,9 @@ The important mutants in current desktop policy are questions such as:
 - can collision policy overwrite a file?;
 - can playback proceed after the source bytes change?;
 - can an ambiguous playback audio track be guessed?;
-- does multi-track preflight require explicit user confirmation rather than treating a probe default as intent?; and
+- does multi-track preflight require explicit user confirmation rather than treating a probe default as intent?;
+- can a custody confirmation token authorize a changed plan?;
+- can source deletion bypass its provenance/safety gate?; and
 - can an unallowlisted desktop method execute?
 
 Those decisions live in Python, so Poodle is the meaningful mutation tool for them. Installing Stryker solely to mutate JSX branches or static guidance copy would increase dependency/runtime surface without improving evidence-policy assurance.
@@ -122,6 +139,8 @@ Poodle workflows are targeted by design. Routine PR CI already runs static analy
 Transcript tools retain a manually dispatchable mutation workflow covering generation, speaker, and publication decisions. Playback is stricter because it introduces a privileged evidence-to-native-media boundary: its workflow runs automatically on pull requests that change playback authorization, its trusted-host bridge, their dedicated tests, Poodle configuration, or the workflow itself. Its baseline also includes the hardened media-probe tests used by playback authorization, so an incompatible probe refactor fails before mutation begins. It remains manually dispatchable for explicit requalification. The broader transcript-library mutation workflow continues to cover retrieval/semantic decisions.
 
 Multi-track display metadata and confirmation policy are qualified by the normal repository-wide Python coverage gate plus dedicated media/Processing tests. The Poodle target remains playback authorization/bridge policy rather than expanding mutation scope merely because playback shares the hardened probe.
+
+The Storage/lifecycle UI tranche intentionally does **not** add a Poodle workflow because it does not modify `LibraryCustodyService` decision logic. The new `custody_bridge` is a closed serializer/adapter whose path stripping, validation, forwarding, and error masking are covered directly; the existing custody suite remains the oracle for scope expansion, stale confirmation, source verification, execution ordering, and retention eligibility. A future PR that materially changes custody policy should get a targeted mutation workflow/path filter for those decision-heavy files rather than forcing every Storage/CSS/docs PR to execute a long full-tree sweep.
 
 ## Adding a desktop feature
 

--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -1,12 +1,67 @@
 # Your notes should survive the machinery 📝🦝
 
-EchoFlow keeps **your research notes, tags, collections, and saved searches** beside
+EchoFlow keeps **your evidence notes, tags, collections, and saved searches** beside
 recorded evidence without pretending they are part of the transcript itself.
 
-The recording and canonical transcript describe evidence. A note such as “compare this
-with the 2024 survey” is something **you know, suspect, or want to remember**. EchoFlow
-keeps those kinds of truth separate while still letting them meet through exact evidence
-coordinates.
+The recording and canonical transcript describe evidence. An evidence note such as “compare
+this with the 2024 survey” is something **you know, suspect, or want to remember about a
+specific verified passage**. EchoFlow keeps those kinds of truth separate while still
+letting them meet through exact evidence coordinates.
+
+## What counts as a note today?
+
+EchoFlow currently has one first-class note object: **an evidence note**.
+
+A `ResearchNote` always has:
+
+- a durable note ID and human-authored body;
+- an exact `EvidenceAnchor` naming document identity, canonical SHA-256, canonical segment
+  IDs, and source-relative time coordinates;
+- tag and collection relationships; and
+- created/updated timestamps used for durable history and optimistic concurrency.
+
+That mandatory anchor is a useful semantic promise. A note in today's model means “this
+human observation is attached to this exact recorded evidence.” It does **not** mean any
+arbitrary piece of prose stored somewhere in the application.
+
+Other Research objects have different jobs:
+
+| Object | What it means | A note? |
+|---|---|---|
+| Evidence note | human interpretation/observation attached to exact canonical evidence | **Yes** |
+| Tag | reusable organizational label | No |
+| Collection | reusable grouping/navigation structure | No |
+| Saved search | durable research question plus typed retrieval intent | No |
+| Speaker display name | human label for an anonymous machine-produced speaker reference | No |
+
+Keeping those roles explicit matters for export, deletion, backup, search, and provenance.
+
+### Future freeform notebook pages
+
+A general scratchpad or notebook is a useful later Research capability, but it should be a
+**second knowledge primitive**, not an evidence note with a nullable anchor.
+
+Conceptually, a future `ResearchDocument` or `ResearchMemo` would be authoritative SQLite
+state with its own ID, title/body, tags/collections, created/updated timestamps, and optional
+explicit references to evidence notes or evidence anchors. Unanchored prose would remain
+honestly unanchored. When a user cites evidence inside a memo, that relationship could still
+carry the exact document/canonical/segment/time identity EchoFlow already knows how to
+verify.
+
+That model supports a natural workflow:
+
+```text
+verified passage -> evidence note -> synthesis memo/notebook page
+                              \-> another memo
+```
+
+A future export can then render a memo to Markdown, plain text, HTML, or a portable research
+bundle while preserving explicit evidence references as structured provenance. The export
+format should be a derived presentation, not the authority for the note itself.
+
+This is deliberately post-first-release work. Before backup/restore and research
+portability are frozen, their manifests should be extensible enough to carry a future
+research-document class without pretending it exists today.
 
 ## The short version
 
@@ -242,7 +297,7 @@ second notebook.
 
 The first-release Research tranche is complete across:
 
-- authoritative notes/tags/collections;
+- authoritative evidence notes/tags/collections;
 - unified discovery;
 - note create/edit/delete and label mutation;
 - exact-generation evidence return;
@@ -252,10 +307,11 @@ The first-release Research tranche is complete across:
   sort, result count, and context controls.
 
 Further Research work is polish or post-MVP rather than the next critical-path blocker.
-Selected evidence packets, REFI-QDA interoperability, saved-question snapshots/diffs,
-comparison workspaces, evidence-linked writing/script boards, portable research bundles,
-and live provisional capture remain deliberately later work. See
-**[Post-MVP research roadmap](post-mvp-roadmap.md)**.
+Selected evidence packets, freeform research memos/notebook pages, REFI-QDA
+interoperability, saved-question snapshots/diffs, comparison workspaces, evidence-linked
+writing/script boards, portable research bundles, and live provisional capture remain
+deliberately later work. See **[Post-MVP research roadmap](post-mvp-roadmap.md)**.
 
-The product does not currently provide rich-text/WYSIWYG editing, semantic embeddings over
-note prose, **automatic** cross-generation re-anchoring, or collaborative sync.
+The product does not currently provide freeform notebook pages, rich-text/WYSIWYG editing,
+semantic embeddings over note prose, **automatic** cross-generation re-anchoring, or
+collaborative sync.

--- a/docs/storage-lifecycle.md
+++ b/docs/storage-lifecycle.md
@@ -1,0 +1,126 @@
+# Storage and lifecycle controls
+
+EchoFlow treats local storage changes as custody decisions, not generic file-manager actions.
+
+The desktop **Storage** workspace is the ordinary user surface for the existing safe-deletion and private-retention contracts. It does not own deletion policy. Python calculates a plan, React presents the consequences, and the user must explicitly apply that exact reviewed plan before anything changes.
+
+## Desktop flow
+
+For transcript custody:
+
+1. Choose an indexed transcript.
+2. Select one or more explicit custody scopes.
+3. Ask EchoFlow to **Preview deletion plan**.
+4. Review the backend-calculated effective scopes and actions.
+5. Apply the reviewed plan.
+
+The confirmation token returned with the preview is bound to the exact generation, requested scopes, expanded scopes, affected objects, and preservation state. Execution recalculates the plan. If anything material changed, the old token no longer matches and EchoFlow refuses the stale request.
+
+The token is a change-detection and confirmation primitive, not an authentication secret.
+
+## Separate custody scopes
+
+The desktop presents the same typed scopes as the application service:
+
+| Scope | Meaning |
+|---|---|
+| `library-view` | remove rebuildable search/index state |
+| `derived-artifacts` | remove regenerable TXT/SRT/WebVTT publications |
+| `execution-state` | remove private checkpoints/intermediates for the job |
+| `canonical-transcript` | remove canonical transcript JSON and its disposable descendants |
+| `research-notes` | remove human-authored notes anchored to the exact current generation |
+| `saved-searches` | remove saved searches explicitly constrained to the transcript |
+| `source-recording` | remove the original recording after an additional safety gate and provenance check |
+
+Selecting `canonical-transcript` automatically expands only to disposable descendants: library view, derived publications, and private execution state. It does **not** imply deletion of research notes, saved searches, or source media.
+
+## Source recording safety
+
+Source recording removal requires both:
+
+- the explicit `source-recording` scope; and
+- a second desktop acknowledgment that enables the backend source safety switch.
+
+Python then verifies that the current recording still matches the source SHA-256 recorded when the transcript was created. If the bytes changed, EchoFlow refuses the operation rather than using old provenance as permission to modify a different file now occupying the same path.
+
+The desktop never receives the source or canonical filesystem path. The lifecycle DTO exposes only a safe source basename for human identification, generation identity, counts, and backend-generated descriptions.
+
+Filesystem deletion is not a claim of forensic secure erasure. SSD wear levelling, snapshots, backups, sync history, and storage-controller behaviour remain outside EchoFlow's proof boundary.
+
+## Private processing cleanup
+
+The second Storage surface cleans old private processing workspaces according to a reviewed retention policy.
+
+The default policy is:
+
+```text
+execution_days = 30
+include_incomplete = false
+```
+
+Only completed job workspaces older than the cutoff are included by default. Failed and interrupted workspaces may still contain resumable state, so they are eligible only when `include_incomplete` is explicitly enabled. The preview marks every candidate whose resume capability would be lost. Running jobs are never eligible.
+
+Retention never age-removes:
+
+- canonical transcript JSON;
+- source recordings;
+- TXT/SRT/WebVTT publications;
+- notes, tags, or collections;
+- saved searches;
+- speaker display names; or
+- lightweight lifecycle manifests.
+
+## Native boundary
+
+Lifecycle operations use a dedicated fixed bridge rather than the general desktop bridge:
+
+```text
+React Storage workspace
+        |
+        | lifecycle_request
+        v
+Tauri fixed command
+        |
+        | python -m echoflow.desktop.custody_bridge
+        v
+LibraryCustodyService
+```
+
+The closed protocol allows only:
+
+```text
+lifecycle.documents.list
+lifecycle.deletion.plan
+lifecycle.deletion.execute
+lifecycle.retention.plan
+lifecycle.retention.execute
+```
+
+React cannot choose a Python module, filesystem path, SQL statement, or arbitrary operation. The Python adapter strips `DeletionAction.path` and `RetentionCandidate.workspace_path` before serialization.
+
+## Failure semantics
+
+The underlying custody executor cannot make SQLite, DuckDB, arbitrary public evidence files, private workspaces, and source media participate in one cross-filesystem ACID transaction.
+
+It therefore orders lower-custody and rebuildable mutations before unique human/source state. If a later operation fails, earlier disposable state may already have changed, but unique research is deliberately not sacrificed first.
+
+See [Safe deletion and retention controls](architecture/safe-deletion-retention.md) for the full application contract and failure-ordering rationale.
+
+## Test contract
+
+The desktop tranche adds coverage for:
+
+- closed lifecycle request methods and bounded parameters;
+- duplicate/out-of-range request rejection;
+- source-path and canonical-path non-disclosure;
+- plan serialization without action paths;
+- retention serialization without private workspace paths;
+- exact confirmation-token forwarding;
+- source safety-switch forwarding;
+- canonical-scope expansion presentation;
+- source second-guard behaviour;
+- retention previews with resume-loss warnings;
+- plan-first application; and
+- axe accessibility with an open destructive plan.
+
+The existing `LibraryCustodyService` tests remain authoritative for scope expansion, plan recalculation, provenance checks, retention eligibility, mutation ordering, and stale-token refusal.

--- a/frontend/SECURITY.md
+++ b/frontend/SECURITY.md
@@ -4,13 +4,15 @@ The desktop client is a presentation and native-host boundary over EchoFlow's lo
 
 ## Trust boundary
 
-The React/WebView layer may display sensitive transcript text, research notes, tags, collection names, speaker labels, paths the user has explicitly selected, and bounded source-declared audio-track labels returned by preflight. Those values are data. They must never become trusted markup or executable content.
+The React/WebView layer may display sensitive transcript text, research notes, tags, collection names, speaker labels, paths the user has explicitly selected, bounded source-declared audio-track labels returned by preflight, and backend-generated lifecycle descriptions. Those values are data. They must never become trusted markup or executable content.
 
 The frontend does not receive arbitrary SQL, shell, database, model-provider, media-probe, or filesystem capabilities. Tauri exposes narrow commands for specific human workflows. Python validates versioned, size-bounded requests with closed schemas before application services run.
 
 The ordinary desktop bridge is fixed to `python -m echoflow.desktop.bridge`. Transcript inspection and speaker management use the separate fixed `python -m echoflow.desktop.transcript_tools_bridge` entry point through Tauri's `transcript_tools_request` command. The webview cannot choose either Python module, substitute a shell command, or provide an arbitrary backend method. The transcript-tools bridge currently allowlists only inspect, speaker presentation, speaker-label set/remove, and deterministic publication operations.
 
 Verified playback has a stricter split. The Python `echoflow.desktop.playback_bridge` is **not** exposed as a Tauri command. Only Rust's fixed `playback_prepare` implementation may call it. That private bridge returns the verified source path to Rust so Rust can open the file, but the raw grant never crosses into the webview.
+
+Lifecycle/storage operations use another fixed boundary. Tauri's `lifecycle_request` can invoke only `python -m echoflow.desktop.custody_bridge`. The bridge's closed protocol allows only document listing, deletion plan/apply, and retention plan/apply. It delegates custody policy to `LibraryCustodyService` and strips destructive filesystem paths before returning presentation DTOs.
 
 Adding a desktop capability requires all three layers to agree deliberately:
 
@@ -48,6 +50,25 @@ Multi-audio **playback** currently fails closed. Canonical evidence records whic
 
 This does not conflict with multi-track transcription. Transcription owns explicit FFmpeg extraction and can prove which selected stream entered ASR; current WebView playback cannot yet prove its rendered embedded track.
 
+## Plan-bound lifecycle mutations
+
+Storage does not expose a generic delete API. React chooses typed intent and requests a preview. Python calculates the exact effective scopes, actions, note-preservation count, affected saved-search count, source safety checks, retention candidates, and resume-loss flags.
+
+A deletion or retention preview returns a confirmation token bound to the current backend plan. Applying the operation sends that token plus the same typed request back to Python. `LibraryCustodyService` recalculates the plan. If evidence, candidates, or requested effects changed, the token no longer matches and execution is refused.
+
+The lifecycle bridge deliberately does **not** serialize:
+
+- `DeletionAction.path`;
+- `RetentionCandidate.workspace_path`;
+- canonical transcript paths; or
+- full source-recording paths.
+
+Document listing exposes at most a source basename as human identification. It never turns that basename into authorization. Source recording removal additionally requires the explicit `source-recording` scope, a second UI acknowledgment that enables `allow_source`, and backend verification that the current source bytes still match transcript provenance.
+
+Retention cleanup is limited by backend policy to private job workspaces. Running jobs are never candidates. Failed/interrupted candidates are included only when the user opts in, and the backend-provided `resume_capability_lost` flag is rendered before application.
+
+EchoFlow does not claim filesystem removal is forensic secure erasure.
+
 ## Opaque native media capability
 
 Rust immediately opens the source authorized by Python and rechecks its size and modification timestamp to narrow the verification/open race. The opened `File` is stored behind an opaque active-session token.
@@ -67,9 +88,9 @@ Session IDs are opaque handles, not independent evidence authority. Creating a s
 
 ## Rendering untrusted local content
 
-React's normal text rendering is the default boundary for transcript, research, filename, speaker, and audio-track metadata. `dangerouslySetInnerHTML` is prohibited unless a future security review adds an explicit sanitizer and a narrowly documented use case. CI rejects its use today.
+React's normal text rendering is the default boundary for transcript, research, filename, speaker, audio-track metadata, and lifecycle descriptions. `dangerouslySetInnerHTML` is prohibited unless a future security review adds an explicit sanitizer and a narrowly documented use case. CI rejects its use today.
 
-Search snippets, note bodies, participant-provided text, filenames, speaker labels, source-declared track titles/languages, and metadata remain text. A malicious recording filename, track title, or transcript containing HTML/script syntax must remain inert in the WebView.
+Search snippets, note bodies, participant-provided text, filenames, speaker labels, source-declared track titles/languages, backend-generated descriptions, and metadata remain text. A malicious recording filename, track title, or transcript containing HTML/script syntax must remain inert in the WebView.
 
 The packaged frontend uses no remote fonts, scripts, stylesheets, analytics, or application telemetry. Network-bearing product behavior must be explicit and separately designed rather than smuggled through presentation code.
 
@@ -77,19 +98,21 @@ The packaged frontend uses no remote fonts, scripts, stylesheets, analytics, or 
 
 `frontend/src/help.ts` contains static local explanatory copy. `InfoPopover` renders that copy through ordinary React text nodes. The guidance layer has no filesystem, database, subprocess, model, media, or network capability and does not load remote documentation.
 
-Help may explain an application rule, such as generation binding, deliberate multi-audio playback refusal, or the need to choose among embedded tracks, but it does not evaluate or enforce those rules. Python remains authoritative. Treating help copy as executable policy would create exactly the duplicate frontend business logic this boundary is designed to avoid.
+Help may explain an application rule, such as generation binding, deliberate multi-audio playback refusal, embedded-track selection, or reviewed lifecycle custody, but it does not evaluate or enforce those rules. Python remains authoritative. Treating help copy as executable policy would create exactly the duplicate frontend business logic this boundary is designed to avoid.
 
-Guidance must not interpolate source/canonical paths, transcript contents, research contents, or other sensitive state into reusable help text. The multi-track chooser is a special inline case: it renders only bounded stream display facts already returned by backend preflight. Tests assert path non-disclosure while help is open.
+Guidance must not interpolate source/canonical paths, transcript contents, research contents, or other sensitive state into reusable help text. Tests assert path non-disclosure while help is open.
 
 ## Path and evidence disclosure
 
-Local paths are sensitive. Intake may intentionally show paths the user has just selected because reviewing that selection is part of the requested action. Evidence navigation, transcript tooling, playback, and multi-track metadata presentation are narrower.
+Local paths are sensitive. Intake may intentionally show paths the user has just selected because reviewing that selection is part of the requested action. Evidence navigation, transcript tooling, playback, lifecycle planning, and multi-track metadata presentation are narrower.
 
 Search/discovery responses return evidence identity, verified segment/word coordinates, seek time, speaker display state, and research metadata without canonical/source filesystem paths. Transcript-tools responses return generation identity, source availability/provenance, speaker state, and publication **filenames**, not canonical/source paths or the selected publication directory. The native folder dialog returns a destination only to the local client so it can submit that explicit intent to Python.
 
 Processing preflight may already operate on a path the user selected, but its returned multi-track DTO exposes only stream index plus bounded descriptive media facts. It does not add another filesystem disclosure surface.
 
 Playback responses to React contain only an opaque session/token, media kind, verified duration, and safe seek coordinate. The source path exists only inside the private Python-to-Rust authorization hop and the Rust session. React never receives it and cannot choose an arbitrary playback file.
+
+Lifecycle responses expose document IDs, canonical digests, safe source basenames, counts, typed scopes/targets, backend descriptions, retention status/timestamps, resume-loss flags, and plan tokens. Full source/canonical/workspace paths stay behind Python.
 
 The frontend must not copy path-bearing values into routine logs. EchoFlow currently has no application telemetry.
 
@@ -115,10 +138,12 @@ Do not hand-edit lockfile integrity hashes.
 
 ## What current tests prove
 
-Python tests cover allowlists, schema validation, stale-generation rejection, error masking, speaker authority, deterministic publication, playback generation/source verification, stream ambiguity, media-probe bounds, embedded-track display metadata, and explicit multi-track confirmation policy. Hypothesis exercises generation-bound and bounded-seek invariants. Targeted Poodle mutation workflows challenge decision-heavy backend code without making every pull request pay the full mutation cost.
+Python tests cover allowlists, schema validation, stale-generation rejection, error masking, speaker authority, deterministic publication, playback generation/source verification, stream ambiguity, media-probe bounds, embedded-track display metadata, explicit multi-track confirmation policy, custody-plan path stripping, lifecycle closed methods, plan-token forwarding, source-gate forwarding, and retention resume-loss presentation data. Hypothesis exercises generation-bound and bounded-seek invariants. Targeted Poodle mutation workflows challenge decision-heavy backend code without making every pull request pay the full mutation cost.
 
-Rust tests cover playback session-token validation, range parsing, unknown sessions, and bounded protocol responses. CI runs both `cargo check --locked` and `cargo test --locked` for the native host.
+Rust tests cover playback session-token validation, range parsing, unknown sessions, and bounded protocol responses. CI runs both `cargo check --locked` and `cargo test --locked` for the native host; lifecycle qualification also compiles the fixed Tauri command mapping.
 
-Frontend tests cover each primary workspace, transcript-tool interactions, verified playback, multi-track Processing preflight, contextual help, hostile-text rendering, keyboard paths, path/capability boundaries, theme persistence/contrast, and axe. Playback qualification includes current and preserved older generations, exact word coordinates, missing/changed/multi-audio failures, audio/video presentation, keyboard preparation, and path non-disclosure. Multi-track Processing qualification proves that no stream is pre-confirmed, Start is blocked until explicit choice, a chosen index is rebound through preflight, and axe remains clean. Guidance qualification includes keyboard dismissal/focus return, screen-sensitive topics, contextual evidence/playback/transcript help, axe with an open panel, and path non-disclosure. Pride and Monochrome use the same semantic-token qualification as every other skin.
+Frontend tests cover each primary workspace, transcript-tool interactions, verified playback, multi-track Processing preflight, lifecycle Storage planning/application, contextual help, hostile-text rendering, keyboard paths, path/capability boundaries, theme persistence/contrast, and axe. Lifecycle tests prove canonical scope expansion is presented from a preview, source removal cannot be previewed without the second guard, private retention distinguishes completed from resumable interrupted work, paths do not enter the DOM, and an open destructive plan remains axe-clean.
+
+Poodle is intentionally not a universal PR tax. The playback mutation workflow is path-filtered to playback authorization/bridge policy. This lifecycle UI tranche does not modify `LibraryCustodyService`, so ordinary quality, boundary tests, and the existing custody service suite are the appropriate qualification. A future change to custody decision logic should receive its own targeted mutation policy rather than making unrelated frontend/docs PRs run every mutant.
 
 These checks do not prove that the host OS, system WebView, Tauri runtime, registry infrastructure, native dependencies, or a compromised same-user process are trustworthy. Native codec availability also varies by operating-system media engine. Packaging, signing, update integrity, managed Python runtime custody, and representative-device WebView qualification remain separate release milestones.

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -100,3 +100,8 @@ pub async fn desktop_request(request: Value) -> Result<Value, String> {
 pub async fn transcript_tools_request(request: Value) -> Result<Value, String> {
     request_module("echoflow.desktop.transcript_tools_bridge", request).await
 }
+
+#[tauri::command]
+pub async fn lifecycle_request(request: Value) -> Result<Value, String> {
+    request_module("echoflow.desktop.custody_bridge", request).await
+}

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -21,6 +21,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             backend::desktop_request,
             backend::transcript_tools_request,
+            backend::lifecycle_request,
             processing::processing_start_task,
             processing::processing_task_status,
             processing::processing_cancel_task,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { createDesktopClient } from "./api/desktop";
+import { createLifecycleClient } from "./api/lifecycle";
 import { createPlaybackClient } from "./api/playback";
 import { createProcessingClient } from "./api/processing";
 import { createTranscriptToolsClient } from "./api/transcriptTools";
@@ -8,27 +9,31 @@ import { InfoPopover } from "./components/InfoPopover";
 import { type Theme } from "./components/WorkspaceHeader";
 import type { HelpTopicId } from "./help";
 import { IntakeWorkspace } from "./IntakeWorkspace";
+import { LifecycleWorkspace } from "./LifecycleWorkspace";
 import { PlaybackProvider } from "./PlaybackContext";
 import { ProcessingCenter } from "./ProcessingCenter";
 import { ResearchWorkspaceWithAnchorReview } from "./ResearchWorkspaceWithAnchorReview";
 import { SearchWorkspace } from "./SearchWorkspace";
 import { DEFAULT_THEME, isTheme, THEME_STORAGE_KEY } from "./themes";
 import "./help.css";
+import "./lifecycle.css";
 import "./processing-center.css";
 import "./theme-extras.css";
 
 const client = createDesktopClient();
+const lifecycle = createLifecycleClient();
 const playback = createPlaybackClient();
 const processing = createProcessingClient();
 const transcriptTools = createTranscriptToolsClient();
 
-type View = "intake" | "processing" | "library" | "research";
+type View = "intake" | "processing" | "library" | "research" | "storage";
 
 const VIEW_HELP_TOPIC: Record<View, HelpTopicId> = {
   intake: "intake",
   processing: "processing",
   library: "library",
   research: "research",
+  storage: "storage",
 };
 
 function initialTheme(): Theme {
@@ -74,6 +79,15 @@ export function App() {
         <SearchWorkspace
           client={client}
           transcriptTools={transcriptTools}
+          theme={theme}
+          onThemeChange={setTheme}
+        />
+      );
+    }
+    if (view === "storage") {
+      return (
+        <LifecycleWorkspace
+          lifecycle={lifecycle}
           theme={theme}
           onThemeChange={setTheme}
         />
@@ -133,6 +147,14 @@ export function App() {
             onClick={() => setView("research")}
           >
             <span aria-hidden="true">✦</span> Research
+          </button>
+          <button
+            className={view === "storage" ? "nav-item nav-item-active" : "nav-item"}
+            type="button"
+            aria-current={view === "storage" ? "page" : undefined}
+            onClick={() => setView("storage")}
+          >
+            <span aria-hidden="true">▣</span> Storage
           </button>
         </nav>
 

--- a/frontend/src/LifecycleWorkspace.tsx
+++ b/frontend/src/LifecycleWorkspace.tsx
@@ -1,0 +1,522 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type {
+  DeletionPlan,
+  DeletionReceipt,
+  DeletionScope,
+  LifecycleClient,
+  LifecycleDocument,
+  RetentionPlan,
+  RetentionReceipt,
+} from "./api/lifecycle";
+import { InfoPopover } from "./components/InfoPopover";
+import { type Theme, WorkspaceHeader } from "./components/WorkspaceHeader";
+
+interface LifecycleWorkspaceProps {
+  lifecycle: LifecycleClient;
+  theme: Theme;
+  onThemeChange: (theme: Theme) => void;
+}
+
+interface ScopeCopy {
+  id: DeletionScope;
+  label: string;
+  description: string;
+  destructive?: boolean;
+}
+
+const SCOPE_COPY: readonly ScopeCopy[] = [
+  {
+    id: "library-view",
+    label: "Remove from Library search",
+    description: "Removes rebuildable search state. Canonical transcript evidence and the recording stay in place.",
+  },
+  {
+    id: "derived-artifacts",
+    label: "Delete derived transcript files",
+    description: "Deletes regenerable TXT, SRT, and WebVTT publications next to the canonical transcript.",
+  },
+  {
+    id: "execution-state",
+    label: "Delete private processing state",
+    description: "Deletes checkpoints and intermediates for this job. Lightweight lifecycle history remains.",
+  },
+  {
+    id: "canonical-transcript",
+    label: "Delete canonical transcript evidence",
+    description: "Also removes Library search state, derived transcript files, and private execution state. Notes and the original recording are not implied.",
+    destructive: true,
+  },
+  {
+    id: "research-notes",
+    label: "Delete anchored research notes",
+    description: "Deletes human-authored notes anchored to this exact canonical generation. Tags and collections are not globally deleted.",
+    destructive: true,
+  },
+  {
+    id: "saved-searches",
+    label: "Delete transcript-scoped saved searches",
+    description: "Deletes only saved searches that explicitly constrain themselves to this transcript.",
+    destructive: true,
+  },
+  {
+    id: "source-recording",
+    label: "Delete the original recording",
+    description: "Deletes the source media only after EchoFlow verifies it still matches the bytes used for transcription.",
+    destructive: true,
+  },
+];
+
+function documentLabel(document: LifecycleDocument): string {
+  return document.source_name ? `${document.source_name} · ${document.document_id}` : document.document_id;
+}
+
+function scopeLabel(scope: DeletionScope): string {
+  return SCOPE_COPY.find((item) => item.id === scope)?.label ?? scope;
+}
+
+export function LifecycleWorkspace({
+  lifecycle,
+  theme,
+  onThemeChange,
+}: LifecycleWorkspaceProps) {
+  const [documents, setDocuments] = useState<LifecycleDocument[]>([]);
+  const [selectedDocumentId, setSelectedDocumentId] = useState("");
+  const [selectedScopes, setSelectedScopes] = useState<DeletionScope[]>([]);
+  const [sourceAcknowledged, setSourceAcknowledged] = useState(false);
+  const [deletionPlan, setDeletionPlan] = useState<DeletionPlan | null>(null);
+  const [deletionReceipt, setDeletionReceipt] = useState<DeletionReceipt | null>(null);
+  const [executionDays, setExecutionDays] = useState("30");
+  const [includeIncomplete, setIncludeIncomplete] = useState(false);
+  const [retentionPlan, setRetentionPlan] = useState<RetentionPlan | null>(null);
+  const [retentionReceipt, setRetentionReceipt] = useState<RetentionReceipt | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedDocument = useMemo(
+    () => documents.find((item) => item.document_id === selectedDocumentId) ?? null,
+    [documents, selectedDocumentId],
+  );
+  const sourceSelected = selectedScopes.includes("source-recording");
+
+  const loadDocuments = useCallback(async () => {
+    const loaded = await lifecycle.documents();
+    setDocuments(loaded);
+    setSelectedDocumentId((current) =>
+      loaded.some((item) => item.document_id === current)
+        ? current
+        : (loaded[0]?.document_id ?? ""),
+    );
+  }, [lifecycle]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setBusy(true);
+    lifecycle
+      .documents()
+      .then((loaded) => {
+        if (cancelled) return;
+        setDocuments(loaded);
+        setSelectedDocumentId(loaded[0]?.document_id ?? "");
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled) setError(caught instanceof Error ? caught.message : "Could not load lifecycle state");
+      })
+      .finally(() => {
+        if (!cancelled) setBusy(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [lifecycle]);
+
+  function resetDeletionReview() {
+    setDeletionPlan(null);
+    setDeletionReceipt(null);
+    setError(null);
+  }
+
+  function resetRetentionReview() {
+    setRetentionPlan(null);
+    setRetentionReceipt(null);
+    setError(null);
+  }
+
+  function selectDocument(documentId: string) {
+    setSelectedDocumentId(documentId);
+    setSelectedScopes([]);
+    setSourceAcknowledged(false);
+    resetDeletionReview();
+  }
+
+  function toggleScope(scope: DeletionScope) {
+    setSelectedScopes((current) =>
+      current.includes(scope) ? current.filter((item) => item !== scope) : [...current, scope],
+    );
+    if (scope === "source-recording") setSourceAcknowledged(false);
+    resetDeletionReview();
+  }
+
+  async function previewDeletion() {
+    if (!selectedDocument || selectedScopes.length === 0) return;
+    setBusy(true);
+    setError(null);
+    setDeletionReceipt(null);
+    try {
+      setDeletionPlan(
+        await lifecycle.planDeletion(
+          selectedDocument.document_id,
+          selectedScopes,
+          sourceSelected && sourceAcknowledged,
+        ),
+      );
+    } catch (caught) {
+      setDeletionPlan(null);
+      setError(caught instanceof Error ? caught.message : "Could not preview deletion");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function applyDeletion() {
+    if (!deletionPlan) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const receipt = await lifecycle.executeDeletion(
+        deletionPlan,
+        sourceSelected && sourceAcknowledged,
+      );
+      setDeletionReceipt(receipt);
+      setDeletionPlan(null);
+      setSelectedScopes([]);
+      setSourceAcknowledged(false);
+      await loadDocuments();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not apply deletion plan");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function previewRetention() {
+    const days = Number(executionDays);
+    setBusy(true);
+    setError(null);
+    setRetentionReceipt(null);
+    try {
+      setRetentionPlan(
+        await lifecycle.planRetention({
+          executionDays: days,
+          includeIncomplete,
+        }),
+      );
+    } catch (caught) {
+      setRetentionPlan(null);
+      setError(caught instanceof Error ? caught.message : "Could not preview cleanup");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function applyRetention() {
+    if (!retentionPlan) return;
+    setBusy(true);
+    setError(null);
+    try {
+      setRetentionReceipt(await lifecycle.executeRetention(retentionPlan));
+      setRetentionPlan(null);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not apply cleanup plan");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const deletionPreviewDisabled =
+    busy ||
+    !selectedDocument?.deletion_ready ||
+    selectedScopes.length === 0 ||
+    (sourceSelected && !sourceAcknowledged);
+
+  return (
+    <>
+      <WorkspaceHeader
+        eyebrow="Local custody"
+        title="Storage & deletion"
+        theme={theme}
+        onThemeChange={onThemeChange}
+      />
+
+      <div className="lifecycle-page">
+        <div className="lifecycle-intro">
+          <div>
+            <p className="section-kicker">Review before mutation</p>
+            <h2>Nothing here is a one-click mystery delete.</h2>
+            <p>
+              EchoFlow asks Python to calculate the exact consequences first. Applying a plan repeats the same request with a token bound to that reviewed state.
+            </p>
+          </div>
+          <InfoPopover topic="storage" label="How storage controls work" />
+        </div>
+
+        {error ? (
+          <div className="lifecycle-alert lifecycle-alert-error" role="alert">
+            {error}
+          </div>
+        ) : null}
+
+        <section className="lifecycle-card" aria-labelledby="transcript-custody-heading">
+          <div className="lifecycle-card-heading">
+            <div>
+              <p className="section-kicker">Transcript custody</p>
+              <h2 id="transcript-custody-heading">Choose exactly what should leave</h2>
+            </div>
+            <span className="lifecycle-badge">Plan first</span>
+          </div>
+
+          {documents.length === 0 ? (
+            <p className="lifecycle-empty">No indexed transcripts are currently available for lifecycle management.</p>
+          ) : (
+            <>
+              <label className="lifecycle-field">
+                <span>Transcript</span>
+                <select
+                  aria-label="Transcript to manage"
+                  value={selectedDocumentId}
+                  disabled={busy}
+                  onChange={(event) => selectDocument(event.target.value)}
+                >
+                  {documents.map((document) => (
+                    <option key={document.document_id} value={document.document_id}>
+                      {documentLabel(document)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {selectedDocument ? (
+                <div className="lifecycle-document-facts" aria-label="Selected transcript facts">
+                  <span>{selectedDocument.segment_count.toLocaleString()} segments</span>
+                  <span>{selectedDocument.detected_language ?? "Language unavailable"}</span>
+                  <span>{selectedDocument.deletion_ready ? "Canonical generation verified in index" : "Library rebuild required before deletion"}</span>
+                </div>
+              ) : null}
+
+              <fieldset className="lifecycle-scopes">
+                <legend>What do you want to remove?</legend>
+                {SCOPE_COPY.map((scope) => (
+                  <label
+                    key={scope.id}
+                    className={scope.destructive ? "lifecycle-scope lifecycle-scope-destructive" : "lifecycle-scope"}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedScopes.includes(scope.id)}
+                      disabled={busy}
+                      onChange={() => toggleScope(scope.id)}
+                    />
+                    <span>
+                      <strong>{scope.label}</strong>
+                      <small>{scope.description}</small>
+                    </span>
+                  </label>
+                ))}
+              </fieldset>
+
+              {sourceSelected ? (
+                <label className="lifecycle-source-guard">
+                  <input
+                    type="checkbox"
+                    checked={sourceAcknowledged}
+                    disabled={busy}
+                    onChange={(event) => {
+                      setSourceAcknowledged(event.target.checked);
+                      resetDeletionReview();
+                    }}
+                  />
+                  <span>
+                    <strong>I understand this deletes the original recording.</strong>
+                    <small>
+                      EchoFlow will verify that the current source bytes still match transcript provenance before allowing deletion. Filesystem deletion is not a claim of forensic secure erasure.
+                    </small>
+                  </span>
+                </label>
+              ) : null}
+
+              <div className="lifecycle-actions">
+                <button
+                  className="secondary-action"
+                  type="button"
+                  disabled={deletionPreviewDisabled}
+                  onClick={() => void previewDeletion()}
+                >
+                  Preview deletion plan
+                </button>
+              </div>
+            </>
+          )}
+
+          {deletionPlan ? (
+            <div className="lifecycle-plan" aria-label="Deletion plan">
+              <div className="lifecycle-plan-heading">
+                <div>
+                  <p className="section-kicker">Backend-calculated plan</p>
+                  <h3>Review {deletionPlan.actions.length} planned action{deletionPlan.actions.length === 1 ? "" : "s"}</h3>
+                </div>
+                <span>{deletionPlan.effective_scopes.length} effective scopes</span>
+              </div>
+
+              <ul className="lifecycle-action-list">
+                {deletionPlan.actions.map((action, index) => (
+                  <li key={`${action.target}-${index}`}>{action.description}</li>
+                ))}
+              </ul>
+
+              <div className="lifecycle-plan-facts">
+                <p>
+                  <strong>{deletionPlan.preserved_note_count}</strong> anchored note{deletionPlan.preserved_note_count === 1 ? "" : "s"} preserved by this plan.
+                </p>
+                <p>
+                  <strong>{deletionPlan.affected_saved_search_count}</strong> saved search{deletionPlan.affected_saved_search_count === 1 ? "" : "es"} may be affected by the transcript change.
+                </p>
+              </div>
+
+              <details>
+                <summary>Why did EchoFlow expand my selection?</summary>
+                <p>
+                  Requested: {deletionPlan.requested_scopes.map(scopeLabel).join(", ")}. Effective: {deletionPlan.effective_scopes.map(scopeLabel).join(", ")}.
+                </p>
+                <p>
+                  Canonical transcript deletion automatically includes only disposable descendants. Human research and source media still require their own explicit scopes.
+                </p>
+              </details>
+
+              <button
+                className="danger-action"
+                type="button"
+                disabled={busy}
+                onClick={() => void applyDeletion()}
+              >
+                Apply reviewed plan
+              </button>
+            </div>
+          ) : null}
+
+          {deletionReceipt ? (
+            <div className="lifecycle-alert lifecycle-alert-success" role="status">
+              Applied custody plan for {deletionReceipt.document_id}. {deletionReceipt.executed_targets.length} target{deletionReceipt.executed_targets.length === 1 ? "" : "s"} changed; {deletionReceipt.preserved_note_count} note{deletionReceipt.preserved_note_count === 1 ? "" : "s"} preserved.
+            </div>
+          ) : null}
+        </section>
+
+        <section className="lifecycle-card" aria-labelledby="retention-heading">
+          <div className="lifecycle-card-heading">
+            <div>
+              <p className="section-kicker">Private processing cleanup</p>
+              <h2 id="retention-heading">Clean up old resumable workspaces</h2>
+            </div>
+            <span className="lifecycle-badge">Evidence-safe</span>
+          </div>
+
+          <p className="lifecycle-copy">
+            This cleanup applies only to private checkpoints and intermediates under EchoFlow state. It never age-deletes canonical JSON, original recordings, published transcripts, notes, tags, collections, saved searches, or lifecycle manifests.
+          </p>
+
+          <div className="lifecycle-retention-controls">
+            <label className="lifecycle-field">
+              <span>Remove eligible processing state older than</span>
+              <span className="lifecycle-number-field">
+                <input
+                  aria-label="Execution retention days"
+                  type="number"
+                  min="0"
+                  max="36500"
+                  value={executionDays}
+                  disabled={busy}
+                  onChange={(event) => {
+                    setExecutionDays(event.target.value);
+                    resetRetentionReview();
+                  }}
+                />
+                <span>days</span>
+              </span>
+            </label>
+
+            <label className="lifecycle-source-guard lifecycle-incomplete-guard">
+              <input
+                type="checkbox"
+                checked={includeIncomplete}
+                disabled={busy}
+                onChange={(event) => {
+                  setIncludeIncomplete(event.target.checked);
+                  resetRetentionReview();
+                }}
+              />
+              <span>
+                <strong>Also include failed and interrupted jobs</strong>
+                <small>These may still be resumable. The preview will mark every candidate whose resume capability would be lost. Running jobs are never eligible.</small>
+              </span>
+            </label>
+          </div>
+
+          <button
+            className="secondary-action"
+            type="button"
+            disabled={busy || executionDays.trim() === ""}
+            onClick={() => void previewRetention()}
+          >
+            Preview cleanup
+          </button>
+
+          {retentionPlan ? (
+            <div className="lifecycle-plan" aria-label="Retention plan">
+              <div className="lifecycle-plan-heading">
+                <div>
+                  <p className="section-kicker">Backend-calculated cleanup</p>
+                  <h3>{retentionPlan.candidates.length} eligible workspace{retentionPlan.candidates.length === 1 ? "" : "s"}</h3>
+                </div>
+                <span>{retentionPlan.policy.execution_days} day cutoff</span>
+              </div>
+
+              {retentionPlan.candidates.length === 0 ? (
+                <p className="lifecycle-empty">Nothing currently matches this cleanup policy.</p>
+              ) : (
+                <ul className="lifecycle-candidate-list">
+                  {retentionPlan.candidates.map((candidate) => (
+                    <li key={candidate.job_id}>
+                      <div>
+                        <strong>{candidate.job_id}</strong>
+                        <span>{candidate.status} · last updated {candidate.updated_at}</span>
+                      </div>
+                      {candidate.resume_capability_lost ? (
+                        <span className="lifecycle-resume-warning">Resume will be lost</span>
+                      ) : (
+                        <span>Completed state</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              <button
+                className="danger-action"
+                type="button"
+                disabled={busy || retentionPlan.candidates.length === 0}
+                onClick={() => void applyRetention()}
+              >
+                Apply cleanup plan
+              </button>
+            </div>
+          ) : null}
+
+          {retentionReceipt ? (
+            <div className="lifecycle-alert lifecycle-alert-success" role="status">
+              Removed private processing state for {retentionReceipt.discarded_job_ids.length} job{retentionReceipt.discarded_job_ids.length === 1 ? "" : "s"}. Canonical evidence and human research were outside this operation.
+            </div>
+          ) : null}
+        </section>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/api/lifecycle.ts
+++ b/frontend/src/api/lifecycle.ts
@@ -1,0 +1,290 @@
+export type DeletionScope =
+  | "library-view"
+  | "derived-artifacts"
+  | "execution-state"
+  | "canonical-transcript"
+  | "research-notes"
+  | "saved-searches"
+  | "source-recording";
+
+export interface LifecycleDocument {
+  document_id: string;
+  canonical_sha256: string | null;
+  source_name: string | null;
+  segment_count: number;
+  detected_language: string | null;
+  deletion_ready: boolean;
+}
+
+export interface DeletionAction {
+  target: string;
+  description: string;
+}
+
+export interface DeletionPlan {
+  document_id: string;
+  canonical_sha256: string;
+  requested_scopes: DeletionScope[];
+  effective_scopes: DeletionScope[];
+  actions: DeletionAction[];
+  preserved_note_count: number;
+  affected_saved_search_count: number;
+  confirmation_token: string;
+}
+
+export interface DeletionReceipt {
+  document_id: string;
+  executed_targets: string[];
+  preserved_note_count: number;
+  affected_saved_search_count: number;
+}
+
+export interface RetentionPolicy {
+  executionDays: number;
+  includeIncomplete: boolean;
+}
+
+export interface RetentionCandidate {
+  job_id: string;
+  status: "interrupted" | "failed" | "completed";
+  updated_at: string;
+  resume_capability_lost: boolean;
+}
+
+export interface RetentionPlan {
+  policy: {
+    execution_days: number;
+    include_incomplete: boolean;
+  };
+  candidates: RetentionCandidate[];
+  confirmation_token: string;
+}
+
+export interface RetentionReceipt {
+  discarded_job_ids: string[];
+}
+
+export interface LifecycleClient {
+  documents(): Promise<LifecycleDocument[]>;
+  planDeletion(
+    documentId: string,
+    scopes: DeletionScope[],
+    allowSource: boolean,
+  ): Promise<DeletionPlan>;
+  executeDeletion(
+    plan: DeletionPlan,
+    allowSource: boolean,
+  ): Promise<DeletionReceipt>;
+  planRetention(policy: RetentionPolicy): Promise<RetentionPlan>;
+  executeRetention(plan: RetentionPlan): Promise<RetentionReceipt>;
+}
+
+interface DesktopError {
+  code: string;
+  message: string;
+}
+
+interface DesktopResponse<T> {
+  protocol_version: 1;
+  request_id: string;
+  ok: boolean;
+  result: T | null;
+  error: DesktopError | null;
+}
+
+function assertResponse<T>(value: unknown): DesktopResponse<T> {
+  if (!value || typeof value !== "object") {
+    throw new Error("EchoFlow lifecycle service returned an invalid response");
+  }
+  const candidate = value as Partial<DesktopResponse<T>>;
+  if (
+    candidate.protocol_version !== 1 ||
+    typeof candidate.request_id !== "string" ||
+    typeof candidate.ok !== "boolean"
+  ) {
+    throw new Error("EchoFlow lifecycle service returned an incompatible response");
+  }
+  return candidate as DesktopResponse<T>;
+}
+
+class TauriLifecycleClient implements LifecycleClient {
+  private async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const response = assertResponse<T>(
+      await invoke<unknown>("lifecycle_request", {
+        request: {
+          protocol_version: 1,
+          request_id: crypto.randomUUID(),
+          method,
+          params,
+        },
+      }),
+    );
+    if (!response.ok || response.result === null) {
+      throw new Error(response.error?.message ?? "EchoFlow could not complete that lifecycle request");
+    }
+    return response.result;
+  }
+
+  documents(): Promise<LifecycleDocument[]> {
+    return this.request("lifecycle.documents.list", {});
+  }
+
+  planDeletion(
+    documentId: string,
+    scopes: DeletionScope[],
+    allowSource: boolean,
+  ): Promise<DeletionPlan> {
+    return this.request("lifecycle.deletion.plan", {
+      document_id: documentId,
+      scopes,
+      allow_source: allowSource,
+    });
+  }
+
+  executeDeletion(plan: DeletionPlan, allowSource: boolean): Promise<DeletionReceipt> {
+    return this.request("lifecycle.deletion.execute", {
+      document_id: plan.document_id,
+      scopes: plan.requested_scopes,
+      allow_source: allowSource,
+      confirmation_token: plan.confirmation_token,
+    });
+  }
+
+  planRetention(policy: RetentionPolicy): Promise<RetentionPlan> {
+    return this.request("lifecycle.retention.plan", {
+      execution_days: policy.executionDays,
+      include_incomplete: policy.includeIncomplete,
+    });
+  }
+
+  executeRetention(plan: RetentionPlan): Promise<RetentionReceipt> {
+    return this.request("lifecycle.retention.execute", {
+      execution_days: plan.policy.execution_days,
+      include_incomplete: plan.policy.include_incomplete,
+      confirmation_token: plan.confirmation_token,
+    });
+  }
+}
+
+class MockLifecycleClient implements LifecycleClient {
+  private documentsState: LifecycleDocument[] = [
+    {
+      document_id: "interview-42",
+      canonical_sha256: "a".repeat(64),
+      source_name: "oral-history-42.m4a",
+      segment_count: 182,
+      detected_language: "en",
+      deletion_ready: true,
+    },
+    {
+      document_id: "interview-11",
+      canonical_sha256: "c".repeat(64),
+      source_name: "field-interview-11.mp4",
+      segment_count: 96,
+      detected_language: "en",
+      deletion_ready: true,
+    },
+  ];
+
+  async documents(): Promise<LifecycleDocument[]> {
+    return this.documentsState.map((item) => ({ ...item }));
+  }
+
+  async planDeletion(
+    documentId: string,
+    scopes: DeletionScope[],
+    allowSource: boolean,
+  ): Promise<DeletionPlan> {
+    const document = this.documentsState.find((item) => item.document_id === documentId);
+    if (!document?.canonical_sha256) throw new Error("Transcript is not ready for custody changes");
+    if (scopes.length === 0) throw new Error("Choose at least one deletion scope");
+    if (scopes.includes("source-recording") && !allowSource) {
+      throw new Error("Source recording deletion requires the explicit source safety switch");
+    }
+    const effective = [...scopes];
+    if (scopes.includes("canonical-transcript")) {
+      (["library-view", "derived-artifacts", "execution-state"] as DeletionScope[]).forEach((scope) => {
+        if (!effective.includes(scope)) effective.push(scope);
+      });
+    }
+    const descriptions: Record<DeletionScope, string> = {
+      "library-view": "remove transcript from the rebuildable lexical index",
+      "derived-artifacts": "delete regenerable transcript publication exports",
+      "execution-state": "delete private checkpoint and intermediate workspace",
+      "canonical-transcript": "delete canonical transcript evidence",
+      "research-notes": "delete research notes anchored to this exact transcript generation",
+      "saved-searches": "delete saved searches explicitly scoped to this transcript",
+      "source-recording": "delete the original source recording",
+    };
+    return {
+      document_id: documentId,
+      canonical_sha256: document.canonical_sha256,
+      requested_scopes: [...scopes],
+      effective_scopes: effective,
+      actions: effective.map((scope) => ({ target: scope, description: descriptions[scope] })),
+      preserved_note_count: scopes.includes("research-notes") ? 0 : 2,
+      affected_saved_search_count: 1,
+      confirmation_token: `mock-delete:${documentId}:${scopes.join(",")}:${allowSource}`,
+    };
+  }
+
+  async executeDeletion(plan: DeletionPlan, allowSource: boolean): Promise<DeletionReceipt> {
+    const expected = await this.planDeletion(plan.document_id, plan.requested_scopes, allowSource);
+    if (expected.confirmation_token !== plan.confirmation_token) {
+      throw new Error("Deletion plan changed; preview it again");
+    }
+    if (plan.effective_scopes.includes("library-view")) {
+      this.documentsState = this.documentsState.filter((item) => item.document_id !== plan.document_id);
+    }
+    return {
+      document_id: plan.document_id,
+      executed_targets: plan.actions.map((action) => action.target),
+      preserved_note_count: plan.preserved_note_count,
+      affected_saved_search_count: plan.affected_saved_search_count,
+    };
+  }
+
+  async planRetention(policy: RetentionPolicy): Promise<RetentionPlan> {
+    const candidates: RetentionCandidate[] = [
+      {
+        job_id: "job-completed-2",
+        status: "completed",
+        updated_at: "2026-07-01T16:48:00+00:00",
+        resume_capability_lost: false,
+      },
+    ];
+    if (policy.includeIncomplete) {
+      candidates.push({
+        job_id: "job-interrupted-7",
+        status: "interrupted",
+        updated_at: "2026-07-02T12:35:00+00:00",
+        resume_capability_lost: true,
+      });
+    }
+    return {
+      policy: {
+        execution_days: policy.executionDays,
+        include_incomplete: policy.includeIncomplete,
+      },
+      candidates,
+      confirmation_token: `mock-retention:${policy.executionDays}:${policy.includeIncomplete}`,
+    };
+  }
+
+  async executeRetention(plan: RetentionPlan): Promise<RetentionReceipt> {
+    const expected = await this.planRetention({
+      executionDays: plan.policy.execution_days,
+      includeIncomplete: plan.policy.include_incomplete,
+    });
+    if (expected.confirmation_token !== plan.confirmation_token) {
+      throw new Error("Retention plan changed; preview it again");
+    }
+    return { discarded_job_ids: plan.candidates.map((candidate) => candidate.job_id) };
+  }
+}
+
+export function createLifecycleClient(): LifecycleClient {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("e2e") === "1" ? new MockLifecycleClient() : new TauriLifecycleClient();
+}

--- a/frontend/src/help.ts
+++ b/frontend/src/help.ts
@@ -4,6 +4,7 @@ export type HelpTopicId =
   | "processing"
   | "library"
   | "research"
+  | "storage"
   | "evidence"
   | "playback"
   | "transcript-tools";
@@ -31,13 +32,13 @@ export const HELP_TOPICS: Record<HelpTopicId, HelpTopic> = {
   intake: {
     title: "Adding evidence",
     summary:
-      "This screen decides what local material EchoFlow may use. Selecting something does not silently copy, transcribe, or delete it.",
+      "This screen decides what local material EchoFlow may use. Selecting something does not silently copy, transcribe, or remove it.",
     points: [
       "Choose files for a one-time action, or choose a folder if you may want EchoFlow to remember that location.",
       "Remembering a folder stores a local permission so future refreshes can discover material there.",
       "Discovery and processing are separate. Automatic processing requires its own explicit opt-in.",
     ],
-    note: "Forgetting a remembered folder removes EchoFlow's permission record. It does not delete files inside the folder.",
+    note: "Forgetting a remembered folder removes EchoFlow's permission record. It does not change files inside the folder.",
   },
   processing: {
     title: "Processing recordings",
@@ -72,6 +73,18 @@ export const HELP_TOPICS: Record<HelpTopicId, HelpTopic> = {
       "If an older note cites an older transcript generation, EchoFlow can reopen that exact preserved evidence instead of silently moving the citation.",
       "Re-anchoring is deliberate maintenance, not an automatic rewrite of your research history.",
     ],
+  },
+  storage: {
+    title: "Storage and lifecycle controls",
+    summary:
+      "Storage changes are reviewable custody operations. EchoFlow calculates the exact consequences before it applies a cleanup or removal plan.",
+    points: [
+      "Library search state, derived publications, processing state, canonical evidence, research, saved searches, and source media are separate custody scopes.",
+      "Canonical transcript removal expands only to disposable descendants. Human research and source media remain separately selected.",
+      "Source-media changes require an additional acknowledgment and a provenance check against the bytes used for transcription.",
+      "Processing cleanup is limited to private checkpoints and intermediates, and the preview identifies candidates whose resume capability would be lost.",
+    ],
+    note: "Filesystem removal is not a claim of forensic secure erasure from device history, snapshots, backups, or external sync systems.",
   },
   evidence: {
     title: "Using the Evidence reader",

--- a/frontend/src/lifecycle.css
+++ b/frontend/src/lifecycle.css
@@ -1,0 +1,230 @@
+.lifecycle-page {
+  max-width: 1180px;
+  margin: 36px auto 0;
+  display: grid;
+  gap: 22px;
+}
+
+.lifecycle-intro,
+.lifecycle-card-heading,
+.lifecycle-plan-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.lifecycle-intro h2,
+.lifecycle-card h2,
+.lifecycle-plan h3 {
+  margin: 6px 0 0;
+  letter-spacing: -0.03em;
+}
+
+.lifecycle-intro h2 { font-size: clamp(1.4rem, 2.4vw, 2rem); }
+.lifecycle-intro > div > p:last-child,
+.lifecycle-copy,
+.lifecycle-empty {
+  color: var(--muted);
+  line-height: 1.6;
+}
+.lifecycle-intro > div > p:last-child { max-width: 760px; margin: 10px 0 0; }
+
+.lifecycle-card {
+  padding: clamp(20px, 3vw, 32px);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.lifecycle-card-heading { margin-bottom: 20px; }
+.lifecycle-badge {
+  flex: none;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-soft);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 720;
+}
+
+.lifecycle-field {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.lifecycle-field select,
+.lifecycle-field input[type="number"] {
+  min-height: 44px;
+  border: 1px solid var(--control-border);
+  border-radius: 10px;
+  padding: 9px 11px;
+}
+.lifecycle-field select { width: min(100%, 680px); }
+
+.lifecycle-document-facts,
+.lifecycle-plan-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0 22px;
+}
+.lifecycle-document-facts span,
+.lifecycle-plan-facts p {
+  margin: 0;
+  padding: 7px 10px;
+  border-radius: 9px;
+  background: var(--surface-soft);
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.lifecycle-scopes {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  display: grid;
+  gap: 9px;
+}
+.lifecycle-scopes legend {
+  margin-bottom: 10px;
+  color: var(--ink);
+  font-weight: 760;
+}
+.lifecycle-scope,
+.lifecycle-source-guard {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 13px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-raised);
+}
+.lifecycle-scope input,
+.lifecycle-source-guard input {
+  margin: 3px 0 0;
+  flex: none;
+}
+.lifecycle-scope span,
+.lifecycle-source-guard span { display: grid; gap: 4px; }
+.lifecycle-scope strong,
+.lifecycle-source-guard strong { font-size: 0.88rem; }
+.lifecycle-scope small,
+.lifecycle-source-guard small {
+  color: var(--muted);
+  line-height: 1.45;
+}
+.lifecycle-scope-destructive strong { color: var(--danger); }
+.lifecycle-source-guard {
+  margin-top: 14px;
+  border-color: color-mix(in srgb, var(--danger) 56%, var(--border));
+}
+.lifecycle-source-guard strong { color: var(--danger); }
+.lifecycle-incomplete-guard { margin-top: 0; border-color: var(--border); }
+.lifecycle-incomplete-guard strong { color: var(--ink); }
+
+.lifecycle-actions { margin-top: 18px; }
+.secondary-action,
+.danger-action {
+  min-height: 42px;
+  border-radius: 10px;
+  padding: 9px 14px;
+  font-weight: 720;
+}
+.secondary-action {
+  border: 1px solid var(--control-border);
+  background: var(--surface-raised);
+}
+.danger-action {
+  border: 1px solid var(--danger);
+  background: var(--danger);
+  color: var(--surface-raised);
+}
+
+.lifecycle-plan {
+  margin-top: 22px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface-soft);
+}
+.lifecycle-plan-heading > span {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 720;
+}
+.lifecycle-action-list,
+.lifecycle-candidate-list {
+  margin: 16px 0;
+  padding-left: 20px;
+  line-height: 1.55;
+}
+.lifecycle-action-list li + li { margin-top: 7px; }
+.lifecycle-plan details { margin: 14px 0; }
+.lifecycle-plan details p { color: var(--muted); line-height: 1.5; }
+
+.lifecycle-alert {
+  padding: 12px 14px;
+  border-radius: 11px;
+  border: 1px solid var(--border);
+  line-height: 1.5;
+}
+.lifecycle-alert-error {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 55%, var(--border));
+  background: color-mix(in srgb, var(--danger) 8%, var(--surface));
+}
+.lifecycle-alert-success {
+  margin-top: 16px;
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--ink);
+}
+
+.lifecycle-retention-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.7fr) minmax(280px, 1.3fr);
+  gap: 14px;
+  margin: 18px 0;
+}
+.lifecycle-number-field {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.lifecycle-number-field input { width: 112px; }
+.lifecycle-number-field > span { color: var(--muted); }
+
+.lifecycle-candidate-list {
+  list-style: none;
+  padding: 0;
+}
+.lifecycle-candidate-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border);
+}
+.lifecycle-candidate-list li:last-child { border-bottom: 0; }
+.lifecycle-candidate-list li > div { display: grid; gap: 3px; }
+.lifecycle-candidate-list li span { color: var(--muted); font-size: 0.76rem; }
+.lifecycle-candidate-list .lifecycle-resume-warning { color: var(--danger); font-weight: 760; }
+
+@media (max-width: 760px) {
+  .lifecycle-intro,
+  .lifecycle-card-heading,
+  .lifecycle-plan-heading,
+  .lifecycle-candidate-list li {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .lifecycle-retention-controls { grid-template-columns: 1fr; }
+  .lifecycle-badge { align-self: flex-start; }
+}

--- a/frontend/src/lifecycle.css
+++ b/frontend/src/lifecycle.css
@@ -142,8 +142,8 @@
 }
 .danger-action {
   border: 1px solid var(--danger);
-  background: var(--danger);
-  color: var(--surface-raised);
+  background: var(--surface-raised);
+  color: var(--danger);
 }
 
 .lifecycle-plan {

--- a/frontend/src/theme-extras.css
+++ b/frontend/src/theme-extras.css
@@ -1,31 +1,50 @@
 :root[data-theme="pride"] {
   color-scheme: light;
-  --bg: #fff7fb;
-  --surface: #ffffff;
+  --bg: #fff9fb;
+  --surface: #fffefe;
   --surface-raised: #ffffff;
-  --surface-soft: #f5e7f1;
-  --ink: #251f28;
-  --muted: #625665;
-  --border: #8b7789;
-  --accent: #6d2f7d;
-  --accent-strong: #552160;
-  --accent-soft: #f0dcec;
+  --surface-soft: #f3edf3;
+  --ink: #201f25;
+  --muted: #5f5864;
+  --border: #857a87;
+  --accent: #4f3c78;
+  --accent-strong: #3b2c61;
+  --accent-soft: #e9e3f5;
   --on-accent: #ffffff;
-  --focus: #005a73;
+  --focus: #005d73;
   --danger: #8f3341;
   --control-bg: #ffffff;
-  --control-ink: #251f28;
-  --control-border: #786878;
-  --selection-bg: #6d2f7d;
+  --control-ink: #201f25;
+  --control-border: #766d79;
+  --selection-bg: #4f3c78;
   --selection-ink: #ffffff;
-  --shadow: 0 24px 70px rgba(88, 41, 78, 0.1);
+  --shadow: 0 24px 70px rgba(64, 47, 69, 0.1);
+}
+
+:root[data-theme="pride"] .app-shell {
+  background: linear-gradient(
+    120deg,
+    #ffd8e0 0%,
+    #ffe6c7 16%,
+    #fff5bf 32%,
+    #d8f1d8 48%,
+    #d7e8ff 64%,
+    #e3dcff 80%,
+    #f3d8f0 100%
+  );
+  background-attachment: fixed;
+}
+
+:root[data-theme="pride"] .sidebar {
+  background: color-mix(in srgb, var(--surface) 78%, transparent);
+  backdrop-filter: blur(14px);
 }
 
 :root[data-theme="pride"] body::before {
   content: "";
   position: fixed;
   inset: 0 0 auto;
-  height: 4px;
+  height: 5px;
   z-index: 1000;
   pointer-events: none;
   background: linear-gradient(

--- a/frontend/tests/lifecycle.spec.ts
+++ b/frontend/tests/lifecycle.spec.ts
@@ -22,7 +22,9 @@ test("canonical deletion is previewed before backend-bound application", async (
   await expect(
     plan.getByRole("heading", { name: "Review 4 planned actions" }),
   ).toBeVisible();
-  await expect(plan.getByText("delete canonical transcript evidence")).toBeVisible();
+  await expect(
+    plan.getByText("delete canonical transcript evidence", { exact: true }),
+  ).toBeVisible();
   await expect(plan.getByText(/2 anchored notes preserved/)).toBeVisible();
   await plan.getByText("Why did EchoFlow expand my selection?").click();
   await expect(

--- a/frontend/tests/lifecycle.spec.ts
+++ b/frontend/tests/lifecycle.spec.ts
@@ -1,0 +1,80 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+async function openStorage(page: import("@playwright/test").Page) {
+  await page.goto("/?e2e=1");
+  await page.getByRole("button", { name: "Storage" }).click();
+  await expect(page.getByRole("heading", { name: "Storage & deletion" })).toBeVisible();
+}
+
+test("canonical deletion is previewed before backend-bound application", async ({ page }) => {
+  await openStorage(page);
+
+  const transcript = page.getByRole("combobox", { name: "Transcript to manage" });
+  await expect(transcript).toContainText("oral-history-42.m4a");
+
+  await page.getByRole("checkbox", { name: /Delete canonical transcript evidence/ }).check();
+  await page.getByRole("button", { name: "Preview deletion plan" }).click();
+
+  const plan = page.getByLabel("Deletion plan");
+  await expect(plan.getByRole("heading", { name: "Review 4 planned actions" })).toBeVisible();
+  await expect(plan.getByText("delete canonical transcript evidence")).toBeVisible();
+  await expect(plan.getByText(/2 anchored notes preserved/)).toBeVisible();
+  await expect(plan.getByText(/Canonical transcript deletion automatically includes/)).toBeVisible();
+
+  await plan.getByRole("button", { name: "Apply reviewed plan" }).click();
+  await expect(page.getByRole("status")).toContainText("Applied custody plan for interview-42");
+  await expect(transcript).not.toContainText("oral-history-42.m4a");
+});
+
+test("source deletion requires a second explicit guard and never exposes source paths", async ({
+  page,
+}) => {
+  await openStorage(page);
+
+  await page.getByRole("checkbox", { name: /Delete the original recording/ }).check();
+  await expect(page.getByRole("button", { name: "Preview deletion plan" })).toBeDisabled();
+
+  await page
+    .getByRole("checkbox", { name: /I understand this deletes the original recording/ })
+    .check();
+  await page.getByRole("button", { name: "Preview deletion plan" }).click();
+
+  await expect(page.getByLabel("Deletion plan")).toContainText("delete the original source recording");
+  await expect(page.getByText(/forensic secure erasure/)).toBeVisible();
+  await expect(page.getByText("source_path")).toHaveCount(0);
+  await expect(page.getByText("canonical_path")).toHaveCount(0);
+  await expect(page.getByText("/secret/")).toHaveCount(0);
+});
+
+test("retention preview separates completed cleanup from resumable interrupted work", async ({
+  page,
+}) => {
+  await openStorage(page);
+
+  await page.getByRole("button", { name: "Preview cleanup" }).click();
+  const firstPlan = page.getByLabel("Retention plan");
+  await expect(firstPlan).toContainText("job-completed-2");
+  await expect(firstPlan).not.toContainText("job-interrupted-7");
+
+  await page.getByRole("checkbox", { name: /Also include failed and interrupted jobs/ }).check();
+  await expect(firstPlan).toHaveCount(0);
+  await page.getByRole("button", { name: "Preview cleanup" }).click();
+
+  const secondPlan = page.getByLabel("Retention plan");
+  await expect(secondPlan).toContainText("job-interrupted-7");
+  await expect(secondPlan).toContainText("Resume will be lost");
+
+  await secondPlan.getByRole("button", { name: "Apply cleanup plan" }).click();
+  await expect(page.getByRole("status")).toContainText("Removed private processing state for 2 jobs");
+  await expect(page.getByText(/Canonical evidence and human research were outside this operation/)).toBeVisible();
+});
+
+test("storage screen and open plan pass accessibility checks", async ({ page }) => {
+  await openStorage(page);
+  await page.getByRole("checkbox", { name: /Remove from Library search/ }).check();
+  await page.getByRole("button", { name: "Preview deletion plan" }).click();
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations).toEqual([]);
+});

--- a/frontend/tests/lifecycle.spec.ts
+++ b/frontend/tests/lifecycle.spec.ts
@@ -13,17 +13,26 @@ test("canonical deletion is previewed before backend-bound application", async (
   const transcript = page.getByRole("combobox", { name: "Transcript to manage" });
   await expect(transcript).toContainText("oral-history-42.m4a");
 
-  await page.getByRole("checkbox", { name: /Delete canonical transcript evidence/ }).check();
+  await page
+    .getByRole("checkbox", { name: /Delete canonical transcript evidence/ })
+    .check();
   await page.getByRole("button", { name: "Preview deletion plan" }).click();
 
   const plan = page.getByLabel("Deletion plan");
-  await expect(plan.getByRole("heading", { name: "Review 4 planned actions" })).toBeVisible();
+  await expect(
+    plan.getByRole("heading", { name: "Review 4 planned actions" }),
+  ).toBeVisible();
   await expect(plan.getByText("delete canonical transcript evidence")).toBeVisible();
   await expect(plan.getByText(/2 anchored notes preserved/)).toBeVisible();
-  await expect(plan.getByText(/Canonical transcript deletion automatically includes/)).toBeVisible();
+  await plan.getByText("Why did EchoFlow expand my selection?").click();
+  await expect(
+    plan.getByText(/Canonical transcript deletion automatically includes/),
+  ).toBeVisible();
 
   await plan.getByRole("button", { name: "Apply reviewed plan" }).click();
-  await expect(page.getByRole("status")).toContainText("Applied custody plan for interview-42");
+  await expect(page.getByRole("status")).toContainText(
+    "Applied custody plan for interview-42",
+  );
   await expect(transcript).not.toContainText("oral-history-42.m4a");
 });
 
@@ -33,14 +42,18 @@ test("source deletion requires a second explicit guard and never exposes source 
   await openStorage(page);
 
   await page.getByRole("checkbox", { name: /Delete the original recording/ }).check();
-  await expect(page.getByRole("button", { name: "Preview deletion plan" })).toBeDisabled();
+  await expect(
+    page.getByRole("button", { name: "Preview deletion plan" }),
+  ).toBeDisabled();
 
   await page
     .getByRole("checkbox", { name: /I understand this deletes the original recording/ })
     .check();
   await page.getByRole("button", { name: "Preview deletion plan" }).click();
 
-  await expect(page.getByLabel("Deletion plan")).toContainText("delete the original source recording");
+  await expect(page.getByLabel("Deletion plan")).toContainText(
+    "delete the original source recording",
+  );
   await expect(page.getByText(/forensic secure erasure/)).toBeVisible();
   await expect(page.getByText("source_path")).toHaveCount(0);
   await expect(page.getByText("canonical_path")).toHaveCount(0);
@@ -57,7 +70,9 @@ test("retention preview separates completed cleanup from resumable interrupted w
   await expect(firstPlan).toContainText("job-completed-2");
   await expect(firstPlan).not.toContainText("job-interrupted-7");
 
-  await page.getByRole("checkbox", { name: /Also include failed and interrupted jobs/ }).check();
+  await page
+    .getByRole("checkbox", { name: /Also include failed and interrupted jobs/ })
+    .check();
   await expect(firstPlan).toHaveCount(0);
   await page.getByRole("button", { name: "Preview cleanup" }).click();
 
@@ -66,12 +81,22 @@ test("retention preview separates completed cleanup from resumable interrupted w
   await expect(secondPlan).toContainText("Resume will be lost");
 
   await secondPlan.getByRole("button", { name: "Apply cleanup plan" }).click();
-  await expect(page.getByRole("status")).toContainText("Removed private processing state for 2 jobs");
-  await expect(page.getByText(/Canonical evidence and human research were outside this operation/)).toBeVisible();
+  await expect(page.getByRole("status")).toContainText(
+    "Removed private processing state for 2 jobs",
+  );
+  await expect(
+    page.getByText(/Canonical evidence and human research were outside this operation/),
+  ).toBeVisible();
 });
 
-test("storage screen and open plan pass accessibility checks", async ({ page }) => {
+test("storage guidance and open plan pass accessibility checks", async ({ page }) => {
   await openStorage(page);
+  await page.getByRole("button", { name: "How storage controls work" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Storage and lifecycle controls" }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+
   await page.getByRole("checkbox", { name: /Remove from Library search/ }).check();
   await page.getByRole("button", { name: "Preview deletion plan" }).click();
 

--- a/frontend/tests/theme-special.spec.ts
+++ b/frontend/tests/theme-special.spec.ts
@@ -27,14 +27,20 @@ function isGray(hex: string): boolean {
   return normalized.slice(0, 2) === normalized.slice(2, 4) && normalized.slice(2, 4) === normalized.slice(4, 6);
 }
 
-test("Pride uses decoration without changing the semantic theme contract", async ({ page }) => {
+test("Pride uses a full-spectrum backdrop without changing the semantic theme contract", async ({ page }) => {
   await page.goto("/?e2e=1");
   await page.getByLabel("Theme").selectOption("pride");
 
-  const decoration = await page.evaluate(() =>
-    getComputedStyle(document.body, "::before").backgroundImage,
+  const decoration = await page.locator(".app-shell").evaluate(
+    (element) => getComputedStyle(element).backgroundImage,
   );
   expect(decoration).toContain("linear-gradient");
+  expect(decoration.match(/rgb\(/g)?.length ?? 0).toBeGreaterThanOrEqual(6);
+
+  const edge = await page.evaluate(() =>
+    getComputedStyle(document.body, "::before").backgroundImage,
+  );
+  expect(edge).toContain("linear-gradient");
   await expect(page.locator("html")).toHaveCSS("color-scheme", /light/);
 });
 

--- a/src/echoflow/desktop/custody_bridge.py
+++ b/src/echoflow/desktop/custody_bridge.py
@@ -68,7 +68,9 @@ class _DeletionPlanParams(BaseModel):
 
     @field_validator("scopes")
     @classmethod
-    def unique_scopes(cls, values: tuple[DeletionScope, ...]) -> tuple[DeletionScope, ...]:
+    def unique_scopes(
+        cls, values: tuple[DeletionScope, ...]
+    ) -> tuple[DeletionScope, ...]:
         if len(values) != len(set(values)):
             raise ValueError("deletion scopes cannot repeat")
         return values
@@ -245,7 +247,9 @@ def _failure(request_id: str, *, code: str, message: str) -> dict[str, object]:
     }
 
 
-def handle_request(payload: object, service: LibraryCustodyService) -> dict[str, object]:
+def handle_request(
+    payload: object, service: LibraryCustodyService
+) -> dict[str, object]:
     request_id = "unknown"
     if isinstance(payload, dict) and isinstance(payload.get("request_id"), str):
         request_id = payload["request_id"][:128]

--- a/src/echoflow/desktop/custody_bridge.py
+++ b/src/echoflow/desktop/custody_bridge.py
@@ -1,15 +1,22 @@
-"""Narrow desktop adapter for custody-aware lifecycle operations.
+"""Trusted-host bridge for custody-aware lifecycle operations.
 
-The desktop may request plans and submit plan-bound confirmations. It never receives
-filesystem paths and does not reimplement deletion or retention policy.
+The webview may request plans and submit plan-bound confirmations through a fixed Tauri
+command. It never receives filesystem paths and cannot choose a Python module, SQL query,
+or arbitrary local file operation.
 """
 
 from __future__ import annotations
 
+import json
+import sys
+from contextlib import redirect_stdout
 from pathlib import Path
+from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
+from echoflow.app.app_container import AppContainer
+from echoflow.core.errors import EchoFlowError
 from echoflow.library.custody import (
     DeletionPlan,
     DeletionReceipt,
@@ -19,6 +26,25 @@ from echoflow.library.custody import (
     RetentionPolicy,
     RetentionReceipt,
 )
+
+_PROTOCOL_VERSION = 1
+_MAX_REQUEST_BYTES = 128 * 1024
+LifecycleMethod = Literal[
+    "lifecycle.documents.list",
+    "lifecycle.deletion.plan",
+    "lifecycle.deletion.execute",
+    "lifecycle.retention.plan",
+    "lifecycle.retention.execute",
+]
+
+
+class _Request(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    protocol_version: Literal[1]
+    request_id: str = Field(min_length=1, max_length=128)
+    method: LifecycleMethod
+    params: dict[str, object] = Field(default_factory=dict)
 
 
 class _NoParams(BaseModel):
@@ -152,7 +178,7 @@ def dispatch_custody(
     params: dict[str, object],
     service: LibraryCustodyService,
 ) -> object:
-    """Dispatch bounded lifecycle operations after the outer bridge allowlist accepts them."""
+    """Dispatch only the lifecycle methods named by the closed request schema."""
     if method == "lifecycle.documents.list":
         _NoParams.model_validate(params)
         return _serialize_documents(service)
@@ -197,3 +223,85 @@ def dispatch_custody(
             )
         )
     raise ValueError("Unsupported lifecycle desktop method")
+
+
+def _success(request_id: str, result: object) -> dict[str, object]:
+    return {
+        "protocol_version": _PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": True,
+        "result": result,
+        "error": None,
+    }
+
+
+def _failure(request_id: str, *, code: str, message: str) -> dict[str, object]:
+    return {
+        "protocol_version": _PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": False,
+        "result": None,
+        "error": {"code": code, "message": message},
+    }
+
+
+def handle_request(payload: object, service: LibraryCustodyService) -> dict[str, object]:
+    request_id = "unknown"
+    if isinstance(payload, dict) and isinstance(payload.get("request_id"), str):
+        request_id = payload["request_id"][:128]
+    try:
+        request = _Request.model_validate(payload)
+        return _success(
+            request.request_id,
+            dispatch_custody(request.method, request.params, service),
+        )
+    except ValidationError:
+        return _failure(
+            request_id,
+            code="invalid_request",
+            message="Lifecycle request is invalid or incompatible",
+        )
+    except EchoFlowError as exc:
+        return _failure(
+            request_id,
+            code=exc.code.value,
+            message=exc.public_message,
+        )
+    except ValueError as exc:
+        return _failure(request_id, code="invalid_request", message=str(exc))
+    except Exception:
+        return _failure(
+            request_id,
+            code="internal_error",
+            message="EchoFlow could not complete the local lifecycle request",
+        )
+
+
+def main() -> int:
+    raw = sys.stdin.buffer.read(_MAX_REQUEST_BYTES + 1)
+    if len(raw) > _MAX_REQUEST_BYTES:
+        response = _failure(
+            "unknown",
+            code="invalid_request",
+            message="Lifecycle request exceeded the safe size limit",
+        )
+    else:
+        try:
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            response = _failure(
+                "unknown",
+                code="invalid_request",
+                message="Lifecycle request was not valid JSON",
+            )
+        else:
+            with redirect_stdout(sys.stderr):
+                container = AppContainer()
+                response = handle_request(payload, container.library_custody())
+    sys.stdout.write(json.dumps(response, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/echoflow/desktop/custody_bridge.py
+++ b/src/echoflow/desktop/custody_bridge.py
@@ -108,7 +108,7 @@ class _RetentionExecuteParams(_RetentionPlanParams):
 
 
 def _serialize_documents(service: LibraryCustodyService) -> list[dict[str, object]]:
-    documents = []
+    documents: list[dict[str, object]] = []
     for document in service.transcript_library.documents():
         source_name = Path(document.source_path).name if document.source_path else None
         documents.append(
@@ -185,43 +185,43 @@ def dispatch_custody(
         _NoParams.model_validate(params)
         return _serialize_documents(service)
     if method == "lifecycle.deletion.plan":
-        request = _DeletionPlanParams.model_validate(params)
+        deletion_plan = _DeletionPlanParams.model_validate(params)
         return _serialize_deletion_plan(
             service.plan_deletion(
-                request.document_id,
-                request.scopes,
-                allow_source=request.allow_source,
+                deletion_plan.document_id,
+                deletion_plan.scopes,
+                allow_source=deletion_plan.allow_source,
             )
         )
     if method == "lifecycle.deletion.execute":
-        request = _DeletionExecuteParams.model_validate(params)
+        deletion_execute = _DeletionExecuteParams.model_validate(params)
         return _serialize_deletion_receipt(
             service.execute_deletion(
-                request.document_id,
-                request.scopes,
-                confirmation_token=request.confirmation_token,
-                allow_source=request.allow_source,
+                deletion_execute.document_id,
+                deletion_execute.scopes,
+                confirmation_token=deletion_execute.confirmation_token,
+                allow_source=deletion_execute.allow_source,
             )
         )
     if method == "lifecycle.retention.plan":
-        request = _RetentionPlanParams.model_validate(params)
+        retention_plan = _RetentionPlanParams.model_validate(params)
         return _serialize_retention_plan(
             service.plan_retention(
                 RetentionPolicy(
-                    execution_days=request.execution_days,
-                    include_incomplete=request.include_incomplete,
+                    execution_days=retention_plan.execution_days,
+                    include_incomplete=retention_plan.include_incomplete,
                 )
             )
         )
     if method == "lifecycle.retention.execute":
-        request = _RetentionExecuteParams.model_validate(params)
+        retention_execute = _RetentionExecuteParams.model_validate(params)
         return _serialize_retention_receipt(
             service.execute_retention(
                 RetentionPolicy(
-                    execution_days=request.execution_days,
-                    include_incomplete=request.include_incomplete,
+                    execution_days=retention_execute.execution_days,
+                    include_incomplete=retention_execute.include_incomplete,
                 ),
-                confirmation_token=request.confirmation_token,
+                confirmation_token=retention_execute.confirmation_token,
             )
         )
     raise ValueError("Unsupported lifecycle desktop method")

--- a/src/echoflow/desktop/custody_bridge.py
+++ b/src/echoflow/desktop/custody_bridge.py
@@ -1,0 +1,199 @@
+"""Narrow desktop adapter for custody-aware lifecycle operations.
+
+The desktop may request plans and submit plan-bound confirmations. It never receives
+filesystem paths and does not reimplement deletion or retention policy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from echoflow.library.custody import (
+    DeletionPlan,
+    DeletionReceipt,
+    DeletionScope,
+    LibraryCustodyService,
+    RetentionPlan,
+    RetentionPolicy,
+    RetentionReceipt,
+)
+
+
+class _NoParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class _DeletionPlanParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    document_id: str = Field(min_length=1, max_length=1_024)
+    scopes: tuple[DeletionScope, ...] = Field(min_length=1, max_length=16)
+    allow_source: bool = False
+
+    @field_validator("document_id")
+    @classmethod
+    def strip_document_id(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("document_id cannot be blank")
+        return stripped
+
+    @field_validator("scopes")
+    @classmethod
+    def unique_scopes(cls, values: tuple[DeletionScope, ...]) -> tuple[DeletionScope, ...]:
+        if len(values) != len(set(values)):
+            raise ValueError("deletion scopes cannot repeat")
+        return values
+
+
+class _DeletionExecuteParams(_DeletionPlanParams):
+    confirmation_token: str = Field(min_length=1, max_length=4_096)
+
+    @field_validator("confirmation_token")
+    @classmethod
+    def strip_confirmation_token(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("confirmation_token cannot be blank")
+        return stripped
+
+
+class _RetentionPlanParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    execution_days: int = Field(default=30, ge=0, le=36_500)
+    include_incomplete: bool = False
+
+
+class _RetentionExecuteParams(_RetentionPlanParams):
+    confirmation_token: str = Field(min_length=1, max_length=4_096)
+
+    @field_validator("confirmation_token")
+    @classmethod
+    def strip_confirmation_token(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("confirmation_token cannot be blank")
+        return stripped
+
+
+def _serialize_documents(service: LibraryCustodyService) -> list[dict[str, object]]:
+    documents = []
+    for document in service.transcript_library.documents():
+        source_name = Path(document.source_path).name if document.source_path else None
+        documents.append(
+            {
+                "document_id": document.document_id,
+                "canonical_sha256": document.canonical_sha256,
+                "source_name": source_name,
+                "segment_count": document.segment_count,
+                "detected_language": document.detected_language,
+                "deletion_ready": document.canonical_sha256 is not None,
+            }
+        )
+    return sorted(documents, key=lambda item: str(item["document_id"]))
+
+
+def _serialize_deletion_plan(plan: DeletionPlan) -> dict[str, object]:
+    return {
+        "document_id": plan.document_id,
+        "canonical_sha256": plan.canonical_sha256,
+        "requested_scopes": [scope.value for scope in plan.requested_scopes],
+        "effective_scopes": [scope.value for scope in plan.effective_scopes],
+        "actions": [
+            {
+                "target": action.target.value,
+                "description": action.description,
+            }
+            for action in plan.actions
+        ],
+        "preserved_note_count": len(plan.preserved_note_ids),
+        "affected_saved_search_count": len(plan.affected_saved_search_ids),
+        "confirmation_token": plan.confirmation_token,
+    }
+
+
+def _serialize_deletion_receipt(receipt: DeletionReceipt) -> dict[str, object]:
+    return {
+        "document_id": receipt.document_id,
+        "executed_targets": [target.value for target in receipt.executed_targets],
+        "preserved_note_count": len(receipt.preserved_note_ids),
+        "affected_saved_search_count": len(receipt.affected_saved_search_ids),
+    }
+
+
+def _serialize_retention_plan(plan: RetentionPlan) -> dict[str, object]:
+    return {
+        "policy": {
+            "execution_days": plan.policy.execution_days,
+            "include_incomplete": plan.policy.include_incomplete,
+        },
+        "candidates": [
+            {
+                "job_id": candidate.job_id,
+                "status": candidate.status.value,
+                "updated_at": candidate.updated_at,
+                "resume_capability_lost": candidate.resume_capability_lost,
+            }
+            for candidate in plan.candidates
+        ],
+        "confirmation_token": plan.confirmation_token,
+    }
+
+
+def _serialize_retention_receipt(receipt: RetentionReceipt) -> dict[str, object]:
+    return {"discarded_job_ids": list(receipt.discarded_job_ids)}
+
+
+def dispatch_custody(
+    method: str,
+    params: dict[str, object],
+    service: LibraryCustodyService,
+) -> object:
+    """Dispatch bounded lifecycle operations after the outer bridge allowlist accepts them."""
+    if method == "lifecycle.documents.list":
+        _NoParams.model_validate(params)
+        return _serialize_documents(service)
+    if method == "lifecycle.deletion.plan":
+        request = _DeletionPlanParams.model_validate(params)
+        return _serialize_deletion_plan(
+            service.plan_deletion(
+                request.document_id,
+                request.scopes,
+                allow_source=request.allow_source,
+            )
+        )
+    if method == "lifecycle.deletion.execute":
+        request = _DeletionExecuteParams.model_validate(params)
+        return _serialize_deletion_receipt(
+            service.execute_deletion(
+                request.document_id,
+                request.scopes,
+                confirmation_token=request.confirmation_token,
+                allow_source=request.allow_source,
+            )
+        )
+    if method == "lifecycle.retention.plan":
+        request = _RetentionPlanParams.model_validate(params)
+        return _serialize_retention_plan(
+            service.plan_retention(
+                RetentionPolicy(
+                    execution_days=request.execution_days,
+                    include_incomplete=request.include_incomplete,
+                )
+            )
+        )
+    if method == "lifecycle.retention.execute":
+        request = _RetentionExecuteParams.model_validate(params)
+        return _serialize_retention_receipt(
+            service.execute_retention(
+                RetentionPolicy(
+                    execution_days=request.execution_days,
+                    include_incomplete=request.include_incomplete,
+                ),
+                confirmation_token=request.confirmation_token,
+            )
+        )
+    raise ValueError("Unsupported lifecycle desktop method")

--- a/src/echoflow/desktop/custody_bridge.py
+++ b/src/echoflow/desktop/custody_bridge.py
@@ -267,8 +267,12 @@ def handle_request(payload: object, service: LibraryCustodyService) -> dict[str,
             code=exc.code.value,
             message=exc.public_message,
         )
-    except ValueError as exc:
-        return _failure(request_id, code="invalid_request", message=str(exc))
+    except ValueError:
+        return _failure(
+            request_id,
+            code="invalid_request",
+            message="Lifecycle request is invalid",
+        )
     except Exception:
         return _failure(
             request_id,

--- a/src/echoflow/desktop/tests/test_custody_bridge.py
+++ b/src/echoflow/desktop/tests/test_custody_bridge.py
@@ -21,6 +21,9 @@ from echoflow.library.custody import (
 from echoflow.library.index import IndexedDocument
 from echoflow.workspace.lifecycle import JobStatus
 
+_DELETE_CONFIRMATION = "delete:bound-plan"
+_RETENTION_CONFIRMATION = "retention:bound-plan"
+
 
 class _TranscriptLibrary:
     def documents(self) -> tuple[IndexedDocument, ...]:
@@ -69,7 +72,7 @@ class _CustodyFake:
             ),
             preserved_note_ids=("note-1", "note-2"),
             affected_saved_search_ids=("search-1",),
-            confirmation_token="delete:bound-plan",
+            confirmation_token=_DELETE_CONFIRMATION,
         )
 
     def execute_deletion(
@@ -80,7 +83,7 @@ class _CustodyFake:
         confirmation_token: str,
         allow_source: bool = False,
     ) -> DeletionReceipt:
-        assert confirmation_token == "delete:bound-plan"
+        assert confirmation_token == _DELETE_CONFIRMATION
         self.deletion_allow_source = allow_source
         return DeletionReceipt(
             document_id=document_id,
@@ -103,7 +106,7 @@ class _CustodyFake:
                     resume_capability_lost=True,
                 ),
             ),
-            confirmation_token="retention:bound-plan",
+            confirmation_token=_RETENTION_CONFIRMATION,
         )
 
     def execute_retention(
@@ -112,7 +115,7 @@ class _CustodyFake:
         *,
         confirmation_token: str,
     ) -> RetentionReceipt:
-        assert confirmation_token == "retention:bound-plan"
+        assert confirmation_token == _RETENTION_CONFIRMATION
         self.retention_policy = policy
         return RetentionReceipt(
             confirmation_token=confirmation_token,
@@ -175,7 +178,7 @@ def test_deletion_execute_forwards_exact_plan_confirmation() -> None:
             "document_id": "doc-1",
             "scopes": ["canonical-transcript"],
             "allow_source": False,
-            "confirmation_token": "delete:bound-plan",
+            "confirmation_token": _DELETE_CONFIRMATION,
         },
         _service(fake),
     )
@@ -220,7 +223,7 @@ def test_retention_execute_forwards_reviewed_policy_and_token() -> None:
         {
             "execution_days": 30,
             "include_incomplete": False,
-            "confirmation_token": "retention:bound-plan",
+            "confirmation_token": _RETENTION_CONFIRMATION,
         },
         _service(fake),
     )

--- a/src/echoflow/desktop/tests/test_custody_bridge.py
+++ b/src/echoflow/desktop/tests/test_custody_bridge.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+
+from echoflow.desktop.custody_bridge import dispatch_custody, handle_request
+from echoflow.library.custody import (
+    DeletionAction,
+    DeletionPlan,
+    DeletionReceipt,
+    DeletionScope,
+    DeletionTarget,
+    LibraryCustodyService,
+    RetentionCandidate,
+    RetentionPlan,
+    RetentionPolicy,
+    RetentionReceipt,
+)
+from echoflow.library.index import IndexedDocument
+from echoflow.workspace.lifecycle import JobStatus
+
+
+class _TranscriptLibrary:
+    def documents(self) -> tuple[IndexedDocument, ...]:
+        return (
+            IndexedDocument(
+                document_id="doc-1",
+                source_sha256="b" * 64,
+                detected_language="en",
+                canonical_path="/private/library/doc-1.json",
+                source_path="/secret/interviews/oral-history.m4a",
+                segment_count=12,
+                canonical_sha256="a" * 64,
+            ),
+        )
+
+
+class _CustodyFake:
+    def __init__(self) -> None:
+        self.transcript_library = _TranscriptLibrary()
+        self.deletion_allow_source: bool | None = None
+        self.retention_policy: RetentionPolicy | None = None
+        self.fail_unexpected = False
+
+    def plan_deletion(
+        self,
+        document_id: str,
+        scopes: tuple[DeletionScope, ...],
+        *,
+        allow_source: bool = False,
+    ) -> DeletionPlan:
+        if self.fail_unexpected:
+            raise RuntimeError("secret /private/library/doc-1.json")
+        self.deletion_allow_source = allow_source
+        return DeletionPlan(
+            document_id=document_id,
+            canonical_sha256="a" * 64,
+            requested_scopes=scopes,
+            effective_scopes=scopes,
+            actions=(
+                DeletionAction(
+                    target=DeletionTarget.CANONICAL_TRANSCRIPT,
+                    object_id="a" * 64,
+                    description="delete canonical transcript evidence",
+                    path="/private/library/doc-1.json",
+                ),
+            ),
+            preserved_note_ids=("note-1", "note-2"),
+            affected_saved_search_ids=("search-1",),
+            confirmation_token="delete:bound-plan",
+        )
+
+    def execute_deletion(
+        self,
+        document_id: str,
+        scopes: tuple[DeletionScope, ...],
+        *,
+        confirmation_token: str,
+        allow_source: bool = False,
+    ) -> DeletionReceipt:
+        assert confirmation_token == "delete:bound-plan"
+        self.deletion_allow_source = allow_source
+        return DeletionReceipt(
+            document_id=document_id,
+            confirmation_token=confirmation_token,
+            executed_targets=(DeletionTarget.CANONICAL_TRANSCRIPT,),
+            preserved_note_ids=("note-1",),
+            affected_saved_search_ids=("search-1",),
+        )
+
+    def plan_retention(self, policy: RetentionPolicy) -> RetentionPlan:
+        self.retention_policy = policy
+        return RetentionPlan(
+            policy=policy,
+            candidates=(
+                RetentionCandidate(
+                    job_id="job-1",
+                    status=JobStatus.INTERRUPTED,
+                    updated_at="2026-07-01T00:00:00+00:00",
+                    workspace_path="/private/state/jobs/job-1",
+                    resume_capability_lost=True,
+                ),
+            ),
+            confirmation_token="retention:bound-plan",
+        )
+
+    def execute_retention(
+        self,
+        policy: RetentionPolicy,
+        *,
+        confirmation_token: str,
+    ) -> RetentionReceipt:
+        assert confirmation_token == "retention:bound-plan"
+        self.retention_policy = policy
+        return RetentionReceipt(
+            confirmation_token=confirmation_token,
+            discarded_job_ids=("job-1",),
+        )
+
+
+def _service(fake: _CustodyFake | None = None) -> LibraryCustodyService:
+    return cast(LibraryCustodyService, fake or _CustodyFake())
+
+
+def test_document_list_exposes_only_source_basename() -> None:
+    result = dispatch_custody("lifecycle.documents.list", {}, _service())
+
+    assert result == [
+        {
+            "document_id": "doc-1",
+            "canonical_sha256": "a" * 64,
+            "source_name": "oral-history.m4a",
+            "segment_count": 12,
+            "detected_language": "en",
+            "deletion_ready": True,
+        }
+    ]
+    assert "/secret/" not in repr(result)
+    assert "canonical_path" not in repr(result)
+
+
+def test_deletion_plan_omits_action_paths_and_preserves_backend_decisions() -> None:
+    fake = _CustodyFake()
+    result = dispatch_custody(
+        "lifecycle.deletion.plan",
+        {
+            "document_id": "doc-1",
+            "scopes": ["canonical-transcript", "source-recording"],
+            "allow_source": True,
+        },
+        _service(fake),
+    )
+
+    assert isinstance(result, dict)
+    assert result["actions"] == [
+        {
+            "target": "canonical-transcript",
+            "description": "delete canonical transcript evidence",
+        }
+    ]
+    assert result["preserved_note_count"] == 2
+    assert result["affected_saved_search_count"] == 1
+    assert fake.deletion_allow_source is True
+    assert "/private/" not in repr(result)
+    assert "path" not in repr(result)
+
+
+def test_deletion_execute_forwards_exact_plan_confirmation() -> None:
+    fake = _CustodyFake()
+    result = dispatch_custody(
+        "lifecycle.deletion.execute",
+        {
+            "document_id": "doc-1",
+            "scopes": ["canonical-transcript"],
+            "allow_source": False,
+            "confirmation_token": "delete:bound-plan",
+        },
+        _service(fake),
+    )
+
+    assert result == {
+        "document_id": "doc-1",
+        "executed_targets": ["canonical-transcript"],
+        "preserved_note_count": 1,
+        "affected_saved_search_count": 1,
+    }
+
+
+def test_retention_plan_omits_private_workspace_path_and_reports_resume_loss() -> None:
+    fake = _CustodyFake()
+    result = dispatch_custody(
+        "lifecycle.retention.plan",
+        {"execution_days": 45, "include_incomplete": True},
+        _service(fake),
+    )
+
+    assert isinstance(result, dict)
+    assert result["candidates"] == [
+        {
+            "job_id": "job-1",
+            "status": "interrupted",
+            "updated_at": "2026-07-01T00:00:00+00:00",
+            "resume_capability_lost": True,
+        }
+    ]
+    assert fake.retention_policy == RetentionPolicy(
+        execution_days=45,
+        include_incomplete=True,
+    )
+    assert "/private/state" not in repr(result)
+    assert "workspace_path" not in repr(result)
+
+
+def test_retention_execute_forwards_reviewed_policy_and_token() -> None:
+    fake = _CustodyFake()
+    result = dispatch_custody(
+        "lifecycle.retention.execute",
+        {
+            "execution_days": 30,
+            "include_incomplete": False,
+            "confirmation_token": "retention:bound-plan",
+        },
+        _service(fake),
+    )
+
+    assert result == {"discarded_job_ids": ["job-1"]}
+    assert fake.retention_policy == RetentionPolicy(execution_days=30)
+
+
+@pytest.mark.parametrize(
+    "method,params",
+    [
+        ("lifecycle.documents.list", {"extra": True}),
+        (
+            "lifecycle.deletion.plan",
+            {
+                "document_id": "doc-1",
+                "scopes": ["library-view", "library-view"],
+            },
+        ),
+        (
+            "lifecycle.retention.plan",
+            {"execution_days": 36_501, "include_incomplete": False},
+        ),
+    ],
+)
+def test_dispatch_rejects_extra_duplicate_or_out_of_range_inputs(
+    method: str,
+    params: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        dispatch_custody(method, params, _service())
+
+
+def test_closed_protocol_rejects_unknown_method() -> None:
+    response = handle_request(
+        {
+            "protocol_version": 1,
+            "request_id": "request-1",
+            "method": "lifecycle.files.delete-anything",
+            "params": {},
+        },
+        _service(),
+    )
+
+    assert response["ok"] is False
+    assert response["error"] == {
+        "code": "invalid_request",
+        "message": "Lifecycle request is invalid or incompatible",
+    }
+
+
+def test_unexpected_errors_are_masked_without_paths() -> None:
+    fake = _CustodyFake()
+    fake.fail_unexpected = True
+    response = handle_request(
+        {
+            "protocol_version": 1,
+            "request_id": "request-2",
+            "method": "lifecycle.deletion.plan",
+            "params": {"document_id": "doc-1", "scopes": ["library-view"]},
+        },
+        _service(fake),
+    )
+
+    assert response["ok"] is False
+    assert response["error"] == {
+        "code": "internal_error",
+        "message": "EchoFlow could not complete the local lifecycle request",
+    }
+    assert "/private/" not in repr(response)


### PR DESCRIPTION
## Summary

Add a native Storage workspace over EchoFlow's existing plan-bound custody and retention authority without moving deletion policy into React.

- expose document listing, deletion plan/apply, and retention plan/apply through a dedicated fixed Python custody bridge and fixed Tauri command
- strip canonical/source/action/workspace filesystem paths before lifecycle responses reach the webview
- present explicit custody scopes, backend-computed scope expansion/actions, preserved-note and affected-saved-search counts, then apply only the reviewed confirmation-bound plan
- require a second source-recording acknowledgment before the backend source safety switch can be submitted
- preview private processing cleanup and visibly mark failed/interrupted candidates whose resume capability would be lost
- add lifecycle-specific Playwright/axe and Python bridge boundary tests
- repair the Pride skin so the full app shell carries a visible full-spectrum rainbow gradient while semantic status/control colors remain accessible and non-rainbow-dependent
- add a Pride regression test that requires the full-shell gradient and keep Pride inside the shared contrast/axe qualification
- truth-sync README, architecture, lifecycle, research-note taxonomy, frontend security/testing, and roadmap documentation
- record a product-identity checkpoint before packaging and a post-MVP freeform research memo/notebook primitive distinct from evidence-anchored notes

## Authority boundary

`LibraryCustodyService` remains the only deletion/retention policy authority. `echoflow.desktop.custody_bridge` is a closed serializer/adapter; Tauri exposes only the fixed `lifecycle_request`; React renders typed intent and backend results. This PR does not modify custody decision logic or add a generic filesystem capability.

## Mutation policy

This tranche does not modify playback or `LibraryCustodyService` decision logic, so it does not trigger the targeted playback Poodle workflow or add a new universal mutation tax. Existing custody service tests remain the policy oracle; the new adapter/browser tests cover path stripping, closed methods, confirmation forwarding, source guard presentation, retention resume-loss presentation, and accessibility.

## Qualification

Exact head `e2ecd60a27e4d30165160a21a1f99d84a1e09ea5` passed Quality #917 end to end:

- Ruff lint/format, strict mypy, Vulture, Radon, Mermaid portability, lock/dependency/security audit: green
- TypeScript, production frontend build, frontend dependency audit: green
- Playwright/axe: 61/61 green, including lifecycle flows and full-spectrum Pride regression/accessibility qualification
- native Tauri locked compile and Rust tests: green
- Linux branch-coverage test suite, distributions, clean-wheel install: green
- macOS full tests, runner policy, distributions, clean-wheel install: green
- Windows full tests, runner policy, distributions, clean-wheel install: green

No mutation workflow fired, as intended for this presentation/adapter tranche.