### PR TITLE
Stabilize native bridge concurrency and Processing diagnostics

### DIFF
--- a/docs/development/native-processing-diagnostics.md
+++ b/docs/development/native-processing-diagnostics.md
@@ -90,26 +90,38 @@ WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri dev
 
 Do not make the workaround a global environment setting.
 
+In a debug source build, Rust automatically prefers the repository `.venv` interpreter when `../.venv/bin/python` (or the Windows equivalent) exists. An explicit `SCHOLION_PYTHON` override is normally unnecessary.
+
 ## 5. Force the known repository interpreter for one launch
 
-macOS/Linux:
+Only use an override when diagnosing interpreter selection.
+
+On macOS/Linux, preserve the `.venv/bin/python` path itself:
 
 ```bash
-SCHOLION_PYTHON="$(realpath ../.venv/bin/python)" npm run tauri dev
+SCHOLION_PYTHON="../.venv/bin/python" npm run tauri dev
 ```
 
 Linux/Wayland when the DMABUF workaround is also required:
 
 ```bash
 WEBKIT_DISABLE_DMABUF_RENDERER=1 \
-SCHOLION_PYTHON="$(realpath ../.venv/bin/python)" \
+SCHOLION_PYTHON="../.venv/bin/python" \
 npm run tauri dev
 ```
 
-PowerShell:
+If an absolute path is useful, construct it without resolving the final `python` symlink:
+
+```bash
+SCHOLION_PYTHON="$(pwd)/../.venv/bin/python" npm run tauri dev
+```
+
+**Do not run `realpath` or `readlink -f` on `.venv/bin/python`.** On Unix, virtual-environment launchers are commonly symlinks to a base interpreter. Resolving that symlink first can turn the command into the underlying uv/Python runtime path, bypass the virtual environment's `pyvenv.cfg`, and make `python -m scholion...` fail with `ModuleNotFoundError` even though `.venv` itself is healthy.
+
+PowerShell can use the repository path directly:
 
 ```powershell
-$env:SCHOLION_PYTHON = (Resolve-Path ..\.venv\Scripts\python.exe)
+$env:SCHOLION_PYTHON = "..\.venv\Scripts\python.exe"
 npm.cmd run tauri dev
 ```
 
@@ -129,11 +141,21 @@ It deliberately does **not** log request params, evidence paths, transcript text
 
 A successful request should show a `bridge start` line followed by `bridge finish`. If start appears without finish, the Python child did not return. If finish appears and a `bridge parse failure` follows, the child returned bytes that were not one valid protocol JSON response.
 
+If every bridge exits immediately with status 1, `stdout_bytes=0`, and a small nonzero stderr after an explicit `SCHOLION_PYTHON` override, first run:
+
+```bash
+"$SCHOLION_PYTHON" -c "import sys, scholion; print(sys.executable); print(sys.prefix); print(scholion.__file__)"
+```
+
+An import failure means the selected executable is not entering Scholion's application environment. Remove the override and let the debug host select the repository `.venv`, or point the override at `.venv/bin/python` without resolving symlinks.
+
 ## 7. Processing-specific behavior
 
 The Processing screen now treats machine readiness as the primary operation. Once readiness returns, the hardware/model UI renders without waiting for job history or remembered-folder discovery.
 
 The machine check is bounded to 15 seconds. A timeout is surfaced as an explicit error instead of leaving the card on `Checking…` forever. Job-history and recording-discovery refreshes are independently bounded and cannot blank an otherwise healthy readiness result.
+
+Repeated success/failure alternation for identical native calls can indicate overlapping one-shot bridge processes contending for the same local database-backed state. Native source builds serialize those bridge processes so one control-plane request crosses the database boundary at a time. Long-running transcription/model workers use their separate task process path.
 
 ## 8. What browser E2E does not prove
 

--- a/docs/development/project-local-toolchain.md
+++ b/docs/development/project-local-toolchain.md
@@ -74,6 +74,27 @@ which python
 
 which should resolve to the repository's `.venv/bin/python`.
 
+### Preserve the virtual-environment launcher path
+
+On Unix, `.venv/bin/python` is often a symlink to the base interpreter used to create the environment. That symlink path is significant because Python uses the virtual-environment layout and `pyvenv.cfg` to establish `sys.prefix` and discover the environment's installed packages.
+
+Do **not** canonicalize the launcher before passing it to another process:
+
+```bash
+# Correct
+SCHOLION_PYTHON="../.venv/bin/python" npm run tauri dev
+
+# Also correct when an absolute spelling is useful
+SCHOLION_PYTHON="$(pwd)/../.venv/bin/python" npm run tauri dev
+
+# Wrong: may dereference the venv launcher into uv's/base Python runtime
+SCHOLION_PYTHON="$(realpath ../.venv/bin/python)" npm run tauri dev
+```
+
+Likewise, avoid `readlink -f` on the venv Python executable. Dereferencing the final symlink can bypass the application environment and produce `ModuleNotFoundError: No module named 'scholion'` even though `.venv` itself is healthy.
+
+For normal debug source builds, no `SCHOLION_PYTHON` override is required: the Tauri host already prefers the repository `.venv` when it exists.
+
 ## Bootstrap on Windows PowerShell
 
 From the repository root:

--- a/frontend/scripts/desktop-doctor.mjs
+++ b/frontend/scripts/desktop-doctor.mjs
@@ -70,14 +70,19 @@ function looksLikePath(value) {
   return isAbsolute(value) || value.includes("/") || value.includes("\\");
 }
 
+function pythonBootstrapRemedy(source) {
+  const bootstrap = "From the repository root run: python3.12 scripts/bootstrap_python.py";
+  return source === "SCHOLION_PYTHON"
+    ? `Fix or unset SCHOLION_PYTHON. ${bootstrap}`
+    : bootstrap;
+}
+
 function checkPythonBackend(command, source) {
   if (looksLikePath(command) && !existsSync(command)) {
     fail(
       "Python backend",
       `${source} points to a file that does not exist: ${command}`,
-      source === "SCHOLION_PYTHON"
-        ? "Fix or unset SCHOLION_PYTHON, or create the repository environment with: uv sync --locked --extra transcription"
-        : "From the repository root run: uv sync --locked --extra transcription",
+      pythonBootstrapRemedy(source),
     );
     return;
   }
@@ -97,9 +102,7 @@ function checkPythonBackend(command, source) {
   fail(
     "Python backend",
     detail,
-    source === "SCHOLION_PYTHON"
-      ? "Fix or unset SCHOLION_PYTHON, or create the repository environment with: uv sync --locked --extra transcription"
-      : "From the repository root run: uv sync --locked --extra transcription",
+    pythonBootstrapRemedy(source),
   );
 }
 
@@ -215,7 +218,7 @@ if (mode === "mock") {
     fail(
       "Python backend",
       "the repository .venv is missing",
-      "From the repository root run: uv sync --locked --extra transcription",
+      pythonBootstrapRemedy("repository .venv"),
     );
   }
 

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -3,8 +3,16 @@ use std::env;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Mutex;
 
 const MAX_REQUEST_BYTES: usize = 128 * 1024;
+
+// Each one-shot Python bridge process composes application services that may open the
+// same DuckDB-backed projections. DuckDB does not support overlapping writer processes
+// against one database file, so native bridge calls must cross that boundary serially.
+// Long-running Processing workers use a separate command path and are not held behind
+// this lock.
+static BRIDGE_PROCESS_LOCK: Mutex<()> = Mutex::new(());
 
 pub(crate) fn configured_python() -> PathBuf {
     if let Ok(value) = env::var("SCHOLION_PYTHON") {
@@ -54,6 +62,10 @@ fn request_method(request: &Value) -> &str {
 }
 
 fn run_python_request(module: &'static str, request: Value) -> Result<Value, String> {
+    let _bridge_guard = BRIDGE_PROCESS_LOCK
+        .lock()
+        .map_err(|_| "Scholion's local desktop bridge is unavailable".to_string())?;
+
     let method = request_method(&request).to_string();
     let encoded =
         serde_json::to_vec(&request).map_err(|_| "Could not encode desktop request".to_string())?;

--- a/frontend/src-tauri/src/processing.rs
+++ b/frontend/src-tauri/src/processing.rs
@@ -121,7 +121,7 @@ fn validate_envelope(task: &Value) -> Result<TaskEnvelope, String> {
 
 fn python_unavailable_message() -> String {
     if cfg!(debug_assertions) {
-        "Scholion's local Python worker is unavailable. From the repository root run `uv sync --locked --extra transcription`, or set SCHOLION_PYTHON to a compatible interpreter."
+        "Scholion's local Python worker is unavailable. From the repository root run `python3.12 scripts/bootstrap_python.py`, or set SCHOLION_PYTHON to a compatible repository virtual-environment interpreter."
             .to_string()
     } else {
         "Scholion's local Python worker is unavailable".to_string()

--- a/frontend/src/processing-center.css
+++ b/frontend/src/processing-center.css
@@ -26,19 +26,26 @@
   line-height: 1.55;
 }
 .processing-intro > p { margin: 0; font-size: 0.92rem; }
-.processing-status { max-width: 1180px; margin: 0 auto 16px; font-size: 0.82rem; }
+.processing-status {
+  max-width: 1180px;
+  margin: 0 auto 20px;
+  display: grid;
+  gap: 7px;
+  font-size: 0.82rem;
+}
 .processing-status p { margin: 0; }
-.processing-status .error-banner { margin: 8px 0 0; }
+.processing-status .error-banner { margin: 0; }
 .processing-grid {
   max-width: 1180px;
-  margin: 0 auto 14px;
+  margin: 0 auto 18px;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
+  align-items: start;
 }
 .processing-card {
   max-width: 1180px;
-  margin: 0 auto 14px;
+  margin: 0 auto 18px;
   border: 1px solid var(--border);
   border-radius: 20px;
   background: var(--surface);
@@ -188,6 +195,16 @@
 .audio-track-option strong { overflow-wrap: anywhere; }
 .audio-track-option small { color: var(--muted); line-height: 1.4; }
 .processing-advanced { margin: 18px 0 0; }
+.processing-advanced > p {
+  margin: 0;
+  padding: 0 17px 2px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+.processing-advanced > .readiness-checks {
+  margin: 12px 17px 16px;
+}
 .advanced-processing-grid { padding: 0 17px 16px; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .advanced-processing-grid label { display: grid; gap: 6px; font-size: 0.78rem; font-weight: 650; }
 .advanced-processing-grid select {

--- a/src/scholion/desktop/host_protocol.py
+++ b/src/scholion/desktop/host_protocol.py
@@ -42,6 +42,15 @@ def failure_response(request_id: str, *, code: str, message: str) -> BridgeRespo
     }
 
 
+def _request_id(payload: object) -> str:
+    if not isinstance(payload, dict):
+        return "unknown"
+    value = payload.get("request_id")
+    if not isinstance(value, str) or not value:
+        return "unknown"
+    return value[:128]
+
+
 def run_stdio_bridge(
     handler: BridgeHandler,
     *,
@@ -52,7 +61,8 @@ def run_stdio_bridge(
 
     ``handler`` remains bridge-specific. Constructing services inside it happens while
     stdout is redirected to stderr so application diagnostics cannot corrupt the single
-    JSON response expected by the Rust host.
+    JSON response expected by the Rust host. Unexpected handler/bootstrap failures are
+    normalized into one bounded protocol response instead of crashing the Python process.
     """
     raw = sys.stdin.buffer.read(MAX_REQUEST_BYTES + 1)
     if len(raw) > MAX_REQUEST_BYTES:
@@ -71,8 +81,15 @@ def run_stdio_bridge(
                 message=invalid_json_message,
             )
         else:
-            with redirect_stdout(sys.stderr):
-                response = handler(payload)
+            try:
+                with redirect_stdout(sys.stderr):
+                    response = handler(payload)
+            except Exception:
+                response = failure_response(
+                    _request_id(payload),
+                    code="internal_error",
+                    message="Scholion could not initialize the local desktop service",
+                )
 
     sys.stdout.write(json.dumps(response, sort_keys=True))
     sys.stdout.write("\n")

--- a/src/scholion/desktop/tests/test_host_protocol.py
+++ b/src/scholion/desktop/tests/test_host_protocol.py
@@ -74,6 +74,27 @@ def test_stdio_bridge_runs_only_valid_bounded_json_and_keeps_diagnostics_off_std
     assert "diagnostic from application service" in stderr
 
 
+def test_stdio_bridge_normalizes_unexpected_handler_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(_payload: object) -> dict[str, object]:
+        raise RuntimeError("private implementation detail")
+
+    response, stderr = _run(
+        monkeypatch,
+        b'{"request_id":"r-bootstrap"}',
+        handler,
+    )
+
+    assert response == failure_response(
+        "r-bootstrap",
+        code="internal_error",
+        message="Scholion could not initialize the local desktop service",
+    )
+    assert stderr == ""
+    assert "private implementation detail" not in json.dumps(response)
+
+
 def test_stdio_bridge_rejects_invalid_json_before_dispatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Real-device source-build testing exposed intermittent native bridge failures where identical one-shot desktop requests could alternate between success and process exit while the underlying Python operations were healthy in isolation.

This PR hardens that boundary without exposing local workstation details.

### Native bridge stability

- serialize one-shot Python bridge processes before they cross shared local database-backed state
- keep long-running transcription/model workers on their separate task-process path
- normalize unexpected bridge handler/bootstrap exceptions into one bounded `internal_error` protocol response instead of letting the Python process exit outside the protocol
- add regression coverage that verifies private exception details do not cross the bridge response

### Source-build recovery

- preserve the repository `.venv/bin/python` launcher path when using `SCHOLION_PYTHON`
- explicitly warn against dereferencing the final virtualenv Python symlink with `realpath` or `readlink -f`
- document that normal debug builds already prefer the repository virtual environment and usually need no interpreter override
- route desktop-doctor and long-running-worker recovery advice through the repository-owned `scripts/bootstrap_python.py` path instead of assuming a user/system `uv` command
- document the repeated success/failure signature associated with overlapping one-shot bridge processes

### Processing layout polish

- stop the two readiness cards from stretching to artificial equal heights
- normalize spacing around status/error copy
- give expanded readiness details consistent internal padding

## Privacy note

The PR description and committed documentation use only generic paths and generalized diagnostic signatures. No local username, hostname, home-directory path, recording path, transcript content, or machine-specific log excerpt is included.

## Qualification

CI should exercise Python protocol tests, Rust formatting/clippy/native tests, strict frontend checks, browser accessibility/E2E, and platform smoke. A real native source-build retest remains part of acceptance because browser mocks do not exercise the Rust-to-Python transport boundary.