### PR TITLE
Expose safe Processing task feedback and capability state

### DIFF
--- a/frontend/src-tauri/src/processing.rs
+++ b/frontend/src-tauri/src/processing.rs
@@ -151,6 +151,19 @@ fn read_worker_outcome(child: &mut Child) -> Option<WorkerOutcome> {
     parse_worker_outcome(&bytes)
 }
 
+fn ensure_no_running_task(entries: &mut HashMap<String, ProcessEntry>) -> Result<(), String> {
+    for entry in entries.values_mut() {
+        entry.refresh()?;
+    }
+    if entries.values().any(|entry| entry.state == "running") {
+        return Err(
+            "Another local processing task is already running. Wait for it to finish or stop it first."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 #[derive(Default)]
 pub struct ProcessingProcesses {
     entries: Mutex<HashMap<String, ProcessEntry>>,
@@ -220,6 +233,7 @@ pub async fn processing_start_task(
     if entries.contains_key(&envelope.task_id) {
         return Err("Processing task identifier is already in use".to_string());
     }
+    ensure_no_running_task(&mut entries)?;
 
     let mut child = Command::new(crate::backend::configured_python())
         .args(["-m", "scholion.desktop.processing_worker"])
@@ -301,6 +315,16 @@ pub async fn processing_cancel_task(
 mod tests {
     use super::*;
 
+    fn completed_entry(state: &'static str) -> ProcessEntry {
+        ProcessEntry {
+            child: None,
+            state,
+            exit_code: None,
+            error_code: None,
+            error_message: None,
+        }
+    }
+
     #[test]
     fn worker_outcome_requires_a_valid_versioned_shape() {
         let success = br#"{"protocol_version":1,"ok":true,"error":null}"#;
@@ -344,5 +368,16 @@ mod tests {
         assert!(valid_worker_error(&valid));
         assert!(!valid_worker_error(&invalid_code));
         assert!(!valid_worker_error(&oversized_message));
+    }
+
+    #[test]
+    fn only_one_long_running_processing_task_can_be_active() {
+        let mut entries = HashMap::from([("active".to_string(), completed_entry("running"))]);
+
+        let error = ensure_no_running_task(&mut entries).expect_err("running task must block");
+        assert!(error.contains("already running"));
+
+        entries.get_mut("active").expect("entry exists").state = "completed";
+        assert!(ensure_no_running_task(&mut entries).is_ok());
     }
 }

--- a/frontend/src-tauri/src/processing.rs
+++ b/frontend/src-tauri/src/processing.rs
@@ -1,12 +1,14 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::Mutex;
 use tauri::State;
 
 const MAX_TASK_BYTES: usize = 64 * 1024;
+const MAX_TASK_RESULT_BYTES: usize = 8 * 1024;
+const WORKER_PROTOCOL_VERSION: u8 = 1;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -24,17 +26,34 @@ struct TaskEnvelope {
     kind: TaskKind,
 }
 
+#[derive(Debug, Deserialize)]
+struct WorkerError {
+    code: String,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkerOutcome {
+    protocol_version: u8,
+    ok: bool,
+    error: Option<WorkerError>,
+}
+
 #[derive(Clone, Serialize)]
 pub struct TaskStatus {
     task_id: String,
     state: &'static str,
     exit_code: Option<i32>,
+    error_code: Option<String>,
+    error_message: Option<String>,
 }
 
 struct ProcessEntry {
     child: Option<Child>,
     state: &'static str,
     exit_code: Option<i32>,
+    error_code: Option<String>,
+    error_message: Option<String>,
 }
 
 impl ProcessEntry {
@@ -43,6 +62,8 @@ impl ProcessEntry {
             child: Some(child),
             state: "running",
             exit_code: None,
+            error_code: None,
+            error_message: None,
         }
     }
 
@@ -60,12 +81,22 @@ impl ProcessEntry {
     }
 
     fn finish(&mut self, status: ExitStatus) {
+        let outcome = self.child.as_mut().and_then(read_worker_outcome);
         self.exit_code = status.code();
-        self.state = if status.success() {
+        self.state = if status.success() && outcome.as_ref().is_none_or(|item| item.ok) {
             "completed"
         } else {
             "failed"
         };
+        if self.state == "failed" {
+            if let Some(error) = outcome.and_then(|item| item.error) {
+                self.error_code = Some(error.code);
+                self.error_message = Some(error.message);
+            } else {
+                self.error_code = Some("worker_failed".to_string());
+                self.error_message = Some("Local processing stopped before completion".to_string());
+            }
+        }
         self.child = None;
     }
 
@@ -74,8 +105,25 @@ impl ProcessEntry {
             task_id: task_id.to_string(),
             state: self.state,
             exit_code: self.exit_code,
+            error_code: self.error_code.clone(),
+            error_message: self.error_message.clone(),
         }
     }
+}
+
+fn read_worker_outcome(child: &mut Child) -> Option<WorkerOutcome> {
+    let stdout = child.stdout.take()?;
+    let mut bounded = stdout.take((MAX_TASK_RESULT_BYTES + 1) as u64);
+    let mut bytes = Vec::new();
+    bounded.read_to_end(&mut bytes).ok()?;
+    if bytes.len() > MAX_TASK_RESULT_BYTES {
+        return None;
+    }
+    let outcome: WorkerOutcome = serde_json::from_slice(&bytes).ok()?;
+    if outcome.protocol_version != WORKER_PROTOCOL_VERSION {
+        return None;
+    }
+    Some(outcome)
 }
 
 #[derive(Default)]
@@ -151,7 +199,7 @@ pub async fn processing_start_task(
     let mut child = Command::new(crate::backend::configured_python())
         .args(["-m", "scholion.desktop.processing_worker"])
         .stdin(Stdio::piped())
-        .stdout(Stdio::null())
+        .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
         .map_err(|_| python_unavailable_message())?;
@@ -217,6 +265,8 @@ pub async fn processing_cancel_task(
         })?;
         entry.exit_code = status.code();
         entry.state = "cancelled";
+        entry.error_code = None;
+        entry.error_message = None;
         entry.child = None;
     }
     Ok(entry.status(&task_id))

--- a/frontend/src-tauri/src/processing.rs
+++ b/frontend/src-tauri/src/processing.rs
@@ -8,6 +8,8 @@ use tauri::State;
 
 const MAX_TASK_BYTES: usize = 64 * 1024;
 const MAX_TASK_RESULT_BYTES: usize = 8 * 1024;
+const MAX_PUBLIC_ERROR_CODE_BYTES: usize = 128;
+const MAX_PUBLIC_ERROR_MESSAGE_BYTES: usize = 1024;
 const WORKER_PROTOCOL_VERSION: u8 = 1;
 
 #[derive(Debug, Deserialize)]
@@ -83,13 +85,16 @@ impl ProcessEntry {
     fn finish(&mut self, status: ExitStatus) {
         let outcome = self.child.as_mut().and_then(read_worker_outcome);
         self.exit_code = status.code();
-        self.state = if status.success() && outcome.as_ref().is_none_or(|item| item.ok) {
+        self.state = if worker_completed(status.success(), outcome.as_ref()) {
             "completed"
         } else {
             "failed"
         };
         if self.state == "failed" {
-            if let Some(error) = outcome.and_then(|item| item.error) {
+            if let Some(error) = outcome
+                .filter(|item| !item.ok)
+                .and_then(|item| item.error)
+            {
                 self.error_code = Some(error.code);
                 self.error_message = Some(error.message);
             } else {
@@ -111,19 +116,42 @@ impl ProcessEntry {
     }
 }
 
+fn worker_completed(process_succeeded: bool, outcome: Option<&WorkerOutcome>) -> bool {
+    process_succeeded && matches!(outcome, Some(item) if item.ok)
+}
+
+fn valid_worker_error(error: &WorkerError) -> bool {
+    !error.code.is_empty()
+        && error.code.len() <= MAX_PUBLIC_ERROR_CODE_BYTES
+        && error
+            .code
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+        && !error.message.trim().is_empty()
+        && error.message.len() <= MAX_PUBLIC_ERROR_MESSAGE_BYTES
+}
+
+fn parse_worker_outcome(bytes: &[u8]) -> Option<WorkerOutcome> {
+    if bytes.is_empty() || bytes.len() > MAX_TASK_RESULT_BYTES {
+        return None;
+    }
+    let outcome: WorkerOutcome = serde_json::from_slice(bytes).ok()?;
+    if outcome.protocol_version != WORKER_PROTOCOL_VERSION {
+        return None;
+    }
+    match (&outcome.ok, &outcome.error) {
+        (true, None) => Some(outcome),
+        (false, Some(error)) if valid_worker_error(error) => Some(outcome),
+        _ => None,
+    }
+}
+
 fn read_worker_outcome(child: &mut Child) -> Option<WorkerOutcome> {
     let stdout = child.stdout.take()?;
     let mut bounded = stdout.take((MAX_TASK_RESULT_BYTES + 1) as u64);
     let mut bytes = Vec::new();
     bounded.read_to_end(&mut bytes).ok()?;
-    if bytes.len() > MAX_TASK_RESULT_BYTES {
-        return None;
-    }
-    let outcome: WorkerOutcome = serde_json::from_slice(&bytes).ok()?;
-    if outcome.protocol_version != WORKER_PROTOCOL_VERSION {
-        return None;
-    }
-    Some(outcome)
+    parse_worker_outcome(&bytes)
 }
 
 #[derive(Default)]
@@ -270,4 +298,56 @@ pub async fn processing_cancel_task(
         entry.child = None;
     }
     Ok(entry.status(&task_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_outcome_requires_a_valid_versioned_shape() {
+        let success = br#"{"protocol_version":1,"ok":true,"error":null}"#;
+        let failure = br#"{"protocol_version":1,"ok":false,"error":{"code":"transcription_failed","message":"Local transcription did not complete"}}"#;
+        let wrong_version = br#"{"protocol_version":2,"ok":true,"error":null}"#;
+        let success_with_error = br#"{"protocol_version":1,"ok":true,"error":{"code":"bad","message":"should not exist"}}"#;
+        let failure_without_error = br#"{"protocol_version":1,"ok":false,"error":null}"#;
+
+        assert!(parse_worker_outcome(success).is_some());
+        assert!(parse_worker_outcome(failure).is_some());
+        assert!(parse_worker_outcome(wrong_version).is_none());
+        assert!(parse_worker_outcome(success_with_error).is_none());
+        assert!(parse_worker_outcome(failure_without_error).is_none());
+        assert!(parse_worker_outcome(&[]).is_none());
+    }
+
+    #[test]
+    fn malformed_or_missing_outcome_never_counts_as_completed() {
+        let success = parse_worker_outcome(
+            br#"{"protocol_version":1,"ok":true,"error":null}"#,
+        );
+
+        assert!(worker_completed(true, success.as_ref()));
+        assert!(!worker_completed(true, None));
+        assert!(!worker_completed(false, success.as_ref()));
+    }
+
+    #[test]
+    fn worker_error_fields_are_bounded_and_structured() {
+        let valid = WorkerError {
+            code: "resource_admission_failed".to_string(),
+            message: "Current resources are below the safe requirement".to_string(),
+        };
+        let invalid_code = WorkerError {
+            code: "../../private".to_string(),
+            message: "No".to_string(),
+        };
+        let oversized_message = WorkerError {
+            code: "internal_error".to_string(),
+            message: "x".repeat(MAX_PUBLIC_ERROR_MESSAGE_BYTES + 1),
+        };
+
+        assert!(valid_worker_error(&valid));
+        assert!(!valid_worker_error(&invalid_code));
+        assert!(!valid_worker_error(&oversized_message));
+    }
 }

--- a/frontend/src-tauri/src/processing.rs
+++ b/frontend/src-tauri/src/processing.rs
@@ -91,10 +91,7 @@ impl ProcessEntry {
             "failed"
         };
         if self.state == "failed" {
-            if let Some(error) = outcome
-                .filter(|item| !item.ok)
-                .and_then(|item| item.error)
-            {
+            if let Some(error) = outcome.filter(|item| !item.ok).and_then(|item| item.error) {
                 self.error_code = Some(error.code);
                 self.error_message = Some(error.message);
             } else {
@@ -322,9 +319,7 @@ mod tests {
 
     #[test]
     fn malformed_or_missing_outcome_never_counts_as_completed() {
-        let success = parse_worker_outcome(
-            br#"{"protocol_version":1,"ok":true,"error":null}"#,
-        );
+        let success = parse_worker_outcome(br#"{"protocol_version":1,"ok":true,"error":null}"#);
 
         assert!(worker_completed(true, success.as_ref()));
         assert!(!worker_completed(true, None));

--- a/frontend/src/ProcessingCenter.tsx
+++ b/frontend/src/ProcessingCenter.tsx
@@ -79,6 +79,7 @@ function taskLabel(task: ProcessingTaskStatus | null): string {
   if (task.state === "running") return "Running on this computer.";
   if (task.state === "completed") return "Completed.";
   if (task.state === "cancelled") return "Cancelled. Resumable progress was kept when possible.";
+  if (task.error_message?.trim()) return task.error_message;
   return "Stopped before completion. Refresh to see whether it can be resumed.";
 }
 
@@ -146,6 +147,8 @@ export function ProcessingCenter({
   const [execution, setExecution] = useState<ExecutionOptions>(defaultExecutionOptions);
   const [task, setTask] = useState<ProcessingTaskStatus | null>(null);
   const [taskDescription, setTaskDescription] = useState<string | null>(null);
+  const [taskModelId, setTaskModelId] = useState<string | null>(null);
+  const [taskModelAction, setTaskModelAction] = useState<"install" | "remove" | null>(null);
   const [pendingRemove, setPendingRemove] = useState<ProcessingModel | null>(null);
   const [pendingDiscard, setPendingDiscard] = useState<ProcessingJob | null>(null);
   const [busy, setBusy] = useState(false);
@@ -153,8 +156,10 @@ export function ProcessingCenter({
     "Checking this computer so Scholion can choose transcription settings that will run safely.",
   );
   const [error, setError] = useState<string | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
+    setRefreshError(null);
     const nextReadiness = await withTimeout(
       processing.readiness(profile),
       READINESS_TIMEOUT_MS,
@@ -170,7 +175,7 @@ export function ProcessingCenter({
       .then(setJobs)
       .catch((caught) => {
         setJobs([]);
-        setError(errorMessage(caught, "Scholion could not load previous transcription jobs."));
+        setRefreshError(errorMessage(caught, "Scholion could not load previous transcription jobs."));
       });
 
     void withTimeout(
@@ -184,11 +189,11 @@ export function ProcessingCenter({
 
   useEffect(() => {
     setBusy(true);
-    setError(null);
+    setRefreshError(null);
     void refresh()
       .catch((caught) => {
         setReadiness(null);
-        setError(
+        setRefreshError(
           errorMessage(
             caught,
             "Scholion could not check this computer for local transcription.",
@@ -199,15 +204,46 @@ export function ProcessingCenter({
   }, [refresh]);
 
   useEffect(() => {
+    if (readiness?.capabilities.speaker_labeling.available !== false) return;
+    setExecution((current) => {
+      if (
+        !current.diarize &&
+        !current.allowDiarizationModelDownload &&
+        current.speakers === null &&
+        current.minSpeakers === null &&
+        current.maxSpeakers === null
+      ) {
+        return current;
+      }
+      return {
+        ...current,
+        diarize: false,
+        allowDiarizationModelDownload: false,
+        speakers: null,
+        minSpeakers: null,
+        maxSpeakers: null,
+      };
+    });
+  }, [readiness]);
+
+  useEffect(() => {
     if (!task || task.state !== "running") return undefined;
     const timer = window.setInterval(() => {
       void processing
         .taskStatus(task.task_id)
         .then(async (next) => {
           setTask(next);
-          if (next.state !== "running") await refresh();
+          if (next.state === "failed") {
+            setError(next.error_message ?? "Local processing stopped before completion.");
+            setStatus("Local processing stopped before completion.");
+          }
+          if (next.state !== "running") {
+            await refresh();
+          }
         })
-        .catch(() => undefined);
+        .catch((caught) => {
+          setError(errorMessage(caught, "Scholion could not check the current local task."));
+        });
     }, 1500);
     return () => window.clearInterval(timer);
   }, [processing, refresh, task]);
@@ -227,6 +263,7 @@ export function ProcessingCenter({
     () => readiness?.strategies.filter((strategy) => strategy.feasible) ?? [],
     [readiness],
   );
+  const speakerLabeling = readiness?.capabilities.speaker_labeling ?? null;
 
   const preflightOptions: PreflightOptions = {
     profile,
@@ -360,6 +397,8 @@ export function ProcessingCenter({
             execution,
           );
       setTask(started);
+      setTaskModelId(null);
+      setTaskModelAction(null);
       setTaskDescription(`Transcribing ${preflight.recording_name}`);
       setStatus("Transcription started on this computer.");
       await refresh();
@@ -376,6 +415,8 @@ export function ProcessingCenter({
     try {
       const started = await processing.resumeTranscription(job, execution);
       setTask(started);
+      setTaskModelId(null);
+      setTaskModelAction(null);
       setTaskDescription(`Resuming ${job.recording_name}`);
       setStatus(`Resuming ${job.recording_name} from saved progress.`);
       await refresh();
@@ -392,6 +433,8 @@ export function ProcessingCenter({
     try {
       const started = await processing.installModel(model.model_id);
       setTask(started);
+      setTaskModelId(model.model_id);
+      setTaskModelAction("install");
       setTaskDescription(`Downloading ${model.model_id} transcription model`);
       setStatus(`Downloading the ${model.model_id} transcription model to this device. Scholion will check it before using it.`);
     } catch (caught) {
@@ -407,6 +450,8 @@ export function ProcessingCenter({
     try {
       const started = await processing.removeModel(model);
       setTask(started);
+      setTaskModelId(model.model_id);
+      setTaskModelAction("remove");
       setTaskDescription(`Removing ${model.model_id} transcription model`);
       setPendingRemove(null);
       setStatus(`Removing the ${model.model_id} transcription model from this device.`);
@@ -496,6 +541,7 @@ export function ProcessingCenter({
 
       <div className="processing-status" aria-live="polite">
         <p role="status">{status}</p>
+        {refreshError && <p className="error-banner" role="alert">{refreshError}</p>}
         {error && <p className="error-banner" role="alert">{error}</p>}
       </div>
 
@@ -603,24 +649,32 @@ export function ProcessingCenter({
         </div>
         <p>Models are downloaded only when you choose. Once installed, transcription can run without an internet connection.</p>
         <div className="model-list">
-          {readiness?.models.map((model) => (
-            <article key={model.model_id} className="model-row">
-              <div>
-                <strong>{model.model_id}</strong>
-                <span>{model.installed ? `Installed · ${formatBytes(model.installed_size_bytes ?? model.estimated_cache_bytes)}` : `Download size about ${formatBytes(model.estimated_cache_bytes)}`}</span>
-              </div>
-              <div className="model-actions">
-                {model.installed ? (
-                  <>
-                    <button type="button" onClick={() => void verifyModel(model)} disabled={busy}>Check files</button>
-                    <button type="button" className="danger-link" onClick={() => setPendingRemove(model)} disabled={busy}>Remove</button>
-                  </>
-                ) : (
-                  <button type="button" className="secondary-action" onClick={() => void installModel(model)} disabled={busy}>Download model</button>
-                )}
-              </div>
-            </article>
-          ))}
+          {readiness?.models.map((model) => {
+            const modelTaskActive = task?.state === "running" && taskModelId === model.model_id;
+            const downloading = modelTaskActive && taskModelAction === "install";
+            const removing = modelTaskActive && taskModelAction === "remove";
+            return (
+              <article key={model.model_id} className="model-row">
+                <div>
+                  <strong>{model.model_id}</strong>
+                  <span>{model.installed ? `Installed · ${formatBytes(model.installed_size_bytes ?? model.estimated_cache_bytes)}` : `Download size about ${formatBytes(model.estimated_cache_bytes)}`}</span>
+                  {modelTaskActive && (
+                    <progress aria-label={`${downloading ? "Downloading" : "Removing"} ${model.model_id} model`} />
+                  )}
+                </div>
+                <div className="model-actions">
+                  {model.installed ? (
+                    <>
+                      <button type="button" onClick={() => void verifyModel(model)} disabled={busy || modelTaskActive}>Check files</button>
+                      <button type="button" className="danger-link" onClick={() => setPendingRemove(model)} disabled={busy || modelTaskActive}>{removing ? "Removing…" : "Remove"}</button>
+                    </>
+                  ) : (
+                    <button type="button" className="secondary-action" onClick={() => void installModel(model)} disabled={busy || modelTaskActive}>{downloading ? "Downloading…" : "Download model"}</button>
+                  )}
+                </div>
+              </article>
+            );
+          })}
         </div>
         {pendingRemove && (
           <div className="confirmation-panel" aria-label={`Remove ${pendingRemove.model_id} confirmation`}>
@@ -733,12 +787,20 @@ export function ProcessingCenter({
               <label className="checkbox-row">
                 <input
                   type="checkbox"
-                  checked={execution.diarize}
+                  checked={execution.diarize && speakerLabeling?.available === true}
+                  disabled={busy || speakerLabeling?.available !== true}
                   onChange={(event) => setExecution((current) => ({ ...current, diarize: event.target.checked, allowDiarizationModelDownload: event.target.checked ? current.allowDiarizationModelDownload : false }))}
                 />
-                <span><strong>Label speakers automatically</strong><small>Adds recording-specific labels such as Speaker 1 and Speaker 2 after transcription.</small></span>
+                <span>
+                  <strong>Label speakers automatically</strong>
+                  <small>
+                    {speakerLabeling?.available
+                      ? "Adds recording-specific labels such as Speaker 1 and Speaker 2 after transcription."
+                      : speakerLabeling?.message ?? "Checking whether local speaker labeling is available."}
+                  </small>
+                </span>
               </label>
-              {execution.diarize && (
+              {execution.diarize && speakerLabeling?.available === true && (
                 <label className="checkbox-row">
                   <input
                     type="checkbox"

--- a/frontend/src/api/processing.ts
+++ b/frontend/src/api/processing.ts
@@ -45,10 +45,19 @@ export interface ProcessingModel {
   verification: string | null;
 }
 
+export interface ProcessingCapability {
+  available: boolean;
+  reason_code: string | null;
+  message: string | null;
+}
+
 export interface ProcessingReadiness {
   health: {
     status: "healthy" | "degraded" | "unhealthy";
     checks: ProcessingHealthCheck[];
+  };
+  capabilities: {
+    speaker_labeling: ProcessingCapability;
   };
   resources: {
     platform: string;
@@ -131,6 +140,8 @@ export interface ProcessingTaskStatus {
   task_id: string;
   state: "running" | "completed" | "failed" | "cancelled";
   exit_code: number | null;
+  error_code: string | null;
+  error_message: string | null;
 }
 
 export interface PreflightOptions {
@@ -411,6 +422,7 @@ class MockProcessingClient implements ProcessingClient {
 
   async readiness(profile: ProcessingProfile): Promise<ProcessingReadiness> {
     const recommendedModel = profile === "screening" ? "tiny" : profile === "accuracy" ? "medium" : "small";
+    const speakerLabelingHeld = new URLSearchParams(window.location.search).get("speaker-labeling-held") === "1";
     return {
       health: {
         status: "healthy",
@@ -419,6 +431,15 @@ class MockProcessingClient implements ProcessingClient {
           { check_id: "ffmpeg", status: "pass", summary: "FFmpeg and FFprobe are available", required: true, error_code: null },
           { check_id: "system_resources", status: "pass", summary: "Local resources are available", required: true, error_code: null },
         ],
+      },
+      capabilities: {
+        speaker_labeling: speakerLabelingHeld
+          ? {
+              available: false,
+              reason_code: "security_hold",
+              message: "Speaker labeling is temporarily unavailable because a local dependency does not meet Scholion's security requirement.",
+            }
+          : { available: true, reason_code: null, message: null },
       },
       resources: {
         platform: "Linux",
@@ -565,6 +586,8 @@ class MockProcessingClient implements ProcessingClient {
     if (!task) throw new Error("Unknown processing task");
     task.state = "cancelled";
     task.exit_code = null;
+    task.error_code = null;
+    task.error_message = null;
     return { ...task };
   }
 
@@ -574,6 +597,8 @@ class MockProcessingClient implements ProcessingClient {
       task_id: `mock-task-${this.taskCounter}`,
       state: "running",
       exit_code: null,
+      error_code: null,
+      error_message: null,
     };
     this.tasks.set(status.task_id, status);
     return { ...status };

--- a/frontend/src/processing-center.css
+++ b/frontend/src/processing-center.css
@@ -140,6 +140,12 @@
 .job-main > div:first-child { display: grid; gap: 4px; }
 .model-row span,
 .job-main span { color: var(--muted); font-size: 0.76rem; }
+.model-row progress {
+  width: min(260px, 100%);
+  height: 8px;
+  margin-top: 6px;
+  accent-color: var(--accent);
+}
 .model-actions,
 .job-actions,
 .task-actions,

--- a/frontend/tests/processing.spec.ts
+++ b/frontend/tests/processing.spec.ts
@@ -85,6 +85,32 @@ test("starting work uses the local-task path", async ({ page }) => {
   await expect(page.getByText(/Transcribing interview-01\.m4a/)).toBeVisible();
 });
 
+test("model downloads show an explicit in-place running state", async ({ page }) => {
+  await openProcessing(page);
+
+  const tinyModel = page.locator("article.model-row").filter({ hasText: "tiny" });
+  await tinyModel.getByRole("button", { name: "Download model" }).click();
+
+  await expect(tinyModel.getByRole("button", { name: "Downloading…" })).toBeDisabled();
+  await expect(tinyModel.getByRole("progressbar", { name: "Downloading tiny model" })).toBeVisible();
+});
+
+test("speaker labeling is disabled when the backend places the capability on security hold", async ({ page }) => {
+  await openProcessing(page, "&speaker-labeling-held=1");
+  await page.getByRole("button", { name: "Choose recording" }).click();
+  await page.getByRole("button", { name: "Check recording" }).click();
+  await page.getByText("Advanced options").click();
+
+  const speakerLabeling = page.getByLabel("Label speakers automatically");
+  await expect(speakerLabeling).toBeDisabled();
+  await expect(
+    page.getByText(/temporarily unavailable because a local dependency does not meet Scholion's security requirement/),
+  ).toBeVisible();
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations).toEqual([]);
+});
+
 test("interrupted work offers resume and a fresh retry as distinct actions", async ({ page }) => {
   await openProcessing(page);
 

--- a/src/scholion/app/processing_center.py
+++ b/src/scholion/app/processing_center.py
@@ -15,6 +15,7 @@ from scholion.runner.topology import (
     HardwareTopologyInspector,
     NvidiaSmiAcceleratorProbe,
 )
+from scholion.transcription.diarization_status import diarization_runtime_status
 from scholion.transcription.models import TranscriptionJobPlan
 from scholion.transcription.planner import TranscriptionJobPlanner
 from scholion.workspace.lifecycle import (
@@ -208,6 +209,7 @@ class ProcessingCenterService:
             None,
         )
         inventory = self.model_manager.inventory()
+        speaker_labeling = diarization_runtime_status()
         recommended_model: str | None = None
         recommended_installed = False
         if recommended is not None:
@@ -230,6 +232,9 @@ class ProcessingCenterService:
                     }
                     for check in health.checks
                 ],
+            },
+            "capabilities": {
+                "speaker_labeling": speaker_labeling.to_dict(),
             },
             "resources": {
                 "platform": resources.platform,

--- a/src/scholion/desktop/processing_worker.py
+++ b/src/scholion/desktop/processing_worker.py
@@ -9,18 +9,21 @@ from __future__ import annotations
 
 import json
 import sys
+from contextlib import redirect_stdout
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from scholion.app.app_container import AppContainer
 from scholion.app.job_runner import TranscriptionJobRunner
+from scholion.core.errors import ScholionError
 from scholion.runner.models import ProcessingProfile
 from scholion.transcription.export import TranscriptExportFormat
 from scholion.transcription.speaker_models import SpeakerDiarizationRequest
 from scholion.workspace.models import JobId
 
 _MAX_TASK_BYTES = 64 * 1024
+_WORKER_PROTOCOL_VERSION = 1
 
 
 class _TaskKind(BaseModel):
@@ -248,19 +251,70 @@ def run_task(payload: object, container: AppContainer) -> None:
     _run_model_remove(_ModelRemove.model_validate(payload), container)
 
 
+def _write_outcome(
+    *,
+    ok: bool,
+    error_code: str | None = None,
+    error_message: str | None = None,
+) -> None:
+    error: dict[str, str] | None = None
+    if error_code is not None and error_message is not None:
+        error = {"code": error_code, "message": error_message}
+    sys.stdout.write(
+        json.dumps(
+            {
+                "protocol_version": _WORKER_PROTOCOL_VERSION,
+                "ok": ok,
+                "error": error,
+            },
+            sort_keys=True,
+        )
+    )
+    sys.stdout.write("\n")
+
+
 def main() -> int:
     raw = sys.stdin.buffer.read(_MAX_TASK_BYTES + 1)
     if len(raw) > _MAX_TASK_BYTES:
+        _write_outcome(
+            ok=False,
+            error_code="invalid_task",
+            error_message="The local processing task exceeded the safe size limit",
+        )
         return 2
     try:
         payload = json.loads(raw)
-        run_task(payload, AppContainer())
+        with redirect_stdout(sys.stderr):
+            run_task(payload, AppContainer())
     except (UnicodeDecodeError, json.JSONDecodeError, ValidationError, ValueError):
+        _write_outcome(
+            ok=False,
+            error_code="invalid_task",
+            error_message="The local processing task was invalid or incompatible",
+        )
         return 2
+    except ScholionError as exc:
+        _write_outcome(
+            ok=False,
+            error_code=exc.code.value,
+            error_message=exc.public_message,
+        )
+        return exc.exit_code
     except KeyboardInterrupt:
+        _write_outcome(
+            ok=False,
+            error_code="cancelled",
+            error_message="Local processing was interrupted",
+        )
         return 130
     except BaseException:
+        _write_outcome(
+            ok=False,
+            error_code="internal_error",
+            error_message="Local processing did not complete successfully",
+        )
         return 1
+    _write_outcome(ok=True)
     return 0
 
 

--- a/src/scholion/desktop/tests/test_processing_worker.py
+++ b/src/scholion/desktop/tests/test_processing_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,6 +10,7 @@ import pytest
 
 from scholion.desktop import processing_worker as worker
 from scholion.runner.models import ProcessingProfile
+from scholion.transcription.errors import DiarizationDependencyError
 from scholion.transcription.export import TranscriptExportFormat
 from scholion.workspace.models import JobId
 
@@ -325,19 +327,24 @@ def _stdin(monkeypatch: pytest.MonkeyPatch, payload: bytes) -> None:
 
 def test_main_rejects_oversized_invalid_and_validation_payloads(
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     _stdin(monkeypatch, b"x" * (worker._MAX_TASK_BYTES + 1))
     assert worker.main() == 2
+    assert json.loads(capsys.readouterr().out)["error"]["code"] == "invalid_task"
 
     _stdin(monkeypatch, b"not-json")
     assert worker.main() == 2
+    assert json.loads(capsys.readouterr().out)["error"]["code"] == "invalid_task"
 
     _stdin(monkeypatch, b"{}")
     assert worker.main() == 2
+    assert json.loads(capsys.readouterr().out)["error"]["code"] == "invalid_task"
 
 
 def test_main_maps_success_interrupt_and_unexpected_failure(
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     payload = b'{"task_id":"task","kind":"model_install","model_id":"small"}'
     monkeypatch.setattr(worker, "AppContainer", lambda: cast(Any, object()))
@@ -345,6 +352,11 @@ def test_main_maps_success_interrupt_and_unexpected_failure(
     _stdin(monkeypatch, payload)
     monkeypatch.setattr(worker, "run_task", lambda value, container: None)
     assert worker.main() == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "error": None,
+        "ok": True,
+        "protocol_version": 1,
+    }
 
     _stdin(monkeypatch, payload)
 
@@ -353,6 +365,7 @@ def test_main_maps_success_interrupt_and_unexpected_failure(
 
     monkeypatch.setattr(worker, "run_task", interrupt)
     assert worker.main() == 130
+    assert json.loads(capsys.readouterr().out)["error"]["code"] == "cancelled"
 
     _stdin(monkeypatch, payload)
 
@@ -361,3 +374,33 @@ def test_main_maps_success_interrupt_and_unexpected_failure(
 
     monkeypatch.setattr(worker, "run_task", explode)
     assert worker.main() == 1
+    unknown = json.loads(capsys.readouterr().out)
+    assert unknown["error"] == {
+        "code": "internal_error",
+        "message": "Local processing did not complete successfully",
+    }
+    assert "private internal failure" not in json.dumps(unknown)
+
+
+def test_main_emits_only_public_scholion_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = b'{"task_id":"task","kind":"model_install","model_id":"small"}'
+    monkeypatch.setattr(worker, "AppContainer", lambda: cast(Any, object()))
+    _stdin(monkeypatch, payload)
+
+    def unavailable(value: object, container: object) -> None:
+        raise DiarizationDependencyError(
+            "Speaker labeling is unavailable in this build",
+            cause=RuntimeError("private dependency detail"),
+        )
+
+    monkeypatch.setattr(worker, "run_task", unavailable)
+    assert worker.main() == 2
+    outcome = json.loads(capsys.readouterr().out)
+    assert outcome["error"] == {
+        "code": "diarization_dependency_unavailable",
+        "message": "Speaker labeling is unavailable in this build",
+    }
+    assert "private dependency detail" not in json.dumps(outcome)

--- a/src/scholion/transcription/diarization_status.py
+++ b/src/scholion/transcription/diarization_status.py
@@ -1,0 +1,78 @@
+"""Cheap local availability check for the optional diarization runtime.
+
+This probe deliberately avoids importing pyannote or loading model checkpoints. It exists so
+consumer surfaces can refuse an unavailable or security-held capability before a long-running
+job is launched.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib import metadata
+
+VersionReader = Callable[[str], str]
+
+_MINIMUM_SAFE_LIGHTNING = (2, 6, 6)
+_STABLE_VERSION = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:\.post\d+)?$")
+
+
+@dataclass(frozen=True, slots=True)
+class DiarizationRuntimeStatus:
+    """Public capability state safe to expose without local paths or package internals."""
+
+    available: bool
+    reason_code: str | None
+    message: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "available": self.available,
+            "reason_code": self.reason_code,
+            "message": self.message,
+        }
+
+
+def diarization_runtime_status(
+    version_reader: VersionReader = metadata.version,
+) -> DiarizationRuntimeStatus:
+    """Return whether speaker labeling can be offered in the current local runtime."""
+
+    try:
+        version_reader("pyannote-audio")
+        lightning_version = version_reader("lightning")
+    except metadata.PackageNotFoundError:
+        return DiarizationRuntimeStatus(
+            available=False,
+            reason_code="dependencies_missing",
+            message="Speaker labeling is not installed in this local environment.",
+        )
+
+    match = _STABLE_VERSION.fullmatch(lightning_version)
+    if match is None:
+        return DiarizationRuntimeStatus(
+            available=False,
+            reason_code="dependency_unverified",
+            message=(
+                "Speaker labeling is unavailable because a local dependency cannot be "
+                "proven safe for model loading."
+            ),
+        )
+
+    parsed = tuple(int(component) for component in match.groups())
+    if parsed < _MINIMUM_SAFE_LIGHTNING:
+        return DiarizationRuntimeStatus(
+            available=False,
+            reason_code="security_hold",
+            message=(
+                "Speaker labeling is temporarily unavailable because a local dependency "
+                "does not meet Scholion's security requirement."
+            ),
+        )
+
+    return DiarizationRuntimeStatus(
+        available=True,
+        reason_code=None,
+        message=None,
+    )

--- a/src/scholion/transcription/tests/test_diarization_status.py
+++ b/src/scholion/transcription/tests/test_diarization_status.py
@@ -1,0 +1,46 @@
+from importlib import metadata
+
+from scholion.transcription.diarization_status import diarization_runtime_status
+
+
+def _versions(values: dict[str, str]):
+    def read(name: str) -> str:
+        if name not in values:
+            raise metadata.PackageNotFoundError(name)
+        return values[name]
+
+    return read
+
+
+def test_status_reports_missing_optional_dependencies_without_importing_runtime() -> None:
+    status = diarization_runtime_status(_versions({}))
+
+    assert status.available is False
+    assert status.reason_code == "dependencies_missing"
+    assert status.message == "Speaker labeling is not installed in this local environment."
+
+
+def test_status_fails_closed_for_unverifiable_or_security_held_lightning() -> None:
+    unverified = diarization_runtime_status(
+        _versions({"pyannote-audio": "4.0.7", "lightning": "2.7.0rc1"})
+    )
+    held = diarization_runtime_status(
+        _versions({"pyannote-audio": "4.0.7", "lightning": "2.6.5"})
+    )
+
+    assert unverified.available is False
+    assert unverified.reason_code == "dependency_unverified"
+    assert "proven safe" in (unverified.message or "")
+    assert held.available is False
+    assert held.reason_code == "security_hold"
+    assert "security requirement" in (held.message or "")
+
+
+def test_status_reports_ready_only_after_dependency_floor_is_met() -> None:
+    status = diarization_runtime_status(
+        _versions({"pyannote-audio": "4.0.7", "lightning": "2.6.6"})
+    )
+
+    assert status.available is True
+    assert status.reason_code is None
+    assert status.message is None

--- a/src/scholion/transcription/tests/test_diarization_status.py
+++ b/src/scholion/transcription/tests/test_diarization_status.py
@@ -12,12 +12,14 @@ def _versions(values: dict[str, str]):
     return read
 
 
-def test_status_reports_missing_optional_dependencies_without_importing_runtime() -> None:
+def test_status_reports_missing_dependencies_without_importing_runtime() -> None:
     status = diarization_runtime_status(_versions({}))
 
     assert status.available is False
     assert status.reason_code == "dependencies_missing"
-    assert status.message == "Speaker labeling is not installed in this local environment."
+    assert (
+        status.message == "Speaker labeling is not installed in this local environment."
+    )
 
 
 def test_status_fails_closed_for_unverifiable_or_security_held_lightning() -> None:


### PR DESCRIPTION
## Summary

Follow-up to merged #113 and part of #114. Long-running model/transcription workers previously surfaced only process state and exit code, which made safe application failures indistinguishable from opaque worker crashes. Model downloads also started silently in the model list, background refresh failures could remain visible beside otherwise healthy readiness state, and speaker labeling could be offered even when its optional local runtime was unavailable or security-held.

This PR adds a narrow worker-result channel and Processing task-feedback/capability UI:

- Python emits one bounded versioned JSON outcome after a task finishes
- application diagnostics are redirected away from that outcome channel
- known Scholion failures expose only the existing approved public error code/message
- validation failures and unknown exceptions collapse to fixed generic messages
- exception causes, tracebacks, local paths, request payloads, transcript content, and model-cache paths are not serialized
- Rust reads at most 8 KiB from worker stdout, validates the protocol version and public error field bounds, and stores only approved error code/message in task status
- malformed, missing, contradictory, or oversized worker outcomes fail closed instead of being mistaken for successful completion
- React surfaces the approved task failure reason instead of only saying the task stopped
- model install/remove rows show an explicit indeterminate progress state and action-specific copy while the worker is active
- the native supervisor permits only one long-running Processing task at a time so React cannot orphan an earlier worker by starting a second one
- background readiness/job refresh errors use a separate lifecycle so they clear on retry instead of becoming stale action errors
- Python exposes a read-only speaker-labeling capability status without importing pyannote or loading a checkpoint
- the capability probe distinguishes missing dependencies, unverifiable dependency versions, and the Lightning security hold
- Processing disables speaker labeling with the backend's safe reason when the capability cannot run
- browser coverage exercises model-running state and the security-held speaker-labeling presentation

## Privacy boundary

No workstation identifiers or copied local logs are included. The worker channel is a typed application boundary, not a debug-output tunnel.

## Deliberately deferred

Byte-accurate model-download progress remains deferred unless the provider can expose it safely without widening the worker protocol. A future native model-directory reveal action must remain host-owned and must not grant React arbitrary path-opening authority.

## Qualification

The branch is based on current `main` after #113 merged. It remains draft until the complete Python, Rust/native Tauri, browser accessibility/E2E, and platform smoke matrix is green.

## Dependency note

RustSec issues #118-#134 are transitive Tauri/Linux dependency debt and are being handled separately under release blocker #135. This PR does not claim to remediate or suppress those advisories.