### PR TITLE
Triage known upstream Rust advisories behind one release gate

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -105,11 +105,20 @@ jobs:
         with:
           persist-credentials: false
 
+      # These exact advisories are known transitive debt in the stable Tauri 2
+      # Linux stack and are owned by Scholion release blocker #135. This is not
+      # a claim that they are fixed. RUSTSEC-2024-0429 is real glib unsoundness
+      # and blocks a public Linux package until the upstream GTK4 migration (or
+      # another reviewed supported remediation) removes the affected graph.
+      # Keep this list explicit: any new RustSec advisory remains unignored and
+      # therefore continues to fail/alert normally. Remove IDs as the graph is
+      # remediated rather than carrying stale exceptions forward.
       - name: Audit locked Rust dependency graph
         uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: frontend/src-tauri
+          ignore: RUSTSEC-2024-0370,RUSTSEC-2024-0411,RUSTSEC-2024-0412,RUSTSEC-2024-0413,RUSTSEC-2024-0414,RUSTSEC-2024-0415,RUSTSEC-2024-0416,RUSTSEC-2024-0417,RUSTSEC-2024-0418,RUSTSEC-2024-0419,RUSTSEC-2024-0420,RUSTSEC-2024-0429,RUSTSEC-2025-0075,RUSTSEC-2025-0080,RUSTSEC-2025-0081,RUSTSEC-2025-0098,RUSTSEC-2025-0100
 
   osv-cross-ecosystem-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -105,6 +105,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Declare known Linux release-blocking Rust debt
+        run: >-
+          echo "::warning title=Known Tauri 2 Linux RustSec debt::RUSTSEC-2024-0429 remains in the current Tauri 2 GTK3 graph. Public Linux packaging is blocked by Scholion issue #135 until the affected graph is removed."
+
       # These exact advisories are known transitive debt in the stable Tauri 2
       # Linux stack and are owned by Scholion release blocker #135. This is not
       # a claim that they are fixed. RUSTSEC-2024-0429 is real glib unsoundness

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -12,6 +12,7 @@ This area explains how Scholion turns architecture claims into failing tests ins
 | [Desktop development prerequisites](desktop-development.md) | browser mock, native Tauri, real processing, Node/Rust/Python/native prerequisites |
 | [Desktop source-build troubleshooting](troubleshooting.md) | symptom-first recovery for Tauri/Python/WebKitGTK/Wayland/port failures and safe cleanup |
 | [Pre-release security hardening](../security/release-hardening.md) | signed manifests/updates/models, parser/process isolation, keychain, and application-layer encryption sequencing |
+| [Rust dependency advisory policy](rust-advisory-policy.md) | RustSec triage, the temporary Tauri 2 advisory allowlist, and the Linux release gate for GTK3/GLib debt |
 | [Desktop themes and accessibility](desktop-accessibility.md) | semantic theme contract, eight skins, contrast/native-control rules, adding a skin safely |
 | [Frontend testing strategy](frontend-testing.md) | frontend/backend test ownership, Processing/Library/Research/transcript-tools coverage, and why Stryker is not currently a routine tool |
 | [Testing and regression bisection](testing-and-bisect.md) | repository-wide test strategy, colocation, mutation anticipation, deterministic bisect oracles |

--- a/docs/development/rust-advisory-policy.md
+++ b/docs/development/rust-advisory-policy.md
@@ -1,0 +1,62 @@
+# Rust dependency advisory policy
+
+Scholion audits the locked Rust graph with RustSec. Findings are not all the same kind of risk, and a transitive advisory is not automatically fixable by adding or upgrading a direct Scholion dependency.
+
+## Current Tauri 2 Linux debt
+
+The current stable Tauri 2 Linux runtime resolves through GTK3/WebKitGTK-era bindings. That graph includes the archived gtk-rs GTK3 family and `glib 0.18.5`.
+
+RustSec currently reports a known family of transitive advisories tracked by Scholion issue #135:
+
+- RUSTSEC-2024-0411 through RUSTSEC-2024-0420 for the unmaintained GTK3 binding family;
+- RUSTSEC-2024-0429 for unsoundness in `glib::VariantStrIter`;
+- RUSTSEC-2024-0370 for unmaintained `proc-macro-error`; and
+- RUSTSEC-2025-0075, RUSTSEC-2025-0080, RUSTSEC-2025-0081, RUSTSEC-2025-0098, and RUSTSEC-2025-0100 for the unmaintained `unic-*` family.
+
+RUSTSEC-2024-0429 is materially different from an `unmaintained` notice. RustSec marks `glib >=0.15.0,<0.20.0` as affected for the relevant iterator functions and `glib >=0.20.0` as patched. The Tauri 2 GTK3 graph cannot be made to consume that API generation by a compatible leaf-package bump.
+
+## Temporary audit allowlist
+
+`.github/workflows/security.yml` passes the exact known advisory IDs above to `rustsec/audit-check` through its supported `ignore` input.
+
+That allowlist means **tracked elsewhere**, not **fixed**.
+
+The purpose is to prevent one known upstream migration from creating a new GitHub issue for every transitive crate on every audit run while preserving the useful invariant that an unfamiliar advisory ID still fails/alerts normally.
+
+Rules for changing the allowlist:
+
+1. Every ignored ID must have a named open owner/gate such as #135.
+2. Do not add an ID merely to make CI green. First classify whether it is vulnerable/unsound, unmaintained, yanked, or otherwise informational and trace the dependency root.
+3. Prefer removal or an upstream-supported dependency update over an exception.
+4. Remove an ID as soon as the effective shipped graph no longer contains the affected dependency.
+5. If a crate remains only as lockfile residue, prove that it is absent from the shipped target graph before downgrading the finding to cleanup debt.
+6. Never use success on one operating system to waive a target-specific dependency problem on another.
+
+## Linux release gate
+
+A public Linux package must not be represented as release-qualified while RUSTSEC-2024-0429 remains in the shipped Linux graph.
+
+The intended remediation is adoption of a stable/reviewed Tauri Linux runtime using maintained GTK4/WebKitGTK 6-era dependencies, or another upstream-supported runtime that removes the affected GLib implementation. Experimental personal forks, moving git branches, or application-level GTK/GLib overrides are not an acceptable production shortcut because they replace one known dependency problem with an unowned framework fork.
+
+Before closing #135:
+
+- re-run RustSec with the temporary allowlist removed;
+- verify the effective Linux graph no longer contains the affected GLib/GTK3 dependencies;
+- prove whether `proc-macro-error` and `unic-*` are gone or non-shipped residue;
+- keep cargo-deny source/license policy green;
+- qualify the native app on Linux Wayland and X11; and
+- keep Windows and macOS CI green.
+
+## Dependency-update decision rule
+
+When RustSec reports a new Rust finding, start from the dependency root rather than the leaf crate name:
+
+```text
+Scholion direct dependency
+        ↓
+framework/runtime dependency
+        ↓
+transitive crate named by RustSec
+```
+
+If Scholion owns the direct dependency choice and a compatible patched release exists, update it and regenerate the lockfile. If the affected crate is constrained by a framework runtime, follow the framework's supported migration path or explicitly track the upstream blocker. Do not force an ABI/API-incompatible crate generation underneath a framework just to make the advisory line disappear.


### PR DESCRIPTION
## Summary

The scheduled RustSec audit exposed 17 advisories in Scholion's locked Rust graph. They are not 17 independent application bugs: the GTK3/GLib family is transitive debt in the current stable Tauri 2 Linux runtime, while the remaining `proc-macro-error` and `unic-*` advisories are likewise upstream/transitive dependency debt.

This PR keeps that debt visible without allowing the audit action to generate one GitHub issue per transitive crate on every run:

- consolidate the current advisory family under release blocker #135
- use rustsec/audit-check's supported `ignore` input for exactly the 17 currently known IDs
- document in the workflow that the allowlist is temporary tracked debt, not remediation
- explicitly state that RUSTSEC-2024-0429 is real `glib 0.18.5` unsoundness and blocks a public Linux package
- leave every unknown/future RustSec advisory unignored so new findings still fail/alert normally
- require IDs to be removed from the allowlist as the Tauri dependency graph is remediated

The individual bot-generated issues #118 through #134 have been closed as `duplicate`, not `completed`; #135 remains open as the migration/release gate.

## Why this does not bump GTK directly

Scholion directly depends on Tauri, not the GTK3 crates. Stable Tauri 2's Linux runtime currently resolves through GTK3/WebKitGTK-era bindings. Tauri is actively migrating its Linux runtime to GTK4/WebKitGTK 6.0 upstream, and its own RustSec triage identifies that migration as the remediation for the affected `glib` unsoundness. Forcing GTK4 or a newer GLib underneath the stable Tauri 2 API graph would not be a compatible application-level dependency update.

This PR therefore does not introduce arbitrary git forks, moving upstream branches, vendored framework patches, or a false claim that the advisories are fixed.

## Security semantics

- #135 remains release-blocking for Linux packaging while RUSTSEC-2024-0429 is present in the shipped graph.
- New RustSec IDs are not allowlisted.
- cargo-deny source/license policy remains independent.
- Windows/macOS success does not waive the Linux dependency issue.

## Privacy

No workstation identifiers, usernames, hostnames, home-directory paths, or copied local diagnostic logs are included.