### PR TITLE
Harden native Processing diagnostics and source bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Virtual environments
 .venv/         # In case `.venv` accidentally appears locally
+.tools/        # Project-local developer tool bootstrap (for example uv)
 
 # Pre-commit cache
 .pre-commit/

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -7,8 +7,10 @@ This area explains how Scholion turns architecture claims into failing tests ins
 | Page | What it is for |
 |---|---|
 | [Project-local developer toolchain](project-local-toolchain.md) | isolated `.tools/uv`, `.venv`, lockfile ownership, stale-environment recovery, no required system-wide uv |
+| [Native Processing diagnostics](native-processing-diagnostics.md) | isolate Processing failures across React, Tauri, Rust, Python, Wayland, and interpreter selection |
 | [Desktop development prerequisites](desktop-development.md) | browser mock, native Tauri, real processing, Node/Rust/Python/native prerequisites |
 | [Desktop source-build troubleshooting](troubleshooting.md) | symptom-first recovery for Tauri/Python/WebKitGTK/Wayland/port failures and safe cleanup |
+| [Pre-release security hardening](../security/release-hardening.md) | signed manifests/updates/models, parser/process isolation, keychain, and application-layer encryption sequencing |
 | [Desktop themes and accessibility](desktop-accessibility.md) | semantic theme contract, eight skins, contrast/native-control rules, adding a skin safely |
 | [Frontend testing strategy](frontend-testing.md) | frontend/backend test ownership, Processing/Library/Research/transcript-tools coverage, and why Stryker is not currently a routine tool |
 | [Testing and regression bisection](testing-and-bisect.md) | repository-wide test strategy, colocation, mutation anticipation, deterministic bisect oracles |

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -8,6 +8,7 @@ This area explains how Scholion turns architecture claims into failing tests ins
 |---|---|
 | [Project-local developer toolchain](project-local-toolchain.md) | isolated `.tools/uv`, `.venv`, lockfile ownership, stale-environment recovery, no required system-wide uv |
 | [Native Processing diagnostics](native-processing-diagnostics.md) | isolate Processing failures across React, Tauri, Rust, Python, Wayland, and interpreter selection |
+| [Native release qualification checklist](release-native-checklist.md) | real-device React → Tauri → Rust → Python qualification across supported OSes |
 | [Desktop development prerequisites](desktop-development.md) | browser mock, native Tauri, real processing, Node/Rust/Python/native prerequisites |
 | [Desktop source-build troubleshooting](troubleshooting.md) | symptom-first recovery for Tauri/Python/WebKitGTK/Wayland/port failures and safe cleanup |
 | [Pre-release security hardening](../security/release-hardening.md) | signed manifests/updates/models, parser/process isolation, keychain, and application-layer encryption sequencing |

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,6 +6,7 @@ This area explains how Scholion turns architecture claims into failing tests ins
 
 | Page | What it is for |
 |---|---|
+| [Project-local developer toolchain](project-local-toolchain.md) | isolated `.tools/uv`, `.venv`, lockfile ownership, stale-environment recovery, no required system-wide uv |
 | [Desktop development prerequisites](desktop-development.md) | browser mock, native Tauri, real processing, Node/Rust/Python/native prerequisites |
 | [Desktop source-build troubleshooting](troubleshooting.md) | symptom-first recovery for Tauri/Python/WebKitGTK/Wayland/port failures and safe cleanup |
 | [Desktop themes and accessibility](desktop-accessibility.md) | semantic theme contract, eight skins, contrast/native-control rules, adding a skin safely |
@@ -84,6 +85,8 @@ The frontend currently does not use Stryker. That is deliberate: decision-heavy 
 A new interactive desktop slice should normally include semantic-role/keyboard assertions, an axe pass, positive behavior, at least one meaningful negative/boundary case, and path/capability assertions when sensitive local state is involved.
 
 Theme-aware components inherit the shared registry-driven contrast matrix. Do not create a private palette test for every component.
+
+Mock-browser coverage is not native transport coverage. Any release-critical path that crosses React → Tauri → Rust → Python must also have a native integration/representative-device qualification path; `?e2e=1` intentionally replaces the real native client and therefore cannot prove that IPC/process wiring works on an installed machine.
 
 ## Performance qualification
 

--- a/docs/development/native-processing-diagnostics.md
+++ b/docs/development/native-processing-diagnostics.md
@@ -1,0 +1,148 @@
+# Native Processing diagnostics
+
+Use this page when the Processing screen stays on **Checking…**, reports that Scholion cannot inspect the computer, or behaves differently from the CLI.
+
+The goal is to isolate the failing layer without changing user data.
+
+## 1. Verify the Python application layer
+
+From the repository root with Scholion's `.venv` active:
+
+```bash
+scholion doctor
+scholion runner --json
+scholion strategies --json
+scholion models --json
+```
+
+If these fail, fix the Python environment or local prerequisite first. If they succeed, continue.
+
+## 2. Test the exact Processing bridge methods
+
+Machine readiness:
+
+```bash
+printf '%s\n' \
+'{"protocol_version":1,"request_id":"debug-readiness","method":"processing.readiness","params":{"profile":"balanced"}}' \
+| python -m scholion.desktop.bridge \
+| python -m json.tool
+```
+
+Job history:
+
+```bash
+printf '%s\n' \
+'{"protocol_version":1,"request_id":"debug-jobs","method":"processing.jobs.list","params":{}}' \
+| python -m scholion.desktop.bridge \
+| python -m json.tool
+```
+
+A healthy result has `"ok": true`. If both calls succeed but the desktop does not, the failure is above the Python bridge.
+
+## 3. Check for an interpreter override
+
+macOS/Linux:
+
+```bash
+echo "SCHOLION_PYTHON=${SCHOLION_PYTHON-<unset>}"
+```
+
+PowerShell:
+
+```powershell
+Get-Item Env:SCHOLION_PYTHON -ErrorAction SilentlyContinue
+```
+
+`SCHOLION_PYTHON` is an explicit developer override. If it points to an old environment, remove it for the current shell and retry.
+
+macOS/Linux:
+
+```bash
+unset SCHOLION_PYTHON
+```
+
+PowerShell:
+
+```powershell
+Remove-Item Env:SCHOLION_PYTHON -ErrorAction SilentlyContinue
+```
+
+## 4. Verify native source prerequisites
+
+From `frontend/`:
+
+```bash
+npm ci
+npm run doctor:desktop
+```
+
+Then launch:
+
+```bash
+npm run tauri dev
+```
+
+On Linux/Wayland, if WebKitGTK terminates with `Error 71 (Protocol error) dispatching to Wayland display`, retry only that launch with:
+
+```bash
+WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri dev
+```
+
+Do not make the workaround a global environment setting.
+
+## 5. Force the known repository interpreter for one launch
+
+macOS/Linux:
+
+```bash
+SCHOLION_PYTHON="$(realpath ../.venv/bin/python)" npm run tauri dev
+```
+
+Linux/Wayland when the DMABUF workaround is also required:
+
+```bash
+WEBKIT_DISABLE_DMABUF_RENDERER=1 \
+SCHOLION_PYTHON="$(realpath ../.venv/bin/python)" \
+npm run tauri dev
+```
+
+PowerShell:
+
+```powershell
+$env:SCHOLION_PYTHON = (Resolve-Path ..\.venv\Scripts\python.exe)
+npm.cmd run tauri dev
+```
+
+Unset the override after diagnosis if it is not intended to persist.
+
+## 6. Read the Rust bridge diagnostics
+
+Debug builds log a narrow lifecycle line for each Python bridge request. The log includes only:
+
+- bridge module;
+- protocol method;
+- selected Python executable;
+- child exit status; and
+- stdout/stderr byte counts.
+
+It deliberately does **not** log request params, evidence paths, transcript text, or model/source contents.
+
+A successful request should show a `bridge start` line followed by `bridge finish`. If start appears without finish, the Python child did not return. If finish appears and a `bridge parse failure` follows, the child returned bytes that were not one valid protocol JSON response.
+
+## 7. Processing-specific behavior
+
+The Processing screen now treats machine readiness as the primary operation. Once readiness returns, the hardware/model UI renders without waiting for job history or remembered-folder discovery.
+
+The machine check is bounded to 15 seconds. A timeout is surfaced as an explicit error instead of leaving the card on `Checking…` forever. Job-history and recording-discovery refreshes are independently bounded and cannot blank an otherwise healthy readiness result.
+
+## 8. What browser E2E does not prove
+
+`/?e2e=1` intentionally injects mock clients. That is appropriate for browser interaction and accessibility coverage, but it does not execute:
+
+```text
+React → Tauri invoke → Rust host → Python bridge
+```
+
+Release qualification therefore needs at least one real native transport smoke on every supported OS, plus representative CPU-only and CUDA-capable machines.
+
+See [Project-local developer toolchain](project-local-toolchain.md) for environment setup and [Desktop source-build troubleshooting](troubleshooting.md) for broader OS-specific failures.

--- a/docs/development/project-local-toolchain.md
+++ b/docs/development/project-local-toolchain.md
@@ -1,0 +1,179 @@
+# Project-local developer toolchain
+
+Scholion source development deliberately separates **tools that build/manage the repository** from **libraries that belong to the application**.
+
+The supported project-local layout is:
+
+```text
+Scholion/
+├── .tools/
+│   └── uv/              disposable project-local tool bootstrap
+├── .venv/               Scholion's locked Python environment
+├── frontend/
+│   └── node_modules/    locked JavaScript dependencies
+├── uv.lock
+├── pyproject.toml
+└── frontend/package-lock.json
+```
+
+`.tools/` and `.venv/` are disposable developer state and are ignored by Git. They are not user evidence and are not application data.
+
+## Why `uv` is outside `.venv`
+
+`uv` manages `.venv`. If `uv` is installed *inside* the environment it manages, deleting a stale `.venv` also deletes the tool needed to recreate it:
+
+```text
+uv manages .venv
+     ↓
+uv lives inside .venv
+     ↓
+delete stale .venv
+     ↓
+uv is gone
+     ↓
+need uv to recreate .venv
+```
+
+Keeping the bootstrap tool in `.tools/uv` avoids that cycle while still preventing a system-wide install.
+
+A shared user-local `uv` installation is also technically valid because each repository still has its own lockfile and `.venv`. Scholion nevertheless documents the project-local path because it gives contributors a stricter tool-version boundary and avoids relying on shell PATH state.
+
+## Bootstrap on Linux or macOS
+
+Use Python 3.12 to run the repository bootstrap from the repository root:
+
+```bash
+python3.12 scripts/bootstrap_python.py
+```
+
+If `python` already resolves to Python 3.12:
+
+```bash
+python scripts/bootstrap_python.py
+```
+
+The script:
+
+1. creates `.tools/uv` with the invoking Python 3.12 interpreter;
+2. installs the repository-pinned `uv` version into that tool environment;
+3. runs `.tools/uv/bin/uv sync --locked --extra transcription`;
+4. verifies that `.venv` can import Scholion; and
+5. leaves system package-manager state untouched.
+
+Activate the resulting application environment with:
+
+```bash
+source .venv/bin/activate
+```
+
+The prompt may display `(scholion)` rather than `(.venv)`. The prompt text is a friendly environment name. The authoritative check is:
+
+```bash
+which python
+```
+
+which should resolve to the repository's `.venv/bin/python`.
+
+## Bootstrap on Windows PowerShell
+
+From the repository root:
+
+```powershell
+py -3.12 scripts\bootstrap_python.py
+```
+
+Then activate:
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+```
+
+If local PowerShell policy prevents activation, activation is optional. Run the environment explicitly instead:
+
+```powershell
+.\.venv\Scripts\python.exe -m scholion --help
+```
+
+The bootstrap itself does not change PowerShell execution policy.
+
+## Lockfile ownership
+
+Different ecosystems have different project-local dependency graphs:
+
+| Layer | Tool | Repository authority | Installed state |
+|---|---|---|---|
+| Python application | project-local `uv` | `pyproject.toml` + `uv.lock` | `.venv/` |
+| JavaScript desktop | npm | `frontend/package.json` + `frontend/package-lock.json` | `frontend/node_modules/` |
+| Rust/Tauri host | Cargo | `frontend/src-tauri/Cargo.toml` + `Cargo.lock` | Cargo user cache + `frontend/src-tauri/target/` |
+
+Do not delete or regenerate a lockfile merely to make a version conflict disappear. Lockfiles are part of the source-build contract. Disposable installed state can be rebuilt from them.
+
+## Recovering from a stale or deleted virtual environment
+
+Symptoms can include:
+
+```text
+(.venv) ...
+bash: /path/to/Scholion/.venv/bin/uv: No such file or directory
+```
+
+or:
+
+```text
+bash: uv: command not found
+```
+
+First leave any stale activation and clear Bash's executable-location cache:
+
+```bash
+deactivate 2>/dev/null || true
+hash -r
+type -a uv || true
+```
+
+A surviving interpreter under `~/.local/share/uv/python/...` does not imply that the `uv` executable still exists. `uv` may previously have downloaded that Python runtime while its own executable was later removed.
+
+For Scholion, recover without a system-wide install:
+
+```bash
+python3.12 scripts/bootstrap_python.py
+source .venv/bin/activate
+```
+
+Then verify:
+
+```bash
+python --version
+which python
+scholion doctor
+scholion runner --json
+scholion strategies --json
+scholion models --json
+```
+
+## Why `.venv/bin/pip` may be absent
+
+A uv-managed environment does not require `pip` inside the application environment. Absence of `.venv/bin/pip` alone is not evidence that `.venv` is broken.
+
+The separate `.tools/uv` bootstrap environment *does* use its own pip to install the pinned `uv` tool. That pip belongs to the disposable tool bootstrap, not to Scholion's runtime dependency graph.
+
+## Do not use system-wide installation as the default recovery step
+
+Do not reflexively run `sudo pacman -S uv`, `sudo apt install ...`, or an equivalent system-level package command merely because `uv` is missing. A contributor may intentionally keep development tools isolated from operating-system package state.
+
+Likewise, do not present `curl ... | sh` as an unexplained incantation. A remote installer script is code fetched over HTTPS and immediately executed. If a contributor chooses a user-local upstream installer instead of Scholion's project-local bootstrap, they should understand and inspect that trust boundary.
+
+## After pulling new source
+
+A Git pull updates the repository. It does not automatically synchronize every installed dependency tree. When lockfiles changed, rebuild the relevant disposable state:
+
+```bash
+python3.12 scripts/bootstrap_python.py
+cd frontend
+npm ci
+npm run doctor:desktop
+```
+
+For the native host, `cargo check --locked --manifest-path frontend/src-tauri/Cargo.toml` is the authoritative compile check.
+
+See [Desktop source-build troubleshooting](troubleshooting.md) for platform-specific failures and [Desktop development prerequisites](desktop-development.md) for the complete native stack.

--- a/docs/development/release-native-checklist.md
+++ b/docs/development/release-native-checklist.md
@@ -1,0 +1,51 @@
+# Native release qualification checklist
+
+Browser mocks are necessary but insufficient evidence for a desktop application. Before a release candidate is considered qualified, exercise the real native seams on representative machines.
+
+## Processing transport
+
+For each supported OS, verify through the native Tauri window that:
+
+- Processing readiness leaves `Checking…` and renders actual CPU/RAM/accelerator information;
+- model inventory appears from the real Python bridge;
+- previous-job history loads independently from readiness;
+- a missing/broken Python interpreter produces a bounded, useful error;
+- a child process that exits non-zero produces a bounded, useful error;
+- an invalid protocol response produces a bounded, useful error;
+- a stalled readiness request does not spin forever;
+- debug diagnostics do not include evidence paths, transcript text, or request params.
+
+## Representative machines
+
+Minimum evidence set:
+
+- Windows 8 GB CPU-only;
+- Windows or Linux 16 GB commodity system;
+- Apple Silicon macOS;
+- NVIDIA dGPU laptop/workstation;
+- 32/64 GB high-end workstation.
+
+Hardware policy must remain conservative on small devices and must not artificially disable feasible acceleration on capable devices.
+
+## Linux desktop stack
+
+Qualify at least one Wayland and one X11 session. Record whether WebKitGTK requires the per-launch `WEBKIT_DISABLE_DMABUF_RENDERER=1` workaround. Do not silently persist that environment variable system-wide.
+
+## Dependency/bootstrap recovery
+
+From a clean checkout on each OS:
+
+1. bootstrap Python with the project-local toolchain;
+2. delete `.venv` and prove it can be recreated without deleting `.tools/uv`;
+3. run `npm ci` from `frontend/`;
+4. run `npm run doctor:desktop`;
+5. run the locked native Cargo compile;
+6. launch the native app and exercise Processing readiness.
+
+Also qualify a pull in which one or more lockfiles changed. The contributor workflow should identify which disposable installed state must be synchronized instead of recommending global package upgrades.
+
+## Supply-chain and containment gates
+
+Before public distribution, execute the acceptance criteria in [Pre-release security hardening](../security/release-hardening.md) for signed manifests/update/model trust and hostile-input/process containment.
+
+Application-layer encryption/keychain work follows its documented threat model and recovery contract rather than being inferred from this checklist.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,19 @@
+# Scholion security design notes
+
+Scholion is local-first, but local-first is not synonymous with automatically safe. Security work covers evidence custody, hostile media parsing, process capability, dependency/model provenance, update authenticity, secret/key storage, and recovery semantics.
+
+## Current release-hardening plan
+
+See **[Pre-release security hardening roadmap](release-hardening.md)** for the ordered work covering:
+
+- application-layer encryption;
+- OS keychain integration;
+- cryptographic signatures for manifests;
+- sandboxing native parsers;
+- tighter process isolation;
+- a secure update framework; and
+- a model-signing trust root.
+
+The roadmap groups these into supply-chain trust, hostile-input containment, and data-at-rest/key custody. It also records native React → Tauri → Rust → Python qualification as a release gate after real-device testing exposed a gap that browser mocks cannot cover.
+
+Repository vulnerability reporting and disclosure policy remain in the root **[SECURITY.md](../../SECURITY.md)**.

--- a/docs/security/release-hardening.md
+++ b/docs/security/release-hardening.md
@@ -1,0 +1,111 @@
+# Pre-release security hardening roadmap
+
+This document turns the remaining security ideas into an ordered release-hardening program rather than seven unrelated checkboxes. Scholion is local-first, but local software still processes hostile media, stores sensitive research, downloads executable/model artifacts, and crosses a WebView → Rust → Python boundary. Privacy therefore depends on both custody and containment.
+
+## Release gate A: supply-chain trust
+
+### Cryptographic signatures for manifests
+
+Application/model manifests must be signed with an offline-controlled signing identity. Verification happens before a manifest can authorize an application update, model revision, or hash set. Signature failure, unknown key ID, malformed metadata, rollback, and expired metadata fail closed.
+
+Acceptance evidence:
+
+- signed manifest fixture verifies;
+- modified bytes fail verification;
+- unknown/revoked key fails;
+- rollback to an older trusted version is rejected according to explicit policy;
+- verification is independent of transport security.
+
+### Secure update framework
+
+Application updates need a signed metadata framework with rollback/freeze protection, explicit channel/version semantics, staged download, hash verification, and atomic activation. An update check may make an outbound request without becoming telemetry; the privacy contract must state what network metadata is exposed.
+
+Do not ship an auto-updater that trusts only HTTPS or a mutable release URL.
+
+### Model-signing trust root
+
+The curated model catalog must resolve to a trusted manifest containing repository/source identity, immutable revision, required files, sizes, hashes, license/source metadata, and a Scholion-trusted signature. Hugging Face or another transport host is a distribution mechanism, not the trust root.
+
+Application update signing and model signing may share verification primitives, but should use separable signing roles/keys so compromise of one authority does not automatically authorize the other.
+
+## Release gate B: hostile-input containment
+
+### Sandboxing native parsers
+
+FFmpeg/FFprobe, native decoders, archive/parsing helpers, and future media parsers should be treated as hostile-input surfaces. The goal is to make a parser compromise materially less useful.
+
+Platform work should evaluate:
+
+- Linux seccomp/namespaces or an appropriate sandbox launcher;
+- macOS sandbox/hardened-runtime entitlements;
+- Windows AppContainer/job-object/restricted-token options;
+- read-only source handles where practical;
+- no ambient access to the whole Scholion workspace during probe/decode;
+- explicit CPU/memory/time/output limits.
+
+The sandbox boundary must be tested with malformed/truncated media and intentional parser failure.
+
+### Tighter process isolation
+
+Long-running transcription, probing, model verification, and helper processes should receive only the filesystem/network/device capabilities they need. Process supervision should include bounded startup/response time, cancellation, exit-state capture, and cleanup after crashes.
+
+The React WebView never receives arbitrary Python-module selection, shell-command capability, or raw filesystem authority.
+
+## Release gate C: data-at-rest protection
+
+### OS keychain integration
+
+If Scholion protects application secrets or encryption keys, those secrets should be wrapped by the operating system's credential/key facility where available rather than stored beside encrypted data.
+
+Target abstractions:
+
+- Windows Credential Manager/DPAPI or platform-appropriate protected storage;
+- macOS Keychain;
+- Linux Secret Service/libsecret when available, with an explicit fallback policy for headless/minimal systems.
+
+Key loss/recovery behavior must be documented before encryption becomes default.
+
+### Application-layer encryption
+
+Application-layer encryption is not an automatic launch blocker until the threat model defines what it protects beyond filesystem/full-disk encryption. It materially changes backup, restore, portability, corruption recovery, key rotation, multi-machine use, and evidence export.
+
+Before implementation, decide independently for:
+
+- authoritative research SQLite;
+- canonical transcript evidence;
+- remembered locations/preferences;
+- processing checkpoints/temp state;
+- model cache;
+- derived search indexes.
+
+Do not encrypt rebuildable projections in a way that creates new irreplaceable key-bound state. Do not make canonical evidence unrecoverable without an explicit recovery/export story.
+
+## Ordering and dependencies
+
+Recommended sequence:
+
+1. define trust-root/key-rotation policy;
+2. signed application/model manifests;
+3. secure update framework + model-signing trust root;
+4. parser sandbox and process-capability reduction;
+5. native end-to-end qualification across supported OSes;
+6. keychain abstraction and recovery design;
+7. application-layer encryption only after a documented threat model and portability/backup contract.
+
+The first five are release-hardening work. Keychain/encryption may be release blockers if the threat model shows an unacceptable at-rest risk; otherwise they should not be bolted on without recovery semantics.
+
+## Native transport qualification discovered during real-device testing
+
+Browser Playwright uses `?e2e=1` and intentionally swaps in mock clients. That is useful UI evidence but does not prove React → Tauri → Rust → Python wiring works on a real machine.
+
+Before release, qualification must include:
+
+- real `processing.readiness` and `processing.jobs.list` through the native Tauri command;
+- bounded failure when the Python child never responds;
+- useful controlled error propagation when spawn/exit/JSON parsing fails;
+- no evidence/request parameters in routine native diagnostics;
+- Linux Wayland/WebKitGTK qualification including the known DMABUF workaround path;
+- Windows and macOS native transport smoke;
+- representative CPU-only and CUDA-capable devices.
+
+This is a release seam, not a browser-mock seam.

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -30,7 +30,7 @@ pub(crate) fn configured_python() -> PathBuf {
 
 fn python_unavailable_message() -> String {
     if cfg!(debug_assertions) {
-        "Scholion's local Python service is unavailable. From the repository root run `uv sync --locked --extra transcription`, or set SCHOLION_PYTHON to a compatible interpreter."
+        "Scholion's local Python service is unavailable. From the repository root run `python3.12 scripts/bootstrap_python.py`, or set SCHOLION_PYTHON to a compatible interpreter."
             .to_string()
     } else {
         "Scholion's local Python service is unavailable".to_string()
@@ -46,14 +46,30 @@ fn python_exit_message() -> String {
     }
 }
 
+fn request_method(request: &Value) -> &str {
+    request
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>")
+}
+
 fn run_python_request(module: &'static str, request: Value) -> Result<Value, String> {
+    let method = request_method(&request).to_string();
     let encoded =
         serde_json::to_vec(&request).map_err(|_| "Could not encode desktop request".to_string())?;
     if encoded.len() > MAX_REQUEST_BYTES {
         return Err("Desktop request exceeded the safe size limit".to_string());
     }
 
-    let mut child = Command::new(configured_python())
+    let python = configured_python();
+    if cfg!(debug_assertions) {
+        eprintln!(
+            "[scholion-desktop] bridge start module={module} method={method} python={}",
+            python.display()
+        );
+    }
+
+    let mut child = Command::new(&python)
         .args(["-m", module])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -73,12 +89,30 @@ fn run_python_request(module: &'static str, request: Value) -> Result<Value, Str
     let output = child
         .wait_with_output()
         .map_err(|_| "Scholion's local Python service did not finish cleanly".to_string())?;
+
+    if cfg!(debug_assertions) {
+        eprintln!(
+            "[scholion-desktop] bridge finish module={module} method={method} status={} stdout_bytes={} stderr_bytes={}",
+            output.status,
+            output.stdout.len(),
+            output.stderr.len()
+        );
+    }
+
     if !output.status.success() {
         return Err(python_exit_message());
     }
 
-    serde_json::from_slice(&output.stdout)
-        .map_err(|_| "Scholion's local Python service returned an invalid response".to_string())
+    serde_json::from_slice(&output.stdout).map_err(|_| {
+        if cfg!(debug_assertions) {
+            eprintln!(
+                "[scholion-desktop] bridge parse failure module={module} method={method} stdout_bytes={} stderr_bytes={}",
+                output.stdout.len(),
+                output.stderr.len()
+            );
+        }
+        "Scholion's local Python service returned an invalid response".to_string()
+    })
 }
 
 async fn request_module(module: &'static str, request: Value) -> Result<Value, String> {

--- a/frontend/src/ProcessingCenter.tsx
+++ b/frontend/src/ProcessingCenter.tsx
@@ -23,6 +23,9 @@ interface ProcessingCenterProps {
   onThemeChange: (theme: Theme) => void;
 }
 
+const READINESS_TIMEOUT_MS = 15_000;
+const SECONDARY_REFRESH_TIMEOUT_MS = 15_000;
+
 const PROFILE_COPY: Record<
   ProcessingProfile,
   { label: string; detail: string }
@@ -91,6 +94,28 @@ function deviceLabel(device: string): string {
   return device.toUpperCase();
 }
 
+function errorMessage(caught: unknown, fallback: string): string {
+  if (caught instanceof Error && caught.message.trim()) return caught.message;
+  if (typeof caught === "string" && caught.trim()) return caught;
+  return fallback;
+}
+
+async function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timeoutId: number | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = window.setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+  }
+}
+
 function defaultExecutionOptions(): ExecutionOptions {
   return {
     diarize: false,
@@ -130,18 +155,31 @@ export function ProcessingCenter({
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    const [nextReadiness, nextJobs] = await Promise.all([
+    const nextReadiness = await withTimeout(
       processing.readiness(profile),
-      processing.jobs(),
-    ]);
+      READINESS_TIMEOUT_MS,
+      "Scholion's local processing service did not answer the machine check within 15 seconds.",
+    );
     setReadiness(nextReadiness);
-    setJobs(nextJobs);
-    try {
-      const discovered = await client.discoverRecordings();
-      setRecordings(discovered.recordings);
-    } catch {
-      setRecordings([]);
-    }
+
+    void withTimeout(
+      processing.jobs(),
+      SECONDARY_REFRESH_TIMEOUT_MS,
+      "Previous transcription jobs did not load within 15 seconds.",
+    )
+      .then(setJobs)
+      .catch((caught) => {
+        setJobs([]);
+        setError(errorMessage(caught, "Scholion could not load previous transcription jobs."));
+      });
+
+    void withTimeout(
+      client.discoverRecordings(),
+      SECONDARY_REFRESH_TIMEOUT_MS,
+      "Remembered recording locations did not finish checking within 15 seconds.",
+    )
+      .then((discovered) => setRecordings(discovered.recordings))
+      .catch(() => setRecordings([]));
   }, [client, processing, profile]);
 
   useEffect(() => {
@@ -149,10 +187,12 @@ export function ProcessingCenter({
     setError(null);
     void refresh()
       .catch((caught) => {
+        setReadiness(null);
         setError(
-          caught instanceof Error
-            ? caught.message
-            : "Scholion could not check this computer for local transcription.",
+          errorMessage(
+            caught,
+            "Scholion could not check this computer for local transcription.",
+          ),
         );
       })
       .finally(() => setBusy(false));

--- a/frontend/src/api/nativeProtocol.ts
+++ b/frontend/src/api/nativeProtocol.ts
@@ -22,6 +22,28 @@ export interface NativeProtocolMessages {
   failure: string;
 }
 
+export function nativeInvokeErrorMessage(
+  caught: unknown,
+  fallback: string,
+): string {
+  if (caught instanceof Error && caught.message.trim()) {
+    return caught.message;
+  }
+  if (typeof caught === "string" && caught.trim()) {
+    return caught;
+  }
+  if (
+    caught &&
+    typeof caught === "object" &&
+    "message" in caught &&
+    typeof caught.message === "string" &&
+    caught.message.trim()
+  ) {
+    return caught.message;
+  }
+  return fallback;
+}
+
 export function parseNativeProtocolResponse<T>(
   value: unknown,
   messages: NativeProtocolMessages,
@@ -47,17 +69,21 @@ export async function invokeNativeProtocol<T>(
   messages: NativeProtocolMessages,
 ): Promise<T> {
   const { invoke } = await import("@tauri-apps/api/core");
-  const response = parseNativeProtocolResponse<T>(
-    await invoke<unknown>(command, {
+  let rawResponse: unknown;
+  try {
+    rawResponse = await invoke<unknown>(command, {
       request: {
         protocol_version: 1,
         request_id: crypto.randomUUID(),
         method,
         params,
       },
-    }),
-    messages,
-  );
+    });
+  } catch (caught) {
+    throw new Error(nativeInvokeErrorMessage(caught, messages.failure));
+  }
+
+  const response = parseNativeProtocolResponse<T>(rawResponse, messages);
   if (!response.ok || response.result === null) {
     throw new Error(response.error?.message ?? messages.failure);
   }

--- a/frontend/src/api/nativeProtocol.ts
+++ b/frontend/src/api/nativeProtocol.ts
@@ -80,7 +80,9 @@ export async function invokeNativeProtocol<T>(
       },
     });
   } catch (caught) {
-    throw new Error(nativeInvokeErrorMessage(caught, messages.failure));
+    throw new Error(nativeInvokeErrorMessage(caught, messages.failure), {
+      cause: caught,
+    });
   }
 
   const response = parseNativeProtocolResponse<T>(rawResponse, messages);

--- a/frontend/tests/frontend-contracts.spec.ts
+++ b/frontend/tests/frontend-contracts.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { parseNativeProtocolResponse } from "../src/api/nativeProtocol";
+import {
+  nativeInvokeErrorMessage,
+  parseNativeProtocolResponse,
+} from "../src/api/nativeProtocol";
 import { formatEvidenceTime } from "../src/format";
 import { DEFAULT_THEME, isTheme, THEMES } from "../src/themes";
 
@@ -83,4 +86,20 @@ test("native protocol parser accepts version one and rejects malformed envelopes
       messages,
     ),
   ).toThrow("incompatible native response");
+});
+
+test("native invoke errors preserve controlled Rust messages", () => {
+  expect(
+    nativeInvokeErrorMessage(
+      "Scholion's local Python service exited unexpectedly",
+      "fallback",
+    ),
+  ).toBe("Scholion's local Python service exited unexpectedly");
+  expect(nativeInvokeErrorMessage(new Error("native command failed"), "fallback")).toBe(
+    "native command failed",
+  );
+  expect(nativeInvokeErrorMessage({ message: "structured native failure" }, "fallback")).toBe(
+    "structured native failure",
+  );
+  expect(nativeInvokeErrorMessage({ code: "unknown" }, "fallback")).toBe("fallback");
 });

--- a/scripts/bootstrap_python.py
+++ b/scripts/bootstrap_python.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+UV_VERSION = "0.12.5"
+
+
+def run(*args: str, cwd: Path | None = None) -> None:
+    subprocess.run(args, cwd=cwd, check=True)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    tools_root = repo_root / ".tools" / "uv"
+    tools_python = (
+        tools_root / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else tools_root / "bin" / "python"
+    )
+    uv_executable = (
+        tools_root / "Scripts" / "uv.exe"
+        if os.name == "nt"
+        else tools_root / "bin" / "uv"
+    )
+
+    if sys.version_info[:2] != (3, 12):
+        print(
+            "Scholion requires Python 3.12 for source development. "
+            f"This bootstrap is running under {sys.version.split()[0]}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not tools_python.exists():
+        print(f"Creating project-local uv tool environment at {tools_root}")
+        run(sys.executable, "-m", "venv", str(tools_root))
+
+    print(f"Ensuring uv {UV_VERSION} is installed only inside .tools/uv")
+    run(
+        str(tools_python),
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        f"uv=={UV_VERSION}",
+    )
+
+    print("Synchronizing Scholion's locked Python environment")
+    run(
+        str(uv_executable),
+        "sync",
+        "--locked",
+        "--extra",
+        "transcription",
+        cwd=repo_root,
+    )
+
+    project_python = (
+        repo_root / ".venv" / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else repo_root / ".venv" / "bin" / "python"
+    )
+    if not project_python.exists():
+        print("Bootstrap completed without creating .venv/bin/python", file=sys.stderr)
+        return 3
+
+    run(str(project_python), "-c", "import scholion; print('Scholion import OK')")
+    print()
+    print("Project-local toolchain is ready:")
+    print(f"  uv tool: {uv_executable}")
+    print(f"  project Python: {project_python}")
+    print("No system-wide uv installation was required.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_python.py
+++ b/scripts/bootstrap_python.py
@@ -5,11 +5,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-UV_VERSION = "0.12.5"
+UV_VERSION = "0.11.33"
 
 
 def run(*args: str, cwd: Path | None = None) -> None:
-    subprocess.run(args, cwd=cwd, check=True)
+    # Every executable/argument is constructed from repository-controlled paths and
+    # fixed literals; no shell is involved and no user-provided command is executed.
+    subprocess.run(args, cwd=cwd, check=True)  # noqa: S603
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Real-device Linux testing exposed a gap between healthy Python Processing services and the native desktop UI. On a Ryzen 9 7950X / 64 GB / RTX 4080 workstation, `scholion doctor`, runner inspection, CUDA strategy assessment, model inventory, and the exact `processing.readiness` / `processing.jobs.list` Python bridge requests all succeeded, while the native Processing screen remained stuck on `Checking…`.

This PR hardens that native boundary and turns the developer-setup lessons into repeatable repository tooling/documentation.

### Processing/native diagnostics

- preserve controlled Tauri/Rust rejection messages instead of flattening string/object failures into a generic frontend error
- make machine readiness the primary Processing refresh instead of coupling it to job history with one `Promise.all`
- render readiness as soon as it returns; load prior jobs and remembered recordings independently
- bound readiness and secondary refreshes to 15 seconds so the UI cannot wait forever
- add debug-only Rust bridge lifecycle diagnostics for module, protocol method, selected Python executable, exit status, and stdout/stderr byte counts
- deliberately avoid logging request params, evidence paths, transcript text, or source/model content
- update the debug Python-unavailable recovery message to point at the repository bootstrap
- add frontend contract coverage for native error normalization

### Project-local source bootstrap

- ignore `.tools/` as disposable developer state
- add `scripts/bootstrap_python.py`
- pin the same `uv 0.11.33` used by CI inside `Scholion/.tools/uv`
- keep the package manager outside `.venv` so deleting a stale application environment does not delete the tool required to recreate it
- sync `.venv` from `uv.lock` with the transcription extra and verify the Scholion import
- require no system-wide uv installation
- document Linux/macOS and Windows project-local setup, lockfile ownership, stale-shell recovery, missing-pip semantics, and post-pull synchronization

### Native release qualification

- add a Processing diagnostic runbook containing the exact CLI/bridge/Tauri/Wayland checks used during the real-device investigation
- record that browser Playwright uses `?e2e=1` mocks and therefore cannot qualify the real React → Tauri → Rust → Python seam
- add a native release checklist for supported operating systems and representative CPU-only/CUDA hardware

### Pre-release security hardening

Add an ordered security roadmap covering:

1. cryptographic signatures for manifests
2. secure application updates
3. model-signing trust root
4. sandboxing native parsers
5. tighter process isolation
6. OS keychain integration
7. application-layer encryption after threat-model, recovery, backup, and portability semantics are defined

The plan groups these into supply-chain trust, hostile-input/process containment, and data-at-rest/key custody rather than treating them as interchangeable checkboxes.

## What this PR does not claim

The direct Python bridge is healthy on the reproducing Linux machine, but the exact underlying native stall has not yet been proven from CI because existing browser E2E intentionally mocks the native client. The new timeout/error propagation/Rust diagnostics make the failing native seam observable instead of leaving the UI indefinitely ambiguous. Real-device retest of this branch is still required.

The frontend timeout does not kill an already-running native invocation; process-level cancellation/isolation is tracked in the release-hardening plan.

This PR also does not implement the secure update/model trust root or application-layer encryption. It records those as explicit pre-release security work with acceptance boundaries.

## Qualification

The branch is intended to run the existing locked Python quality checks, strict TypeScript/build, frontend contracts/Playwright/axe, native Cargo check/tests, and platform smoke. A real-device Processing retest remains part of acceptance because that is the seam browser mocks cannot prove.