### PR TITLE
refactor(architecture): consolidate desktop transport and composition seams

### DIFF
--- a/docs/architecture/redundancy-audit.md
+++ b/docs/architecture/redundancy-audit.md
@@ -1,0 +1,180 @@
+# Architecture and redundancy audit
+
+This audit exists to remove duplicated **meaning and ownership**, not to minimize file count.
+EchoFlow deliberately has several narrow adapters because playback, custody, transcript tools,
+processing, research, and ordinary desktop operations do not share the same authority.
+Similar-looking code is only a problem when it can drift into different behavior or makes the
+real composition root unclear.
+
+## Status
+
+The first cleanup tranche is implemented on the architecture-audit branch. It removes shared
+transport/composition boilerplate without widening any native capability. A second Research
+cleanup remains before the product-identity/packaging checkpoint because saved-search
+management is currently duplicated on the same screen.
+
+## Changes made in this tranche
+
+### Trusted-host Python protocol mechanics
+
+Playback, transcript tools, and lifecycle custody each had their own copy of the same bounded
+stdin/stdout JSON loop, protocol response envelope, request-size cap, and stdout redirection.
+They now share `echoflow.desktop.host_protocol` for **transport mechanics only**.
+
+The helper does not know:
+
+- which methods a bridge accepts;
+- which application service is being called;
+- which Tauri command invokes it;
+- any filesystem path or SQL/database capability; or
+- how domain errors are classified for the caller.
+
+Each bridge therefore keeps its closed Pydantic request schema, domain dispatcher, service,
+and public error policy. This is intentionally not a universal desktop bridge.
+
+### Application composition ownership
+
+`PlaybackAuthorizationService`, `SpeakerPresentationService`, and `TranscriptToolsService`
+are now composed by `AppContainer` instead of being manually assembled inside desktop bridge
+modules. The bridge is an adapter; the application container is the composition root.
+
+This matters because otherwise a future dependency change could be applied to the application
+container while the native desktop silently continued constructing an older graph.
+
+### Processing preflight DTOs
+
+First-run preflight and retry preflight genuinely share profile, strategy, audio-stream, and
+enhancement options. Those fields now live in one strict `_PlanningOptionsParams` base while
+the two request types keep their distinct identity field (`input_path` versus
+`source_job_id`). The refactor removes duplicated validation without pretending the two
+operations are the same command.
+
+### Frontend native protocol transport
+
+Lifecycle, transcript tools, and research-anchor maintenance repeated the same versioned
+request envelope, response validation, Tauri invocation, and public-error unwrapping. They
+now use `frontend/src/api/nativeProtocol.ts`.
+
+The helper accepts only the fixed native protocol commands currently intended for this
+contract:
+
+- `desktop_request`;
+- `transcript_tools_request`; and
+- `lifecycle_request`.
+
+It does not accept an arbitrary command string. Playback remains separate because its Rust
+API returns opaque media-session state rather than the Python desktop protocol envelope.
+
+## Patterns intentionally retained
+
+### Fixed Rust module wrappers
+
+`frontend/src-tauri/src/backend.rs` already has the right shape. One private Rust function
+owns process spawning, request-size enforcement, and Python stdout parsing, while tiny wrapper
+functions bind each capability to a hard-coded Python module. Do not replace those wrappers
+with a webview-supplied module name.
+
+### Separate bridge authorities
+
+`desktop_request`, `transcript_tools_request`, `lifecycle_request`, and the private playback
+path are separate because their authority differs. A generic dispatcher would save lines and
+weaken the threat model.
+
+### Explicit Pydantic request models
+
+`ConfigDict(extra="forbid")` appears often because rejecting unexpected fields is part of the
+boundary contract. A global inheritance hierarchy merely to remove those lines would hide a
+security property rather than simplify it.
+
+### Domain-visible E2E fixtures
+
+Mocks repeat some DTO shape intentionally. They are executable product examples and make it
+obvious what the browser can see. Centralizing every fixture into a factory would reduce
+literal duplication while making path-disclosure and human-copy tests harder to inspect.
+
+## Remaining high-value cleanup
+
+### 1. Consolidate saved-search management
+
+This is the largest real product redundancy found by the audit.
+
+`ResearchWorkspace` and `ResearchSearchControlsPanel` currently render two saved-search
+management surfaces on the same Research screen. Both operate on the same authoritative
+SQLite `SavedSearch` / `SavedSearchIntent` objects, but one surface uses the older simple
+`workspace.research.saved_search.*` bridge family while the typed search panel uses
+`workspace.research.search.saved.*`.
+
+The older create operation is not a different research primitive. It simply compiles a
+query-only request into default lexical typed intent. The typed panel can express the full
+saved question and should become the single creation/edit/run/delete surface.
+
+The cleanup should:
+
+1. add typed saved-search run and delete operations under the Research search control
+   service/bridge;
+2. keep optimistic concurrency on destructive/update operations;
+3. move run/delete presentation into the typed saved-search panel;
+4. remove the duplicate saved-search editor/results block from `ResearchWorkspace`;
+5. remove the older simple desktop methods and client calls once no UI uses them; and
+6. migrate the existing backend/browser lifecycle tests instead of deleting coverage.
+
+No SQLite data migration is required because both endpoint families already use the same
+saved-search authority.
+
+### 2. Share Research evidence serialization
+
+`echoflow.desktop.bridge` and `research_search_bridge` independently serialize the same
+`EvidenceWord`, `EvidenceContextSegment`, speaker labels, exact canonical generation, timing,
+research labels, and `WorkspaceSearchPassage` fields. That can eventually make ordinary
+Library discovery and typed Research search disagree about what an evidence DTO means.
+
+Extract one presentation serializer module and have both adapters depend on it. This is a
+contract-drift fix, not an attempt to move search semantics into serialization.
+
+### 3. Finish frontend protocol migration
+
+The new fixed-command helper should also replace the equivalent transport boilerplate inside
+`api/desktop.ts` and `api/processing.ts`. Those files are broader clients, so migrate them in
+a focused change with their existing interaction tests rather than coupling the change to the
+smaller adapter cleanup above.
+
+### 4. Move Processing Center composition into `AppContainer`
+
+The ordinary desktop bridge still manually assembles `ProcessingCenterService`. Its
+dependencies are already container-owned. Move that composition after the general bridge is
+made smaller so the edit does not combine a composition change with unrelated dispatch
+rewrites.
+
+### 5. Share Research label normalization
+
+The generic research bridge and typed search bridge enforce the same trim/length/control-
+character/case-fold de-duplication rules. Move that exact rule to one small Research desktop
+validation helper when the saved-search/Research adapter cleanup touches both files.
+
+## Lower-value repetition not worth a framework
+
+- repeated `new URLSearchParams(...).get("e2e")` checks can become one helper if test-mode
+  wiring changes, but they do not currently threaten authority or correctness;
+- small one-field Pydantic validators are clearer beside their request than behind a generic
+  validation DSL;
+- React loading/error state often looks similar but belongs to different interaction
+  lifecycles; and
+- separate semantic CSS classes are not redundant merely because they share token values.
+
+## Test policy
+
+The shared Python host transport has direct unit tests for bounded JSON input, response
+versioning, dispatch suppression on malformed input, and stdout isolation. The frontend
+response parser has a pure contract test in the Playwright test runner in addition to the
+existing feature-flow tests.
+
+Because this tranche changes `playback_bridge.py`, the targeted Playback Mutation workflow is
+expected to run. That is appropriate: mutation testing remains path-targeted to a changed
+security-sensitive seam rather than becoming a universal CI tax.
+
+## Exit criterion for the audit
+
+Before the product-identity checkpoint, finish the saved-search consolidation and shared
+Research evidence serialization, then re-run the ordinary quality matrix plus only the
+mutation workflows selected by touched decision-heavy files. At that point the remaining
+similarity should be intentional authority separation, not evolutionary residue.

--- a/frontend/src/api/lifecycle.ts
+++ b/frontend/src/api/lifecycle.ts
@@ -1,3 +1,5 @@
+import { invokeNativeProtocol } from "./nativeProtocol";
+
 export type DeletionScope =
   | "library-view"
   | "derived-artifacts"
@@ -79,51 +81,20 @@ export interface LifecycleClient {
   executeRetention(plan: RetentionPlan): Promise<RetentionReceipt>;
 }
 
-interface DesktopError {
-  code: string;
-  message: string;
-}
-
-interface DesktopResponse<T> {
-  protocol_version: 1;
-  request_id: string;
-  ok: boolean;
-  result: T | null;
-  error: DesktopError | null;
-}
-
-function assertResponse<T>(value: unknown): DesktopResponse<T> {
-  if (!value || typeof value !== "object") {
-    throw new Error("EchoFlow lifecycle service returned an invalid response");
-  }
-  const candidate = value as Partial<DesktopResponse<T>>;
-  if (
-    candidate.protocol_version !== 1 ||
-    typeof candidate.request_id !== "string" ||
-    typeof candidate.ok !== "boolean"
-  ) {
-    throw new Error("EchoFlow lifecycle service returned an incompatible response");
-  }
-  return candidate as DesktopResponse<T>;
-}
+const LIFECYCLE_PROTOCOL_MESSAGES = {
+  invalid: "EchoFlow lifecycle service returned an invalid response",
+  incompatible: "EchoFlow lifecycle service returned an incompatible response",
+  failure: "EchoFlow could not complete that lifecycle request",
+} as const;
 
 class TauriLifecycleClient implements LifecycleClient {
-  private async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
-    const { invoke } = await import("@tauri-apps/api/core");
-    const response = assertResponse<T>(
-      await invoke<unknown>("lifecycle_request", {
-        request: {
-          protocol_version: 1,
-          request_id: crypto.randomUUID(),
-          method,
-          params,
-        },
-      }),
+  private request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    return invokeNativeProtocol<T>(
+      "lifecycle_request",
+      method,
+      params,
+      LIFECYCLE_PROTOCOL_MESSAGES,
     );
-    if (!response.ok || response.result === null) {
-      throw new Error(response.error?.message ?? "EchoFlow could not complete that lifecycle request");
-    }
-    return response.result;
   }
 
   documents(): Promise<LifecycleDocument[]> {

--- a/frontend/src/api/nativeProtocol.ts
+++ b/frontend/src/api/nativeProtocol.ts
@@ -8,7 +8,7 @@ interface NativeProtocolError {
   message: string;
 }
 
-interface NativeProtocolResponse<T> {
+export interface NativeProtocolResponse<T> {
   protocol_version: 1;
   request_id: string;
   ok: boolean;
@@ -16,13 +16,13 @@ interface NativeProtocolResponse<T> {
   error: NativeProtocolError | null;
 }
 
-interface NativeProtocolMessages {
+export interface NativeProtocolMessages {
   invalid: string;
   incompatible: string;
   failure: string;
 }
 
-function assertResponse<T>(
+export function parseNativeProtocolResponse<T>(
   value: unknown,
   messages: NativeProtocolMessages,
 ): NativeProtocolResponse<T> {
@@ -47,7 +47,7 @@ export async function invokeNativeProtocol<T>(
   messages: NativeProtocolMessages,
 ): Promise<T> {
   const { invoke } = await import("@tauri-apps/api/core");
-  const response = assertResponse<T>(
+  const response = parseNativeProtocolResponse<T>(
     await invoke<unknown>(command, {
       request: {
         protocol_version: 1,

--- a/frontend/src/api/nativeProtocol.ts
+++ b/frontend/src/api/nativeProtocol.ts
@@ -1,0 +1,65 @@
+export type NativeProtocolCommand =
+  | "desktop_request"
+  | "transcript_tools_request"
+  | "lifecycle_request";
+
+interface NativeProtocolError {
+  code: string;
+  message: string;
+}
+
+interface NativeProtocolResponse<T> {
+  protocol_version: 1;
+  request_id: string;
+  ok: boolean;
+  result: T | null;
+  error: NativeProtocolError | null;
+}
+
+interface NativeProtocolMessages {
+  invalid: string;
+  incompatible: string;
+  failure: string;
+}
+
+function assertResponse<T>(
+  value: unknown,
+  messages: NativeProtocolMessages,
+): NativeProtocolResponse<T> {
+  if (!value || typeof value !== "object") {
+    throw new Error(messages.invalid);
+  }
+  const candidate = value as Partial<NativeProtocolResponse<T>>;
+  if (
+    candidate.protocol_version !== 1 ||
+    typeof candidate.request_id !== "string" ||
+    typeof candidate.ok !== "boolean"
+  ) {
+    throw new Error(messages.incompatible);
+  }
+  return candidate as NativeProtocolResponse<T>;
+}
+
+export async function invokeNativeProtocol<T>(
+  command: NativeProtocolCommand,
+  method: string,
+  params: Record<string, unknown>,
+  messages: NativeProtocolMessages,
+): Promise<T> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  const response = assertResponse<T>(
+    await invoke<unknown>(command, {
+      request: {
+        protocol_version: 1,
+        request_id: crypto.randomUUID(),
+        method,
+        params,
+      },
+    }),
+    messages,
+  );
+  if (!response.ok || response.result === null) {
+    throw new Error(response.error?.message ?? messages.failure);
+  }
+  return response.result;
+}

--- a/frontend/src/api/transcriptTools.ts
+++ b/frontend/src/api/transcriptTools.ts
@@ -1,3 +1,5 @@
+import { invokeNativeProtocol } from "./nativeProtocol";
+
 export type TranscriptExportFormat = "txt" | "srt" | "vtt";
 export type SpeakerPresentationKind =
   | "single-speaker"
@@ -94,19 +96,6 @@ export interface TranscriptPublishResult {
   publications: TranscriptPublication[];
 }
 
-interface TranscriptToolsError {
-  code: string;
-  message: string;
-}
-
-interface TranscriptToolsResponse<T> {
-  protocol_version: 1;
-  request_id: string;
-  ok: boolean;
-  result: T | null;
-  error: TranscriptToolsError | null;
-}
-
 export interface TranscriptToolsClient {
   inspect(ref: TranscriptGenerationRef): Promise<TranscriptToolsSnapshot>;
   speakerSpans(ref: TranscriptGenerationRef): Promise<TranscriptSpeakerSpan[]>;
@@ -124,39 +113,20 @@ export interface TranscriptToolsClient {
   ): Promise<TranscriptPublishResult>;
 }
 
-function assertResponse<T>(value: unknown): TranscriptToolsResponse<T> {
-  if (!value || typeof value !== "object") {
-    throw new Error("EchoFlow transcript tools returned an invalid response");
-  }
-  const candidate = value as Partial<TranscriptToolsResponse<T>>;
-  if (
-    candidate.protocol_version !== 1 ||
-    typeof candidate.request_id !== "string" ||
-    typeof candidate.ok !== "boolean"
-  ) {
-    throw new Error("EchoFlow transcript tools returned an incompatible response");
-  }
-  return candidate as TranscriptToolsResponse<T>;
-}
+const TRANSCRIPT_TOOLS_PROTOCOL_MESSAGES = {
+  invalid: "EchoFlow transcript tools returned an invalid response",
+  incompatible: "EchoFlow transcript tools returned an incompatible response",
+  failure: "EchoFlow could not complete that transcript-tools request",
+} as const;
 
 class TauriTranscriptToolsClient implements TranscriptToolsClient {
-  private async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
-    const { invoke } = await import("@tauri-apps/api/core");
-    const request = {
-      protocol_version: 1,
-      request_id: crypto.randomUUID(),
+  private request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    return invokeNativeProtocol<T>(
+      "transcript_tools_request",
       method,
       params,
-    };
-    const response = assertResponse<T>(
-      await invoke<unknown>("transcript_tools_request", { request }),
+      TRANSCRIPT_TOOLS_PROTOCOL_MESSAGES,
     );
-    if (!response.ok || response.result === null) {
-      throw new Error(
-        response.error?.message ?? "EchoFlow could not complete that transcript-tools request",
-      );
-    }
-    return response.result;
   }
 
   inspect(ref: TranscriptGenerationRef): Promise<TranscriptToolsSnapshot> {

--- a/frontend/src/researchAnchorApi.ts
+++ b/frontend/src/researchAnchorApi.ts
@@ -1,4 +1,5 @@
 import type { ResearchNoteResult } from "./api/desktop";
+import { invokeNativeProtocol } from "./api/nativeProtocol";
 
 export type ResearchAnchorStatus = "current_verified" | "older_verified" | "unavailable";
 
@@ -37,18 +38,11 @@ interface ReanchorResult {
   current: boolean;
 }
 
-interface DesktopError {
-  code: string;
-  message: string;
-}
-
-interface DesktopResponse<T> {
-  protocol_version: 1;
-  request_id: string;
-  ok: boolean;
-  result: T | null;
-  error: DesktopError | null;
-}
+const ANCHOR_PROTOCOL_MESSAGES = {
+  invalid: "EchoFlow desktop bridge returned an incompatible response",
+  incompatible: "EchoFlow desktop bridge returned an incompatible response",
+  failure: "EchoFlow could not complete that request",
+} as const;
 
 let mockReanchored = false;
 
@@ -56,28 +50,13 @@ function isMockMode(): boolean {
   return new URLSearchParams(window.location.search).get("e2e") === "1";
 }
 
-async function request<T>(method: string, params: Record<string, unknown>): Promise<T> {
-  const { invoke } = await import("@tauri-apps/api/core");
-  const response = (await invoke<unknown>("desktop_request", {
-    request: {
-      protocol_version: 1,
-      request_id: crypto.randomUUID(),
-      method,
-      params,
-    },
-  })) as DesktopResponse<T>;
-  if (
-    !response ||
-    response.protocol_version !== 1 ||
-    typeof response.request_id !== "string" ||
-    typeof response.ok !== "boolean"
-  ) {
-    throw new Error("EchoFlow desktop bridge returned an incompatible response");
-  }
-  if (!response.ok || response.result === null) {
-    throw new Error(response.error?.message ?? "EchoFlow could not complete that request");
-  }
-  return response.result;
+function request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+  return invokeNativeProtocol<T>(
+    "desktop_request",
+    method,
+    params,
+    ANCHOR_PROTOCOL_MESSAGES,
+  );
 }
 
 function mockPreview(

--- a/frontend/tests/frontend-contracts.spec.ts
+++ b/frontend/tests/frontend-contracts.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { parseNativeProtocolResponse } from "../src/api/nativeProtocol";
 import { formatEvidenceTime } from "../src/format";
 import { DEFAULT_THEME, isTheme, THEMES } from "../src/themes";
 
@@ -45,4 +46,41 @@ test("evidence time formatting is deterministic at minute and hour boundaries", 
 test("Pride and Monochrome advertise the correct native scheme", () => {
   expect(THEMES.find((theme) => theme.id === "pride")?.scheme).toBe("light");
   expect(THEMES.find((theme) => theme.id === "monochrome")?.scheme).toBe("dark");
+});
+
+test("native protocol parser accepts version one and rejects malformed envelopes", () => {
+  const messages = {
+    invalid: "invalid native response",
+    incompatible: "incompatible native response",
+    failure: "native request failed",
+  } as const;
+
+  expect(
+    parseNativeProtocolResponse<{ value: number }>(
+      {
+        protocol_version: 1,
+        request_id: "request-1",
+        ok: true,
+        result: { value: 7 },
+        error: null,
+      },
+      messages,
+    ),
+  ).toEqual({
+    protocol_version: 1,
+    request_id: "request-1",
+    ok: true,
+    result: { value: 7 },
+    error: null,
+  });
+
+  expect(() => parseNativeProtocolResponse(null, messages)).toThrow(
+    "invalid native response",
+  );
+  expect(() =>
+    parseNativeProtocolResponse(
+      { protocol_version: 2, request_id: "request-1", ok: true },
+      messages,
+    ),
+  ).toThrow("incompatible native response");
 });

--- a/src/echoflow/app/app_container.py
+++ b/src/echoflow/app/app_container.py
@@ -22,6 +22,7 @@ from echoflow.library.duckdb_research_projection import DuckDbResearchProjection
 from echoflow.library.duckdb_semantic import DuckDbSemanticIndex
 from echoflow.library.evidence import EvidenceLocator
 from echoflow.library.locations import JsonLibraryLocationStore, LibraryLocationService
+from echoflow.library.playback import PlaybackAuthorizationService
 from echoflow.library.research import ResearchNavigationService
 from echoflow.library.research_projector import ResearchStateProjector
 from echoflow.library.research_workspace import ResearchWorkspaceService
@@ -29,7 +30,9 @@ from echoflow.library.semantic import EmbeddingProfile, SentenceTransformersE5Pr
 from echoflow.library.service import TranscriptLibraryService
 from echoflow.library.speaker_label_service import SpeakerLabelService
 from echoflow.library.speaker_labels import SpeakerLabelStore
+from echoflow.library.speaker_presentation import SpeakerPresentationService
 from echoflow.library.sqlite_research_state import SqliteResearchStateStore
+from echoflow.library.transcript_tools import TranscriptToolsService
 from echoflow.library.workspace_metadata import SqliteWorkspaceMetadataStore
 from echoflow.media.probe import FfprobeMediaProbe
 from echoflow.media.selection import AudioStreamSelector
@@ -281,6 +284,12 @@ class AppContainer(containers.DeclarativeContainer):
         config=config,
         file_manager=file_manager,
     )
+    playback_authorization = providers.Singleton(
+        PlaybackAuthorizationService,
+        index=transcript_index,
+        file_manager=file_manager,
+        media_probe=media_probe,
+    )
     speaker_label_store = providers.Singleton(
         _create_speaker_label_store,
         config=config,
@@ -295,6 +304,19 @@ class AppContainer(containers.DeclarativeContainer):
         SpeakerLabelService,
         index=transcript_index,
         store=speaker_label_store,
+        file_manager=file_manager,
+    )
+    speaker_presentation = providers.Singleton(
+        SpeakerPresentationService,
+        index=transcript_index,
+        label_store=speaker_label_store,
+        file_manager=file_manager,
+    )
+    transcript_tools = providers.Singleton(
+        TranscriptToolsService,
+        index=transcript_index,
+        speaker_labels=speaker_labels,
+        speaker_presentation=speaker_presentation,
         file_manager=file_manager,
     )
     research_state_store = providers.Singleton(

--- a/src/echoflow/app/tests/test_app_container_desktop_services.py
+++ b/src/echoflow/app/tests/test_app_container_desktop_services.py
@@ -1,0 +1,29 @@
+from echoflow.app.app_container import AppContainer
+from echoflow.library.playback import PlaybackAuthorizationService
+from echoflow.library.speaker_presentation import SpeakerPresentationService
+from echoflow.library.transcript_tools import TranscriptToolsService
+
+
+def test_desktop_services_are_composed_by_application_container() -> None:
+    container = AppContainer()
+
+    playback = container.playback_authorization()
+    presentation = container.speaker_presentation()
+    transcript_tools = container.transcript_tools()
+
+    assert isinstance(playback, PlaybackAuthorizationService)
+    assert isinstance(presentation, SpeakerPresentationService)
+    assert isinstance(transcript_tools, TranscriptToolsService)
+
+    assert playback.index is container.transcript_index()
+    assert playback.file_manager is container.file_manager()
+    assert playback.media_probe is container.media_probe()
+
+    assert presentation.index is container.transcript_index()
+    assert presentation.label_store is container.speaker_label_store()
+    assert presentation.file_manager is container.file_manager()
+
+    assert transcript_tools.index is container.transcript_index()
+    assert transcript_tools.speaker_labels is container.speaker_labels()
+    assert transcript_tools.speaker_presentation is presentation
+    assert transcript_tools.file_manager is container.file_manager()

--- a/src/echoflow/desktop/custody_bridge.py
+++ b/src/echoflow/desktop/custody_bridge.py
@@ -7,9 +7,6 @@ or arbitrary local file operation.
 
 from __future__ import annotations
 
-import json
-import sys
-from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Literal
 
@@ -17,6 +14,11 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 
 from echoflow.app.app_container import AppContainer
 from echoflow.core.errors import EchoFlowError
+from echoflow.desktop.host_protocol import (
+    failure_response,
+    run_stdio_bridge,
+    success_response,
+)
 from echoflow.library.custody import (
     DeletionPlan,
     DeletionReceipt,
@@ -27,8 +29,6 @@ from echoflow.library.custody import (
     RetentionReceipt,
 )
 
-_PROTOCOL_VERSION = 1
-_MAX_REQUEST_BYTES = 128 * 1024
 LifecycleMethod = Literal[
     "lifecycle.documents.list",
     "lifecycle.deletion.plan",
@@ -227,26 +227,6 @@ def dispatch_custody(
     raise ValueError("Unsupported lifecycle desktop method")
 
 
-def _success(request_id: str, result: object) -> dict[str, object]:
-    return {
-        "protocol_version": _PROTOCOL_VERSION,
-        "request_id": request_id,
-        "ok": True,
-        "result": result,
-        "error": None,
-    }
-
-
-def _failure(request_id: str, *, code: str, message: str) -> dict[str, object]:
-    return {
-        "protocol_version": _PROTOCOL_VERSION,
-        "request_id": request_id,
-        "ok": False,
-        "result": None,
-        "error": {"code": code, "message": message},
-    }
-
-
 def handle_request(
     payload: object, service: LibraryCustodyService
 ) -> dict[str, object]:
@@ -255,30 +235,30 @@ def handle_request(
         request_id = payload["request_id"][:128]
     try:
         request = _Request.model_validate(payload)
-        return _success(
+        return success_response(
             request.request_id,
             dispatch_custody(request.method, request.params, service),
         )
     except ValidationError:
-        return _failure(
+        return failure_response(
             request_id,
             code="invalid_request",
             message="Lifecycle request is invalid or incompatible",
         )
     except EchoFlowError as exc:
-        return _failure(
+        return failure_response(
             request_id,
             code=exc.code.value,
             message=exc.public_message,
         )
     except ValueError:
-        return _failure(
+        return failure_response(
             request_id,
             code="invalid_request",
             message="Lifecycle request is invalid",
         )
     except Exception:
-        return _failure(
+        return failure_response(
             request_id,
             code="internal_error",
             message="EchoFlow could not complete the local lifecycle request",
@@ -286,29 +266,11 @@ def handle_request(
 
 
 def main() -> int:
-    raw = sys.stdin.buffer.read(_MAX_REQUEST_BYTES + 1)
-    if len(raw) > _MAX_REQUEST_BYTES:
-        response = _failure(
-            "unknown",
-            code="invalid_request",
-            message="Lifecycle request exceeded the safe size limit",
-        )
-    else:
-        try:
-            payload = json.loads(raw)
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            response = _failure(
-                "unknown",
-                code="invalid_request",
-                message="Lifecycle request was not valid JSON",
-            )
-        else:
-            with redirect_stdout(sys.stderr):
-                container = AppContainer()
-                response = handle_request(payload, container.library_custody())
-    sys.stdout.write(json.dumps(response, sort_keys=True))
-    sys.stdout.write("\n")
-    return 0
+    return run_stdio_bridge(
+        lambda payload: handle_request(payload, AppContainer().library_custody()),
+        oversized_message="Lifecycle request exceeded the safe size limit",
+        invalid_json_message="Lifecycle request was not valid JSON",
+    )
 
 
 if __name__ == "__main__":

--- a/src/echoflow/desktop/host_protocol.py
+++ b/src/echoflow/desktop/host_protocol.py
@@ -1,0 +1,79 @@
+"""Shared mechanics for fixed trusted-host Python bridges.
+
+This module owns only the versioned stdin/stdout transport envelope. It deliberately knows
+nothing about desktop methods, application services, filesystem paths, or Tauri commands.
+Each bridge keeps its own closed request schema, dispatcher, service composition, and public
+error policy.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from contextlib import redirect_stdout
+
+PROTOCOL_VERSION = 1
+MAX_REQUEST_BYTES = 128 * 1024
+
+BridgeResponse = dict[str, object]
+BridgeHandler = Callable[[object], BridgeResponse]
+
+
+def success_response(request_id: str, result: object) -> BridgeResponse:
+    """Build the common successful trusted-host response envelope."""
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": True,
+        "result": result,
+        "error": None,
+    }
+
+
+def failure_response(request_id: str, *, code: str, message: str) -> BridgeResponse:
+    """Build the common failed trusted-host response envelope."""
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "request_id": request_id,
+        "ok": False,
+        "result": None,
+        "error": {"code": code, "message": message},
+    }
+
+
+def run_stdio_bridge(
+    handler: BridgeHandler,
+    *,
+    oversized_message: str,
+    invalid_json_message: str,
+) -> int:
+    """Run one bounded JSON request without broadening a bridge's authority.
+
+    ``handler`` remains bridge-specific. Constructing services inside it happens while
+    stdout is redirected to stderr so application diagnostics cannot corrupt the single
+    JSON response expected by the Rust host.
+    """
+    raw = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
+    if len(raw) > MAX_REQUEST_BYTES:
+        response = failure_response(
+            "unknown",
+            code="invalid_request",
+            message=oversized_message,
+        )
+    else:
+        try:
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            response = failure_response(
+                "unknown",
+                code="invalid_request",
+                message=invalid_json_message,
+            )
+        else:
+            with redirect_stdout(sys.stderr):
+                response = handler(payload)
+
+    sys.stdout.write(json.dumps(response, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0

--- a/src/echoflow/desktop/playback_bridge.py
+++ b/src/echoflow/desktop/playback_bridge.py
@@ -117,7 +117,9 @@ def handle_request(
 
 def main() -> int:
     return run_stdio_bridge(
-        lambda payload: handle_request(payload, AppContainer().playback_authorization()),
+        lambda payload: handle_request(
+            payload, AppContainer().playback_authorization()
+        ),
         oversized_message="Playback authorization request exceeded the safe size limit",
         invalid_json_message="Playback authorization request was not valid JSON",
     )

--- a/src/echoflow/desktop/playback_bridge.py
+++ b/src/echoflow/desktop/playback_bridge.py
@@ -81,14 +81,6 @@ def dispatch_playback(
     )
 
 
-def _service(container: AppContainer) -> PlaybackAuthorizationService:
-    return PlaybackAuthorizationService(
-        index=container.transcript_index(),
-        file_manager=container.file_manager(),
-        media_probe=container.media_probe(),
-    )
-
-
 def handle_request(
     payload: object,
     service: PlaybackAuthorizationService,
@@ -125,7 +117,7 @@ def handle_request(
 
 def main() -> int:
     return run_stdio_bridge(
-        lambda payload: handle_request(payload, _service(AppContainer())),
+        lambda payload: handle_request(payload, AppContainer().playback_authorization()),
         oversized_message="Playback authorization request exceeded the safe size limit",
         invalid_json_message="Playback authorization request was not valid JSON",
     )

--- a/src/echoflow/desktop/playback_bridge.py
+++ b/src/echoflow/desktop/playback_bridge.py
@@ -6,19 +6,19 @@ host must convert it to an opaque media session before returning anything to the
 
 from __future__ import annotations
 
-import json
-import sys
-from contextlib import redirect_stdout
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from echoflow.app.app_container import AppContainer
 from echoflow.core.errors import EchoFlowError
+from echoflow.desktop.host_protocol import (
+    failure_response,
+    run_stdio_bridge,
+    success_response,
+)
 from echoflow.library.playback import PlaybackAuthorizationService, PlaybackGrant
 
-_PROTOCOL_VERSION = 1
-_MAX_REQUEST_BYTES = 128 * 1024
 PlaybackMethod = Literal["playback.authorize"]
 
 
@@ -81,26 +81,6 @@ def dispatch_playback(
     )
 
 
-def _success(request_id: str, result: object) -> dict[str, object]:
-    return {
-        "protocol_version": _PROTOCOL_VERSION,
-        "request_id": request_id,
-        "ok": True,
-        "result": result,
-        "error": None,
-    }
-
-
-def _failure(request_id: str, *, code: str, message: str) -> dict[str, object]:
-    return {
-        "protocol_version": _PROTOCOL_VERSION,
-        "request_id": request_id,
-        "ok": False,
-        "result": None,
-        "error": {"code": code, "message": message},
-    }
-
-
 def _service(container: AppContainer) -> PlaybackAuthorizationService:
     return PlaybackAuthorizationService(
         index=container.transcript_index(),
@@ -117,26 +97,26 @@ def handle_request(
     try:
         request = _Request.model_validate(payload)
         request_id = request.request_id
-        return _success(
+        return success_response(
             request_id,
             dispatch_playback(request.method, request.params, service),
         )
     except ValidationError:
-        return _failure(
+        return failure_response(
             request_id,
             code="invalid_request",
             message="Playback authorization request is invalid",
         )
     except EchoFlowError as exc:
-        return _failure(
+        return failure_response(
             request_id,
             code=exc.code.value,
             message=exc.public_message,
         )
     except ValueError as exc:
-        return _failure(request_id, code="invalid_request", message=str(exc))
+        return failure_response(request_id, code="invalid_request", message=str(exc))
     except Exception:
-        return _failure(
+        return failure_response(
             request_id,
             code="internal_error",
             message="EchoFlow could not authorize local playback",
@@ -144,29 +124,11 @@ def handle_request(
 
 
 def main() -> int:
-    raw = sys.stdin.buffer.read(_MAX_REQUEST_BYTES + 1)
-    if len(raw) > _MAX_REQUEST_BYTES:
-        response = _failure(
-            "unknown",
-            code="invalid_request",
-            message="Playback authorization request exceeded the safe size limit",
-        )
-    else:
-        try:
-            payload = json.loads(raw)
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            response = _failure(
-                "unknown",
-                code="invalid_request",
-                message="Playback authorization request was not valid JSON",
-            )
-        else:
-            with redirect_stdout(sys.stderr):
-                container = AppContainer()
-                response = handle_request(payload, _service(container))
-    sys.stdout.write(json.dumps(response, sort_keys=True))
-    sys.stdout.write("\n")
-    return 0
+    return run_stdio_bridge(
+        lambda payload: handle_request(payload, _service(AppContainer())),
+        oversized_message="Playback authorization request exceeded the safe size limit",
+        invalid_json_message="Playback authorization request was not valid JSON",
+    )
 
 
 if __name__ == "__main__":

--- a/src/echoflow/desktop/processing_bridge.py
+++ b/src/echoflow/desktop/processing_bridge.py
@@ -25,18 +25,19 @@ class _ReadinessParams(BaseModel):
     profile: ProcessingProfile = ProcessingProfile.BALANCED
 
 
-class _PreflightParams(BaseModel):
+class _PlanningOptionsParams(BaseModel):
+    """Options shared by first-run and retry preflight requests."""
+
     model_config = ConfigDict(extra="forbid")
 
-    input_path: str = Field(min_length=1, max_length=32_768)
     profile: ProcessingProfile = ProcessingProfile.BALANCED
     strategy_id: str | None = Field(default=None, min_length=1, max_length=200)
     audio_stream_index: int | None = Field(default=None, ge=0, le=10_000)
     enhance: bool = False
 
-    @field_validator("input_path", "strategy_id")
+    @field_validator("strategy_id")
     @classmethod
-    def strip_optional_text(cls, value: str | None) -> str | None:
+    def strip_strategy_id(cls, value: str | None) -> str | None:
         if value is None:
             return None
         stripped = value.strip()
@@ -45,20 +46,24 @@ class _PreflightParams(BaseModel):
         return stripped
 
 
-class _RetryPreflightParams(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class _PreflightParams(_PlanningOptionsParams):
+    input_path: str = Field(min_length=1, max_length=32_768)
 
-    source_job_id: str = Field(min_length=1, max_length=200)
-    profile: ProcessingProfile = ProcessingProfile.BALANCED
-    strategy_id: str | None = Field(default=None, min_length=1, max_length=200)
-    audio_stream_index: int | None = Field(default=None, ge=0, le=10_000)
-    enhance: bool = False
-
-    @field_validator("source_job_id", "strategy_id")
+    @field_validator("input_path")
     @classmethod
-    def strip_optional_text(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
+    def strip_input_path(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("processing text values cannot be blank")
+        return stripped
+
+
+class _RetryPreflightParams(_PlanningOptionsParams):
+    source_job_id: str = Field(min_length=1, max_length=200)
+
+    @field_validator("source_job_id")
+    @classmethod
+    def strip_source_job_id(cls, value: str) -> str:
         stripped = value.strip()
         if not stripped:
             raise ValueError("processing text values cannot be blank")

--- a/src/echoflow/desktop/tests/test_host_protocol.py
+++ b/src/echoflow/desktop/tests/test_host_protocol.py
@@ -8,6 +8,7 @@ import pytest
 
 from echoflow.desktop.host_protocol import (
     MAX_REQUEST_BYTES,
+    BridgeHandler,
     failure_response,
     run_stdio_bridge,
     success_response,
@@ -22,7 +23,7 @@ class _BinaryInput:
 def _run(
     monkeypatch: pytest.MonkeyPatch,
     payload: bytes,
-    handler,
+    handler: BridgeHandler,
 ) -> tuple[dict[str, object], str]:
     stdout = io.StringIO()
     stderr = io.StringIO()

--- a/src/echoflow/desktop/tests/test_host_protocol.py
+++ b/src/echoflow/desktop/tests/test_host_protocol.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from echoflow.desktop.host_protocol import (
+    MAX_REQUEST_BYTES,
+    failure_response,
+    run_stdio_bridge,
+    success_response,
+)
+
+
+class _BinaryInput:
+    def __init__(self, payload: bytes) -> None:
+        self.buffer = io.BytesIO(payload)
+
+
+def _run(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: bytes,
+    handler,
+) -> tuple[dict[str, object], str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdin", _BinaryInput(payload))
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    result = run_stdio_bridge(
+        handler,
+        oversized_message="too large",
+        invalid_json_message="bad json",
+    )
+    assert result == 0
+    return json.loads(stdout.getvalue()), stderr.getvalue()
+
+
+def test_response_builders_share_one_versioned_envelope() -> None:
+    assert success_response("r-1", {"value": 7}) == {
+        "protocol_version": 1,
+        "request_id": "r-1",
+        "ok": True,
+        "result": {"value": 7},
+        "error": None,
+    }
+    assert failure_response("r-2", code="invalid_request", message="nope") == {
+        "protocol_version": 1,
+        "request_id": "r-2",
+        "ok": False,
+        "result": None,
+        "error": {"code": "invalid_request", "message": "nope"},
+    }
+
+
+def test_stdio_bridge_runs_only_valid_bounded_json_and_keeps_diagnostics_off_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+
+    def handler(payload: object) -> dict[str, object]:
+        calls.append(payload)
+        print("diagnostic from application service")
+        return success_response("r-3", {"accepted": True})
+
+    response, stderr = _run(monkeypatch, b'{"request_id":"r-3"}', handler)
+
+    assert response["ok"] is True
+    assert response["result"] == {"accepted": True}
+    assert calls == [{"request_id": "r-3"}]
+    assert "diagnostic from application service" in stderr
+
+
+def test_stdio_bridge_rejects_invalid_json_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    def handler(_payload: object) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return success_response("never", None)
+
+    response, _ = _run(monkeypatch, b"not-json", handler)
+
+    assert called is False
+    assert response["error"] == {"code": "invalid_request", "message": "bad json"}
+
+
+def test_stdio_bridge_rejects_oversized_input_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    def handler(_payload: object) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return success_response("never", None)
+
+    response, _ = _run(monkeypatch, b"x" * (MAX_REQUEST_BYTES + 1), handler)
+
+    assert called is False
+    assert response["error"] == {"code": "invalid_request", "message": "too large"}

--- a/src/echoflow/desktop/transcript_tools_bridge.py
+++ b/src/echoflow/desktop/transcript_tools_bridge.py
@@ -14,10 +14,7 @@ from echoflow.desktop.host_protocol import (
     success_response,
 )
 from echoflow.library.speaker_label_service import SpeakerRosterEntry
-from echoflow.library.speaker_presentation import (
-    SpeakerPresentationService,
-    SpeakerPresentationSpan,
-)
+from echoflow.library.speaker_presentation import SpeakerPresentationSpan
 from echoflow.library.transcript_tools import TranscriptDetails, TranscriptToolsService
 from echoflow.transcription.export import TranscriptExportFormat
 
@@ -217,20 +214,6 @@ def dispatch_transcript_tools(
     raise ValueError("Unsupported transcript-tools method")
 
 
-def _service(container: AppContainer) -> TranscriptToolsService:
-    labels = container.speaker_label_store()
-    return TranscriptToolsService(
-        index=container.transcript_index(),
-        speaker_labels=container.speaker_labels(),
-        speaker_presentation=SpeakerPresentationService(
-            index=container.transcript_index(),
-            label_store=labels,
-            file_manager=container.file_manager(),
-        ),
-        file_manager=container.file_manager(),
-    )
-
-
 def handle_request(
     payload: object, service: TranscriptToolsService
 ) -> dict[str, object]:
@@ -266,7 +249,7 @@ def handle_request(
 
 def main() -> int:
     return run_stdio_bridge(
-        lambda payload: handle_request(payload, _service(AppContainer())),
+        lambda payload: handle_request(payload, AppContainer().transcript_tools()),
         oversized_message="Transcript-tools request exceeded the safe size limit",
         invalid_json_message="Transcript-tools request was not valid JSON",
     )

--- a/src/echoflow/desktop/transcript_tools_bridge.py
+++ b/src/echoflow/desktop/transcript_tools_bridge.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-import json
-import sys
-from contextlib import redirect_stdout
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from echoflow.app.app_container import AppContainer
 from echoflow.core.errors import EchoFlowError
+from echoflow.desktop.host_protocol import (
+    failure_response,
+    run_stdio_bridge,
+    success_response,
+)
 from echoflow.library.speaker_label_service import SpeakerRosterEntry
 from echoflow.library.speaker_presentation import (
     SpeakerPresentationService,
@@ -18,9 +20,6 @@ from echoflow.library.speaker_presentation import (
 )
 from echoflow.library.transcript_tools import TranscriptDetails, TranscriptToolsService
 from echoflow.transcription.export import TranscriptExportFormat
-
-_PROTOCOL_VERSION = 1
-_MAX_REQUEST_BYTES = 128 * 1024
 
 TranscriptToolMethod = Literal[
     "transcripts.tools.inspect",
@@ -218,26 +217,6 @@ def dispatch_transcript_tools(
     raise ValueError("Unsupported transcript-tools method")
 
 
-def _success(request_id: str, result: object) -> dict[str, object]:
-    return {
-        "protocol_version": _PROTOCOL_VERSION,
-        "request_id": request_id,
-        "ok": True,
-        "result": result,
-        "error": None,
-    }
-
-
-def _failure(request_id: str, *, code: str, message: str) -> dict[str, object]:
-    return {
-        "protocol_version": _PROTOCOL_VERSION,
-        "request_id": request_id,
-        "ok": False,
-        "result": None,
-        "error": {"code": code, "message": message},
-    }
-
-
 def _service(container: AppContainer) -> TranscriptToolsService:
     labels = container.speaker_label_store()
     return TranscriptToolsService(
@@ -259,26 +238,26 @@ def handle_request(
     try:
         request = _Request.model_validate(payload)
         request_id = request.request_id
-        return _success(
+        return success_response(
             request_id,
             dispatch_transcript_tools(request.method, request.params, service),
         )
     except ValidationError:
-        return _failure(
+        return failure_response(
             request_id,
             code="invalid_request",
             message="Transcript-tools request is invalid",
         )
     except EchoFlowError as exc:
-        return _failure(
+        return failure_response(
             request_id,
             code=exc.code.value,
             message=exc.public_message,
         )
     except ValueError as exc:
-        return _failure(request_id, code="invalid_request", message=str(exc))
+        return failure_response(request_id, code="invalid_request", message=str(exc))
     except Exception:
-        return _failure(
+        return failure_response(
             request_id,
             code="internal_error",
             message="EchoFlow could not complete that transcript-tools request",
@@ -286,29 +265,11 @@ def handle_request(
 
 
 def main() -> int:
-    raw = sys.stdin.buffer.read(_MAX_REQUEST_BYTES + 1)
-    if len(raw) > _MAX_REQUEST_BYTES:
-        response = _failure(
-            "unknown",
-            code="invalid_request",
-            message="Transcript-tools request exceeded the safe size limit",
-        )
-    else:
-        try:
-            payload = json.loads(raw)
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            response = _failure(
-                "unknown",
-                code="invalid_request",
-                message="Transcript-tools request was not valid JSON",
-            )
-        else:
-            with redirect_stdout(sys.stderr):
-                container = AppContainer()
-                response = handle_request(payload, _service(container))
-    sys.stdout.write(json.dumps(response, sort_keys=True))
-    sys.stdout.write("\n")
-    return 0
+    return run_stdio_bridge(
+        lambda payload: handle_request(payload, _service(AppContainer())),
+        oversized_message="Transcript-tools request exceeded the safe size limit",
+        invalid_json_message="Transcript-tools request was not valid JSON",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

First implementation tranche from the pre-packaging architecture/redundancy audit.

- centralize bounded trusted-host Python stdin/stdout protocol mechanics without merging bridge authorities
- preserve closed playback, transcript-tools, and lifecycle request schemas and their distinct public error policies
- move playback authorization and transcript/speaker tooling composition into `AppContainer`
- share only genuine first-run/retry Processing preflight options
- add a fixed-command TypeScript native protocol helper for lifecycle, transcript tools, and Research anchor maintenance
- keep playback outside the frontend helper because its Rust opaque-session DTO is a different contract
- add direct Python transport tests, DI composition tests, and a pure frontend response-envelope contract test
- document intentional repetition versus real evolutionary residue in `docs/architecture/redundancy-audit.md`

## Security boundary

This PR does **not** create a generic bridge, dynamic Python module selector, arbitrary Tauri command invocation, filesystem capability, SQL capability, or shared domain dispatcher. `frontend/src-tauri/src/backend.rs` already has the correct fixed-module wrapper pattern and remains unchanged.

The shared Python helper knows only the protocol response envelope, 128 KiB request cap, JSON stdin/stdout, and stdout isolation. Each bridge still owns its method allowlist, Pydantic request DTOs, service, serialization, and domain-specific error mapping.

The frontend helper accepts only the fixed `desktop_request`, `transcript_tools_request`, and `lifecycle_request` command union. Playback remains private to its separate Rust authorization/session path.

## Audit findings intentionally not folded into this plumbing commit

The audit found two higher-level Research cleanups that should finish before the product-identity checkpoint:

1. the same authoritative saved-search objects are currently managed in two separate panels/API families on the Research screen; the typed Research search surface should become the single create/edit/run/delete surface and the older simple endpoint family should be retired after coverage migrates;
2. ordinary desktop discovery and typed Research search independently serialize the same evidence word/context/speaker/generation DTO shape and should share one presentation serializer to prevent contract drift.

The audit record also notes lower-priority follow-ups: migrate the broad `api/desktop.ts` / `api/processing.ts` transport boilerplate to the fixed frontend helper, move `ProcessingCenterService` composition fully into `AppContainer`, and share exact Research-label normalization when both Research adapters are next touched.

## Mutation policy

This PR changes `playback_bridge.py`, so the targeted Playback Mutation workflow **should** run. That is an appropriate use of mutation testing for a changed security-sensitive seam. No universal mutation workflow is added.

## Qualification

Draft until the exact-head Quality matrix and targeted Playback Mutation workflow are green. CI gates must be fixed at source rather than relaxed.