### PR TITLE
Establish signed update and curated model trust primitives

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -12,7 +12,9 @@ See **[Pre-release security hardening roadmap](release-hardening.md)** for the o
 - sandboxing native parsers;
 - tighter process isolation;
 - a secure update framework; and
-- a model-signing trust root.
+- curated model trust rooted in signed Scholion releases.
+
+See **[Signed update and model trust channel](update-model-trust.md)** for the concrete #110 contract: exact-byte signed update envelopes, anti-rollback/expiry semantics, privacy-preserving update behavior, and project-owned pinned model metadata with full file-set/size/SHA-256 verification.
 
 The roadmap groups these into supply-chain trust, hostile-input containment, and data-at-rest/key custody. It also records native React → Tauri → Rust → Python qualification as a release gate after real-device testing exposed a gap that browser mocks cannot cover.
 

--- a/docs/security/release-hardening.md
+++ b/docs/security/release-hardening.md
@@ -4,17 +4,21 @@ This document turns the remaining security ideas into an ordered release-hardeni
 
 ## Release gate A: supply-chain trust
 
-### Cryptographic signatures for manifests
+### Cryptographic signatures for release metadata
 
-Application/model manifests must be signed with an offline-controlled signing identity. Verification happens before a manifest can authorize an application update, model revision, or hash set. Signature failure, unknown key ID, malformed metadata, rollback, and expired metadata fail closed.
+Application update metadata must be signed with an offline-controlled signing identity. Verification happens before release metadata can authorize an application update or artifact hash set. Signature failure, unknown key ID, malformed metadata, rollback, and expired metadata fail closed.
+
+The curated model-trust catalog is bundled inside the signed Scholion release rather than fetched as independently mutable policy. Its bytes therefore inherit the release artifact's authenticated custody. If Scholion ever distributes model-trust policy independently of an application release, that channel must gain its own separately pinned signature/key role before it can authorize a model revision or hash set.
 
 Acceptance evidence:
 
-- signed manifest fixture verifies;
-- modified bytes fail verification;
+- signed release-manifest fixture verifies;
+- modified signed payload bytes fail verification;
 - unknown/revoked key fails;
-- rollback to an older trusted version is rejected according to explicit policy;
-- verification is independent of transport security.
+- rollback to an older trusted release sequence is rejected according to explicit policy;
+- verification is independent of transport security;
+- a curated model entry cannot trust a moving revision, undeclared file, size mismatch, hash mismatch, or cache/path escape; and
+- an independently fetched model-policy channel, if one is ever introduced, cannot become authoritative without a separately reviewed signature boundary.
 
 ### Secure update framework
 
@@ -22,11 +26,15 @@ Application updates need a signed metadata framework with rollback/freeze protec
 
 Do not ship an auto-updater that trusts only HTTPS or a mutable release URL.
 
-### Model-signing trust root
+### Curated model trust root
 
-The curated model catalog must resolve to a trusted manifest containing repository/source identity, immutable revision, required files, sizes, hashes, license/source metadata, and a Scholion-trusted signature. Hugging Face or another transport host is a distribution mechanism, not the trust root.
+The curated model catalog must resolve to repository/source identity, immutable revision, exact allowed files, sizes, hashes, and license/source metadata. Hugging Face or another transport host is a distribution mechanism, not the trust root.
 
-Application update signing and model signing may share verification primitives, but should use separable signing roles/keys so compromise of one authority does not automatically authorize the other.
+For the first-release design, that catalog ships inside the signed Scholion application release. Updating model trust therefore requires a reviewed Scholion release and cannot happen because an upstream repository changes `main` or `HEAD`.
+
+If future product requirements demand model-policy updates between application releases, introduce a separate signed model-policy envelope and separable key role before enabling that behavior. Do not silently turn the current static catalog into remotely mutable configuration.
+
+See **[Signed update and model trust channel](update-model-trust.md)** for the concrete #110 schemas, threat model, and verification rules.
 
 ## Release gate B: hostile-input containment
 
@@ -84,9 +92,9 @@ Do not encrypt rebuildable projections in a way that creates new irreplaceable k
 
 Recommended sequence:
 
-1. define trust-root/key-rotation policy;
-2. signed application/model manifests;
-3. secure update framework + model-signing trust root;
+1. define application update trust-root/key-rotation policy;
+2. signed application release metadata + bundled curated model trust;
+3. secure update framework + pinned model installation/verification;
 4. parser sandbox and process-capability reduction;
 5. native end-to-end qualification across supported OSes;
 6. keychain abstraction and recovery design;

--- a/docs/security/update-model-trust.md
+++ b/docs/security/update-model-trust.md
@@ -1,0 +1,167 @@
+# Signed update and model trust channel
+
+Scholion has two related but distinct supply-chain trust problems: application releases and local model snapshots. Both need project-owned trust roots, but neither should turn a local-first application into a telemetry client or make an upstream distribution host authoritative for what Scholion executes.
+
+This document defines the first-release contract tracked by issue #110.
+
+## Trust boundaries
+
+### Application releases
+
+The native desktop host owns application-update trust. A release check must fetch only a bounded signed metadata envelope from a fixed Scholion update endpoint. The request must not include an installation identifier, corpus metadata, hardware inventory, recording names, research state, model inventory, or behavioral telemetry.
+
+The envelope carries exact signed payload bytes plus a key identifier, signature algorithm, and signature. The signed payload is typed data only: release sequence, channel, version, publication/expiry timestamps, release-notes URL, and per-platform artifact URL/size/SHA-256. Unknown envelope or payload fields fail closed.
+
+The signature covers the exact payload bytes rather than a re-serialized JSON object. This avoids cross-language JSON canonicalization becoming part of the security boundary.
+
+The production verifier belongs in the native/Tauri layer and must use a reviewed signature implementation with public keys pinned in the application. Scholion must not implement Ed25519 arithmetic itself in Python.
+
+### Models
+
+The application package owns a curated model-trust catalog. A model entry identifies:
+
+- Scholion model ID and engine;
+- exact upstream repository identity;
+- immutable 40-character upstream revision;
+- source URL;
+- license ID and license URL; and
+- every allowed snapshot file with exact relative path, byte size, and SHA-256.
+
+A distribution service such as Hugging Face transports bytes. It does not decide which revision or file hashes Scholion trusts.
+
+The provider must eventually request the exact curated revision and verify the downloaded snapshot against the bundled trust entry before writing a local managed-model manifest or reporting the model as trusted/ready. Snapshot verification rejects path escape, cache escape, missing files, undeclared files, size mismatch, and hash mismatch.
+
+Integrity and policy trust are separate states. A snapshot can be internally well-formed or match its repository identity without being trusted by Scholion policy. Consumer UI and documentation must not collapse those states into one word such as “verified.”
+
+## Update manifest v1
+
+The wire envelope is deliberately small:
+
+```json
+{
+  "schema_version": 1,
+  "key_id": "release-2026",
+  "algorithm": "ed25519",
+  "payload_base64": "<exact signed payload bytes>",
+  "signature_base64": "<64-byte signature>"
+}
+```
+
+After signature verification, the payload is parsed as:
+
+```json
+{
+  "schema_version": 1,
+  "sequence": 42,
+  "channel": "stable",
+  "version": "1.0.0",
+  "published_at": "2026-08-23T15:00:00Z",
+  "expires_at": "2026-08-30T15:00:00Z",
+  "release_notes_url": "https://updates.example.invalid/releases/1.0.0",
+  "artifacts": [
+    {
+      "platform": "linux-x86_64",
+      "url": "https://updates.example.invalid/artifacts/scholion-linux-x86_64.tar.zst",
+      "size_bytes": 123,
+      "sha256": "<64 lowercase hexadecimal characters>"
+    }
+  ]
+}
+```
+
+The repository examples use `.invalid` hosts intentionally. A production endpoint and signing keys must be provisioned separately.
+
+### Replay, downgrade, and freeze policy
+
+The native client persists the highest successfully trusted manifest sequence. A subsequently signed manifest with a lower sequence is rejected. Re-seeing the same sequence is allowed so a user can check repeatedly without manufacturing state changes.
+
+Signed metadata expires. Expired metadata cannot authorize an update, which limits indefinite replay of old signed metadata after hosting compromise. A client that stays offline past expiry continues to run normally; it simply cannot authorize a new update until it can obtain fresh signed metadata.
+
+A valid signature does not mean “install immediately.” Version/channel/platform policy and explicit user intent are separate decisions after trust verification.
+
+## Model trust catalog v1
+
+The bundled catalog shape is:
+
+```json
+{
+  "schema_version": 1,
+  "models": [
+    {
+      "model_id": "tiny",
+      "engine": "faster-whisper",
+      "repository_id": "Systran/faster-whisper-tiny",
+      "revision": "<40 lowercase hexadecimal characters>",
+      "source_url": "https://huggingface.co/Systran/faster-whisper-tiny",
+      "license_id": "<reviewed license identifier>",
+      "license_url": "<reviewed HTTPS license URL>",
+      "files": [
+        {
+          "path": "model.bin",
+          "size_bytes": 123,
+          "sha256": "<64 lowercase hexadecimal characters>"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Production entries must be generated from a deliberately reviewed immutable upstream revision. Do not guess hashes, copy mutable `main`/`HEAD`, or treat whatever revision happened to download during development as trusted policy.
+
+Changing a trusted model revision is a security-sensitive repository change. The review should record why the revision changed, source/license changes, file-set changes, regression evidence, and regenerated hashes/sizes. The new catalog ships with a signed Scholion release.
+
+## Threat model
+
+| Threat | Control | Residual risk / follow-up |
+|---|---|---|
+| Upstream model repository compromised | Bundled exact revision + full allowed-file SHA-256/size set; downloaded bytes do not become trusted merely because upstream served them | A malicious revision intentionally approved into Scholion remains a review failure; review and regression evidence are required |
+| Release hosting/CDN compromised | Manifest signature is verified independently of HTTPS; artifact hash is signed metadata | Availability can still be denied; connection metadata remains visible to host/CDN |
+| Malicious mirror/artifact replacement | Signed artifact SHA-256/size must match staged bytes before installation | Native staged-download/atomic activation is still implementation work |
+| Old signed metadata replayed | Monotonic sequence rejects rollback; expiry limits freeze/replay window | Long-term offline users cannot check for updates until online again, but local operation remains unaffected |
+| Update metadata injects remote commands/config | Strict schemas reject unknown fields; only typed release/artifact metadata exists | Future schema changes require an explicit versioned review |
+| Update request leaks product behavior | Request is a metadata GET with no installation ID, corpus, hardware, research, or usage payload | IP address, request time, TLS/client/network metadata remain visible to network/hosting layers |
+| Signing key compromise | Key IDs permit explicit rotation/revocation policy; release and model-signing roles should remain separable | Concrete key custody, rotation, and revocation implementation is still release work |
+| Local model cache is tampered with | File set, size, hash, path, and cache containment are rechecked before trust | Local machine compromise outside Scholion's threat boundary can also alter the application binary or pinned keys |
+
+## User-visible update behavior
+
+The default first-release behavior is manual: **Check for updates** is an explicit user action. Periodic checks, if added, are separately opt-in and must be easy to disable.
+
+A manual check should communicate four states without implying telemetry-free networking:
+
+1. update checks are off / have not been requested;
+2. checking the signed release metadata requires a network request and exposes ordinary connection metadata such as IP address and time to the hosting/CDN layer;
+3. no trusted newer release is available; or
+4. a trusted newer release is available, with version/release notes and an explicit install/download action.
+
+Network failure, offline mode, signature failure, expiry, rollback, or unsupported platform must never block opening Scholion or using existing local recordings, transcripts, models, or research.
+
+## What this foundation implements
+
+The `scholion.supply_chain` package currently provides:
+
+- strict curated model catalog parsing;
+- immutable-revision validation;
+- exact model snapshot file-set/size/SHA-256 verification;
+- path/cache containment checks;
+- strict signed-update envelope and payload parsing;
+- an explicit signature-verifier interface;
+- expiry and anti-rollback sequence enforcement; and
+- tests for tampering, unknown keys, stale metadata, hostile paths, undeclared files, and malformed/extra remote configuration.
+
+## Remaining work under #110
+
+This foundation deliberately does **not** claim #110 is complete. Before closing the issue:
+
+- choose and pin the production native signature-verification implementation and public key(s);
+- implement fixed-endpoint manual update checking in the Tauri host;
+- persist highest trusted sequence without creating an identifier sent to the server;
+- stage downloads, enforce signed size/hash, and use platform-appropriate signed/atomic installation;
+- implement explicit update UI and separately opt-in periodic checks;
+- review real upstream faster-whisper revisions and generate the production curated model catalog;
+- wire `ModelManager`/`HuggingFaceModelProvider` to request only the curated revision and require trust verification before registration;
+- record trusted policy identity in the local model manifest and expose “integrity checked” versus “trusted by Scholion policy” accurately; and
+- add native/offline regression qualification across supported platforms.
+
+Until those steps land, current local/offline workflows remain unchanged and no update service is required for Scholion to run.

--- a/src/scholion/supply_chain/__init__.py
+++ b/src/scholion/supply_chain/__init__.py
@@ -1,0 +1,29 @@
+"""Supply-chain trust primitives for models and application releases."""
+
+from scholion.supply_chain.model_trust import (
+    ModelTrustCatalog,
+    ModelTrustEvidence,
+    TrustedModelFile,
+    TrustedModelSpec,
+    verify_trusted_model_snapshot,
+)
+from scholion.supply_chain.update_manifest import (
+    ReleaseArtifact,
+    SignedUpdateEnvelope,
+    UpdateManifestPayload,
+    UpdateTrustError,
+    verify_signed_update_manifest,
+)
+
+__all__ = [
+    "ModelTrustCatalog",
+    "ModelTrustEvidence",
+    "ReleaseArtifact",
+    "SignedUpdateEnvelope",
+    "TrustedModelFile",
+    "TrustedModelSpec",
+    "UpdateManifestPayload",
+    "UpdateTrustError",
+    "verify_signed_update_manifest",
+    "verify_trusted_model_snapshot",
+]

--- a/src/scholion/supply_chain/model_trust.py
+++ b/src/scholion/supply_chain/model_trust.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+_MODEL_CATALOG_SCHEMA_VERSION = 1
+_MODEL_VERIFICATION_METHOD = "scholion_curated_sha256_v1"
+_SHA256_HEX_LENGTH = 64
+_GIT_REVISION_HEX_LENGTH = 40
+_READ_CHUNK_BYTES = 1024 * 1024
+
+
+def _require_exact_keys(document: dict[str, Any], expected: set[str]) -> None:
+    actual = set(document)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        details: list[str] = []
+        if missing:
+            details.append("missing=" + ",".join(missing))
+        if extra:
+            details.append("extra=" + ",".join(extra))
+        raise ValueError("unexpected trust-manifest fields: " + "; ".join(details))
+
+
+def _require_str(document: dict[str, Any], key: str) -> str:
+    value = document.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _require_int(document: dict[str, Any], key: str) -> int:
+    value = document.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def _require_https_url(value: str, field: str) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError(f"{field} must be an HTTPS URL")
+
+
+def _require_lower_hex(value: str, *, length: int, field: str) -> None:
+    if len(value) != length or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{field} must be {length} lowercase hexadecimal characters")
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedModelFile:
+    path: str
+    size_bytes: int
+    sha256_hex: str
+
+    def __post_init__(self) -> None:
+        if not self.path or "\\" in self.path:
+            raise ValueError("trusted model file path must use non-empty POSIX syntax")
+        pure = PurePosixPath(self.path)
+        if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+            raise ValueError("trusted model file path must stay inside the snapshot")
+        if self.size_bytes < 1:
+            raise ValueError("trusted model file size must be positive")
+        _require_lower_hex(self.sha256_hex, length=_SHA256_HEX_LENGTH, field="sha256")
+
+    @classmethod
+    def from_dict(cls, document: dict[str, Any]) -> TrustedModelFile:
+        _require_exact_keys(document, {"path", "size_bytes", "sha256"})
+        return cls(
+            path=_require_str(document, "path"),
+            size_bytes=_require_int(document, "size_bytes"),
+            sha256_hex=_require_str(document, "sha256"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256_hex,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedModelSpec:
+    model_id: str
+    engine: str
+    repository_id: str
+    revision: str
+    source_url: str
+    license_id: str
+    license_url: str
+    files: tuple[TrustedModelFile, ...]
+
+    def __post_init__(self) -> None:
+        for field in ("model_id", "engine", "repository_id", "license_id"):
+            value = getattr(self, field)
+            if not value.strip():
+                raise ValueError(f"{field} cannot be empty")
+        _require_lower_hex(
+            self.revision,
+            length=_GIT_REVISION_HEX_LENGTH,
+            field="model revision",
+        )
+        _require_https_url(self.source_url, "source_url")
+        _require_https_url(self.license_url, "license_url")
+        if not self.files:
+            raise ValueError("trusted model must declare at least one file")
+        paths = tuple(item.path for item in self.files)
+        if len(paths) != len(set(paths)):
+            raise ValueError("trusted model file paths must be unique")
+
+    @classmethod
+    def from_dict(cls, document: dict[str, Any]) -> TrustedModelSpec:
+        _require_exact_keys(
+            document,
+            {
+                "model_id",
+                "engine",
+                "repository_id",
+                "revision",
+                "source_url",
+                "license_id",
+                "license_url",
+                "files",
+            },
+        )
+        raw_files = document.get("files")
+        if not isinstance(raw_files, list) or any(not isinstance(item, dict) for item in raw_files):
+            raise ValueError("files must be a list of objects")
+        return cls(
+            model_id=_require_str(document, "model_id"),
+            engine=_require_str(document, "engine"),
+            repository_id=_require_str(document, "repository_id"),
+            revision=_require_str(document, "revision"),
+            source_url=_require_str(document, "source_url"),
+            license_id=_require_str(document, "license_id"),
+            license_url=_require_str(document, "license_url"),
+            files=tuple(TrustedModelFile.from_dict(item) for item in raw_files),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "model_id": self.model_id,
+            "engine": self.engine,
+            "repository_id": self.repository_id,
+            "revision": self.revision,
+            "source_url": self.source_url,
+            "license_id": self.license_id,
+            "license_url": self.license_url,
+            "files": [item.to_dict() for item in self.files],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ModelTrustCatalog:
+    schema_version: int
+    models: tuple[TrustedModelSpec, ...]
+
+    def __post_init__(self) -> None:
+        if self.schema_version != _MODEL_CATALOG_SCHEMA_VERSION:
+            raise ValueError("unsupported model trust catalog schema version")
+        if not self.models:
+            raise ValueError("model trust catalog cannot be empty")
+        model_ids = tuple(item.model_id for item in self.models)
+        if len(model_ids) != len(set(model_ids)):
+            raise ValueError("trusted model IDs must be unique")
+
+    @classmethod
+    def from_dict(cls, document: dict[str, Any]) -> ModelTrustCatalog:
+        _require_exact_keys(document, {"schema_version", "models"})
+        raw_models = document.get("models")
+        if not isinstance(raw_models, list) or any(not isinstance(item, dict) for item in raw_models):
+            raise ValueError("models must be a list of objects")
+        return cls(
+            schema_version=_require_int(document, "schema_version"),
+            models=tuple(TrustedModelSpec.from_dict(item) for item in raw_models),
+        )
+
+    def require(self, model_id: str) -> TrustedModelSpec:
+        match = next((item for item in self.models if item.model_id == model_id), None)
+        if match is None:
+            raise ValueError(f"model is not trusted by Scholion policy: {model_id}")
+        return match
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "models": [item.to_dict() for item in self.models],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ModelTrustEvidence:
+    model_id: str
+    repository_id: str
+    revision: str
+    verification: str
+    verified_files: int
+    total_bytes: int
+
+
+def _hash_file(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_READ_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_trusted_model_snapshot(
+    spec: TrustedModelSpec,
+    *,
+    snapshot_root: Path,
+    cache_root: Path,
+) -> ModelTrustEvidence:
+    resolved_snapshot = snapshot_root.expanduser().resolve(strict=True)
+    resolved_cache = cache_root.expanduser().resolve(strict=True)
+    if not resolved_snapshot.is_dir() or not resolved_snapshot.is_relative_to(resolved_cache):
+        raise ValueError("trusted model snapshot must be a directory inside the model cache")
+
+    declared_paths = {item.path for item in spec.files}
+    observed_paths = {
+        path.relative_to(resolved_snapshot).as_posix()
+        for path in resolved_snapshot.rglob("*")
+        if path.is_file()
+    }
+    if observed_paths != declared_paths:
+        missing = sorted(declared_paths - observed_paths)
+        extra = sorted(observed_paths - declared_paths)
+        details: list[str] = []
+        if missing:
+            details.append("missing=" + ",".join(missing))
+        if extra:
+            details.append("undeclared=" + ",".join(extra))
+        raise ValueError("model snapshot file set does not match trusted policy: " + "; ".join(details))
+
+    total_bytes = 0
+    for trusted_file in spec.files:
+        candidate = resolved_snapshot.joinpath(*PurePosixPath(trusted_file.path).parts)
+        if not candidate.is_file():
+            raise ValueError(f"trusted model file is missing: {trusted_file.path}")
+        resolved_candidate = candidate.resolve(strict=True)
+        if not resolved_candidate.is_relative_to(resolved_cache):
+            raise ValueError("trusted model file resolves outside the model cache")
+        size_bytes = candidate.stat().st_size
+        if size_bytes != trusted_file.size_bytes:
+            raise ValueError(f"trusted model file size mismatch: {trusted_file.path}")
+        if _hash_file(candidate) != trusted_file.sha256_hex:
+            raise ValueError(f"trusted model file hash mismatch: {trusted_file.path}")
+        total_bytes += size_bytes
+
+    return ModelTrustEvidence(
+        model_id=spec.model_id,
+        repository_id=spec.repository_id,
+        revision=spec.revision,
+        verification=_MODEL_VERIFICATION_METHOD,
+        verified_files=len(spec.files),
+        total_bytes=total_bytes,
+    )

--- a/src/scholion/supply_chain/model_trust.py
+++ b/src/scholion/supply_chain/model_trust.py
@@ -47,7 +47,9 @@ def _require_https_url(value: str, field: str) -> None:
 
 
 def _require_lower_hex(value: str, *, length: int, field: str) -> None:
-    if len(value) != length or any(character not in "0123456789abcdef" for character in value):
+    if len(value) != length or any(
+        character not in "0123456789abcdef" for character in value
+    ):
         raise ValueError(f"{field} must be {length} lowercase hexadecimal characters")
 
 
@@ -61,7 +63,11 @@ class TrustedModelFile:
         if not self.path or "\\" in self.path:
             raise ValueError("trusted model file path must use non-empty POSIX syntax")
         pure = PurePosixPath(self.path)
-        if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+        if (
+            not pure.parts
+            or pure.is_absolute()
+            or any(part in {"", ".", ".."} for part in pure.parts)
+        ):
             raise ValueError("trusted model file path must stay inside the snapshot")
         if self.size_bytes < 1:
             raise ValueError("trusted model file size must be positive")
@@ -129,7 +135,9 @@ class TrustedModelSpec:
             },
         )
         raw_files = document.get("files")
-        if not isinstance(raw_files, list) or any(not isinstance(item, dict) for item in raw_files):
+        if not isinstance(raw_files, list) or any(
+            not isinstance(item, dict) for item in raw_files
+        ):
             raise ValueError("files must be a list of objects")
         return cls(
             model_id=_require_str(document, "model_id"),
@@ -173,7 +181,9 @@ class ModelTrustCatalog:
     def from_dict(cls, document: dict[str, Any]) -> ModelTrustCatalog:
         _require_exact_keys(document, {"schema_version", "models"})
         raw_models = document.get("models")
-        if not isinstance(raw_models, list) or any(not isinstance(item, dict) for item in raw_models):
+        if not isinstance(raw_models, list) or any(
+            not isinstance(item, dict) for item in raw_models
+        ):
             raise ValueError("models must be a list of objects")
         return cls(
             schema_version=_require_int(document, "schema_version"),
@@ -219,8 +229,12 @@ def verify_trusted_model_snapshot(
 ) -> ModelTrustEvidence:
     resolved_snapshot = snapshot_root.expanduser().resolve(strict=True)
     resolved_cache = cache_root.expanduser().resolve(strict=True)
-    if not resolved_snapshot.is_dir() or not resolved_snapshot.is_relative_to(resolved_cache):
-        raise ValueError("trusted model snapshot must be a directory inside the model cache")
+    if not resolved_snapshot.is_dir() or not resolved_snapshot.is_relative_to(
+        resolved_cache
+    ):
+        raise ValueError(
+            "trusted model snapshot must be a directory inside the model cache"
+        )
 
     declared_paths = {item.path for item in spec.files}
     observed_paths = {
@@ -236,7 +250,10 @@ def verify_trusted_model_snapshot(
             details.append("missing=" + ",".join(missing))
         if extra:
             details.append("undeclared=" + ",".join(extra))
-        raise ValueError("model snapshot file set does not match trusted policy: " + "; ".join(details))
+        raise ValueError(
+            "model snapshot file set does not match trusted policy: "
+            + "; ".join(details)
+        )
 
     total_bytes = 0
     for trusted_file in spec.files:

--- a/src/scholion/supply_chain/tests/test_model_trust.py
+++ b/src/scholion/supply_chain/tests/test_model_trust.py
@@ -129,6 +129,22 @@ def test_snapshot_verification_checks_exact_file_set_hash_and_size(
         )
 
 
+def test_snapshot_verification_rejects_size_mismatch(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    snapshot = cache_root / "snapshots" / ("a" * 40)
+    snapshot.mkdir(parents=True)
+    model = b"model"
+    (snapshot / "model.bin").write_bytes(model)
+    spec = _spec((_trusted_file("model.bin", model),))
+
+    (snapshot / "model.bin").write_bytes(b"model-expanded")
+
+    with pytest.raises(ValueError, match="size mismatch"):
+        verify_trusted_model_snapshot(
+            spec, snapshot_root=snapshot, cache_root=cache_root
+        )
+
+
 def test_snapshot_verification_rejects_undeclared_file(tmp_path: Path) -> None:
     cache_root = tmp_path / "cache"
     snapshot = cache_root / "snapshots" / ("a" * 40)

--- a/src/scholion/supply_chain/tests/test_model_trust.py
+++ b/src/scholion/supply_chain/tests/test_model_trust.py
@@ -122,7 +122,7 @@ def test_snapshot_verification_checks_exact_file_set_hash_and_size(
     assert evidence.verified_files == 2
     assert evidence.total_bytes == len(model) + len(config)
 
-    (snapshot / "model.bin").write_bytes(b"tampered!!!!")
+    (snapshot / "model.bin").write_bytes(b"other-bytes")
     with pytest.raises(ValueError, match="hash mismatch"):
         verify_trusted_model_snapshot(
             spec, snapshot_root=snapshot, cache_root=cache_root

--- a/src/scholion/supply_chain/tests/test_model_trust.py
+++ b/src/scholion/supply_chain/tests/test_model_trust.py
@@ -1,0 +1,142 @@
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from scholion.supply_chain.model_trust import (
+    ModelTrustCatalog,
+    TrustedModelFile,
+    TrustedModelSpec,
+    verify_trusted_model_snapshot,
+)
+
+
+def _trusted_file(path: str, content: bytes) -> TrustedModelFile:
+    return TrustedModelFile(
+        path=path,
+        size_bytes=len(content),
+        sha256_hex=sha256(content).hexdigest(),
+    )
+
+
+def _spec(files: tuple[TrustedModelFile, ...]) -> TrustedModelSpec:
+    return TrustedModelSpec(
+        model_id="tiny",
+        engine="faster-whisper",
+        repository_id="example/faster-whisper-tiny",
+        revision="a" * 40,
+        source_url="https://example.invalid/models/tiny",
+        license_id="MIT",
+        license_url="https://example.invalid/licenses/mit",
+        files=files,
+    )
+
+
+def test_catalog_requires_exact_trust_metadata() -> None:
+    content = b"model"
+    catalog = ModelTrustCatalog.from_dict(
+        {
+            "schema_version": 1,
+            "models": [
+                {
+                    "model_id": "tiny",
+                    "engine": "faster-whisper",
+                    "repository_id": "example/faster-whisper-tiny",
+                    "revision": "a" * 40,
+                    "source_url": "https://example.invalid/models/tiny",
+                    "license_id": "MIT",
+                    "license_url": "https://example.invalid/licenses/mit",
+                    "files": [
+                        {
+                            "path": "model.bin",
+                            "size_bytes": len(content),
+                            "sha256": sha256(content).hexdigest(),
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    trusted = catalog.require("tiny")
+    assert trusted.revision == "a" * 40
+    assert trusted.files[0].sha256_hex == sha256(content).hexdigest()
+
+
+def test_catalog_rejects_moving_or_ambiguous_revision() -> None:
+    with pytest.raises(ValueError, match="model revision"):
+        _spec((_trusted_file("model.bin", b"model"),)).__class__(
+            model_id="tiny",
+            engine="faster-whisper",
+            repository_id="example/faster-whisper-tiny",
+            revision="main",
+            source_url="https://example.invalid/models/tiny",
+            license_id="MIT",
+            license_url="https://example.invalid/licenses/mit",
+            files=(_trusted_file("model.bin", b"model"),),
+        )
+
+
+def test_trusted_file_rejects_path_escape() -> None:
+    with pytest.raises(ValueError, match="inside the snapshot"):
+        TrustedModelFile(
+            path="../private.txt",
+            size_bytes=1,
+            sha256_hex="0" * 64,
+        )
+
+
+def test_snapshot_verification_checks_exact_file_set_hash_and_size(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    snapshot = cache_root / "snapshots" / ("a" * 40)
+    snapshot.mkdir(parents=True)
+    model = b"model-bytes"
+    config = b"{}"
+    (snapshot / "model.bin").write_bytes(model)
+    (snapshot / "config.json").write_bytes(config)
+    spec = _spec(
+        (
+            _trusted_file("model.bin", model),
+            _trusted_file("config.json", config),
+        )
+    )
+
+    evidence = verify_trusted_model_snapshot(
+        spec,
+        snapshot_root=snapshot,
+        cache_root=cache_root,
+    )
+
+    assert evidence.verification == "scholion_curated_sha256_v1"
+    assert evidence.verified_files == 2
+    assert evidence.total_bytes == len(model) + len(config)
+
+    (snapshot / "model.bin").write_bytes(b"tampered!!!!")
+    with pytest.raises(ValueError, match="hash mismatch"):
+        verify_trusted_model_snapshot(spec, snapshot_root=snapshot, cache_root=cache_root)
+
+
+def test_snapshot_verification_rejects_undeclared_file(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    snapshot = cache_root / "snapshots" / ("a" * 40)
+    snapshot.mkdir(parents=True)
+    model = b"model"
+    (snapshot / "model.bin").write_bytes(model)
+    (snapshot / "surprise.json").write_text("{}", encoding="utf-8")
+    spec = _spec((_trusted_file("model.bin", model),))
+
+    with pytest.raises(ValueError, match="undeclared=surprise.json"):
+        verify_trusted_model_snapshot(spec, snapshot_root=snapshot, cache_root=cache_root)
+
+
+def test_snapshot_verification_rejects_snapshot_outside_cache(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    cache_root.mkdir()
+    snapshot = tmp_path / "elsewhere"
+    snapshot.mkdir()
+    model = b"model"
+    (snapshot / "model.bin").write_bytes(model)
+    spec = _spec((_trusted_file("model.bin", model),))
+
+    with pytest.raises(ValueError, match="inside the model cache"):
+        verify_trusted_model_snapshot(spec, snapshot_root=snapshot, cache_root=cache_root)

--- a/src/scholion/supply_chain/tests/test_model_trust.py
+++ b/src/scholion/supply_chain/tests/test_model_trust.py
@@ -65,7 +65,7 @@ def test_catalog_requires_exact_trust_metadata() -> None:
 
 def test_catalog_rejects_moving_or_ambiguous_revision() -> None:
     with pytest.raises(ValueError, match="model revision"):
-        _spec((_trusted_file("model.bin", b"model"),)).__class__(
+        TrustedModelSpec(
             model_id="tiny",
             engine="faster-whisper",
             repository_id="example/faster-whisper-tiny",
@@ -86,7 +86,18 @@ def test_trusted_file_rejects_path_escape() -> None:
         )
 
 
-def test_snapshot_verification_checks_exact_file_set_hash_and_size(tmp_path: Path) -> None:
+def test_trusted_file_rejects_snapshot_root_as_file_path() -> None:
+    with pytest.raises(ValueError, match="inside the snapshot"):
+        TrustedModelFile(
+            path=".",
+            size_bytes=1,
+            sha256_hex="0" * 64,
+        )
+
+
+def test_snapshot_verification_checks_exact_file_set_hash_and_size(
+    tmp_path: Path,
+) -> None:
     cache_root = tmp_path / "cache"
     snapshot = cache_root / "snapshots" / ("a" * 40)
     snapshot.mkdir(parents=True)
@@ -113,7 +124,9 @@ def test_snapshot_verification_checks_exact_file_set_hash_and_size(tmp_path: Pat
 
     (snapshot / "model.bin").write_bytes(b"tampered!!!!")
     with pytest.raises(ValueError, match="hash mismatch"):
-        verify_trusted_model_snapshot(spec, snapshot_root=snapshot, cache_root=cache_root)
+        verify_trusted_model_snapshot(
+            spec, snapshot_root=snapshot, cache_root=cache_root
+        )
 
 
 def test_snapshot_verification_rejects_undeclared_file(tmp_path: Path) -> None:
@@ -126,7 +139,9 @@ def test_snapshot_verification_rejects_undeclared_file(tmp_path: Path) -> None:
     spec = _spec((_trusted_file("model.bin", model),))
 
     with pytest.raises(ValueError, match="undeclared=surprise.json"):
-        verify_trusted_model_snapshot(spec, snapshot_root=snapshot, cache_root=cache_root)
+        verify_trusted_model_snapshot(
+            spec, snapshot_root=snapshot, cache_root=cache_root
+        )
 
 
 def test_snapshot_verification_rejects_snapshot_outside_cache(tmp_path: Path) -> None:
@@ -139,4 +154,6 @@ def test_snapshot_verification_rejects_snapshot_outside_cache(tmp_path: Path) ->
     spec = _spec((_trusted_file("model.bin", model),))
 
     with pytest.raises(ValueError, match="inside the model cache"):
-        verify_trusted_model_snapshot(spec, snapshot_root=snapshot, cache_root=cache_root)
+        verify_trusted_model_snapshot(
+            spec, snapshot_root=snapshot, cache_root=cache_root
+        )

--- a/src/scholion/supply_chain/tests/test_update_manifest.py
+++ b/src/scholion/supply_chain/tests/test_update_manifest.py
@@ -1,0 +1,197 @@
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scholion.supply_chain.update_manifest import (
+    UpdateTrustError,
+    verify_signed_update_manifest,
+)
+
+
+class FixtureVerifier:
+    def __init__(self, *, accepted_key: str, accepted_payload: bytes, accepted_signature: bytes) -> None:
+        self.accepted_key = accepted_key
+        self.accepted_payload = accepted_payload
+        self.accepted_signature = accepted_signature
+        self.calls = 0
+
+    def verify(
+        self,
+        *,
+        key_id: str,
+        algorithm: str,
+        payload: bytes,
+        signature: bytes,
+    ) -> bool:
+        self.calls += 1
+        return (
+            key_id == self.accepted_key
+            and algorithm == "ed25519"
+            and payload == self.accepted_payload
+            and signature == self.accepted_signature
+        )
+
+
+def _payload(*, sequence: int = 7, expires_delta: timedelta = timedelta(days=7)) -> bytes:
+    now = datetime(2026, 8, 23, 15, 0, tzinfo=timezone.utc)
+    document = {
+        "schema_version": 1,
+        "sequence": sequence,
+        "channel": "stable",
+        "version": "0.2.0",
+        "published_at": now.isoformat().replace("+00:00", "Z"),
+        "expires_at": (now + expires_delta).isoformat().replace("+00:00", "Z"),
+        "release_notes_url": "https://updates.example.invalid/releases/0.2.0",
+        "artifacts": [
+            {
+                "platform": "linux-x86_64",
+                "url": "https://updates.example.invalid/artifacts/scholion-linux-x86_64.tar.zst",
+                "size_bytes": 42,
+                "sha256": "a" * 64,
+            }
+        ],
+    }
+    return json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _envelope(payload: bytes, *, key_id: str = "release-2026", signature: bytes | None = None) -> dict[str, object]:
+    resolved_signature = signature if signature is not None else b"s" * 64
+    return {
+        "schema_version": 1,
+        "key_id": key_id,
+        "algorithm": "ed25519",
+        "payload_base64": base64.b64encode(payload).decode("ascii"),
+        "signature_base64": base64.b64encode(resolved_signature).decode("ascii"),
+    }
+
+
+def test_signature_is_verified_before_payload_can_authorize_release() -> None:
+    payload = _payload()
+    signature = b"s" * 64
+    verifier = FixtureVerifier(
+        accepted_key="release-2026",
+        accepted_payload=payload,
+        accepted_signature=signature,
+    )
+
+    manifest = verify_signed_update_manifest(
+        _envelope(payload, signature=signature),
+        verifier=verifier,
+        now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+        highest_seen_sequence=7,
+    )
+
+    assert verifier.calls == 1
+    assert manifest.version == "0.2.0"
+    assert manifest.artifact_for("linux-x86_64").sha256_hex == "a" * 64
+
+
+def test_modified_payload_fails_existing_signature() -> None:
+    payload = _payload()
+    signature = b"s" * 64
+    verifier = FixtureVerifier(
+        accepted_key="release-2026",
+        accepted_payload=payload,
+        accepted_signature=signature,
+    )
+    tampered = payload.replace(b"0.2.0", b"9.9.9")
+
+    with pytest.raises(UpdateTrustError, match="signature verification failed"):
+        verify_signed_update_manifest(
+            _envelope(tampered, signature=signature),
+            verifier=verifier,
+            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+        )
+
+
+def test_unknown_signing_key_fails_closed() -> None:
+    payload = _payload()
+    signature = b"s" * 64
+    verifier = FixtureVerifier(
+        accepted_key="release-2026",
+        accepted_payload=payload,
+        accepted_signature=signature,
+    )
+
+    with pytest.raises(UpdateTrustError, match="signature verification failed"):
+        verify_signed_update_manifest(
+            _envelope(payload, key_id="unknown-key", signature=signature),
+            verifier=verifier,
+            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+        )
+
+
+def test_rollback_sequence_is_rejected_after_signature_verification() -> None:
+    payload = _payload(sequence=6)
+    signature = b"s" * 64
+    verifier = FixtureVerifier(
+        accepted_key="release-2026",
+        accepted_payload=payload,
+        accepted_signature=signature,
+    )
+
+    with pytest.raises(UpdateTrustError, match="older than a previously trusted sequence"):
+        verify_signed_update_manifest(
+            _envelope(payload, signature=signature),
+            verifier=verifier,
+            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+            highest_seen_sequence=7,
+        )
+
+    assert verifier.calls == 1
+
+
+def test_expired_metadata_is_rejected() -> None:
+    payload = _payload(expires_delta=timedelta(hours=1))
+    signature = b"s" * 64
+    verifier = FixtureVerifier(
+        accepted_key="release-2026",
+        accepted_payload=payload,
+        accepted_signature=signature,
+    )
+
+    with pytest.raises(UpdateTrustError, match="expired"):
+        verify_signed_update_manifest(
+            _envelope(payload, signature=signature),
+            verifier=verifier,
+            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+        )
+
+
+def test_artifact_transport_must_be_https_and_typed() -> None:
+    payload_document = json.loads(_payload().decode("utf-8"))
+    payload_document["artifacts"][0]["url"] = "http://updates.example.invalid/app"
+    payload = json.dumps(payload_document, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    signature = b"s" * 64
+    verifier = FixtureVerifier(
+        accepted_key="release-2026",
+        accepted_payload=payload,
+        accepted_signature=signature,
+    )
+
+    with pytest.raises(UpdateTrustError, match="HTTPS URL"):
+        verify_signed_update_manifest(
+            _envelope(payload, signature=signature),
+            verifier=verifier,
+            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+        )
+
+
+def test_envelope_rejects_unmodeled_remote_configuration() -> None:
+    payload = _payload()
+    envelope = _envelope(payload)
+    envelope["command"] = "run-this"
+    verifier = FixtureVerifier(
+        accepted_key="release-2026",
+        accepted_payload=payload,
+        accepted_signature=b"s" * 64,
+    )
+
+    with pytest.raises(UpdateTrustError, match="unexpected fields"):
+        verify_signed_update_manifest(
+            envelope,
+            verifier=verifier,
+            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+        )

--- a/src/scholion/supply_chain/tests/test_update_manifest.py
+++ b/src/scholion/supply_chain/tests/test_update_manifest.py
@@ -11,7 +11,9 @@ from scholion.supply_chain.update_manifest import (
 
 
 class FixtureVerifier:
-    def __init__(self, *, accepted_key: str, accepted_payload: bytes, accepted_signature: bytes) -> None:
+    def __init__(
+        self, *, accepted_key: str, accepted_payload: bytes, accepted_signature: bytes
+    ) -> None:
         self.accepted_key = accepted_key
         self.accepted_payload = accepted_payload
         self.accepted_signature = accepted_signature
@@ -34,7 +36,9 @@ class FixtureVerifier:
         )
 
 
-def _payload(*, sequence: int = 7, expires_delta: timedelta = timedelta(days=7)) -> bytes:
+def _payload(
+    *, sequence: int = 7, expires_delta: timedelta = timedelta(days=7)
+) -> bytes:
     now = datetime(2026, 8, 23, 15, 0, tzinfo=UTC)
     document = {
         "schema_version": 1,
@@ -56,7 +60,9 @@ def _payload(*, sequence: int = 7, expires_delta: timedelta = timedelta(days=7))
     return json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
-def _envelope(payload: bytes, *, key_id: str = "release-2026", signature: bytes | None = None) -> dict[str, object]:
+def _envelope(
+    payload: bytes, *, key_id: str = "release-2026", signature: bytes | None = None
+) -> dict[str, object]:
     resolved_signature = signature if signature is not None else b"s" * 64
     return {
         "schema_version": 1,
@@ -132,7 +138,9 @@ def test_rollback_sequence_is_rejected_after_signature_verification() -> None:
         accepted_signature=signature,
     )
 
-    with pytest.raises(UpdateTrustError, match="older than a previously trusted sequence"):
+    with pytest.raises(
+        UpdateTrustError, match="older than a previously trusted sequence"
+    ):
         verify_signed_update_manifest(
             _envelope(payload, signature=signature),
             verifier=verifier,
@@ -163,7 +171,9 @@ def test_expired_metadata_is_rejected() -> None:
 def test_artifact_transport_must_be_https_and_typed() -> None:
     payload_document = json.loads(_payload().decode("utf-8"))
     payload_document["artifacts"][0]["url"] = "http://updates.example.invalid/app"
-    payload = json.dumps(payload_document, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload = json.dumps(
+        payload_document, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
     signature = b"s" * 64
     verifier = FixtureVerifier(
         accepted_key="release-2026",

--- a/src/scholion/supply_chain/tests/test_update_manifest.py
+++ b/src/scholion/supply_chain/tests/test_update_manifest.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -35,7 +35,7 @@ class FixtureVerifier:
 
 
 def _payload(*, sequence: int = 7, expires_delta: timedelta = timedelta(days=7)) -> bytes:
-    now = datetime(2026, 8, 23, 15, 0, tzinfo=timezone.utc)
+    now = datetime(2026, 8, 23, 15, 0, tzinfo=UTC)
     document = {
         "schema_version": 1,
         "sequence": sequence,
@@ -79,7 +79,7 @@ def test_signature_is_verified_before_payload_can_authorize_release() -> None:
     manifest = verify_signed_update_manifest(
         _envelope(payload, signature=signature),
         verifier=verifier,
-        now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+        now=datetime(2026, 8, 24, tzinfo=UTC),
         highest_seen_sequence=7,
     )
 
@@ -102,7 +102,7 @@ def test_modified_payload_fails_existing_signature() -> None:
         verify_signed_update_manifest(
             _envelope(tampered, signature=signature),
             verifier=verifier,
-            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+            now=datetime(2026, 8, 24, tzinfo=UTC),
         )
 
 
@@ -119,7 +119,7 @@ def test_unknown_signing_key_fails_closed() -> None:
         verify_signed_update_manifest(
             _envelope(payload, key_id="unknown-key", signature=signature),
             verifier=verifier,
-            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+            now=datetime(2026, 8, 24, tzinfo=UTC),
         )
 
 
@@ -136,7 +136,7 @@ def test_rollback_sequence_is_rejected_after_signature_verification() -> None:
         verify_signed_update_manifest(
             _envelope(payload, signature=signature),
             verifier=verifier,
-            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+            now=datetime(2026, 8, 24, tzinfo=UTC),
             highest_seen_sequence=7,
         )
 
@@ -156,7 +156,7 @@ def test_expired_metadata_is_rejected() -> None:
         verify_signed_update_manifest(
             _envelope(payload, signature=signature),
             verifier=verifier,
-            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+            now=datetime(2026, 8, 24, tzinfo=UTC),
         )
 
 
@@ -175,7 +175,7 @@ def test_artifact_transport_must_be_https_and_typed() -> None:
         verify_signed_update_manifest(
             _envelope(payload, signature=signature),
             verifier=verifier,
-            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+            now=datetime(2026, 8, 24, tzinfo=UTC),
         )
 
 
@@ -193,5 +193,5 @@ def test_envelope_rejects_unmodeled_remote_configuration() -> None:
         verify_signed_update_manifest(
             envelope,
             verifier=verifier,
-            now=datetime(2026, 8, 24, tzinfo=timezone.utc),
+            now=datetime(2026, 8, 24, tzinfo=UTC),
         )

--- a/src/scholion/supply_chain/update_manifest.py
+++ b/src/scholion/supply_chain/update_manifest.py
@@ -4,7 +4,7 @@ import base64
 import binascii
 import json
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
@@ -78,7 +78,7 @@ def _parse_utc_timestamp(value: str, field: str) -> datetime:
         raise UpdateTrustError(f"{field} must be an ISO-8601 timestamp") from exc
     if parsed.tzinfo is None:
         raise UpdateTrustError(f"{field} must include a timezone")
-    return parsed.astimezone(timezone.utc)
+    return parsed.astimezone(UTC)
 
 
 def _decode_base64(value: str, field: str) -> bytes:
@@ -244,7 +244,7 @@ def verify_signed_update_manifest(
     payload = UpdateManifestPayload.from_bytes(envelope.payload)
     if now.tzinfo is None:
         raise UpdateTrustError("current time must include a timezone")
-    resolved_now = now.astimezone(timezone.utc)
+    resolved_now = now.astimezone(UTC)
     if payload.expires_at <= resolved_now:
         raise UpdateTrustError("update metadata has expired")
     if payload.published_at > resolved_now:

--- a/src/scholion/supply_chain/update_manifest.py
+++ b/src/scholion/supply_chain/update_manifest.py
@@ -53,22 +53,32 @@ def _require_int(document: dict[str, Any], key: str) -> int:
 
 def _require_identifier(value: str, field: str) -> None:
     if len(value) > 64 or any(
-        character not in "abcdefghijklmnopqrstuvwxyz0123456789._-" for character in value
+        character not in "abcdefghijklmnopqrstuvwxyz0123456789._-"
+        for character in value
     ):
         raise UpdateTrustError(f"{field} contains unsupported characters")
 
 
 def _require_https_url(value: str, field: str) -> None:
     parsed = urlparse(value)
-    if parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
-        raise UpdateTrustError(f"{field} must be an HTTPS URL without embedded credentials")
+    if (
+        parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+    ):
+        raise UpdateTrustError(
+            f"{field} must be an HTTPS URL without embedded credentials"
+        )
 
 
 def _require_sha256(value: str) -> None:
     if len(value) != _SHA256_HEX_LENGTH or any(
         character not in "0123456789abcdef" for character in value
     ):
-        raise UpdateTrustError("artifact sha256 must be 64 lowercase hexadecimal characters")
+        raise UpdateTrustError(
+            "artifact sha256 must be 64 lowercase hexadecimal characters"
+        )
 
 
 def _parse_utc_timestamp(value: str, field: str) -> datetime:
@@ -146,7 +156,9 @@ class UpdateManifestPayload:
         try:
             document = json.loads(payload.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise UpdateTrustError("signed update payload is not valid UTF-8 JSON") from exc
+            raise UpdateTrustError(
+                "signed update payload is not valid UTF-8 JSON"
+            ) from exc
         if not isinstance(document, dict):
             raise UpdateTrustError("signed update payload must be a JSON object")
         _require_exact_keys(
@@ -183,9 +195,13 @@ class UpdateManifestPayload:
         )
 
     def artifact_for(self, platform: str) -> ReleaseArtifact:
-        match = next((item for item in self.artifacts if item.platform == platform), None)
+        match = next(
+            (item for item in self.artifacts if item.platform == platform), None
+        )
         if match is None:
-            raise UpdateTrustError(f"release does not contain an artifact for {platform}")
+            raise UpdateTrustError(
+                f"release does not contain an artifact for {platform}"
+            )
         return match
 
 
@@ -212,13 +228,21 @@ class SignedUpdateEnvelope:
     def from_dict(cls, document: dict[str, Any]) -> SignedUpdateEnvelope:
         _require_exact_keys(
             document,
-            {"schema_version", "key_id", "algorithm", "payload_base64", "signature_base64"},
+            {
+                "schema_version",
+                "key_id",
+                "algorithm",
+                "payload_base64",
+                "signature_base64",
+            },
         )
         return cls(
             schema_version=_require_int(document, "schema_version"),
             key_id=_require_str(document, "key_id"),
             algorithm=_require_str(document, "algorithm"),
-            payload=_decode_base64(_require_str(document, "payload_base64"), "payload_base64"),
+            payload=_decode_base64(
+                _require_str(document, "payload_base64"), "payload_base64"
+            ),
             signature=_decode_base64(
                 _require_str(document, "signature_base64"), "signature_base64"
             ),
@@ -250,5 +274,7 @@ def verify_signed_update_manifest(
     if payload.published_at > resolved_now:
         raise UpdateTrustError("update metadata publication time is in the future")
     if highest_seen_sequence is not None and payload.sequence < highest_seen_sequence:
-        raise UpdateTrustError("update metadata is older than a previously trusted sequence")
+        raise UpdateTrustError(
+            "update metadata is older than a previously trusted sequence"
+        )
     return payload

--- a/src/scholion/supply_chain/update_manifest.py
+++ b/src/scholion/supply_chain/update_manifest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -83,7 +84,7 @@ def _parse_utc_timestamp(value: str, field: str) -> datetime:
 def _decode_base64(value: str, field: str) -> bytes:
     try:
         return base64.b64decode(value, validate=True)
-    except (ValueError, base64.binascii.Error) as exc:
+    except (ValueError, binascii.Error) as exc:
         raise UpdateTrustError(f"{field} must be valid base64") from exc
 
 
@@ -241,6 +242,8 @@ def verify_signed_update_manifest(
         raise UpdateTrustError("update manifest signature verification failed")
 
     payload = UpdateManifestPayload.from_bytes(envelope.payload)
+    if now.tzinfo is None:
+        raise UpdateTrustError("current time must include a timezone")
     resolved_now = now.astimezone(timezone.utc)
     if payload.expires_at <= resolved_now:
         raise UpdateTrustError("update metadata has expired")

--- a/src/scholion/supply_chain/update_manifest.py
+++ b/src/scholion/supply_chain/update_manifest.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+_ENVELOPE_SCHEMA_VERSION = 1
+_PAYLOAD_SCHEMA_VERSION = 1
+_MAX_PAYLOAD_BYTES = 64 * 1024
+_SHA256_HEX_LENGTH = 64
+_ED25519_SIGNATURE_BYTES = 64
+_ALLOWED_SIGNATURE_ALGORITHM = "ed25519"
+
+
+class UpdateTrustError(ValueError):
+    """Raised when signed update metadata cannot authorize an update."""
+
+
+class SignatureVerifier(Protocol):
+    def verify(
+        self,
+        *,
+        key_id: str,
+        algorithm: str,
+        payload: bytes,
+        signature: bytes,
+    ) -> bool: ...
+
+
+def _require_exact_keys(document: dict[str, Any], expected: set[str]) -> None:
+    actual = set(document)
+    if actual != expected:
+        raise UpdateTrustError("update metadata contains unexpected fields")
+
+
+def _require_str(document: dict[str, Any], key: str) -> str:
+    value = document.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise UpdateTrustError(f"{key} must be a non-empty string")
+    return value
+
+
+def _require_int(document: dict[str, Any], key: str) -> int:
+    value = document.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise UpdateTrustError(f"{key} must be an integer")
+    return value
+
+
+def _require_identifier(value: str, field: str) -> None:
+    if len(value) > 64 or any(
+        character not in "abcdefghijklmnopqrstuvwxyz0123456789._-" for character in value
+    ):
+        raise UpdateTrustError(f"{field} contains unsupported characters")
+
+
+def _require_https_url(value: str, field: str) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
+        raise UpdateTrustError(f"{field} must be an HTTPS URL without embedded credentials")
+
+
+def _require_sha256(value: str) -> None:
+    if len(value) != _SHA256_HEX_LENGTH or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise UpdateTrustError("artifact sha256 must be 64 lowercase hexadecimal characters")
+
+
+def _parse_utc_timestamp(value: str, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise UpdateTrustError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise UpdateTrustError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _decode_base64(value: str, field: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except (ValueError, base64.binascii.Error) as exc:
+        raise UpdateTrustError(f"{field} must be valid base64") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseArtifact:
+    platform: str
+    url: str
+    size_bytes: int
+    sha256_hex: str
+
+    def __post_init__(self) -> None:
+        _require_identifier(self.platform, "platform")
+        _require_https_url(self.url, "artifact url")
+        if self.size_bytes < 1:
+            raise UpdateTrustError("artifact size must be positive")
+        _require_sha256(self.sha256_hex)
+
+    @classmethod
+    def from_dict(cls, document: dict[str, Any]) -> ReleaseArtifact:
+        _require_exact_keys(document, {"platform", "url", "size_bytes", "sha256"})
+        return cls(
+            platform=_require_str(document, "platform"),
+            url=_require_str(document, "url"),
+            size_bytes=_require_int(document, "size_bytes"),
+            sha256_hex=_require_str(document, "sha256"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateManifestPayload:
+    schema_version: int
+    sequence: int
+    channel: str
+    version: str
+    published_at: datetime
+    expires_at: datetime
+    release_notes_url: str
+    artifacts: tuple[ReleaseArtifact, ...]
+
+    def __post_init__(self) -> None:
+        if self.schema_version != _PAYLOAD_SCHEMA_VERSION:
+            raise UpdateTrustError("unsupported update payload schema version")
+        if self.sequence < 1:
+            raise UpdateTrustError("update sequence must be positive")
+        _require_identifier(self.channel, "channel")
+        if not self.version.strip() or len(self.version) > 128:
+            raise UpdateTrustError("version must be a bounded non-empty string")
+        _require_https_url(self.release_notes_url, "release notes url")
+        if self.expires_at <= self.published_at:
+            raise UpdateTrustError("update metadata must expire after publication")
+        if not self.artifacts:
+            raise UpdateTrustError("update metadata must contain at least one artifact")
+        platforms = tuple(item.platform for item in self.artifacts)
+        if len(platforms) != len(set(platforms)):
+            raise UpdateTrustError("update artifact platforms must be unique")
+
+    @classmethod
+    def from_bytes(cls, payload: bytes) -> UpdateManifestPayload:
+        try:
+            document = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpdateTrustError("signed update payload is not valid UTF-8 JSON") from exc
+        if not isinstance(document, dict):
+            raise UpdateTrustError("signed update payload must be a JSON object")
+        _require_exact_keys(
+            document,
+            {
+                "schema_version",
+                "sequence",
+                "channel",
+                "version",
+                "published_at",
+                "expires_at",
+                "release_notes_url",
+                "artifacts",
+            },
+        )
+        raw_artifacts = document.get("artifacts")
+        if not isinstance(raw_artifacts, list) or any(
+            not isinstance(item, dict) for item in raw_artifacts
+        ):
+            raise UpdateTrustError("artifacts must be a list of objects")
+        return cls(
+            schema_version=_require_int(document, "schema_version"),
+            sequence=_require_int(document, "sequence"),
+            channel=_require_str(document, "channel"),
+            version=_require_str(document, "version"),
+            published_at=_parse_utc_timestamp(
+                _require_str(document, "published_at"), "published_at"
+            ),
+            expires_at=_parse_utc_timestamp(
+                _require_str(document, "expires_at"), "expires_at"
+            ),
+            release_notes_url=_require_str(document, "release_notes_url"),
+            artifacts=tuple(ReleaseArtifact.from_dict(item) for item in raw_artifacts),
+        )
+
+    def artifact_for(self, platform: str) -> ReleaseArtifact:
+        match = next((item for item in self.artifacts if item.platform == platform), None)
+        if match is None:
+            raise UpdateTrustError(f"release does not contain an artifact for {platform}")
+        return match
+
+
+@dataclass(frozen=True, slots=True)
+class SignedUpdateEnvelope:
+    schema_version: int
+    key_id: str
+    algorithm: str
+    payload: bytes
+    signature: bytes
+
+    def __post_init__(self) -> None:
+        if self.schema_version != _ENVELOPE_SCHEMA_VERSION:
+            raise UpdateTrustError("unsupported update envelope schema version")
+        _require_identifier(self.key_id, "key_id")
+        if self.algorithm != _ALLOWED_SIGNATURE_ALGORITHM:
+            raise UpdateTrustError("unsupported update signature algorithm")
+        if not self.payload or len(self.payload) > _MAX_PAYLOAD_BYTES:
+            raise UpdateTrustError("signed update payload exceeds its size boundary")
+        if len(self.signature) != _ED25519_SIGNATURE_BYTES:
+            raise UpdateTrustError("update signature has an invalid length")
+
+    @classmethod
+    def from_dict(cls, document: dict[str, Any]) -> SignedUpdateEnvelope:
+        _require_exact_keys(
+            document,
+            {"schema_version", "key_id", "algorithm", "payload_base64", "signature_base64"},
+        )
+        return cls(
+            schema_version=_require_int(document, "schema_version"),
+            key_id=_require_str(document, "key_id"),
+            algorithm=_require_str(document, "algorithm"),
+            payload=_decode_base64(_require_str(document, "payload_base64"), "payload_base64"),
+            signature=_decode_base64(
+                _require_str(document, "signature_base64"), "signature_base64"
+            ),
+        )
+
+
+def verify_signed_update_manifest(
+    document: dict[str, Any],
+    *,
+    verifier: SignatureVerifier,
+    now: datetime,
+    highest_seen_sequence: int | None = None,
+) -> UpdateManifestPayload:
+    envelope = SignedUpdateEnvelope.from_dict(document)
+    if not verifier.verify(
+        key_id=envelope.key_id,
+        algorithm=envelope.algorithm,
+        payload=envelope.payload,
+        signature=envelope.signature,
+    ):
+        raise UpdateTrustError("update manifest signature verification failed")
+
+    payload = UpdateManifestPayload.from_bytes(envelope.payload)
+    resolved_now = now.astimezone(timezone.utc)
+    if payload.expires_at <= resolved_now:
+        raise UpdateTrustError("update metadata has expired")
+    if payload.published_at > resolved_now:
+        raise UpdateTrustError("update metadata publication time is in the future")
+    if highest_seen_sequence is not None and payload.sequence < highest_seen_sequence:
+        raise UpdateTrustError("update metadata is older than a previously trusted sequence")
+    return payload


### PR DESCRIPTION
## Summary

Begins #110 without pretending the production trust channel is already complete.

This PR adds a fail-closed supply-chain trust foundation:

- strict curated model-trust catalog schema with immutable upstream revision, repository/source identity, license metadata, exact file paths, sizes, and SHA-256 values
- snapshot verification that rejects path/cache escape, missing or undeclared files, size mismatch, and hash mismatch
- strict signed update envelope whose signature covers exact payload bytes rather than re-serialized JSON
- typed update payload with sequence, channel, version, publication/expiry time, release notes, and per-platform artifact URL/size/SHA-256
- verifier interface so the production desktop can use a reviewed native signature implementation instead of hand-written Python cryptography
- anti-rollback sequence and expiry checks
- rejection of unknown remote configuration fields and non-HTTPS artifact metadata
- focused tests for tampering, unknown signing keys, rollback, expiry, hostile model paths, undeclared model files, and cache containment
- threat model and privacy/update behavior specification under `docs/security/update-model-trust.md`

## Deliberately not claimed as complete

This branch does **not** contain production signing keys, does not invent real Systran revision hashes, and does not yet make current model installs policy-trusted. Remaining #110 work includes:

- select/pin the production native signature verifier and public key(s)
- implement fixed-endpoint manual update checking in Tauri
- persist highest trusted sequence locally without sending an identifier
- stage/update artifacts with signed size/hash enforcement and platform-safe activation
- add explicit update UI and separately opt-in periodic checks
- review immutable faster-whisper upstream revisions and generate the production curated model catalog
- wire model download/registration to exact trusted revision + full trust verification
- distinguish integrity-checked from Scholion-policy-trusted model state in the consumer surface
- qualify offline/native behavior across supported platforms

## Security/privacy

No telemetry endpoint, remote command channel, arbitrary configuration field, production key, workstation identifier, local path, or corpus/research data is introduced. Network access remains absent from these primitives; existing offline workflows are unchanged.

Closes no issue yet. #110 remains open until the native update and production model-trust integration are complete.