### PR TITLE
Integrate curated model policy trust with managed installs

### DIFF
--- a/docs/architecture/model-management.md
+++ b/docs/architecture/model-management.md
@@ -36,6 +36,11 @@ flowchart LR
     class H,I run
 ```
 
+That diagram describes the current default source-build path. The #110 policy-trust path
+adds an exact project-owned revision/file allowlist between provider download and managed
+registration once a reviewed production trust catalog is bundled and enforcement is
+enabled.
+
 ## Why Scholion does not just trust whatever is in a cache
 
 The Hugging Face cache is a useful byte-level storage layout. Scholion does not need to
@@ -67,34 +72,42 @@ The current contract records at least:
 - measured snapshot size; and
 - local revalidation method.
 
-The manifest is a receipt and dependency record, not a second copy of the model.
+A manifest can now also record a separate policy-trust receipt when installation was
+performed against a supplied curated Scholion trust catalog. That receipt contains the
+catalog schema version, policy model identity and revision, exact-verification method,
+verified file count, and verified byte count.
 
-## The three main responsibilities
+The manifest is a receipt and dependency record, not a second copy of the model. A
+recorded policy receipt is also not a permanent trust bit: current policy verification is
+recomputed when the managed state is read under a loaded trust catalog.
+
+## The main responsibilities
 
 `ModelCatalog` describes the finite set of models Scholion knows how to reason about.
 For faster-whisper, quality/cache metadata is derived from the transcription strategy
 catalog instead of duplicated.
 
 `ModelManager` owns application-level inventory, explicit installation, manifest custody,
-local revalidation, resolved-revision lookup, and removal.
+local revalidation, resolved-revision lookup, removal, and the boundary that applies
+project-owned model policy when a curated catalog is supplied.
 
 `ModelProvider` owns provider-specific mechanics such as obtaining a Hugging Face
 snapshot, validating its cache layout, and removing an exact cached revision.
 
 `ModelStorageAdmitter` checks disk capacity before acquisition starts.
 
-The split matters because “what models does Scholion support?” and “how does this
-provider download bytes?” are different questions.
+`scholion.supply_chain` owns the stronger project policy itself: exact approved
+repository/revision identity plus the full allowed file set, byte sizes, SHA-256 values,
+source/license metadata, and fail-closed snapshot verification.
 
-The separate `scholion.supply_chain` trust layer introduced under issue #110 defines a
-stronger project-owned policy: exact approved repository/revision identity plus the full
-allowed file set, byte sizes, SHA-256 values, source/license metadata, and fail-closed
-snapshot verification. That stronger policy is intentionally distinct from today's
-provider-layout revalidation until it is wired into production model installation.
+The split matters because “what models does Scholion support?”, “how does this provider
+download bytes?”, and “which exact bytes did the project approve?” are different
+questions. The #110 integration deliberately composes those authorities instead of
+turning provider-local validation and project policy into one vague “verified” state.
 
-## Install transaction today
+## Install transaction without a production policy catalog
 
-A model install currently follows this order:
+The current default application composition follows this order:
 
 1. resolve the model ID through the catalog;
 2. reject an invalid/blank requested revision;
@@ -116,9 +129,33 @@ local validation contract,” not “we started trying.”
 
 🦝 The raccoon gets a receipt after the groceries are actually in the pantry.
 
-When #110's production policy integration lands, acquisition must request the curated
-immutable revision and the exact file set, sizes, and SHA-256 values must match the
-bundled trust entry **before** the model can be registered as policy-trusted/ready.
+## Policy-enforced install seam
+
+The #110 integration adds a stricter transaction when `ModelManager` receives a curated
+`ModelTrustCatalog`:
+
+1. resolve the ordinary model catalog entry and the matching project trust entry;
+2. require model ID, engine, and provider repository identity to agree across both
+   catalogs;
+3. reject a caller-supplied revision that differs from the curated immutable revision
+   **before** provider acquisition starts;
+4. ask the provider for exactly the curated revision;
+5. retain the normal provider/cache/repository validation boundary;
+6. require the returned resolved revision to equal the curated revision;
+7. require the observed snapshot file set to equal the curated file set exactly;
+8. verify every curated file's byte size and SHA-256 while enforcing path/cache
+   containment;
+9. create separate policy-trust evidence from the successful exact verification; and
+10. commit the managed manifest only after both local/provider validation and policy
+    validation succeed.
+
+When `enforce_policy_trust=True`, a missing catalog entry or a previously managed
+manifest without current policy evidence fails closed. Existing manifests remain
+parseable so upgrading the manifest format does not itself destroy local custody state.
+
+This mechanism does **not** manufacture the production policy. Tests use synthetic local
+bytes and synthetic immutable revisions. The real faster-whisper entries still require a
+deliberate upstream review and must ship as part of a signed Scholion release.
 
 ## User surface
 
@@ -151,6 +188,10 @@ app storage, and can be used offline after installation. Repository IDs, exact r
 hashes, licenses, and policy-trust evidence belong under technical details or security
 documentation.
 
+Until a reviewed production catalog is actually bundled and enforcement is enabled in
+application composition, ordinary UI must continue to describe the default managed model
+as locally revalidated rather than policy-trusted.
+
 ## Inventory and local revalidation
 
 Inventory and resolved-revision lookup are offline and side-effect free. They do not
@@ -166,26 +207,35 @@ usable under the current custody contract. Validation checks that:
 - the local verification method is supported; and
 - required provider files remain present/non-empty.
 
+If the manager has a current trust catalog and the manifest carries policy-trust
+evidence, it additionally recomputes the exact file-set/size/SHA-256 verification and
+requires the resulting evidence to match the recorded receipt. With policy enforcement
+enabled, a manifest without current policy evidence is rejected.
+
 If external deletion or tampering makes that managed state stale, Scholion fails closed.
+A same-length byte mutation therefore cannot preserve policy trust merely because the
+provider-local required-file check still passes.
 
 The receipt is evidence of what Scholion checked earlier. It is not allowed to become a
-magic amulet that makes missing bytes reappear.
+magic amulet that makes missing or modified bytes reappear.
 
 ## Local revalidation is not policy trust
 
-Current faster-whisper revalidation establishes structural/provider provenance: expected
+Default faster-whisper revalidation establishes structural/provider provenance: expected
 cache layout, repository/revision identity, and required non-empty files.
 
-It does **not** yet prove that every installed byte matches a project-approved
-cryptographic allowlist. Do not describe the current state simply as “verified” where a
-reader could reasonably infer that stronger claim.
+It does **not** by itself prove that every installed byte matches a project-approved
+cryptographic allowlist. Do not describe that default state simply as “verified” where a
+reader could reasonably infer the stronger claim.
 
-The #110 foundation now provides the stronger primitives: a curated immutable model
-policy and exact file-set/size/SHA-256 verification. The remaining production work is to
-review real upstream faster-whisper revisions, ship those curated entries inside a signed
-Scholion release, make provider acquisition request only the approved revision, require
-full trust verification before registration, and record policy identity in the local
-manifest.
+The #110 code path for the stronger guarantee is now integrated into `ModelManager`: a
+supplied curated policy pins the revision, exact-verifies before registration, persists a
+separate policy receipt, and revalidates that receipt later. What remains before the
+product can rely on that guarantee is release content and composition rather than another
+parallel verification mechanism: review real upstream faster-whisper revisions, generate
+and bundle the production catalog, enable enforcement in the application container,
+expose the distinction in technical model state, and make new-transcription admission
+require current policy trust.
 
 See **[Signed update and model trust channel](../security/update-model-trust.md)** for the
 full trust model and privacy boundary.
@@ -194,8 +244,8 @@ full trust model and privacy boundary.
 
 There is one ASR model path.
 
-A new transcription plan must resolve the selected faster-whisper model through the
-locally revalidated managed registry.
+A new transcription plan currently resolves the selected faster-whisper model through
+the locally revalidated managed registry.
 
 If the model is not installed and locally revalidated, planning fails with an
 install-first message.
@@ -215,8 +265,9 @@ There is no:
 Resume restores the exact managed model revision recorded in the checkpoint contract.
 It never downloads a replacement as a side effect.
 
-After #110 integration, “usable for a new transcription” additionally requires current
-Scholion policy trust, not merely the older structural/provider receipt.
+Once the production catalog is bundled and enforcement is enabled, “usable for a new
+transcription” must additionally require current Scholion policy trust. That admission
+switch is intentionally not enabled against synthetic or unreviewed trust data.
 
 ## Network boundary 🔐
 
@@ -259,9 +310,16 @@ These conditions fail closed:
 - storage refusal; and
 - provider removal failure.
 
-Once policy trust is wired into installation, a missing trust entry, moving/unapproved
-revision, undeclared file, size mismatch, or SHA-256 mismatch must also fail closed before
-the snapshot can be registered as policy-trusted.
+With a trust catalog supplied, these conditions also fail closed before policy-trusted
+registration or revalidation:
+
+- missing required trust entry when enforcement is enabled;
+- catalog/model identity mismatch;
+- moving or unapproved revision;
+- undeclared or missing file;
+- byte-size mismatch;
+- SHA-256 mismatch; and
+- persisted policy evidence that no longer matches current verification.
 
 Routine public errors should describe the application failure without leaking private
 internal paths.
@@ -306,9 +364,10 @@ Model management does not currently provide:
 - adoption of arbitrary cache entries;
 - generic arbitrary model hubs;
 - model quota/garbage-collection policy;
-- hosted inventory/telemetry; or
-- production wiring from the #110 curated trust policy into faster-whisper install,
-  revalidation, inventory, and execution admission.
+- hosted inventory/telemetry;
+- a reviewed production faster-whisper policy catalog bundled into application releases;
+- production `AppContainer` policy enforcement and new-transcription admission; or
+- a finished technical-details UI for local revalidation versus current policy trust.
 
 The stable rule is:
 

--- a/docs/security/update-model-trust.md
+++ b/docs/security/update-model-trust.md
@@ -29,9 +29,11 @@ The application package owns a curated model-trust catalog. A model entry identi
 
 A distribution service such as Hugging Face transports bytes. It does not decide which revision or file hashes Scholion trusts.
 
-The provider must eventually request the exact curated revision and verify the downloaded snapshot against the bundled trust entry before writing a local managed-model manifest or reporting the model as trusted/ready. Snapshot verification rejects path escape, cache escape, missing files, undeclared files, size mismatch, and hash mismatch.
+`ModelManager` now contains the production integration seam for this policy. When a curated trust catalog is supplied, installation pins the exact approved revision, rejects a conflicting caller revision before provider acquisition, verifies the complete downloaded snapshot against the bundled entry before committing the managed manifest, records policy-trust evidence separately from provider-local validation, and re-runs that exact policy verification when the managed manifest is read. An enforcement mode rejects managed state that lacks current policy trust.
 
-Integrity/local revalidation and policy trust are separate states. A snapshot can match expected repository/revision/layout rules without being trusted by Scholion policy. Consumer UI and documentation must not collapse those states into one word such as “verified.”
+That seam is intentionally dormant in the ordinary application composition until Scholion ships deliberately reviewed production faster-whisper catalog entries. The current `AppContainer` does not invent or fetch a trust catalog dynamically, and current source builds therefore retain the existing local-revalidation behavior. This prevents scaffolding or development downloads from being mislabeled as project-approved model policy.
+
+Integrity/local revalidation and policy trust remain separate states. A snapshot can match expected repository/revision/layout rules without being trusted by Scholion policy. Consumer UI and documentation must not collapse those states into one word such as “verified.”
 
 ## Update manifest v1
 
@@ -111,6 +113,14 @@ Production entries must be generated from a deliberately reviewed immutable upst
 
 Changing a trusted model revision is a security-sensitive repository change. The review should record why the revision changed, source/license changes, file-set changes, regression evidence, and regenerated hashes/sizes. The new catalog ships with a signed Scholion release.
 
+### Managed policy evidence
+
+A managed-model manifest can now carry a separate policy-trust receipt containing the bundled catalog schema version, model identity, exact revision, policy-verification method, verified file count, and verified byte count. It does not replace provider-local provenance such as the repository identity, resolved revision, snapshot path, measured size, or provider validation method.
+
+The receipt is not treated as a permanent trust bit. With a current trust catalog loaded, `ModelManager` recomputes the exact snapshot verification and requires the observed evidence to match the recorded receipt. A same-length byte mutation, undeclared file, missing file, size change, revision change, or current-policy mismatch therefore invalidates the managed registry instead of continuing to report the model as trusted.
+
+Existing manifests without policy evidence remain parseable for compatibility. When policy enforcement is enabled, those manifests are not admitted as policy-trusted state; they must be reinstalled or otherwise pass the deliberate migration path defined for that release.
+
 ## Threat model
 
 | Threat | Control | Residual risk / follow-up |
@@ -147,7 +157,7 @@ Ordinary product copy should explain the consequences a user actually needs to k
 
 Do not make the primary workflow explain repository cache layouts, digest algorithms, trust-root rotation, or signed-manifest internals. Those are legitimate details, but they are not the job the person is trying to complete.
 
-Until #110's production integration is complete, ordinary UI also must not say or imply that the current managed snapshot is “policy-trusted” or “cryptographically verified.” Today the managed-model path provides explicit installation, immutable resolved-revision custody, containment, and structural/provider revalidation. The stronger curated byte-for-byte trust check is a separate unfinished layer.
+Until #110's production catalog and application enforcement are complete, ordinary UI also must not say or imply that the current managed snapshot is “policy-trusted” or “cryptographically verified.” Today the default managed-model path provides explicit installation, immutable resolved-revision custody, containment, and structural/provider revalidation. The stronger byte-for-byte path now has a tested `ModelManager` integration seam but is not yet the default application policy.
 
 ### Three presentation layers
 
@@ -159,9 +169,9 @@ Use one consistent layering rule across Processing, Settings, help, and document
 
 This keeps Scholion transparent without turning normal use into an architecture lecture. The UI should never hide a material consequence merely because the underlying mechanism is technical, and it should never inflate a weaker backend guarantee into a stronger consumer-facing trust claim.
 
-## What this foundation implements
+## What is implemented
 
-The `scholion.supply_chain` package currently provides:
+The `scholion.supply_chain` package provides:
 
 - strict curated model catalog parsing;
 - immutable-revision validation;
@@ -172,18 +182,30 @@ The `scholion.supply_chain` package currently provides:
 - expiry and anti-rollback sequence enforcement; and
 - tests for tampering, unknown keys, stale metadata, hostile paths, undeclared files, and malformed/extra remote configuration.
 
+The managed-model layer now additionally provides the integration boundary needed to consume that model policy:
+
+- exact curated revision selection before provider acquisition;
+- rejection of caller revision overrides that disagree with policy;
+- full policy verification before a managed manifest is committed;
+- separately persisted local-validation and policy-trust evidence;
+- exact policy revalidation on later managed-registry reads; and
+- an enforcement mode that rejects models without current policy trust.
+
+No production trust entry is generated by these mechanics. Tests use synthetic local bytes and synthetic immutable revisions only.
+
 ## Remaining work under #110
 
-This foundation deliberately does **not** claim #110 is complete. Before closing the issue:
+This tranche deliberately does **not** claim #110 is complete. Before closing the issue:
 
 - choose and pin the production native signature-verification implementation and public key(s);
 - implement fixed-endpoint manual update checking in the Tauri host;
 - persist highest trusted sequence without creating an identifier sent to the server;
 - stage downloads, enforce signed size/hash, and use platform-appropriate signed/atomic installation;
-- implement explicit update UI and separately opt-in periodic checks;
+- implement explicit update UI and separately opt-in periodic checks if periodic checking is retained;
 - review real upstream faster-whisper revisions and generate the production curated model catalog;
-- wire `ModelManager`/`HuggingFaceModelProvider` to request only the curated revision and require trust verification before registration;
-- record trusted policy identity in the local model manifest and expose local-revalidation versus “trusted by Scholion policy” accurately; and
-- add native/offline regression qualification across supported platforms.
+- bundle that reviewed catalog in the application and enable `ModelManager` policy enforcement in production composition;
+- expose local revalidation versus “trusted by Scholion policy” accurately in technical model state and require current policy trust for new-transcription admission once enforcement is enabled;
+- add native/offline regression qualification across supported platforms; and
+- integrate platform code signing/notarization into packaging rather than treating the signed manifest as a substitute.
 
 Until those steps land, current local/offline workflows remain unchanged and no update service is required for Scholion to run.

--- a/src/scholion/model_management/models.py
+++ b/src/scholion/model_management/models.py
@@ -206,14 +206,15 @@ class ManagedModelManifest:
 class ModelInventoryItem:
     spec: ModelSpec
     manifest: ManagedModelManifest | None = None
+    policy_trusted: bool = False
+
+    def __post_init__(self) -> None:
+        if self.policy_trusted and self.manifest is None:
+            raise ValueError("policy-trusted inventory item requires a managed manifest")
 
     @property
     def installed(self) -> bool:
         return self.manifest is not None
-
-    @property
-    def policy_trusted(self) -> bool:
-        return self.manifest is not None and self.manifest.policy_trust is not None
 
     def to_dict(self) -> dict[str, object]:
         return {

--- a/src/scholion/model_management/models.py
+++ b/src/scholion/model_management/models.py
@@ -69,6 +69,55 @@ class InstalledSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class ManagedModelPolicyTrust:
+    """Persisted evidence that a managed snapshot matched the bundled policy catalog."""
+
+    catalog_schema_version: int
+    model_id: str
+    revision: str
+    verification: str
+    verified_files: int
+    total_bytes: int
+
+    def __post_init__(self) -> None:
+        if self.catalog_schema_version < 1:
+            raise ValueError("catalog_schema_version must be positive")
+        for name in ("model_id", "revision", "verification"):
+            if not getattr(self, name).strip():
+                raise ValueError(f"{name} cannot be empty")
+        if self.verified_files < 1:
+            raise ValueError("verified_files must be positive")
+        if self.total_bytes < 1:
+            raise ValueError("total_bytes must be positive")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "catalog_schema_version": self.catalog_schema_version,
+            "model_id": self.model_id,
+            "revision": self.revision,
+            "verification": self.verification,
+            "verified_files": self.verified_files,
+            "total_bytes": self.total_bytes,
+        }
+
+    @classmethod
+    def from_dict(cls, document: dict[str, object]) -> "ManagedModelPolicyTrust":
+        try:
+            return cls(
+                catalog_schema_version=_required_int(
+                    document, "catalog_schema_version"
+                ),
+                model_id=_required_str(document, "model_id"),
+                revision=_required_str(document, "revision"),
+                verification=_required_str(document, "verification"),
+                verified_files=_required_int(document, "verified_files"),
+                total_bytes=_required_int(document, "total_bytes"),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("invalid model policy trust evidence") from exc
+
+
+@dataclass(frozen=True, slots=True)
 class ManagedModelManifest:
     schema_version: int
     model_id: str
@@ -79,6 +128,7 @@ class ManagedModelManifest:
     snapshot_path: Path
     size_bytes: int
     verification: str
+    policy_trust: ManagedModelPolicyTrust | None = None
 
     def __post_init__(self) -> None:
         if self.schema_version != 1:
@@ -101,6 +151,11 @@ class ManagedModelManifest:
         )
         if self.size_bytes < 1:
             raise ValueError("size_bytes must be positive")
+        if self.policy_trust is not None:
+            if self.policy_trust.model_id != self.model_id:
+                raise ValueError("policy trust model identity does not match manifest")
+            if self.policy_trust.revision != self.resolved_revision:
+                raise ValueError("policy trust revision does not match manifest")
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -113,6 +168,9 @@ class ManagedModelManifest:
             "snapshot_path": str(self.snapshot_path),
             "size_bytes": self.size_bytes,
             "verification": self.verification,
+            "policy_trust": (
+                None if self.policy_trust is None else self.policy_trust.to_dict()
+            ),
         }
 
     @classmethod
@@ -121,6 +179,9 @@ class ManagedModelManifest:
             requested = document.get("requested_revision")
             if requested is not None and not isinstance(requested, str):
                 raise ValueError("requested_revision must be a string or null")
+            raw_policy_trust = document.get("policy_trust")
+            if raw_policy_trust is not None and not isinstance(raw_policy_trust, dict):
+                raise ValueError("policy_trust must be an object or null")
             return cls(
                 schema_version=_required_int(document, "schema_version"),
                 model_id=_required_str(document, "model_id"),
@@ -131,6 +192,11 @@ class ManagedModelManifest:
                 snapshot_path=Path(_required_str(document, "snapshot_path")),
                 size_bytes=_required_int(document, "size_bytes"),
                 verification=_required_str(document, "verification"),
+                policy_trust=(
+                    None
+                    if raw_policy_trust is None
+                    else ManagedModelPolicyTrust.from_dict(raw_policy_trust)
+                ),
             )
         except (KeyError, TypeError, ValueError) as exc:
             raise ValueError("invalid model manifest") from exc
@@ -145,9 +211,14 @@ class ModelInventoryItem:
     def installed(self) -> bool:
         return self.manifest is not None
 
+    @property
+    def policy_trusted(self) -> bool:
+        return self.manifest is not None and self.manifest.policy_trust is not None
+
     def to_dict(self) -> dict[str, object]:
         return {
             "spec": self.spec.to_dict(),
             "installed": self.installed,
+            "policy_trusted": self.policy_trusted,
             "manifest": None if self.manifest is None else self.manifest.to_dict(),
         }

--- a/src/scholion/model_management/models.py
+++ b/src/scholion/model_management/models.py
@@ -210,7 +210,9 @@ class ModelInventoryItem:
 
     def __post_init__(self) -> None:
         if self.policy_trusted and self.manifest is None:
-            raise ValueError("policy-trusted inventory item requires a managed manifest")
+            raise ValueError(
+                "policy-trusted inventory item requires a managed manifest"
+            )
 
     @property
     def installed(self) -> bool:

--- a/src/scholion/model_management/service.py
+++ b/src/scholion/model_management/service.py
@@ -7,9 +7,16 @@ from scholion.model_management.errors import ModelManagementError
 from scholion.model_management.models import (
     InstalledSnapshot,
     ManagedModelManifest,
+    ManagedModelPolicyTrust,
     ModelInventoryItem,
+    ModelSpec,
 )
 from scholion.model_management.provider import ModelProvider
+from scholion.supply_chain import (
+    ModelTrustCatalog,
+    TrustedModelSpec,
+    verify_trusted_model_snapshot,
+)
 
 
 class ModelFileStore(Protocol):
@@ -31,7 +38,7 @@ class ModelStorageAdmitter(Protocol):
 
 
 class ModelManager:
-    """Own Scholion's local model inventory and provenance manifests."""
+    """Own Scholion's local model inventory, provenance, and optional policy trust."""
 
     def __init__(
         self,
@@ -41,7 +48,11 @@ class ModelManager:
         file_store: ModelFileStore,
         model_root: Path,
         storage_admitter: ModelStorageAdmitter | None = None,
+        trust_catalog: ModelTrustCatalog | None = None,
+        enforce_policy_trust: bool = False,
     ) -> None:
+        if enforce_policy_trust and trust_catalog is None:
+            raise ValueError("policy-trust enforcement requires a trust catalog")
         self.catalog = catalog
         self.provider = provider
         self.file_store = file_store
@@ -49,6 +60,8 @@ class ModelManager:
         self.cache_root = self.model_root / "faster-whisper"
         self.registry_root = self.model_root / "registry" / "faster-whisper"
         self.storage_admitter = storage_admitter
+        self.trust_catalog = trust_catalog
+        self.enforce_policy_trust = enforce_policy_trust
 
     def inventory(self) -> tuple[ModelInventoryItem, ...]:
         return tuple(
@@ -62,6 +75,17 @@ class ModelManager:
         spec = self.catalog.require(model_id)
         if revision is not None and not revision.strip():
             raise ValueError("revision cannot be empty")
+        trusted_spec = self._trusted_spec_for(spec)
+        requested_revision = revision
+        if trusted_spec is not None:
+            if revision is not None and revision != trusted_spec.revision:
+                raise ValueError(
+                    "requested revision does not match Scholion model policy"
+                )
+            requested_revision = trusted_spec.revision
+        elif self.enforce_policy_trust:
+            raise ValueError(f"model is not trusted by Scholion policy: {model_id}")
+
         if self.storage_admitter is not None:
             self.storage_admitter.admit(self.cache_root, spec.estimated_cache_bytes)
         self._prepare_roots()
@@ -69,9 +93,14 @@ class ModelManager:
             snapshot = self.provider.install(
                 spec,
                 cache_root=self.cache_root,
-                revision=revision,
+                revision=requested_revision,
             )
             self._validate_snapshot(snapshot)
+            policy_trust = self._verify_policy_snapshot(
+                spec,
+                snapshot,
+                trusted_spec,
+            )
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception as exc:
@@ -84,11 +113,12 @@ class ModelManager:
             model_id=spec.model_id,
             engine=spec.engine,
             repository_id=spec.repository_id,
-            requested_revision=revision,
+            requested_revision=requested_revision,
             resolved_revision=snapshot.resolved_revision,
             snapshot_path=snapshot.snapshot_path,
             size_bytes=snapshot.size_bytes,
             verification=snapshot.verification,
+            policy_trust=policy_trust,
         )
         self.file_store.save_file(
             json.dumps(manifest.to_dict(), sort_keys=True).encode("utf-8"),
@@ -121,6 +151,15 @@ class ModelManager:
 
     def is_installed(self, model_id: str) -> bool:
         return self.resolved_revision(model_id) is not None
+
+    def is_policy_trusted(self, model_id: str) -> bool:
+        """Return whether current bundled policy revalidates the managed snapshot."""
+        manifest = self._manifest(model_id)
+        return (
+            manifest is not None
+            and self.trust_catalog is not None
+            and manifest.policy_trust is not None
+        )
 
     def resolved_revision(self, model_id: str) -> str | None:
         """Return the locally revalidated managed revision without network access or writes."""
@@ -170,6 +209,60 @@ class ModelManager:
             raise
         except Exception as exc:
             raise ValueError("managed model snapshot is no longer valid") from exc
+
+        trusted_spec = self._trusted_spec_for(spec)
+        if manifest.policy_trust is not None:
+            if trusted_spec is None:
+                if self.enforce_policy_trust:
+                    raise ValueError("managed model no longer has a trusted policy entry")
+                return
+            observed = self._verify_policy_snapshot(spec, snapshot, trusted_spec)
+            if observed != manifest.policy_trust:
+                raise ValueError("managed model policy trust evidence no longer matches")
+        elif self.enforce_policy_trust:
+            raise ValueError("managed model lacks required policy trust evidence")
+
+    def _trusted_spec_for(self, spec: ModelSpec) -> TrustedModelSpec | None:
+        if self.trust_catalog is None:
+            return None
+        try:
+            trusted_spec = self.trust_catalog.require(spec.model_id)
+        except ValueError:
+            if self.enforce_policy_trust:
+                raise
+            return None
+        if (
+            trusted_spec.engine != spec.engine
+            or trusted_spec.repository_id != spec.repository_id
+        ):
+            raise ValueError("model trust catalog identity does not match model catalog")
+        return trusted_spec
+
+    def _verify_policy_snapshot(
+        self,
+        spec: ModelSpec,
+        snapshot: InstalledSnapshot,
+        trusted_spec: TrustedModelSpec | None,
+    ) -> ManagedModelPolicyTrust | None:
+        if trusted_spec is None:
+            return None
+        if snapshot.resolved_revision != trusted_spec.revision:
+            raise ValueError("downloaded model revision does not match trusted policy")
+        if trusted_spec.model_id != spec.model_id:
+            raise ValueError("trusted model identity does not match requested model")
+        evidence = verify_trusted_model_snapshot(
+            trusted_spec,
+            snapshot_root=snapshot.snapshot_path,
+            cache_root=self.cache_root,
+        )
+        return ManagedModelPolicyTrust(
+            catalog_schema_version=self.trust_catalog.schema_version,
+            model_id=evidence.model_id,
+            revision=evidence.revision,
+            verification=evidence.verification,
+            verified_files=evidence.verified_files,
+            total_bytes=evidence.total_bytes,
+        )
 
     def _validate_snapshot(self, snapshot: InstalledSnapshot) -> None:
         if not snapshot.snapshot_path.is_relative_to(self.cache_root):

--- a/src/scholion/model_management/service.py
+++ b/src/scholion/model_management/service.py
@@ -64,10 +64,17 @@ class ModelManager:
         self.enforce_policy_trust = enforce_policy_trust
 
     def inventory(self) -> tuple[ModelInventoryItem, ...]:
-        return tuple(
-            ModelInventoryItem(spec=spec, manifest=self._manifest(spec.model_id))
-            for spec in self.catalog.specs
-        )
+        inventory: list[ModelInventoryItem] = []
+        for spec in self.catalog.specs:
+            manifest = self._manifest(spec.model_id)
+            inventory.append(
+                ModelInventoryItem(
+                    spec=spec,
+                    manifest=manifest,
+                    policy_trusted=self._has_current_policy_trust(spec, manifest),
+                )
+            )
+        return tuple(inventory)
 
     def install(
         self, model_id: str, *, revision: str | None = None
@@ -154,12 +161,9 @@ class ModelManager:
 
     def is_policy_trusted(self, model_id: str) -> bool:
         """Return whether current bundled policy revalidates the managed snapshot."""
+        spec = self.catalog.require(model_id)
         manifest = self._manifest(model_id)
-        return (
-            manifest is not None
-            and self.trust_catalog is not None
-            and manifest.policy_trust is not None
-        )
+        return self._has_current_policy_trust(spec, manifest)
 
     def resolved_revision(self, model_id: str) -> str | None:
         """Return the locally revalidated managed revision without network access or writes."""
@@ -225,6 +229,17 @@ class ModelManager:
                 )
         elif self.enforce_policy_trust:
             raise ValueError("managed model lacks required policy trust evidence")
+
+    def _has_current_policy_trust(
+        self,
+        spec: ModelSpec,
+        manifest: ManagedModelManifest | None,
+    ) -> bool:
+        return (
+            manifest is not None
+            and manifest.policy_trust is not None
+            and self._trusted_spec_for(spec) is not None
+        )
 
     def _trusted_spec_for(self, spec: ModelSpec) -> TrustedModelSpec | None:
         trust_catalog = self.trust_catalog

--- a/src/scholion/model_management/service.py
+++ b/src/scholion/model_management/service.py
@@ -214,11 +214,15 @@ class ModelManager:
         if manifest.policy_trust is not None:
             if trusted_spec is None:
                 if self.enforce_policy_trust:
-                    raise ValueError("managed model no longer has a trusted policy entry")
+                    raise ValueError(
+                        "managed model no longer has a trusted policy entry"
+                    )
                 return
             observed = self._verify_policy_snapshot(spec, snapshot, trusted_spec)
             if observed != manifest.policy_trust:
-                raise ValueError("managed model policy trust evidence no longer matches")
+                raise ValueError(
+                    "managed model policy trust evidence no longer matches"
+                )
         elif self.enforce_policy_trust:
             raise ValueError("managed model lacks required policy trust evidence")
 
@@ -236,7 +240,9 @@ class ModelManager:
             trusted_spec.engine != spec.engine
             or trusted_spec.repository_id != spec.repository_id
         ):
-            raise ValueError("model trust catalog identity does not match model catalog")
+            raise ValueError(
+                "model trust catalog identity does not match model catalog"
+            )
         return trusted_spec
 
     def _verify_policy_snapshot(

--- a/src/scholion/model_management/service.py
+++ b/src/scholion/model_management/service.py
@@ -223,10 +223,11 @@ class ModelManager:
             raise ValueError("managed model lacks required policy trust evidence")
 
     def _trusted_spec_for(self, spec: ModelSpec) -> TrustedModelSpec | None:
-        if self.trust_catalog is None:
+        trust_catalog = self.trust_catalog
+        if trust_catalog is None:
             return None
         try:
-            trusted_spec = self.trust_catalog.require(spec.model_id)
+            trusted_spec = trust_catalog.require(spec.model_id)
         except ValueError:
             if self.enforce_policy_trust:
                 raise
@@ -246,6 +247,9 @@ class ModelManager:
     ) -> ManagedModelPolicyTrust | None:
         if trusted_spec is None:
             return None
+        trust_catalog = self.trust_catalog
+        if trust_catalog is None:
+            raise ValueError("model policy trust requires a trust catalog")
         if snapshot.resolved_revision != trusted_spec.revision:
             raise ValueError("downloaded model revision does not match trusted policy")
         if trusted_spec.model_id != spec.model_id:
@@ -256,7 +260,7 @@ class ModelManager:
             cache_root=self.cache_root,
         )
         return ManagedModelPolicyTrust(
-            catalog_schema_version=self.trust_catalog.schema_version,
+            catalog_schema_version=trust_catalog.schema_version,
             model_id=evidence.model_id,
             revision=evidence.revision,
             verification=evidence.verification,

--- a/src/scholion/model_management/tests/test_models.py
+++ b/src/scholion/model_management/tests/test_models.py
@@ -5,12 +5,24 @@ import pytest
 from scholion.model_management.models import (
     InstalledSnapshot,
     ManagedModelManifest,
+    ManagedModelPolicyTrust,
     ModelInventoryItem,
     ModelSpec,
 )
 
 
-def _manifest() -> ManagedModelManifest:
+def _policy_trust() -> ManagedModelPolicyTrust:
+    return ManagedModelPolicyTrust(
+        catalog_schema_version=1,
+        model_id="small",
+        revision="abc123",
+        verification="scholion_curated_sha256_v1",
+        verified_files=4,
+        total_bytes=123,
+    )
+
+
+def _manifest(*, policy_trust: ManagedModelPolicyTrust | None = None) -> ManagedModelManifest:
     return ManagedModelManifest(
         schema_version=1,
         model_id="small",
@@ -21,6 +33,7 @@ def _manifest() -> ManagedModelManifest:
         snapshot_path=Path("cache/models/faster-whisper/snapshots/abc123"),
         size_bytes=123,
         verification="required_files_v1",
+        policy_trust=policy_trust,
     )
 
 
@@ -33,6 +46,18 @@ def test_manifest_round_trip_preserves_model_provenance() -> None:
     assert restored.requested_revision == "release-v1"
     assert restored.resolved_revision == "abc123"
     assert restored.verification == "required_files_v1"
+    assert restored.policy_trust is None
+
+
+def test_manifest_round_trip_preserves_policy_trust_evidence() -> None:
+    manifest = _manifest(policy_trust=_policy_trust())
+
+    restored = ManagedModelManifest.from_dict(manifest.to_dict())
+
+    assert restored == manifest
+    assert restored.policy_trust is not None
+    assert restored.policy_trust.verification == "scholion_curated_sha256_v1"
+    assert restored.policy_trust.verified_files == 4
 
 
 @pytest.mark.parametrize(
@@ -44,6 +69,7 @@ def test_manifest_round_trip_preserves_model_provenance() -> None:
         ("size_bytes", "123"),
         ("requested_revision", 7),
         ("verification", ""),
+        ("policy_trust", "trusted"),
     ],
 )
 def test_manifest_parser_rejects_schema_and_type_mutations(
@@ -54,6 +80,20 @@ def test_manifest_parser_rejects_schema_and_type_mutations(
 
     with pytest.raises(ValueError, match="invalid model manifest"):
         ManagedModelManifest.from_dict(document)
+
+
+def test_manifest_rejects_policy_trust_for_different_revision() -> None:
+    trust = ManagedModelPolicyTrust(
+        catalog_schema_version=1,
+        model_id="small",
+        revision="different",
+        verification="scholion_curated_sha256_v1",
+        verified_files=1,
+        total_bytes=1,
+    )
+
+    with pytest.raises(ValueError, match="policy trust revision"):
+        _manifest(policy_trust=trust)
 
 
 def test_model_spec_rejects_storage_and_identity_boundaries() -> None:
@@ -79,8 +119,12 @@ def test_inventory_item_installed_state_tracks_manifest_presence() -> None:
 
     uninstalled = ModelInventoryItem(spec)
     installed = ModelInventoryItem(spec, _manifest())
+    trusted = ModelInventoryItem(spec, _manifest(policy_trust=_policy_trust()))
 
     assert uninstalled.installed is False
     assert installed.installed is True
+    assert installed.policy_trusted is False
+    assert trusted.policy_trusted is True
     assert uninstalled.to_dict()["manifest"] is None
     assert installed.to_dict()["manifest"] is not None
+    assert trusted.to_dict()["policy_trusted"] is True

--- a/src/scholion/model_management/tests/test_models.py
+++ b/src/scholion/model_management/tests/test_models.py
@@ -84,6 +84,50 @@ def test_manifest_parser_rejects_schema_and_type_mutations(
         ManagedModelManifest.from_dict(document)
 
 
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"catalog_schema_version": 0}, "catalog_schema_version must be positive"),
+        ({"model_id": ""}, "model_id cannot be empty"),
+        ({"revision": " "}, "revision cannot be empty"),
+        ({"verification": ""}, "verification cannot be empty"),
+        ({"verified_files": 0}, "verified_files must be positive"),
+        ({"total_bytes": 0}, "total_bytes must be positive"),
+    ],
+)
+def test_policy_trust_rejects_invalid_evidence_boundaries(
+    overrides: dict[str, object], message: str
+) -> None:
+    values: dict[str, object] = {
+        "catalog_schema_version": 1,
+        "model_id": "small",
+        "revision": "abc123",
+        "verification": "scholion_curated_sha256_v1",
+        "verified_files": 1,
+        "total_bytes": 1,
+    }
+    values.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        ManagedModelPolicyTrust(**values)  # type: ignore[arg-type]
+
+
+def test_policy_trust_parser_wraps_missing_or_mistyped_fields() -> None:
+    with pytest.raises(ValueError, match="invalid model policy trust evidence"):
+        ManagedModelPolicyTrust.from_dict({"catalog_schema_version": 1})
+    with pytest.raises(ValueError, match="invalid model policy trust evidence"):
+        ManagedModelPolicyTrust.from_dict(
+            {
+                "catalog_schema_version": True,
+                "model_id": "small",
+                "revision": "abc123",
+                "verification": "scholion_curated_sha256_v1",
+                "verified_files": 1,
+                "total_bytes": 1,
+            }
+        )
+
+
 def test_manifest_rejects_policy_trust_for_different_revision() -> None:
     trust = ManagedModelPolicyTrust(
         catalog_schema_version=1,
@@ -98,6 +142,47 @@ def test_manifest_rejects_policy_trust_for_different_revision() -> None:
         _manifest(policy_trust=trust)
 
 
+def test_manifest_rejects_policy_trust_for_different_model() -> None:
+    trust = ManagedModelPolicyTrust(
+        catalog_schema_version=1,
+        model_id="medium",
+        revision="abc123",
+        verification="scholion_curated_sha256_v1",
+        verified_files=1,
+        total_bytes=1,
+    )
+
+    with pytest.raises(ValueError, match="policy trust model identity"):
+        _manifest(policy_trust=trust)
+
+
+def test_manifest_rejects_empty_requested_revision_and_nonpositive_size() -> None:
+    with pytest.raises(ValueError, match="requested_revision cannot be empty"):
+        ManagedModelManifest(
+            schema_version=1,
+            model_id="small",
+            engine="faster-whisper",
+            repository_id="repo/small",
+            requested_revision=" ",
+            resolved_revision="abc123",
+            snapshot_path=Path("snapshot"),
+            size_bytes=1,
+            verification="required_files_v1",
+        )
+    with pytest.raises(ValueError, match="size_bytes must be positive"):
+        ManagedModelManifest(
+            schema_version=1,
+            model_id="small",
+            engine="faster-whisper",
+            repository_id="repo/small",
+            requested_revision=None,
+            resolved_revision="abc123",
+            snapshot_path=Path("snapshot"),
+            size_bytes=0,
+            verification="required_files_v1",
+        )
+
+
 def test_model_spec_rejects_storage_and_identity_boundaries() -> None:
     with pytest.raises(ValueError, match="estimated_cache_bytes must be positive"):
         ModelSpec("small", "faster-whisper", "repo/small", 0, 1)
@@ -109,7 +194,9 @@ def test_model_spec_rejects_storage_and_identity_boundaries() -> None:
         ModelSpec("small", "faster-whisper", "repo/small", 1, 1, ("",))
 
 
-def test_installed_snapshot_rejects_empty_verification_and_nonpositive_size() -> None:
+def test_installed_snapshot_rejects_empty_revision_verification_and_size() -> None:
+    with pytest.raises(ValueError, match="resolved_revision cannot be empty"):
+        InstalledSnapshot(" ", Path("snapshot"), 1, "verified")
     with pytest.raises(ValueError, match="size_bytes must be positive"):
         InstalledSnapshot("abc", Path("snapshot"), 0, "verified")
     with pytest.raises(ValueError, match="verification cannot be empty"):

--- a/src/scholion/model_management/tests/test_models.py
+++ b/src/scholion/model_management/tests/test_models.py
@@ -116,17 +116,27 @@ def test_installed_snapshot_rejects_empty_verification_and_nonpositive_size() ->
         InstalledSnapshot("abc", Path("snapshot"), 1, " ")
 
 
-def test_inventory_item_installed_state_tracks_manifest_presence() -> None:
+def test_inventory_item_keeps_current_trust_separate_from_recorded_evidence() -> None:
     spec = ModelSpec("small", "faster-whisper", "repo/small", 1, 1)
+    trusted_manifest = _manifest(policy_trust=_policy_trust())
 
     uninstalled = ModelInventoryItem(spec)
     installed = ModelInventoryItem(spec, _manifest())
-    trusted = ModelInventoryItem(spec, _manifest(policy_trust=_policy_trust()))
+    receipt_only = ModelInventoryItem(spec, trusted_manifest)
+    trusted = ModelInventoryItem(spec, trusted_manifest, policy_trusted=True)
 
     assert uninstalled.installed is False
     assert installed.installed is True
     assert installed.policy_trusted is False
+    assert receipt_only.policy_trusted is False
     assert trusted.policy_trusted is True
     assert uninstalled.to_dict()["manifest"] is None
     assert installed.to_dict()["manifest"] is not None
     assert trusted.to_dict()["policy_trusted"] is True
+
+
+def test_inventory_item_rejects_current_trust_without_managed_state() -> None:
+    spec = ModelSpec("small", "faster-whisper", "repo/small", 1, 1)
+
+    with pytest.raises(ValueError, match="requires a managed manifest"):
+        ModelInventoryItem(spec, policy_trusted=True)

--- a/src/scholion/model_management/tests/test_models.py
+++ b/src/scholion/model_management/tests/test_models.py
@@ -22,7 +22,9 @@ def _policy_trust() -> ManagedModelPolicyTrust:
     )
 
 
-def _manifest(*, policy_trust: ManagedModelPolicyTrust | None = None) -> ManagedModelManifest:
+def _manifest(
+    *, policy_trust: ManagedModelPolicyTrust | None = None
+) -> ManagedModelManifest:
     return ManagedModelManifest(
         schema_version=1,
         model_id="small",

--- a/src/scholion/model_management/tests/test_service.py
+++ b/src/scholion/model_management/tests/test_service.py
@@ -106,14 +106,19 @@ def _catalog() -> ModelCatalog:
     )
 
 
-def _trust_catalog() -> ModelTrustCatalog:
+def _trust_catalog(
+    *,
+    model_id: str = "small",
+    engine: str = "faster-whisper",
+    repository_id: str = "Systran/faster-whisper-small",
+) -> ModelTrustCatalog:
     return ModelTrustCatalog(
         schema_version=1,
         models=(
             TrustedModelSpec(
-                model_id="small",
-                engine="faster-whisper",
-                repository_id="Systran/faster-whisper-small",
+                model_id=model_id,
+                engine=engine,
+                repository_id=repository_id,
                 revision=_TRUSTED_REVISION,
                 source_url="https://huggingface.co/Systran/faster-whisper-small",
                 license_id="test-license",
@@ -267,6 +272,62 @@ def test_policy_rejects_revision_override_before_provider_call(tmp_path: Path) -
     assert provider.installs == []
 
 
+def test_policy_rejects_unlisted_model_before_provider_call(tmp_path: Path) -> None:
+    model_root = tmp_path / "models"
+    provider = FakeProvider(model_root / "faster-whisper" / "snapshots" / "abc")
+    manager = ModelManager(
+        catalog=_catalog(),
+        provider=provider,
+        file_store=MemoryStore(),
+        model_root=model_root,
+        trust_catalog=_trust_catalog(model_id="medium"),
+        enforce_policy_trust=True,
+    )
+
+    with pytest.raises(ValueError, match="not trusted"):
+        manager.install("small")
+
+    assert provider.installs == []
+
+
+@pytest.mark.parametrize(
+    "trust_catalog",
+    [
+        _trust_catalog(engine="different-engine"),
+        _trust_catalog(repository_id="attacker/wrong-model"),
+    ],
+)
+def test_policy_rejects_catalog_identity_mismatch_before_provider_call(
+    tmp_path: Path, trust_catalog: ModelTrustCatalog
+) -> None:
+    model_root = tmp_path / "models"
+    provider = FakeProvider(model_root / "faster-whisper" / "snapshots" / "abc")
+    manager = ModelManager(
+        catalog=_catalog(),
+        provider=provider,
+        file_store=MemoryStore(),
+        model_root=model_root,
+        trust_catalog=trust_catalog,
+    )
+
+    with pytest.raises(ValueError, match="identity does not match"):
+        manager.install("small")
+
+    assert provider.installs == []
+
+
+def test_policy_rejects_provider_revision_mismatch_without_registration(
+    tmp_path: Path,
+) -> None:
+    manager, store, provider, _ = _trusted_manager(tmp_path)
+    provider.resolved_revision = "b" * 40
+
+    with pytest.raises(ModelManagementError, match="downloaded and locally validated"):
+        manager.install("small")
+
+    assert manager._manifest_path("small") not in store.files
+
+
 def test_policy_hash_failure_does_not_register_model(tmp_path: Path) -> None:
     manager, store, provider, snapshot_path = _trusted_manager(tmp_path)
     (snapshot_path / "model.bin").write_bytes(b"tampered model bytes")
@@ -285,6 +346,36 @@ def test_policy_tamper_after_install_invalidates_registry(tmp_path: Path) -> Non
 
     with pytest.raises(ModelManagementError, match="registry is invalid"):
         manager.is_policy_trusted("small")
+
+
+def test_policy_receipt_mismatch_invalidates_registry(tmp_path: Path) -> None:
+    manager, store, _, _ = _trusted_manager(tmp_path)
+    manager.install("small")
+    path = manager._manifest_path("small")
+    document = json.loads(store.files[path])
+    document["policy_trust"]["total_bytes"] += 1
+    store.files[path] = json.dumps(document).encode()
+
+    with pytest.raises(ModelManagementError, match="registry is invalid"):
+        manager.is_policy_trusted("small")
+
+
+def test_policy_enforcement_rejects_legacy_manifest_without_receipt(
+    tmp_path: Path,
+) -> None:
+    manager, store, provider = _manager(tmp_path)
+    manager.install("small")
+    enforcing_manager = ModelManager(
+        catalog=_catalog(),
+        provider=provider,
+        file_store=store,
+        model_root=manager.model_root,
+        trust_catalog=_trust_catalog(),
+        enforce_policy_trust=True,
+    )
+
+    with pytest.raises(ModelManagementError, match="registry is invalid"):
+        enforcing_manager.is_installed("small")
 
 
 def test_policy_enforcement_requires_catalog(tmp_path: Path) -> None:
@@ -359,6 +450,15 @@ def test_install_refuses_snapshot_outside_cache(tmp_path: Path) -> None:
         manager.install("small")
 
     assert manager._manifest_path("small") not in store.files
+
+
+def test_inventory_refuses_non_object_manifest(tmp_path: Path) -> None:
+    manager, store, _ = _manager(tmp_path)
+    manager._prepare_roots()
+    store.files[manager._manifest_path("small")] = b"[]"
+
+    with pytest.raises(ModelManagementError, match="registry is invalid"):
+        manager.inventory()
 
 
 def test_inventory_refuses_manifest_with_wrong_identity(tmp_path: Path) -> None:

--- a/src/scholion/model_management/tests/test_service.py
+++ b/src/scholion/model_management/tests/test_service.py
@@ -245,9 +245,7 @@ def test_policy_install_pins_revision_and_persists_exact_trust(tmp_path: Path) -
 def test_recorded_policy_receipt_is_not_current_trust_without_catalog(
     tmp_path: Path,
 ) -> None:
-    manager, store, provider, _ = _trusted_manager(
-        tmp_path, enforce_policy_trust=False
-    )
+    manager, store, provider, _ = _trusted_manager(tmp_path, enforce_policy_trust=False)
     manager.install("small")
     manager_without_catalog = ModelManager(
         catalog=_catalog(),

--- a/src/scholion/model_management/tests/test_service.py
+++ b/src/scholion/model_management/tests/test_service.py
@@ -1,4 +1,5 @@
 import json
+from hashlib import sha256
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,10 @@ from scholion.model_management.catalog import ModelCatalog
 from scholion.model_management.errors import ModelManagementError
 from scholion.model_management.models import InstalledSnapshot, ModelSpec
 from scholion.model_management.service import ModelManager
+from scholion.supply_chain import ModelTrustCatalog, TrustedModelFile, TrustedModelSpec
+
+_TRUSTED_REVISION = "a" * 40
+_TRUSTED_BYTES = b"trusted faster-whisper model bytes"
 
 
 class MemoryStore:
@@ -39,6 +44,8 @@ class MemoryStore:
 class FakeProvider:
     def __init__(self, snapshot_path: Path) -> None:
         self.snapshot_path = snapshot_path
+        self.resolved_revision = snapshot_path.name
+        self.size_bytes = 1234
         self.installs: list[tuple[str, str | None]] = []
         self.validations: list[str] = []
         self.removals: list[str] = []
@@ -54,9 +61,9 @@ class FakeProvider:
     ) -> InstalledSnapshot:
         self.installs.append((spec.model_id, revision))
         return InstalledSnapshot(
-            resolved_revision="resolved-abc",
+            resolved_revision=self.resolved_revision,
             snapshot_path=self.snapshot_path,
-            size_bytes=1234,
+            size_bytes=self.size_bytes,
             verification="fake_verified_v1",
         )
 
@@ -99,6 +106,30 @@ def _catalog() -> ModelCatalog:
     )
 
 
+def _trust_catalog() -> ModelTrustCatalog:
+    return ModelTrustCatalog(
+        schema_version=1,
+        models=(
+            TrustedModelSpec(
+                model_id="small",
+                engine="faster-whisper",
+                repository_id="Systran/faster-whisper-small",
+                revision=_TRUSTED_REVISION,
+                source_url="https://huggingface.co/Systran/faster-whisper-small",
+                license_id="test-license",
+                license_url="https://example.test/license",
+                files=(
+                    TrustedModelFile(
+                        path="model.bin",
+                        size_bytes=len(_TRUSTED_BYTES),
+                        sha256_hex=sha256(_TRUSTED_BYTES).hexdigest(),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
 def _manager(tmp_path: Path) -> tuple[ModelManager, MemoryStore, FakeProvider]:
     model_root = tmp_path / "models"
     provider = FakeProvider(
@@ -117,6 +148,33 @@ def _manager(tmp_path: Path) -> tuple[ModelManager, MemoryStore, FakeProvider]:
     )
 
 
+def _trusted_manager(
+    tmp_path: Path, *, enforce_policy_trust: bool = True
+) -> tuple[ModelManager, MemoryStore, FakeProvider, Path]:
+    model_root = tmp_path / "models"
+    snapshot_path = (
+        model_root
+        / "faster-whisper"
+        / "models--Systran--faster-whisper-small"
+        / "snapshots"
+        / _TRUSTED_REVISION
+    )
+    snapshot_path.mkdir(parents=True)
+    (snapshot_path / "model.bin").write_bytes(_TRUSTED_BYTES)
+    provider = FakeProvider(snapshot_path)
+    provider.size_bytes = len(_TRUSTED_BYTES)
+    store = MemoryStore()
+    manager = ModelManager(
+        catalog=_catalog(),
+        provider=provider,
+        file_store=store,
+        model_root=model_root,
+        trust_catalog=_trust_catalog(),
+        enforce_policy_trust=enforce_policy_trust,
+    )
+    return manager, store, provider, snapshot_path
+
+
 def test_inventory_is_offline_read_only_and_reports_uninstalled_model(
     tmp_path: Path,
 ) -> None:
@@ -127,6 +185,7 @@ def test_inventory_is_offline_read_only_and_reports_uninstalled_model(
     assert len(inventory) == 1
     assert inventory[0].spec.model_id == "small"
     assert inventory[0].installed is False
+    assert inventory[0].policy_trusted is False
     assert provider.installs == []
     assert provider.validations == []
     assert store.directories == set()
@@ -149,15 +208,80 @@ def test_install_records_requested_resolved_and_verification(tmp_path: Path) -> 
     assert manifest.requested_revision == "release-v1"
     assert manifest.resolved_revision == "resolved-abc"
     assert manifest.verification == "fake_verified_v1"
+    assert manifest.policy_trust is None
     assert manifest.size_bytes == 1234
     assert provider.installs == [("small", "release-v1")]
     document = json.loads(store.files[manager._manifest_path("small")])
     assert document["repository_id"] == "Systran/faster-whisper-small"
     assert document["resolved_revision"] == "resolved-abc"
     assert document["verification"] == "fake_verified_v1"
+    assert document["policy_trust"] is None
     assert manager.resolved_revision("small") == "resolved-abc"
     assert manager.is_installed("small") is True
-    assert provider.validations == ["small", "small"]
+    assert manager.is_policy_trusted("small") is False
+    assert provider.validations == ["small", "small", "small"]
+
+
+def test_policy_install_pins_revision_and_persists_exact_trust(tmp_path: Path) -> None:
+    manager, store, provider, _ = _trusted_manager(tmp_path)
+
+    manifest = manager.install("small")
+
+    assert provider.installs == [("small", _TRUSTED_REVISION)]
+    assert manifest.requested_revision == _TRUSTED_REVISION
+    assert manifest.resolved_revision == _TRUSTED_REVISION
+    assert manifest.policy_trust is not None
+    assert manifest.policy_trust.model_id == "small"
+    assert manifest.policy_trust.revision == _TRUSTED_REVISION
+    assert manifest.policy_trust.verification == "scholion_curated_sha256_v1"
+    assert manifest.policy_trust.verified_files == 1
+    assert manifest.policy_trust.total_bytes == len(_TRUSTED_BYTES)
+    document = json.loads(store.files[manager._manifest_path("small")])
+    assert document["policy_trust"]["revision"] == _TRUSTED_REVISION
+    assert manager.is_policy_trusted("small") is True
+
+
+def test_policy_rejects_revision_override_before_provider_call(tmp_path: Path) -> None:
+    manager, _, provider, _ = _trusted_manager(tmp_path)
+
+    with pytest.raises(ValueError, match="does not match Scholion model policy"):
+        manager.install("small", revision="b" * 40)
+
+    assert provider.installs == []
+
+
+def test_policy_hash_failure_does_not_register_model(tmp_path: Path) -> None:
+    manager, store, provider, snapshot_path = _trusted_manager(tmp_path)
+    (snapshot_path / "model.bin").write_bytes(b"tampered model bytes")
+
+    with pytest.raises(ModelManagementError, match="downloaded and locally validated"):
+        manager.install("small")
+
+    assert provider.installs == [("small", _TRUSTED_REVISION)]
+    assert manager._manifest_path("small") not in store.files
+
+
+def test_policy_tamper_after_install_invalidates_registry(tmp_path: Path) -> None:
+    manager, _, _, snapshot_path = _trusted_manager(tmp_path)
+    manager.install("small")
+    (snapshot_path / "model.bin").write_bytes(b"x" * len(_TRUSTED_BYTES))
+
+    with pytest.raises(ModelManagementError, match="registry is invalid"):
+        manager.is_policy_trusted("small")
+
+
+def test_policy_enforcement_requires_catalog(tmp_path: Path) -> None:
+    model_root = tmp_path / "models"
+    provider = FakeProvider(model_root / "faster-whisper" / "snapshots" / "abc")
+
+    with pytest.raises(ValueError, match="requires a trust catalog"):
+        ModelManager(
+            catalog=_catalog(),
+            provider=provider,
+            file_store=MemoryStore(),
+            model_root=model_root,
+            enforce_policy_trust=True,
+        )
 
 
 def test_install_rejects_empty_revision(tmp_path: Path) -> None:

--- a/src/scholion/model_management/tests/test_service.py
+++ b/src/scholion/model_management/tests/test_service.py
@@ -239,6 +239,25 @@ def test_policy_install_pins_revision_and_persists_exact_trust(tmp_path: Path) -
     document = json.loads(store.files[manager._manifest_path("small")])
     assert document["policy_trust"]["revision"] == _TRUSTED_REVISION
     assert manager.is_policy_trusted("small") is True
+    assert manager.inventory()[0].policy_trusted is True
+
+
+def test_recorded_policy_receipt_is_not_current_trust_without_catalog(
+    tmp_path: Path,
+) -> None:
+    manager, store, provider, _ = _trusted_manager(
+        tmp_path, enforce_policy_trust=False
+    )
+    manager.install("small")
+    manager_without_catalog = ModelManager(
+        catalog=_catalog(),
+        provider=provider,
+        file_store=store,
+        model_root=manager.model_root,
+    )
+
+    assert manager_without_catalog.is_policy_trusted("small") is False
+    assert manager_without_catalog.inventory()[0].policy_trusted is False
 
 
 def test_policy_rejects_revision_override_before_provider_call(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes a concrete implementation gap inside #110 without pretending the production trust policy already exists.

This PR wires the existing `scholion.supply_chain` curated-model verifier into `ModelManager` as an explicit optional policy boundary:

- when a curated trust catalog is supplied, request exactly the approved immutable revision;
- reject a conflicting caller-supplied revision before provider acquisition begins;
- retain the existing provider/cache/repository validation boundary;
- require the complete observed snapshot to match the curated file set, byte sizes, and SHA-256 values before committing managed state;
- persist policy-trust evidence separately from provider-local validation/provenance;
- recompute exact policy verification when a trust-bearing managed manifest is read;
- report `policy_trusted` only when a current matching catalog revalidates the receipt, rather than inferring trust from receipt presence;
- provide an enforcement mode that rejects missing current policy trust; and
- keep existing manifests and ordinary no-catalog source builds compatible.

## Why this shape

Local/provider validation and Scholion policy trust are intentionally different guarantees. This change composes the two existing authorities instead of creating another downloader or collapsing both into a generic `verified` flag.

The application container does **not** enable policy enforcement in this PR because the repository does not yet contain deliberately reviewed production faster-whisper trust entries. Tests use synthetic local bytes and synthetic immutable revisions only. No downloaded development snapshot, guessed hash, mutable upstream ref, or placeholder catalog is promoted to project policy.

## Tests

The model-management test tranche now covers:

- legacy/no-policy manifest round trips;
- policy-trust receipt round trips and identity/revision invariants;
- curated revision pinning;
- rejection of revision overrides before the provider is called;
- exact policy evidence persisted only after successful verification;
- tampered snapshot bytes refusing registration;
- post-install tampering invalidating current policy trust;
- a recorded receipt not being reported as current trust when no matching catalog is loaded;
- enforcement refusing to start without a trust catalog; and
- existing local-only inventory/install/remove behavior remaining intact.

## Documentation

Updates the model-management architecture and signed update/model trust docs to distinguish:

1. current default local/provider revalidation;
2. the newly implemented `ModelManager` policy-integration seam; and
3. the still-missing production catalog/application enforcement/admission work.

## Remaining #110 work

This PR does not close #110. Remaining work still includes:

- review real upstream faster-whisper revisions and generate the production curated catalog;
- bundle that catalog and enable policy enforcement in application composition;
- expose local revalidation versus current policy trust accurately in technical model state and new-transcription admission;
- native/Tauri release-signature verification and pinned production key(s);
- fixed-endpoint manual update checking and monotonic sequence persistence;
- staged artifact size/hash enforcement plus platform-safe activation;
- update UI states;
- native/offline qualification; and
- platform code signing/notarization integration.

## Maintenance / redundancy pass

No duplicate trust implementation was found or introduced. `HuggingFaceModelProvider` continues to own provider/cache-layout validation; `scholion.supply_chain` continues to own exact project policy; `ModelManager` composes them transactionally.

The pass did catch and close one state ambiguity before merge: stored policy evidence and **current** policy trust are no longer the same boolean. A future downgrade or partial-catalog build can retain provenance without falsely reporting current trust.

Related: #110, #140
