### PR TITLE
Finish Processing model-cache explanation

### DIFF
--- a/frontend/src/ProcessingCenter.tsx
+++ b/frontend/src/ProcessingCenter.tsx
@@ -586,7 +586,7 @@ export function ProcessingCenter({
                         </small>
                       </dd>
                     </div>
-                  ))
+                  ))}
                 ) : (
                   <div><dt>Graphics</dt><dd>No supported accelerator detected</dd></div>
                 )}
@@ -647,7 +647,7 @@ export function ProcessingCenter({
             </span>
           )}
         </div>
-        <p>Models are downloaded only when you choose. Once installed, transcription can run without an internet connection.</p>
+        <p>Models are downloaded only when you choose. Once installed, transcription can run without an internet connection. Scholion keeps installed models in its private model cache.</p>
         <div className="model-list">
           {readiness?.models.map((model) => {
             const modelTaskActive = task?.state === "running" && taskModelId === model.model_id;

--- a/frontend/src/ProcessingCenter.tsx
+++ b/frontend/src/ProcessingCenter.tsx
@@ -586,7 +586,7 @@ export function ProcessingCenter({
                         </small>
                       </dd>
                     </div>
-                  ))}
+                  ))
                 ) : (
                   <div><dt>Graphics</dt><dd>No supported accelerator detected</dd></div>
                 )}

--- a/frontend/tests/processing-model-cache-copy.spec.ts
+++ b/frontend/tests/processing-model-cache-copy.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("Processing explains where managed transcription models are kept", async ({ page }) => {
+  await page.goto("/?e2e=1");
+  await page.getByRole("button", { name: "Processing" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Transcribe recordings." }),
+  ).toBeVisible();
+
+  await expect(
+    page.getByText(/Scholion keeps installed models in its private model cache/),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Finishes the automatable UI tail of #114 after merged PR #116.

- Processing now tells users that installed transcription models live in Scholion's private model cache.
- The UI does not expose a filesystem path and does not add a generic path-opening capability.
- A focused Playwright acceptance test proves the explanation is visible in the ordinary Processing surface.

## Scope

PR #116 already implemented the substantive runtime/UX work in #114: bounded worker outcomes, safe public failure reasons, in-place indeterminate model task state, speaker-labeling capability gating, and separate refresh-error lifecycle.

This PR addresses criterion 6's remaining presentation gap only.

## Remaining qualification

#114 should stay open after this PR until criterion 7's representative real-device native qualification is recorded for both CPU-only and accelerator-capable machines. Browser mocks are not being misrepresented as native transport evidence.

## Privacy/security

No model-cache path crosses into React. No arbitrary filesystem opener is added. The copy describes custody without widening frontend authority.