### PR TITLE
refactor(runner): remove pre-release model tier compatibility

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -177,7 +177,7 @@ The pre-identity audit is closed. It consolidated capability-blind Python stdin/
 
 The audit deliberately does **not** create a generic bridge, arbitrary Python-module selector, dynamic Tauri command dispatcher, frontend policy framework, or universal Pydantic hierarchy. Similar-looking code remains only where security visibility, lifecycle semantics, readability, or compatibility justify it.
 
-`ModelTier` remains a deprecated compatibility marker because the current CLI policy JSON still exposes `recommended_model_tier`. It is not a model-selection authority. Its retirement belongs with the identity/API migration, where compatibility changes are explicit rather than hidden inside a behavior-preserving refactor.
+A pre-package follow-up retired the deprecated runner `ModelTier` and `recommended_model_tier` wire field before they could become a released compatibility contract. Runner policy now describes only processing intent and resource/admission limits; concrete transcription strategy ranking remains the sole model-selection authority. No canonical evidence, authoritative research, or checkpoint format depended on the removed marker.
 
 See **[Architecture and redundancy audit](docs/architecture/redundancy-audit.md)**.
 
@@ -194,8 +194,6 @@ A rename affects more than the GitHub repository label. Audit and intentionally 
 - documentation/examples and generated artifacts;
 - environment variables and integration points; and
 - migration/compatibility behavior for existing local EchoFlow workspaces.
-
-This is also the correct point to retire compatibility wire names that are no longer product truth, including the deprecated runner `ModelTier` marker if the identity/API migration intentionally changes that CLI shape.
 
 Choose the replacement name first, verify pronunciation/searchability/legal/package-namespace collisions, then perform one deliberate identity migration before installers exist. If EchoFlow remains the name, record that decision and freeze the identity surface.
 

--- a/docs/architecture/redundancy-audit.md
+++ b/docs/architecture/redundancy-audit.md
@@ -96,11 +96,13 @@ Browser mocks deliberately repeat some DTO shape. They are executable examples o
 
 Loading, error, confirmation, and editing state often look alike but belong to different user lifecycles. There is no evidence of policy drift that justifies a generic interaction-state framework.
 
-### Runner `ModelTier` compatibility marker
+## Pre-release compatibility cleanup
 
-`ModelTier` is deprecated as a model-selection authority. Concrete transcription strategy ranking owns engine/model selection. It remains temporarily because `ExecutionPolicy.to_dict()` exposes `recommended_model_tier` through the existing CLI wire shape and cross-layer fixtures still consume that compatibility field.
+The audit initially retained the deprecated runner `ModelTier` marker conservatively because `ExecutionPolicy.to_dict()` exposed `recommended_model_tier` through the development CLI wire shape. A follow-up review before packaging established that the marker was not part of canonical evidence, authoritative research, checkpoint identity, or a released integration contract.
 
-That is explicit compatibility, not active architecture. Its removal should be considered during the identity/API migration, where command/module/environment/package compatibility can be changed deliberately in one migration contract rather than slipped into an otherwise behavior-preserving refactor.
+It was therefore removed before distribution could turn historical residue into compatibility debt. `ExecutionPolicy` now owns only processing intent and resource/admission limits. Concrete transcription strategy ranking remains the sole engine/model-selection authority, including when a resumed job is re-admitted on the current machine.
+
+This is the intended pre-release rule: preserve real user-owned and released contracts aggressively; do not manufacture permanence for an obsolete internal shape merely because tests once serialized it.
 
 ## Test policy
 

--- a/src/echoflow/benchmarking/tests/test_runner.py
+++ b/src/echoflow/benchmarking/tests/test_runner.py
@@ -12,12 +12,7 @@ from echoflow.core.file_manager_facade import FileManagerFacade
 from echoflow.core.performance_tracker import PerformanceTracker
 from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 from echoflow.transcription.models import (
     CanonicalTranscript,
     CpuEngineConfiguration,
@@ -102,11 +97,10 @@ def _plan(tmp_path: Path) -> tuple[TranscriptionJobPlan, WorkspacePaths]:
         effective_memory_available_bytes=6 * GIB,
     )
     policy = ExecutionPolicy(
-        ProcessingProfile.BALANCED,
-        False,
-        4,
-        4 * GIB,
-        ModelTier.STANDARD,
+        profile=ProcessingProfile.BALANCED,
+        provisional=False,
+        cpu_threads=4,
+        memory_budget_bytes=4 * GIB,
     )
     engine = CpuEngineConfiguration(
         "faster-whisper",

--- a/src/echoflow/cli.py
+++ b/src/echoflow/cli.py
@@ -109,7 +109,6 @@ def _render_runner(
         "Provisional": str(policy.provisional).lower(),
         "CPU threads": str(policy.cpu_threads),
         "Memory budget": str(policy.memory_budget_bytes),
-        "Model tier": policy.recommended_model_tier.value,
         "Constraints": ", ".join(policy.constraints) or "none",
     }
     for setting, value in rows.items():

--- a/src/echoflow/runner/__init__.py
+++ b/src/echoflow/runner/__init__.py
@@ -8,17 +8,11 @@ engine strategy selection must respect.
 """
 
 from echoflow.runner.inspector import RunnerInspector
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 from echoflow.runner.policy import RunnerPolicyPlanner
 
 __all__ = [
     "ExecutionPolicy",
-    "ModelTier",
     "ProcessingProfile",
     "RunnerInspector",
     "RunnerPolicyPlanner",

--- a/src/echoflow/runner/models.py
+++ b/src/echoflow/runner/models.py
@@ -10,15 +10,6 @@ class ProcessingProfile(StrEnum):
     ACCURACY = "accuracy"
 
 
-class ModelTier(StrEnum):
-    """Deprecated compatibility value; transcription strategy owns model selection."""
-
-    COMPACT = "compact"
-    STANDARD = "standard"
-    LARGE = "large"
-    STRATEGY_SPECIFIC = "strategy-specific"
-
-
 @dataclass(frozen=True, slots=True)
 class RunnerResources:
     platform: str
@@ -46,11 +37,9 @@ class ExecutionPolicy:
     provisional: bool
     cpu_threads: int
     memory_budget_bytes: int
-    recommended_model_tier: ModelTier = ModelTier.STRATEGY_SPECIFIC
     constraints: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         result = asdict(self)
         result["profile"] = self.profile.value
-        result["recommended_model_tier"] = self.recommended_model_tier.value
         return result

--- a/src/echoflow/runner/policy.py
+++ b/src/echoflow/runner/policy.py
@@ -1,11 +1,6 @@
 from dataclasses import dataclass
 
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,18 +37,10 @@ class RunnerPolicyPlanner:
             memory_budget = self.max_memory_bytes
             constraints.append("configured_memory_limit")
 
-        # Keep the pre-strategy screening wire marker for compatibility. This does
-        # not select an engine model; concrete strategy ranking owns that decision.
-        compatibility_tier = (
-            ModelTier.COMPACT
-            if profile is ProcessingProfile.SCREENING
-            else ModelTier.STRATEGY_SPECIFIC
-        )
         return ExecutionPolicy(
             profile=profile,
             provisional=profile is ProcessingProfile.SCREENING,
             cpu_threads=max(1, cpu_threads),
             memory_budget_bytes=max(0, memory_budget),
-            recommended_model_tier=compatibility_tier,
             constraints=tuple(dict.fromkeys(constraints)),
         )

--- a/src/echoflow/runner/tests/test_models.py
+++ b/src/echoflow/runner/tests/test_models.py
@@ -2,12 +2,7 @@ from dataclasses import FrozenInstanceError, fields
 
 import pytest
 
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 
 
 def test_runner_resources_have_a_stable_machine_readable_shape():
@@ -44,7 +39,7 @@ def test_runner_resources_have_a_stable_machine_readable_shape():
     assert not hasattr(resources, "__dict__")
 
 
-def test_execution_policy_serializes_profile_without_production_model_decision():
+def test_execution_policy_serializes_resource_policy_without_model_selection():
     policy = ExecutionPolicy(
         profile=ProcessingProfile.SCREENING,
         provisional=True,
@@ -57,7 +52,6 @@ def test_execution_policy_serializes_profile_without_production_model_decision()
         "provisional": True,
         "cpu_threads": 2,
         "memory_budget_bytes": 1024,
-        "recommended_model_tier": "strategy-specific",
         "constraints": ("configured_cpu_limit",),
     }
     assert [profile.value for profile in ProcessingProfile] == [
@@ -68,14 +62,3 @@ def test_execution_policy_serializes_profile_without_production_model_decision()
     assert not hasattr(policy, "__dict__")
     with pytest.raises(FrozenInstanceError):
         setattr(policy, fields(policy)[0].name, ProcessingProfile.BALANCED)
-
-
-def test_legacy_model_tier_still_serializes_for_existing_plan_fixtures():
-    policy = ExecutionPolicy(
-        ProcessingProfile.BALANCED,
-        False,
-        4,
-        2048,
-        ModelTier.STANDARD,
-    )
-    assert policy.to_dict()["recommended_model_tier"] == "standard"

--- a/src/echoflow/runner/tests/test_policy.py
+++ b/src/echoflow/runner/tests/test_policy.py
@@ -2,7 +2,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from echoflow.runner.models import ModelTier, ProcessingProfile, RunnerResources
+from echoflow.runner.models import ProcessingProfile, RunnerResources
 from echoflow.runner.policy import RunnerPolicyPlanner
 
 GIB = 1024**3
@@ -32,7 +32,6 @@ def test_screening_is_explicitly_provisional_without_engine_selection():
     assert policy.provisional is True
     assert policy.cpu_threads == 8
     assert policy.memory_budget_bytes == 12 * GIB
-    assert policy.recommended_model_tier is ModelTier.COMPACT
 
 
 def test_non_screening_profiles_share_the_same_resource_budget_for_same_machine():
@@ -43,8 +42,6 @@ def test_non_screening_profiles_share_the_same_resource_budget_for_same_machine(
     assert balanced.cpu_threads == accurate.cpu_threads == 8
     assert balanced.provisional is False
     assert accurate.provisional is False
-    assert balanced.recommended_model_tier is ModelTier.STRATEGY_SPECIFIC
-    assert accurate.recommended_model_tier is ModelTier.STRATEGY_SPECIFIC
 
 
 def test_default_policy_values_and_fraction_are_stable():

--- a/src/echoflow/tests/test_cli.py
+++ b/src/echoflow/tests/test_cli.py
@@ -14,12 +14,7 @@ from echoflow.core.health_check import (
 )
 from echoflow.media.errors import UnsupportedMediaError
 from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 from echoflow.runner.policy import RunnerPolicyPlanner
 from echoflow.transcription.models import (
     CanonicalTranscript,
@@ -159,11 +154,10 @@ def transcription_plan() -> TranscriptionJobPlan:
         constraints=("cpu_affinity",),
     )
     policy = ExecutionPolicy(
-        ProcessingProfile.BALANCED,
-        False,
-        4,
-        4 * 1024**3,
-        ModelTier.STANDARD,
+        profile=ProcessingProfile.BALANCED,
+        provisional=False,
+        cpu_threads=4,
+        memory_budget_bytes=4 * 1024**3,
     )
     engine = CpuEngineConfiguration(
         "faster-whisper",
@@ -320,7 +314,8 @@ def test_runner_json_reports_effective_limits_and_screening_semantics():
     assert payload["resources"]["effective_cpus"] == 4
     assert payload["policy"]["profile"] == "screening"
     assert payload["policy"]["provisional"] is True
-    assert payload["policy"]["recommended_model_tier"] == "compact"
+    assert payload["policy"]["cpu_threads"] == 4
+    assert payload["policy"]["memory_budget_bytes"] == 6 * 1024**3
 
 
 def test_runner_human_output_explains_policy():

--- a/src/echoflow/transcription/planner.py
+++ b/src/echoflow/transcription/planner.py
@@ -5,7 +5,7 @@ from typing import Protocol
 from echoflow.media.models import MediaInfo
 from echoflow.media.selection import AudioStreamSelector
 from echoflow.runner.inspector import RunnerInspector
-from echoflow.runner.models import ExecutionPolicy, ModelTier, ProcessingProfile
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile
 from echoflow.runner.policy import RunnerPolicyPlanner
 from echoflow.runner.topology import HardwareTopology, HardwareTopologyInspector
 from echoflow.transcription.capabilities import (
@@ -203,11 +203,6 @@ class TranscriptionJobPlanner:
             provisional=settings.provisional,
             cpu_threads=policy_threads,
             memory_budget_bytes=current_policy.memory_budget_bytes,
-            recommended_model_tier=(
-                ModelTier.COMPACT
-                if settings.profile is ProcessingProfile.SCREENING
-                else ModelTier.STRATEGY_SPECIFIC
-            ),
             constraints=current_policy.constraints,
         )
         engine = settings.engine.configuration(

--- a/src/echoflow/transcription/tests/test_executor.py
+++ b/src/echoflow/transcription/tests/test_executor.py
@@ -8,12 +8,7 @@ from echoflow.core.performance_tracker import PerformanceTracker
 from echoflow.interfaces.local_file_manager import LocalFileManager
 from echoflow.media.errors import InputChangedError
 from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 from echoflow.runner.policy import RunnerPolicyPlanner
 from echoflow.transcription.assembly import TranscriptAssembler
 from echoflow.transcription.audio import DecodedAudio
@@ -97,11 +92,10 @@ def plan(
     )
     runner = resources()
     policy = ExecutionPolicy(
-        ProcessingProfile.BALANCED,
-        False,
-        4,
-        8 * GIB,
-        ModelTier.STANDARD,
+        profile=ProcessingProfile.BALANCED,
+        provisional=False,
+        cpu_threads=4,
+        memory_budget_bytes=8 * GIB,
     )
     engine = CpuEngineConfiguration(
         "faster-whisper",

--- a/src/echoflow/transcription/tests/test_models.py
+++ b/src/echoflow/transcription/tests/test_models.py
@@ -4,12 +4,7 @@ from pathlib import Path
 import pytest
 
 from echoflow.media.models import InputIdentity, MediaInfo, MediaStream, StreamKind
-from echoflow.runner.models import (
-    ExecutionPolicy,
-    ModelTier,
-    ProcessingProfile,
-    RunnerResources,
-)
+from echoflow.runner.models import ExecutionPolicy, ProcessingProfile, RunnerResources
 from echoflow.transcription.models import (
     CanonicalTranscript,
     CpuEngineConfiguration,
@@ -69,11 +64,10 @@ def values(tmp_path):
         effective_memory_available_bytes=6 * 1024**3,
     )
     policy = ExecutionPolicy(
-        ProcessingProfile.BALANCED,
-        False,
-        4,
-        6 * 1024**3,
-        ModelTier.STANDARD,
+        profile=ProcessingProfile.BALANCED,
+        provisional=False,
+        cpu_threads=4,
+        memory_budget_bytes=6 * 1024**3,
     )
     engine = CpuEngineConfiguration(
         "faster-whisper",


### PR DESCRIPTION
## Summary

Remove the deprecated runner `ModelTier` compatibility surface before packaging can turn it into a released contract.

- delete `ModelTier` and `ExecutionPolicy.recommended_model_tier`
- keep runner policy focused on processing intent plus CPU/memory admission limits
- leave concrete engine/model selection exclusively with transcription strategy ranking
- stop fabricating a model-tier marker during normal planning and checkpoint resume
- remove the obsolete field from human and JSON runner CLI output
- update plan/benchmark/CLI fixtures to use explicit keyword policy construction
- delete the legacy serialization test rather than replacing it with a source-text or existence-only assertion
- truth-sync the roadmap and architecture audit to record the intentional pre-package compatibility cleanup

## Compatibility rationale

This is an intentional pre-release API cleanup. The removed marker is not part of canonical transcript evidence, authoritative research state, checkpoint identity, or a released installer/integration contract. Preserving it at this stage would manufacture future migration debt from an obsolete development-only wire shape.

Canonical evidence, research authority, checkpoint contracts, playback/custody boundaries, and concrete transcription strategy selection are unchanged.

## Test policy

No source-text, existence-only, or self-fulfilling tests are added. Existing behavioral coverage remains in place for runner resource policy, CLI JSON/human presentation, transcription planning/execution, benchmark reporting, and resume admission. No security or quality gate is weakened.

## Qualification

Exact head `780a04700f3e504275ed241cf277602ca0576111` passed Quality run `32542719942` (#941) end to end.

- static gates: `uv lock --check`, Mermaid verification, Ruff lint/format, strict mypy, Vulture, Radon, compileall, and locked dependency/security audit passed
- frontend static: TypeScript, production build, Tauri version-family checks, raw-HTML guard, and dependency audit passed
- Linux: 2,424 passed / 6 skipped; branch-aware coverage remained above the unchanged 90% gate at 90.67%; sdist/wheel build and clean-wheel verification passed
- macOS ARM64: 1,263 Python tests passed; runner-policy inspection, distribution build, and clean-wheel verification passed
- Windows: full platform smoke, runner-policy inspection, distribution build, and clean-wheel verification passed
- browser: 62/62 Playwright tests passed, including accessibility flows
- native Tauri: locked Rust host compile and tests passed
- Playback Mutation workflow correctly skipped its mutation job because this change does not alter playback authorization decision logic

The installed-wheel runner smoke also confirms the released CLI shape now reports only `constraints`, `cpu_threads`, `memory_budget_bytes`, `profile`, and `provisional`; `recommended_model_tier` is absent.

No quality threshold or security boundary was weakened.