### PR TITLE
Activate bundled model policy in application composition

### DIFF
--- a/docs/architecture/model-management.md
+++ b/docs/architecture/model-management.md
@@ -5,11 +5,12 @@
 Scholion needs speech models to transcribe locally. Those model files are large,
 versioned execution dependencies, not mysterious cache confetti.
 
-So Scholion keeps one very deliberate boundary around them:
+So Scholion keeps one deliberate boundary around them:
 
 > **Downloading a model is an explicit action. Running transcription uses a model that
 > Scholion has already installed, locally revalidated, and pinned to an immutable
-> provider revision.**
+> provider revision. When a release bundles Scholion's curated model policy, new
+> transcription additionally requires the installed bytes to match that policy exactly.**
 
 That gives ordinary users a simpler experience and gives maintainers something they can
 actually reason about.
@@ -21,7 +22,10 @@ flowchart LR
     C --> D[Disk admission]
     D --> E[Provider download]
     E --> F[Local revalidation]
-    F --> G[Private managed manifest]
+    F --> P{Bundled model policy?}
+    P -->|No| G[Private managed manifest]
+    P -->|Yes| T[Exact policy verification]
+    T --> G
     G --> H[Local transcription plan]
     H --> I[Local-only execution]
 
@@ -32,14 +36,20 @@ flowchart LR
 
     class A,B,D info
     class C,E network
-    class F,G evidence
+    class F,P,T,G evidence
     class H,I run
 ```
 
-That diagram describes the current default source-build path. The #110 policy-trust path
-adds an exact project-owned revision/file allowlist between provider download and managed
-registration once a reviewed production trust catalog is bundled and enforcement is
-enabled.
+Application composition now loads a packaged `model-trust.json` from
+`scholion.supply_chain` when one is present. A build that contains that reviewed catalog
+automatically constructs `ModelManager` with policy enforcement enabled. A source or
+development build with no packaged catalog retains the existing local/provider
+revalidation path. There is no second runtime switch that can silently ship a catalog
+while leaving it unenforced.
+
+The repository still does **not** contain a production faster-whisper trust catalog. Real
+entries must come from deliberate review of immutable upstream snapshots; tests use only
+synthetic revisions and bytes.
 
 ## Why Scholion does not just trust whatever is in a cache
 
@@ -51,7 +61,8 @@ But “some files exist in a cache directory” is not enough to answer:
 - which model Scholion intended to install;
 - which provider repository it came from;
 - which immutable revision was resolved;
-- whether the expected files are still present; or
+- whether the expected files are still present;
+- whether those bytes match a Scholion-approved release policy; or
 - whether a transcription plan can safely refer to that exact dependency later.
 
 So the provider cache remains the physical home of the bytes while Scholion owns private
@@ -72,7 +83,7 @@ The current contract records at least:
 - measured snapshot size; and
 - local revalidation method.
 
-A manifest can now also record a separate policy-trust receipt when installation was
+A manifest can also record a separate policy-trust receipt when installation was
 performed against a supplied curated Scholion trust catalog. That receipt contains the
 catalog schema version, policy model identity and revision, exact-verification method,
 verified file count, and verified byte count.
@@ -98,16 +109,20 @@ snapshot, validating its cache layout, and removing an exact cached revision.
 
 `scholion.supply_chain` owns the stronger project policy itself: exact approved
 repository/revision identity plus the full allowed file set, byte sizes, SHA-256 values,
-source/license metadata, and fail-closed snapshot verification.
+source/license metadata, strict catalog loading, and fail-closed snapshot verification.
+
+`AppContainer` owns composition. It loads the bundled catalog once and enables policy
+enforcement whenever that catalog exists.
 
 The split matters because “what models does Scholion support?”, “how does this provider
-download bytes?”, and “which exact bytes did the project approve?” are different
-questions. The #110 integration deliberately composes those authorities instead of
-turning provider-local validation and project policy into one vague “verified” state.
+download bytes?”, “which exact bytes did the project approve?”, and “does this build
+require that approval?” are different questions. Scholion composes those authorities
+instead of collapsing provider-local validation and project policy into one vague
+“verified” state.
 
-## Install transaction without a production policy catalog
+## Install transaction without a bundled policy catalog
 
-The current default application composition follows this order:
+A source/development build with no reviewed bundled policy follows this order:
 
 1. resolve the model ID through the catalog;
 2. reject an invalid/blank requested revision;
@@ -129,10 +144,10 @@ local validation contract,” not “we started trying.”
 
 🦝 The raccoon gets a receipt after the groceries are actually in the pantry.
 
-## Policy-enforced install seam
+## Policy-enforced install transaction
 
-The #110 integration adds a stricter transaction when `ModelManager` receives a curated
-`ModelTrustCatalog`:
+When the current Scholion build contains a curated `ModelTrustCatalog`, `AppContainer`
+enables the stricter transaction automatically:
 
 1. resolve the ordinary model catalog entry and the matching project trust entry;
 2. require model ID, engine, and provider repository identity to agree across both
@@ -149,18 +164,38 @@ The #110 integration adds a stricter transaction when `ModelManager` receives a 
 10. commit the managed manifest only after both local/provider validation and policy
     validation succeed.
 
-When `enforce_policy_trust=True`, a missing catalog entry or a previously managed
-manifest without current policy evidence fails closed. Existing manifests remain
-parseable so upgrading the manifest format does not itself destroy local custody state.
+With policy enforcement active, a missing catalog entry or a managed snapshot without
+current policy evidence cannot be admitted to a **new transcription**.
 
-This mechanism does **not** manufacture the production policy. Tests use synthetic local
-bytes and synthetic immutable revisions. The real faster-whisper entries still require a
-deliberate upstream review and must ship as part of a signed Scholion release.
+This mechanism does not manufacture the production policy. The real faster-whisper
+entries still require deliberate upstream review and must ship as part of a signed
+Scholion release.
+
+## Upgrading from a locally revalidated model to policy enforcement
+
+Physical custody and execution admission are intentionally separate states.
+
+When a release first introduces a bundled production policy, a model installed by an
+older Scholion release can still be a valid locally managed snapshot without carrying
+current policy evidence. That is a migration state, not a reason to either grandfather
+untrusted bytes or lose custody of them.
+
+In that state Scholion:
+
+1. keeps the model visible as installed;
+2. reports that it is not trusted by the current bundled policy;
+3. refuses it for a new transcription because `resolved_revision()` is the
+   execution-admission boundary under enforcement;
+4. still allows explicit removal; and
+5. offers a **Reinstall trusted copy** action through the normal curated install path.
+
+A successful curated reinstall replaces the managed registration with exact current
+policy evidence. This is fail-closed execution without a migration dead end.
 
 ## User surface
 
-The normal flow is deliberately boring. After the repository environment is bootstrapped
-and activated:
+The normal flow remains deliberately boring. After the repository environment is
+bootstrapped and activated:
 
 ```bash
 scholion models recommend
@@ -182,23 +217,31 @@ scholion models remove small
 
 The CLI requires confirmation unless `--yes` is supplied.
 
-In the desktop, ordinary copy should explain consequences rather than implementation:
-models download only when the user chooses, stay on this computer in Scholion's private
-app storage, and can be used offline after installation. Repository IDs, exact revisions,
-hashes, licenses, and policy-trust evidence belong under technical details or security
-documentation.
+In the desktop, ordinary copy explains consequences rather than implementation: models
+download only when the user chooses, stay on this computer in Scholion's private app
+storage, and can be used offline after installation.
 
-Until a reviewed production catalog is actually bundled and enforcement is enabled in
-application composition, ordinary UI must continue to describe the default managed model
-as locally revalidated rather than policy-trusted.
+The Processing Center now carries three distinct facts:
+
+- whether the current build enforces a bundled model policy;
+- whether a model is physically installed; and
+- whether that installed model currently satisfies the bundled policy.
+
+A no-policy source build continues to describe the model as locally checked rather than
+policy-trusted. A policy-enforced build can say that a model is trusted by **this
+Scholion build** only after current exact verification succeeds. Legacy installed bytes
+that lack that evidence are shown as needing a trusted reinstall.
+
+Repository IDs, exact revisions, hashes, licenses, and detailed policy receipts remain
+technical/security detail rather than ordinary consumer copy.
 
 ## Inventory and local revalidation
 
-Inventory and resolved-revision lookup are offline and side-effect free. They do not
-create directories, download models, or repair provider state.
+Inventory is offline and side-effect free. It does not create directories, download
+models, or repair provider state.
 
-When a managed manifest exists, Scholion revalidates it before claiming the model is
-usable under the current custody contract. Validation checks that:
+When a managed manifest exists, Scholion revalidates its local custody before presenting
+it as installed. Validation checks that:
 
 - manifest identity still matches the catalog model/repository;
 - the snapshot remains inside Scholion's configured model cache;
@@ -209,12 +252,18 @@ usable under the current custody contract. Validation checks that:
 
 If the manager has a current trust catalog and the manifest carries policy-trust
 evidence, it additionally recomputes the exact file-set/size/SHA-256 verification and
-requires the resulting evidence to match the recorded receipt. With policy enforcement
-enabled, a manifest without current policy evidence is rejected.
+requires the resulting evidence to match the recorded receipt.
 
-If external deletion or tampering makes that managed state stale, Scholion fails closed.
-A same-length byte mutation therefore cannot preserve policy trust merely because the
-provider-local required-file check still passes.
+Inventory deliberately does **not** hide an otherwise valid legacy snapshot merely
+because policy enforcement is now active. That snapshot remains visible/removable but is
+reported with `policy_trusted=false`.
+
+Execution admission is stricter. Under enforcement, `resolved_revision()` requires
+current policy evidence and therefore rejects a legacy/untrusted manifest.
+
+If external deletion or tampering makes managed state stale, Scholion fails closed. A
+same-length byte mutation cannot preserve policy trust merely because the provider-local
+required-file check still passes.
 
 The receipt is evidence of what Scholion checked earlier. It is not allowed to become a
 magic amulet that makes missing or modified bytes reappear.
@@ -225,17 +274,14 @@ Default faster-whisper revalidation establishes structural/provider provenance: 
 cache layout, repository/revision identity, and required non-empty files.
 
 It does **not** by itself prove that every installed byte matches a project-approved
-cryptographic allowlist. Do not describe that default state simply as “verified” where a
-reader could reasonably infer the stronger claim.
+cryptographic allowlist. Do not describe that state simply as “verified” where a reader
+could reasonably infer the stronger claim.
 
-The #110 code path for the stronger guarantee is now integrated into `ModelManager`: a
-supplied curated policy pins the revision, exact-verifies before registration, persists a
-separate policy receipt, and revalidates that receipt later. What remains before the
-product can rely on that guarantee is release content and composition rather than another
-parallel verification mechanism: review real upstream faster-whisper revisions, generate
-and bundle the production catalog, enable enforcement in the application container,
-expose the distinction in technical model state, and make new-transcription admission
-require current policy trust.
+The stronger path is now integrated through installation, manifest custody, application
+composition, new-transcription admission, Processing Center readiness, and migration UX.
+The remaining model-side production task is release content: deliberately review real
+upstream faster-whisper revisions, generate the exact curated catalog, include it in a
+signed release, and qualify those pinned bytes on supported release platforms.
 
 See **[Signed update and model trust channel](../security/update-model-trust.md)** for the
 full trust model and privacy boundary.
@@ -244,13 +290,15 @@ full trust model and privacy boundary.
 
 There is one ASR model path.
 
-A new transcription plan currently resolves the selected faster-whisper model through
-the locally revalidated managed registry.
+A new transcription plan resolves the selected faster-whisper model through the managed
+registry.
 
-If the model is not installed and locally revalidated, planning fails with an
-install-first message.
+In a build without a bundled production policy, that means the locally revalidated
+managed revision. In a build with a bundled policy, the same lookup additionally requires
+current Scholion policy trust. An installed-but-untrusted migration snapshot therefore
+cannot be used to plan a new transcription.
 
-A successful plan therefore records a non-empty immutable resolved revision.
+A successful plan records a non-empty immutable resolved revision.
 
 At execution time, faster-whisper loads that exact local revision with
 `local_files_only=True`.
@@ -262,19 +310,16 @@ There is no:
 - arbitrary configuration revision override; or
 - silent substitution of a newer model because the old one is inconvenient.
 
-Resume restores the exact managed model revision recorded in the checkpoint contract.
-It never downloads a replacement as a side effect.
-
-Once the production catalog is bundled and enforcement is enabled, “usable for a new
-transcription” must additionally require current Scholion policy trust. That admission
-switch is intentionally not enabled against synthetic or unreviewed trust data.
+Resume restores the exact managed model revision recorded in the checkpoint contract. It
+never downloads a replacement as a side effect. Resume reproducibility remains distinct
+from admitting a new job under a newer release policy.
 
 ## Network boundary 🔐
 
 `scholion models install MODEL` is the explicit network-bearing ASR model action.
 
-Inventory, recommendation, planning with an already-managed model, and execution do not
-need to contact the model provider.
+Inventory, recommendation, planning with an already-admissible managed model, and
+execution do not need to contact the model provider.
 
 Model management never uploads source media, transcripts, job metadata, or application
 telemetry to the provider.
@@ -286,10 +331,13 @@ This is why the install boundary is visible to the user instead of being buried 
 
 Removal is intentionally asymmetric with installation:
 
-1. resolve and validate the managed manifest;
+1. resolve and locally validate the managed manifest;
 2. reconstruct the exact installed snapshot identity;
 3. ask the provider to remove that resolved revision from the local cache; and
 4. delete the Scholion manifest **only after provider removal succeeds**.
+
+Policy admission is not required merely to remove an old managed snapshot. That matters
+for migration: an installed-but-untrusted model must remain removable.
 
 If provider removal fails, the manifest is retained.
 
@@ -311,9 +359,9 @@ These conditions fail closed:
 - provider removal failure.
 
 With a trust catalog supplied, these conditions also fail closed before policy-trusted
-registration or revalidation:
+registration or execution admission:
 
-- missing required trust entry when enforcement is enabled;
+- missing required trust entry;
 - catalog/model identity mismatch;
 - moving or unapproved revision;
 - undeclared or missing file;
@@ -364,10 +412,11 @@ Model management does not currently provide:
 - adoption of arbitrary cache entries;
 - generic arbitrary model hubs;
 - model quota/garbage-collection policy;
-- hosted inventory/telemetry;
-- a reviewed production faster-whisper policy catalog bundled into application releases;
-- production `AppContainer` policy enforcement and new-transcription admission; or
-- a finished technical-details UI for local revalidation versus current policy trust.
+- hosted inventory/telemetry; or
+- a reviewed production faster-whisper policy catalog bundled into application releases.
+
+The last item is intentionally not represented by placeholder hashes. A release becomes
+policy-enforced only when reviewed trust content is actually packaged.
 
 The stable rule is:
 

--- a/docs/security/update-model-trust.md
+++ b/docs/security/update-model-trust.md
@@ -29,11 +29,13 @@ The application package owns a curated model-trust catalog. A model entry identi
 
 A distribution service such as Hugging Face transports bytes. It does not decide which revision or file hashes Scholion trusts.
 
-`ModelManager` now contains the production integration seam for this policy. When a curated trust catalog is supplied, installation pins the exact approved revision, rejects a conflicting caller revision before provider acquisition, verifies the complete downloaded snapshot against the bundled entry before committing the managed manifest, records policy-trust evidence separately from provider-local validation, and re-runs that exact policy verification when the managed manifest is read. An enforcement mode rejects managed state that lacks current policy trust.
+`ModelManager` applies that policy transactionally. When a curated trust catalog is supplied, installation pins the exact approved revision, rejects a conflicting caller revision before provider acquisition, verifies the complete downloaded snapshot against the bundled entry before committing the managed manifest, records policy-trust evidence separately from provider-local validation, and re-runs that exact policy verification when managed state is read for trust/admission.
 
-That seam is intentionally dormant in the ordinary application composition until Scholion ships deliberately reviewed production faster-whisper catalog entries. The current `AppContainer` does not invent or fetch a trust catalog dynamically, and current source builds therefore retain the existing local-revalidation behavior. This prevents scaffolding or development downloads from being mislabeled as project-approved model policy.
+Application composition now loads a packaged `model-trust.json` from `scholion.supply_chain`. If the current build contains that catalog, `AppContainer` automatically enables `ModelManager` policy enforcement. If the build contains no catalog, as current source/development builds do, Scholion retains the existing local/provider revalidation path. There is no runtime fetch for policy and no remotely mutable model-policy service.
 
-Integrity/local revalidation and policy trust remain separate states. A snapshot can match expected repository/revision/layout rules without being trusted by Scholion policy. Consumer UI and documentation must not collapse those states into one word such as “verified.”
+The repository still does **not** contain deliberately reviewed production faster-whisper entries. The loader and composition path do not promote development downloads, guessed hashes, mutable refs, or synthetic test data to project policy.
+
+Integrity/local revalidation and policy trust remain separate states. A snapshot can match expected repository/revision/layout rules without being trusted by the current Scholion build. Consumer UI and documentation must not collapse those states into one word such as “verified.”
 
 ## Update manifest v1
 
@@ -113,13 +115,23 @@ Production entries must be generated from a deliberately reviewed immutable upst
 
 Changing a trusted model revision is a security-sensitive repository change. The review should record why the revision changed, source/license changes, file-set changes, regression evidence, and regenerated hashes/sizes. The new catalog ships with a signed Scholion release.
 
+The packaged loader is strict UTF-8 JSON and delegates field/schema validation to the trust model. Invalid packaged policy fails during application composition rather than falling back to a weaker downloaded or remote policy.
+
 ### Managed policy evidence
 
-A managed-model manifest can now carry a separate policy-trust receipt containing the bundled catalog schema version, model identity, exact revision, policy-verification method, verified file count, and verified byte count. It does not replace provider-local provenance such as the repository identity, resolved revision, snapshot path, measured size, or provider validation method.
+A managed-model manifest can carry a separate policy-trust receipt containing the bundled catalog schema version, model identity, exact revision, policy-verification method, verified file count, and verified byte count. It does not replace provider-local provenance such as the repository identity, resolved revision, snapshot path, measured size, or provider validation method.
 
-The receipt is not treated as a permanent trust bit. With a current trust catalog loaded, `ModelManager` recomputes the exact snapshot verification and requires the observed evidence to match the recorded receipt. A same-length byte mutation, undeclared file, missing file, size change, revision change, or current-policy mismatch therefore invalidates the managed registry instead of continuing to report the model as trusted.
+The receipt is not treated as a permanent trust bit. With a current trust catalog loaded, `ModelManager` recomputes the exact snapshot verification and requires the observed evidence to match the recorded receipt. A same-length byte mutation, undeclared file, missing file, size change, revision change, or current-policy mismatch therefore invalidates current policy trust instead of continuing to report the model as trusted.
 
-Existing manifests without policy evidence remain parseable for compatibility. When policy enforcement is enabled, those manifests are not admitted as policy-trusted state; they must be reinstalled or otherwise pass the deliberate migration path defined for that release.
+Existing manifests without policy evidence remain parseable for compatibility. Under enforcement, Scholion deliberately separates **custody** from **execution admission**:
+
+- inventory may still show an otherwise locally valid legacy model as installed;
+- current policy trust is false;
+- new-transcription revision resolution rejects it;
+- removal remains available; and
+- Processing Center offers a trusted reinstall through the curated install path.
+
+This avoids unsafe grandfathering without stranding user-managed local state.
 
 ## Threat model
 
@@ -133,6 +145,7 @@ Existing manifests without policy evidence remain parseable for compatibility. W
 | Update request leaks product behavior | Request is a metadata GET with no installation ID, corpus, hardware, research, or usage payload | IP address, request time, TLS/client/network metadata remain visible to network/hosting layers |
 | Signing key compromise | Key IDs permit explicit rotation/revocation policy; release and model-signing roles should remain separable | Concrete key custody, rotation, and revocation implementation is still release work |
 | Local model cache is tampered with | File set, size, hash, path, and cache containment are rechecked before trust | Local machine compromise outside Scholion's threat boundary can also alter the application binary or pinned keys |
+| Older locally valid model survives upgrade into policy-enforced release | Custody stays visible, but new-transcription admission requires current policy trust; UI offers curated reinstall | Existing checkpoint/resume reproducibility remains a separate compatibility decision, not an authorization for a new job |
 
 ## User-visible behavior
 
@@ -157,7 +170,7 @@ Ordinary product copy should explain the consequences a user actually needs to k
 
 Do not make the primary workflow explain repository cache layouts, digest algorithms, trust-root rotation, or signed-manifest internals. Those are legitimate details, but they are not the job the person is trying to complete.
 
-Until #110's production catalog and application enforcement are complete, ordinary UI also must not say or imply that the current managed snapshot is “policy-trusted” or “cryptographically verified.” Today the default managed-model path provides explicit installation, immutable resolved-revision custody, containment, and structural/provider revalidation. The stronger byte-for-byte path now has a tested `ModelManager` integration seam but is not yet the default application policy.
+The UI now follows the actual build state. A source/development build with no bundled policy describes a managed snapshot as locally checked. A build with a bundled policy distinguishes “installed” from “trusted by this Scholion build.” An installed legacy snapshot that lacks current policy evidence is not called ready and receives an explicit **Reinstall trusted copy** path.
 
 ### Three presentation layers
 
@@ -174,22 +187,26 @@ This keeps Scholion transparent without turning normal use into an architecture 
 The `scholion.supply_chain` package provides:
 
 - strict curated model catalog parsing;
+- strict packaged-catalog loading;
 - immutable-revision validation;
 - exact model snapshot file-set/size/SHA-256 verification;
 - path/cache containment checks;
 - strict signed-update envelope and payload parsing;
 - an explicit signature-verifier interface;
 - expiry and anti-rollback sequence enforcement; and
-- tests for tampering, unknown keys, stale metadata, hostile paths, undeclared files, and malformed/extra remote configuration.
+- tests for tampering, unknown keys, stale metadata, hostile paths, undeclared files, malformed catalogs, and extra remote configuration.
 
-The managed-model layer now additionally provides the integration boundary needed to consume that model policy:
+The managed-model/application layer additionally provides:
 
 - exact curated revision selection before provider acquisition;
 - rejection of caller revision overrides that disagree with policy;
 - full policy verification before a managed manifest is committed;
 - separately persisted local-validation and policy-trust evidence;
-- exact policy revalidation on later managed-registry reads; and
-- an enforcement mode that rejects models without current policy trust.
+- exact policy revalidation on later trust/admission reads;
+- application composition that automatically enables enforcement when a packaged catalog is present;
+- policy-gated new-transcription admission through the managed revision boundary;
+- legacy installed-but-untrusted migration visibility/removal; and
+- Processing Center readiness and trusted-reinstall presentation that keeps installation and policy trust distinct.
 
 No production trust entry is generated by these mechanics. Tests use synthetic local bytes and synthetic immutable revisions only.
 
@@ -203,9 +220,7 @@ This tranche deliberately does **not** claim #110 is complete. Before closing th
 - stage downloads, enforce signed size/hash, and use platform-appropriate signed/atomic installation;
 - implement explicit update UI and separately opt-in periodic checks if periodic checking is retained;
 - review real upstream faster-whisper revisions and generate the production curated model catalog;
-- bundle that reviewed catalog in the application and enable `ModelManager` policy enforcement in production composition;
-- expose local revalidation versus “trusted by Scholion policy” accurately in technical model state and require current policy trust for new-transcription admission once enforcement is enabled;
-- add native/offline regression qualification across supported platforms; and
+- include that reviewed catalog in signed release packaging and qualify the pinned snapshots natively/offline on supported platforms; and
 - integrate platform code signing/notarization into packaging rather than treating the signed manifest as a substitute.
 
-Until those steps land, current local/offline workflows remain unchanged and no update service is required for Scholion to run.
+Until reviewed production trust content is bundled, current source builds remain on their existing local/provider revalidation path. No update service is required for Scholion to open or use its local corpus.

--- a/frontend/src/ProcessingCenter.tsx
+++ b/frontend/src/ProcessingCenter.tsx
@@ -436,7 +436,11 @@ export function ProcessingCenter({
       setTaskModelId(model.model_id);
       setTaskModelAction("install");
       setTaskDescription(`Downloading ${model.model_id} transcription model`);
-      setStatus(`Downloading the ${model.model_id} transcription model to this device. Scholion will check it before using it.`);
+      setStatus(
+        readiness?.model_policy_enforced
+          ? `Downloading the ${model.model_id} transcription model to this device. Scholion will verify it against this build's model policy before using it.`
+          : `Downloading the ${model.model_id} transcription model to this device. Scholion will check it locally before using it.`,
+      );
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Scholion could not start the model download.");
     } finally {
@@ -467,10 +471,16 @@ export function ProcessingCenter({
     setError(null);
     try {
       const verified = await processing.verifyModel(model.model_id);
+      const policyEnforced = readiness?.model_policy_enforced === true;
+      const policyTrusted = readiness?.model_policy_trust[model.model_id] === true;
       setStatus(
-        verified.installed
-          ? `The ${model.model_id} transcription model is ready to use.`
-          : `The ${model.model_id} transcription model is not installed.`,
+        !verified.installed
+          ? `The ${model.model_id} transcription model is not installed.`
+          : policyEnforced && !policyTrusted
+            ? `The ${model.model_id} model is installed but is not trusted by this Scholion build's current model policy. Reinstall it before starting a new transcription.`
+            : policyEnforced
+              ? `The ${model.model_id} transcription model is trusted by this Scholion build and ready to use.`
+              : `The ${model.model_id} transcription model passed local checks and is ready to use.`,
       );
       await refresh();
     } catch (caught) {
@@ -642,22 +652,42 @@ export function ProcessingCenter({
             <h3 id="models-title">Models used for local transcription.</h3>
           </div>
           {recommendedModel && (
-            <span className={readiness?.recommended_model_installed ? "model-ready" : "model-needed"}>
-              {readiness?.recommended_model_installed ? "Recommended model installed" : "Recommended model needs download"}
+            <span className={readiness?.recommended_model_ready ? "model-ready" : "model-needed"}>
+              {readiness?.recommended_model_ready
+                ? "Recommended model ready"
+                : readiness?.recommended_model_installed && readiness.model_policy_enforced
+                  ? "Recommended model needs trusted reinstall"
+                  : "Recommended model needs download"}
             </span>
           )}
         </div>
-        <p>Models are downloaded only when you choose. Once installed, transcription can run without an internet connection. Scholion keeps installed models in its private model cache.</p>
+        <p>
+          Models are downloaded only when you choose. Once installed, transcription can run without an internet connection. Scholion keeps installed models in its private model cache.
+          {readiness?.model_policy_enforced
+            ? " This build also requires installed model bytes to match its bundled Scholion model policy before a new transcription can use them."
+            : " This build checks local model custody and provider structure before use."}
+        </p>
         <div className="model-list">
           {readiness?.models.map((model) => {
             const modelTaskActive = task?.state === "running" && taskModelId === model.model_id;
             const downloading = modelTaskActive && taskModelAction === "install";
             const removing = modelTaskActive && taskModelAction === "remove";
+            const policyTrusted = readiness.model_policy_trust[model.model_id] === true;
+            const needsPolicyReinstall =
+              model.installed && readiness.model_policy_enforced && !policyTrusted;
             return (
               <article key={model.model_id} className="model-row">
                 <div>
                   <strong>{model.model_id}</strong>
-                  <span>{model.installed ? `Installed · ${formatBytes(model.installed_size_bytes ?? model.estimated_cache_bytes)}` : `Download size about ${formatBytes(model.estimated_cache_bytes)}`}</span>
+                  <span>
+                    {model.installed
+                      ? needsPolicyReinstall
+                        ? `Installed · trusted reinstall required · ${formatBytes(model.installed_size_bytes ?? model.estimated_cache_bytes)}`
+                        : readiness.model_policy_enforced && policyTrusted
+                          ? `Trusted by this Scholion build · ${formatBytes(model.installed_size_bytes ?? model.estimated_cache_bytes)}`
+                          : `Installed · ${formatBytes(model.installed_size_bytes ?? model.estimated_cache_bytes)}`
+                      : `Download size about ${formatBytes(model.estimated_cache_bytes)}`}
+                  </span>
                   {modelTaskActive && (
                     <progress aria-label={`${downloading ? "Downloading" : "Removing"} ${model.model_id} model`} />
                   )}
@@ -666,6 +696,11 @@ export function ProcessingCenter({
                   {model.installed ? (
                     <>
                       <button type="button" onClick={() => void verifyModel(model)} disabled={busy || modelTaskActive}>Check files</button>
+                      {needsPolicyReinstall && (
+                        <button type="button" className="secondary-action" onClick={() => void installModel(model)} disabled={busy || modelTaskActive}>
+                          {downloading ? "Reinstalling…" : "Reinstall trusted copy"}
+                        </button>
+                      )}
                       <button type="button" className="danger-link" onClick={() => setPendingRemove(model)} disabled={busy || modelTaskActive}>{removing ? "Removing…" : "Remove"}</button>
                     </>
                   ) : (

--- a/frontend/src/api/processing.ts
+++ b/frontend/src/api/processing.ts
@@ -79,8 +79,11 @@ export interface ProcessingReadiness {
   };
   strategies: ProcessingStrategy[];
   models: ProcessingModel[];
+  model_policy_enforced: boolean;
+  model_policy_trust: Record<string, boolean>;
   recommended_model: string | null;
   recommended_model_installed: boolean;
+  recommended_model_ready: boolean;
 }
 
 export interface ProcessingJob {
@@ -269,9 +272,7 @@ class TauriProcessingClient implements ProcessingClient {
     });
   }
 
-  verifyModel(
-    modelId: string,
-  ): Promise<{ model_id: string; installed: boolean; resolved_revision: string | null }> {
+  verifyModel(modelId: string): Promise<{ model_id: string; installed: boolean; resolved_revision: string | null }> {
     return this.request("processing.model.verify", { model_id: modelId });
   }
 
@@ -283,7 +284,7 @@ class TauriProcessingClient implements ProcessingClient {
   ): Promise<ProcessingTaskStatus> {
     return this.startTask({
       task_id: taskId(),
-      kind: "transcription_start",
+      kind: "transcribe",
       input_path: inputPath,
       ...taskPayload(plan, options, execution),
     });
@@ -297,7 +298,7 @@ class TauriProcessingClient implements ProcessingClient {
   ): Promise<ProcessingTaskStatus> {
     return this.startTask({
       task_id: taskId(),
-      kind: "transcription_retry",
+      kind: "retry",
       source_job_id: sourceJobId,
       ...taskPayload(plan, options, execution),
     });
@@ -309,7 +310,7 @@ class TauriProcessingClient implements ProcessingClient {
   ): Promise<ProcessingTaskStatus> {
     return this.startTask({
       task_id: taskId(),
-      kind: "transcription_resume",
+      kind: "resume",
       job_id: job.job_id,
       diarize: execution.diarize,
       allow_diarization_model_download: execution.allowDiarizationModelDownload,
@@ -323,19 +324,16 @@ class TauriProcessingClient implements ProcessingClient {
   installModel(modelId: string, revision?: string | null): Promise<ProcessingTaskStatus> {
     return this.startTask({
       task_id: taskId(),
-      kind: "model_install",
+      kind: "model-install",
       model_id: modelId,
       revision: revision ?? null,
     });
   }
 
   removeModel(model: ProcessingModel): Promise<ProcessingTaskStatus> {
-    if (!model.resolved_revision) {
-      return Promise.reject(new Error("Model is not installed"));
-    }
     return this.startTask({
       task_id: taskId(),
-      kind: "model_remove",
+      kind: "model-remove",
       model_id: model.model_id,
       expected_revision: model.resolved_revision,
     });
@@ -343,336 +341,17 @@ class TauriProcessingClient implements ProcessingClient {
 
   async taskStatus(taskIdValue: string): Promise<ProcessingTaskStatus> {
     const { invoke } = await import("@tauri-apps/api/core");
-    return invoke<ProcessingTaskStatus>("processing_task_status", { taskId: taskIdValue });
+    return invoke<ProcessingTaskStatus>("processing_task_status", {
+      taskId: taskIdValue,
+    });
   }
 
   async cancelTask(taskIdValue: string): Promise<ProcessingTaskStatus> {
     const { invoke } = await import("@tauri-apps/api/core");
-    return invoke<ProcessingTaskStatus>("processing_cancel_task", { taskId: taskIdValue });
-  }
-}
-
-class MockProcessingClient implements ProcessingClient {
-  private taskCounter = 0;
-  private modelMutation = 0;
-  private tasks = new Map<string, ProcessingTaskStatus>();
-  private models: ProcessingModel[] = [
-    {
-      model_id: "tiny",
-      engine: "faster-whisper",
-      estimated_cache_bytes: 157_286_400,
-      quality_rank: 1,
-      installed: false,
-      resolved_revision: null,
-      installed_size_bytes: null,
-      verification: null,
-    },
-    {
-      model_id: "small",
-      engine: "faster-whisper",
-      estimated_cache_bytes: 786_432_000,
-      quality_rank: 2,
-      installed: true,
-      resolved_revision: "mock-small-revision",
-      installed_size_bytes: 734_003_200,
-      verification: "huggingface_snapshot_required_files_v1",
-    },
-    {
-      model_id: "medium",
-      engine: "faster-whisper",
-      estimated_cache_bytes: 2_621_440_000,
-      quality_rank: 3,
-      installed: false,
-      resolved_revision: null,
-      installed_size_bytes: null,
-      verification: null,
-    },
-  ];
-  private jobMutation = 0;
-  private jobRecords: ProcessingJob[] = [
-    {
-      job_id: "job-interrupted-7",
-      recording_name: "oral-history-07.m4a",
-      status: "interrupted",
-      started_at: "2026-08-20T12:10:00+00:00",
-      updated_at: "2026-08-20T12:35:00+00:00",
-      total_segments: 12,
-      completed_segments: 8,
-      progress_fraction: 8 / 12,
-      resumable: true,
-      artifact_published: false,
-      error_code: null,
-      failure_message: null,
-    },
-    {
-      job_id: "job-completed-2",
-      recording_name: "interview-02.mp4",
-      status: "completed",
-      started_at: "2026-08-19T16:00:00+00:00",
-      updated_at: "2026-08-19T16:48:00+00:00",
-      total_segments: 9,
-      completed_segments: 9,
-      progress_fraction: 1,
-      resumable: false,
-      artifact_published: true,
-      error_code: null,
-      failure_message: null,
-    },
-  ];
-
-  async readiness(profile: ProcessingProfile): Promise<ProcessingReadiness> {
-    const recommendedModel = profile === "screening" ? "tiny" : profile === "accuracy" ? "medium" : "small";
-    const speakerLabelingHeld = new URLSearchParams(window.location.search).get("speaker-labeling-held") === "1";
-    return {
-      health: {
-        status: "healthy",
-        checks: [
-          { check_id: "workspace", status: "pass", summary: "Private workspace is ready", required: true, error_code: null },
-          { check_id: "ffmpeg", status: "pass", summary: "FFmpeg and FFprobe are available", required: true, error_code: null },
-          { check_id: "system_resources", status: "pass", summary: "Local resources are available", required: true, error_code: null },
-        ],
-      },
-      capabilities: {
-        speaker_labeling: speakerLabelingHeld
-          ? {
-              available: false,
-              reason_code: "security_hold",
-              message: "Speaker labeling is temporarily unavailable because a local dependency does not meet Scholion's security requirement.",
-            }
-          : { available: true, reason_code: null, message: null },
-      },
-      resources: {
-        platform: "Linux",
-        machine: "x86_64",
-        processor_name: "AMD Ryzen 7 7700X 8-Core Processor",
-        effective_cpus: 16,
-        memory_total_bytes: 68_719_476_736,
-        memory_available_bytes: 55_834_574_848,
-        effective_memory_available_bytes: 55_834_574_848,
-        constraints: [],
-        accelerators: [
-          {
-            accelerator_id: "cuda:0",
-            backend: "cuda",
-            device_index: 0,
-            name: "NVIDIA GeForce RTX 4080",
-            memory_topology: "dedicated",
-            memory_total_bytes: 17_179_869_184,
-            memory_available_bytes: 15_032_385_536,
-          },
-        ],
-      },
-      policy: {
-        profile,
-        provisional: profile === "screening",
-        cpu_threads: 16,
-        memory_budget_bytes: 41_875_931_136,
-        constraints: [],
-      },
-      strategies: [
-        { strategy_id: "tiny-cpu-int8", model: "tiny", device: "cpu", compute_type: "int8", estimated_peak_memory_bytes: 1_342_177_280, estimated_peak_device_memory_bytes: 0, model_cache_bytes: 157_286_400, feasible: true, rejection_reasons: [], recommended: recommendedModel === "tiny" },
-        { strategy_id: "small-cpu-int8", model: "small", device: "cpu", compute_type: "int8", estimated_peak_memory_bytes: 2_415_919_104, estimated_peak_device_memory_bytes: 0, model_cache_bytes: 786_432_000, feasible: true, rejection_reasons: [], recommended: recommendedModel === "small" },
-        { strategy_id: "medium-cpu-int8", model: "medium", device: "cpu", compute_type: "int8", estimated_peak_memory_bytes: 4_563_402_752, estimated_peak_device_memory_bytes: 0, model_cache_bytes: 2_621_440_000, feasible: true, rejection_reasons: [], recommended: recommendedModel === "medium" },
-      ],
-      models: this.models.map((model) => ({ ...model })),
-      recommended_model: recommendedModel,
-      recommended_model_installed: this.models.some((model) => model.model_id === recommendedModel && model.installed),
-    };
-  }
-
-  async jobs(): Promise<ProcessingJob[]> {
-    return this.jobRecords.map((job) => ({ ...job }));
-  }
-
-  async preflight(inputPath: string, options: PreflightOptions): Promise<ProcessingPreflight> {
-    const name = inputPath.split(/[\\/]/).filter(Boolean).at(-1) ?? inputPath;
-    return this.plan(name, options);
-  }
-
-  async retryPreflight(_sourceJobId: string, options: PreflightOptions): Promise<ProcessingPreflight> {
-    return this.plan("retry-recording.m4a", options);
-  }
-
-  async discardJob(job: ProcessingJob): Promise<void> {
-    const current = this.jobRecords.find((item) => item.job_id === job.job_id);
-    if (!current) throw new Error("Job does not exist");
-    if (current.updated_at !== job.updated_at) throw new Error("Job state changed; refresh before discarding private state");
-    if (current.status === "running") throw new Error("A running job cannot be discarded");
-    this.jobRecords = this.jobRecords.filter((item) => item.job_id !== job.job_id);
-  }
-
-  async verifyModel(modelId: string) {
-    const model = this.models.find((item) => item.model_id === modelId);
-    if (!model) throw new Error("Unknown model");
-    return { model_id: modelId, installed: model.installed, resolved_revision: model.resolved_revision };
-  }
-
-  async startTranscription(
-    _inputPath: string,
-    plan: ProcessingPreflight,
-    _options: PreflightOptions,
-    _execution: ExecutionOptions,
-  ): Promise<ProcessingTaskStatus> {
-    this.jobMutation += 1;
-    this.jobRecords.unshift({
-      job_id: plan.job_id,
-      recording_name: plan.recording_name,
-      status: "running",
-      started_at: `2026-08-20T18:${String(this.jobMutation).padStart(2, "0")}:00+00:00`,
-      updated_at: `2026-08-20T18:${String(this.jobMutation).padStart(2, "0")}:00+00:00`,
-      total_segments: 10,
-      completed_segments: 1,
-      progress_fraction: 0.1,
-      resumable: true,
-      artifact_published: false,
-      error_code: null,
-      failure_message: null,
+    return invoke<ProcessingTaskStatus>("processing_cancel_task", {
+      taskId: taskIdValue,
     });
-    return this.newTask();
-  }
-
-  async retryTranscription(
-    _sourceJobId: string,
-    plan: ProcessingPreflight,
-    options: PreflightOptions,
-    execution: ExecutionOptions,
-  ): Promise<ProcessingTaskStatus> {
-    return this.startTranscription("mock-retry", plan, options, execution);
-  }
-
-  async resumeTranscription(job: ProcessingJob, _execution: ExecutionOptions): Promise<ProcessingTaskStatus> {
-    const current = this.jobRecords.find((item) => item.job_id === job.job_id);
-    if (!current || !current.resumable) throw new Error("Job is not resumable");
-    current.status = "running";
-    current.updated_at = "2026-08-20T18:30:00+00:00";
-    return this.newTask();
-  }
-
-  async installModel(modelId: string): Promise<ProcessingTaskStatus> {
-    const model = this.models.find((item) => item.model_id === modelId);
-    if (!model) throw new Error("Unknown model");
-    this.modelMutation += 1;
-    model.installed = true;
-    model.resolved_revision = `mock-${modelId}-revision-${this.modelMutation}`;
-    model.installed_size_bytes = model.estimated_cache_bytes;
-    model.verification = "huggingface_snapshot_required_files_v1";
-    return this.newTask();
-  }
-
-  async removeModel(model: ProcessingModel): Promise<ProcessingTaskStatus> {
-    const current = this.models.find((item) => item.model_id === model.model_id);
-    if (!current || current.resolved_revision !== model.resolved_revision) {
-      throw new Error("Model state changed; refresh before removing it");
-    }
-    current.installed = false;
-    current.resolved_revision = null;
-    current.installed_size_bytes = null;
-    current.verification = null;
-    return this.newTask();
-  }
-
-  async taskStatus(taskIdValue: string): Promise<ProcessingTaskStatus> {
-    const task = this.tasks.get(taskIdValue);
-    if (!task) throw new Error("Unknown processing task");
-    if (task.state === "running") {
-      task.state = "completed";
-      task.exit_code = 0;
-    }
-    return { ...task };
-  }
-
-  async cancelTask(taskIdValue: string): Promise<ProcessingTaskStatus> {
-    const task = this.tasks.get(taskIdValue);
-    if (!task) throw new Error("Unknown processing task");
-    task.state = "cancelled";
-    task.exit_code = null;
-    task.error_code = null;
-    task.error_message = null;
-    return { ...task };
-  }
-
-  private newTask(): ProcessingTaskStatus {
-    this.taskCounter += 1;
-    const status: ProcessingTaskStatus = {
-      task_id: `mock-task-${this.taskCounter}`,
-      state: "running",
-      exit_code: null,
-      error_code: null,
-      error_message: null,
-    };
-    this.tasks.set(status.task_id, status);
-    return { ...status };
-  }
-
-  private plan(recordingName: string, options: PreflightOptions): ProcessingPreflight {
-    const model = options.profile === "screening" ? "tiny" : options.profile === "accuracy" ? "medium" : "small";
-    const strategy = options.strategyId ?? `${model}-cpu-int8`;
-    const multitrack = new URLSearchParams(window.location.search).get("multitrack") === "1";
-    const audioStreams: ProcessingAudioStream[] = multitrack
-      ? [
-          {
-            index: 1,
-            codec: "aac",
-            duration_seconds: 3_642.5,
-            sample_rate_hz: 48_000,
-            channels: 2,
-            title: "Camera scratch",
-            language: "eng",
-            is_default: false,
-          },
-          {
-            index: 3,
-            codec: "pcm_s16le",
-            duration_seconds: 3_642.5,
-            sample_rate_hz: 48_000,
-            channels: 1,
-            title: "Lav microphone",
-            language: "eng",
-            is_default: true,
-          },
-        ]
-      : [
-          {
-            index: 1,
-            codec: "aac",
-            duration_seconds: 3_642.5,
-            sample_rate_hz: 48_000,
-            channels: 2,
-            title: null,
-            language: null,
-            is_default: false,
-          },
-        ];
-    return {
-      job_id: `job-planned-${this.jobMutation + 10}`,
-      recording_name: recordingName,
-      source_sha256: "e".repeat(64),
-      container_format: "mov,mp4,m4a,3gp,3g2,mj2",
-      duration_seconds: 3_642.5,
-      audio_streams: audioStreams,
-      selected_audio_stream_index: options.audioStreamIndex ?? audioStreams[0]!.index,
-      audio_stream_selection_required: multitrack && options.audioStreamIndex == null,
-      profile: options.profile,
-      provisional: options.profile === "screening",
-      strategy_id: strategy,
-      engine: "faster-whisper",
-      model,
-      model_revision: `mock-${model}-revision`,
-      device: "cpu",
-      compute_type: "int8",
-      cpu_threads: 8,
-      decode_strategy: "ffmpeg_normalize",
-      enhancement_enabled: options.enhance ?? false,
-      estimated_disk_bytes: 612_368_384,
-      estimated_peak_memory_bytes: model === "medium" ? 4_563_402_752 : model === "tiny" ? 1_342_177_280 : 2_415_919_104,
-      memory_budget_bytes: 9_663_676_416,
-      fits_memory_budget: true,
-      warnings: ["paths_are_unreserved"],
-    };
   }
 }
 
-export function createProcessingClient(): ProcessingClient {
-  const params = new URLSearchParams(window.location.search);
-  return params.get("e2e") === "1" ? new MockProcessingClient() : new TauriProcessingClient();
-}
+export const processingClient: ProcessingClient = new TauriProcessingClient();

--- a/frontend/src/api/processing.ts
+++ b/frontend/src/api/processing.ts
@@ -272,7 +272,9 @@ class TauriProcessingClient implements ProcessingClient {
     });
   }
 
-  verifyModel(modelId: string): Promise<{ model_id: string; installed: boolean; resolved_revision: string | null }> {
+  verifyModel(
+    modelId: string,
+  ): Promise<{ model_id: string; installed: boolean; resolved_revision: string | null }> {
     return this.request("processing.model.verify", { model_id: modelId });
   }
 
@@ -284,7 +286,7 @@ class TauriProcessingClient implements ProcessingClient {
   ): Promise<ProcessingTaskStatus> {
     return this.startTask({
       task_id: taskId(),
-      kind: "transcribe",
+      kind: "transcription_start",
       input_path: inputPath,
       ...taskPayload(plan, options, execution),
     });
@@ -298,7 +300,7 @@ class TauriProcessingClient implements ProcessingClient {
   ): Promise<ProcessingTaskStatus> {
     return this.startTask({
       task_id: taskId(),
-      kind: "retry",
+      kind: "transcription_retry",
       source_job_id: sourceJobId,
       ...taskPayload(plan, options, execution),
     });
@@ -310,7 +312,7 @@ class TauriProcessingClient implements ProcessingClient {
   ): Promise<ProcessingTaskStatus> {
     return this.startTask({
       task_id: taskId(),
-      kind: "resume",
+      kind: "transcription_resume",
       job_id: job.job_id,
       diarize: execution.diarize,
       allow_diarization_model_download: execution.allowDiarizationModelDownload,
@@ -324,16 +326,19 @@ class TauriProcessingClient implements ProcessingClient {
   installModel(modelId: string, revision?: string | null): Promise<ProcessingTaskStatus> {
     return this.startTask({
       task_id: taskId(),
-      kind: "model-install",
+      kind: "model_install",
       model_id: modelId,
       revision: revision ?? null,
     });
   }
 
   removeModel(model: ProcessingModel): Promise<ProcessingTaskStatus> {
+    if (!model.resolved_revision) {
+      return Promise.reject(new Error("Model is not installed"));
+    }
     return this.startTask({
       task_id: taskId(),
-      kind: "model-remove",
+      kind: "model_remove",
       model_id: model.model_id,
       expected_revision: model.resolved_revision,
     });
@@ -341,17 +346,367 @@ class TauriProcessingClient implements ProcessingClient {
 
   async taskStatus(taskIdValue: string): Promise<ProcessingTaskStatus> {
     const { invoke } = await import("@tauri-apps/api/core");
-    return invoke<ProcessingTaskStatus>("processing_task_status", {
-      taskId: taskIdValue,
-    });
+    return invoke<ProcessingTaskStatus>("processing_task_status", { taskId: taskIdValue });
   }
 
   async cancelTask(taskIdValue: string): Promise<ProcessingTaskStatus> {
     const { invoke } = await import("@tauri-apps/api/core");
-    return invoke<ProcessingTaskStatus>("processing_cancel_task", {
-      taskId: taskIdValue,
-    });
+    return invoke<ProcessingTaskStatus>("processing_cancel_task", { taskId: taskIdValue });
   }
 }
 
-export const processingClient: ProcessingClient = new TauriProcessingClient();
+class MockProcessingClient implements ProcessingClient {
+  private taskCounter = 0;
+  private modelMutation = 0;
+  private tasks = new Map<string, ProcessingTaskStatus>();
+  private policyTrustedModels = new Set<string>();
+  private models: ProcessingModel[] = [
+    {
+      model_id: "tiny",
+      engine: "faster-whisper",
+      estimated_cache_bytes: 157_286_400,
+      quality_rank: 1,
+      installed: false,
+      resolved_revision: null,
+      installed_size_bytes: null,
+      verification: null,
+    },
+    {
+      model_id: "small",
+      engine: "faster-whisper",
+      estimated_cache_bytes: 786_432_000,
+      quality_rank: 2,
+      installed: true,
+      resolved_revision: "mock-small-revision",
+      installed_size_bytes: 734_003_200,
+      verification: "huggingface_snapshot_required_files_v1",
+    },
+    {
+      model_id: "medium",
+      engine: "faster-whisper",
+      estimated_cache_bytes: 2_621_440_000,
+      quality_rank: 3,
+      installed: false,
+      resolved_revision: null,
+      installed_size_bytes: null,
+      verification: null,
+    },
+  ];
+  private jobMutation = 0;
+  private jobRecords: ProcessingJob[] = [
+    {
+      job_id: "job-interrupted-7",
+      recording_name: "oral-history-07.m4a",
+      status: "interrupted",
+      started_at: "2026-08-20T12:10:00+00:00",
+      updated_at: "2026-08-20T12:35:00+00:00",
+      total_segments: 12,
+      completed_segments: 8,
+      progress_fraction: 8 / 12,
+      resumable: true,
+      artifact_published: false,
+      error_code: null,
+      failure_message: null,
+    },
+    {
+      job_id: "job-completed-2",
+      recording_name: "interview-02.mp4",
+      status: "completed",
+      started_at: "2026-08-19T16:00:00+00:00",
+      updated_at: "2026-08-19T16:48:00+00:00",
+      total_segments: 9,
+      completed_segments: 9,
+      progress_fraction: 1,
+      resumable: false,
+      artifact_published: true,
+      error_code: null,
+      failure_message: null,
+    },
+  ];
+
+  constructor() {
+    const params = new URLSearchParams(window.location.search);
+    if (
+      params.get("model-policy") === "1" &&
+      params.get("model-policy-untrusted") !== "1"
+    ) {
+      this.policyTrustedModels.add("small");
+    }
+  }
+
+  async readiness(profile: ProcessingProfile): Promise<ProcessingReadiness> {
+    const recommendedModel = profile === "screening" ? "tiny" : profile === "accuracy" ? "medium" : "small";
+    const params = new URLSearchParams(window.location.search);
+    const speakerLabelingHeld = params.get("speaker-labeling-held") === "1";
+    const modelPolicyEnforced = params.get("model-policy") === "1";
+    const modelPolicyTrust = Object.fromEntries(
+      this.models.map((model) => [
+        model.model_id,
+        modelPolicyEnforced && this.policyTrustedModels.has(model.model_id),
+      ]),
+    );
+    const recommendedModelInstalled = this.models.some(
+      (model) => model.model_id === recommendedModel && model.installed,
+    );
+    return {
+      health: {
+        status: "healthy",
+        checks: [
+          { check_id: "workspace", status: "pass", summary: "Private workspace is ready", required: true, error_code: null },
+          { check_id: "ffmpeg", status: "pass", summary: "FFmpeg and FFprobe are available", required: true, error_code: null },
+          { check_id: "system_resources", status: "pass", summary: "Local resources are available", required: true, error_code: null },
+        ],
+      },
+      capabilities: {
+        speaker_labeling: speakerLabelingHeld
+          ? {
+              available: false,
+              reason_code: "security_hold",
+              message: "Speaker labeling is temporarily unavailable because a local dependency does not meet Scholion's security requirement.",
+            }
+          : { available: true, reason_code: null, message: null },
+      },
+      resources: {
+        platform: "Linux",
+        machine: "x86_64",
+        processor_name: "AMD Ryzen 7 7700X 8-Core Processor",
+        effective_cpus: 16,
+        memory_total_bytes: 68_719_476_736,
+        memory_available_bytes: 55_834_574_848,
+        effective_memory_available_bytes: 55_834_574_848,
+        constraints: [],
+        accelerators: [
+          {
+            accelerator_id: "cuda:0",
+            backend: "cuda",
+            device_index: 0,
+            name: "NVIDIA GeForce RTX 4080",
+            memory_topology: "dedicated",
+            memory_total_bytes: 17_179_869_184,
+            memory_available_bytes: 15_032_385_536,
+          },
+        ],
+      },
+      policy: {
+        profile,
+        provisional: profile === "screening",
+        cpu_threads: 16,
+        memory_budget_bytes: 41_875_931_136,
+        constraints: [],
+      },
+      strategies: [
+        { strategy_id: "tiny-cpu-int8", model: "tiny", device: "cpu", compute_type: "int8", estimated_peak_memory_bytes: 1_342_177_280, estimated_peak_device_memory_bytes: 0, model_cache_bytes: 157_286_400, feasible: true, rejection_reasons: [], recommended: recommendedModel === "tiny" },
+        { strategy_id: "small-cpu-int8", model: "small", device: "cpu", compute_type: "int8", estimated_peak_memory_bytes: 2_415_919_104, estimated_peak_device_memory_bytes: 0, model_cache_bytes: 786_432_000, feasible: true, rejection_reasons: [], recommended: recommendedModel === "small" },
+        { strategy_id: "medium-cpu-int8", model: "medium", device: "cpu", compute_type: "int8", estimated_peak_memory_bytes: 4_563_402_752, estimated_peak_device_memory_bytes: 0, model_cache_bytes: 2_621_440_000, feasible: true, rejection_reasons: [], recommended: recommendedModel === "medium" },
+      ],
+      models: this.models.map((model) => ({ ...model })),
+      model_policy_enforced: modelPolicyEnforced,
+      model_policy_trust: modelPolicyTrust,
+      recommended_model: recommendedModel,
+      recommended_model_installed: recommendedModelInstalled,
+      recommended_model_ready:
+        recommendedModelInstalled &&
+        (!modelPolicyEnforced || modelPolicyTrust[recommendedModel] === true),
+    };
+  }
+
+  async jobs(): Promise<ProcessingJob[]> {
+    return this.jobRecords.map((job) => ({ ...job }));
+  }
+
+  async preflight(inputPath: string, options: PreflightOptions): Promise<ProcessingPreflight> {
+    const name = inputPath.split(/[\\/]/).filter(Boolean).at(-1) ?? inputPath;
+    return this.plan(name, options);
+  }
+
+  async retryPreflight(_sourceJobId: string, options: PreflightOptions): Promise<ProcessingPreflight> {
+    return this.plan("retry-recording.m4a", options);
+  }
+
+  async discardJob(job: ProcessingJob): Promise<void> {
+    const current = this.jobRecords.find((item) => item.job_id === job.job_id);
+    if (!current) throw new Error("Job does not exist");
+    if (current.updated_at !== job.updated_at) throw new Error("Job state changed; refresh before discarding private state");
+    if (current.status === "running") throw new Error("A running job cannot be discarded");
+    this.jobRecords = this.jobRecords.filter((item) => item.job_id !== job.job_id);
+  }
+
+  async verifyModel(modelId: string) {
+    const model = this.models.find((item) => item.model_id === modelId);
+    if (!model) throw new Error("Unknown model");
+    return { model_id: modelId, installed: model.installed, resolved_revision: model.resolved_revision };
+  }
+
+  async startTranscription(
+    _inputPath: string,
+    plan: ProcessingPreflight,
+    _options: PreflightOptions,
+    _execution: ExecutionOptions,
+  ): Promise<ProcessingTaskStatus> {
+    this.jobMutation += 1;
+    this.jobRecords.unshift({
+      job_id: plan.job_id,
+      recording_name: plan.recording_name,
+      status: "running",
+      started_at: `2026-08-20T18:${String(this.jobMutation).padStart(2, "0")}:00+00:00`,
+      updated_at: `2026-08-20T18:${String(this.jobMutation).padStart(2, "0")}:00+00:00`,
+      total_segments: 10,
+      completed_segments: 1,
+      progress_fraction: 0.1,
+      resumable: true,
+      artifact_published: false,
+      error_code: null,
+      failure_message: null,
+    });
+    return this.newTask();
+  }
+
+  async retryTranscription(
+    _sourceJobId: string,
+    plan: ProcessingPreflight,
+    options: PreflightOptions,
+    execution: ExecutionOptions,
+  ): Promise<ProcessingTaskStatus> {
+    return this.startTranscription("mock-retry", plan, options, execution);
+  }
+
+  async resumeTranscription(job: ProcessingJob, _execution: ExecutionOptions): Promise<ProcessingTaskStatus> {
+    const current = this.jobRecords.find((item) => item.job_id === job.job_id);
+    if (!current || !current.resumable) throw new Error("Job is not resumable");
+    current.status = "running";
+    current.updated_at = "2026-08-20T18:30:00+00:00";
+    return this.newTask();
+  }
+
+  async installModel(modelId: string): Promise<ProcessingTaskStatus> {
+    const model = this.models.find((item) => item.model_id === modelId);
+    if (!model) throw new Error("Unknown model");
+    this.modelMutation += 1;
+    model.installed = true;
+    model.resolved_revision = `mock-${modelId}-revision-${this.modelMutation}`;
+    model.installed_size_bytes = model.estimated_cache_bytes;
+    model.verification = "huggingface_snapshot_required_files_v1";
+    if (new URLSearchParams(window.location.search).get("model-policy") === "1") {
+      this.policyTrustedModels.add(modelId);
+    }
+    return this.newTask();
+  }
+
+  async removeModel(model: ProcessingModel): Promise<ProcessingTaskStatus> {
+    const current = this.models.find((item) => item.model_id === model.model_id);
+    if (!current || current.resolved_revision !== model.resolved_revision) {
+      throw new Error("Model state changed; refresh before removing it");
+    }
+    current.installed = false;
+    current.resolved_revision = null;
+    current.installed_size_bytes = null;
+    current.verification = null;
+    this.policyTrustedModels.delete(model.model_id);
+    return this.newTask();
+  }
+
+  async taskStatus(taskIdValue: string): Promise<ProcessingTaskStatus> {
+    const task = this.tasks.get(taskIdValue);
+    if (!task) throw new Error("Unknown processing task");
+    if (task.state === "running") {
+      task.state = "completed";
+      task.exit_code = 0;
+    }
+    return { ...task };
+  }
+
+  async cancelTask(taskIdValue: string): Promise<ProcessingTaskStatus> {
+    const task = this.tasks.get(taskIdValue);
+    if (!task) throw new Error("Unknown processing task");
+    task.state = "cancelled";
+    task.exit_code = null;
+    task.error_code = null;
+    task.error_message = null;
+    return { ...task };
+  }
+
+  private newTask(): ProcessingTaskStatus {
+    this.taskCounter += 1;
+    const status: ProcessingTaskStatus = {
+      task_id: `mock-task-${this.taskCounter}`,
+      state: "running",
+      exit_code: null,
+      error_code: null,
+      error_message: null,
+    };
+    this.tasks.set(status.task_id, status);
+    return { ...status };
+  }
+
+  private plan(recordingName: string, options: PreflightOptions): ProcessingPreflight {
+    const model = options.profile === "screening" ? "tiny" : options.profile === "accuracy" ? "medium" : "small";
+    const strategy = options.strategyId ?? `${model}-cpu-int8`;
+    const multitrack = new URLSearchParams(window.location.search).get("multitrack") === "1";
+    const audioStreams: ProcessingAudioStream[] = multitrack
+      ? [
+          {
+            index: 1,
+            codec: "aac",
+            duration_seconds: 3_642.5,
+            sample_rate_hz: 48_000,
+            channels: 2,
+            title: "Camera scratch",
+            language: "eng",
+            is_default: false,
+          },
+          {
+            index: 3,
+            codec: "pcm_s16le",
+            duration_seconds: 3_642.5,
+            sample_rate_hz: 48_000,
+            channels: 1,
+            title: "Lav microphone",
+            language: "eng",
+            is_default: true,
+          },
+        ]
+      : [
+          {
+            index: 1,
+            codec: "aac",
+            duration_seconds: 3_642.5,
+            sample_rate_hz: 48_000,
+            channels: 2,
+            title: null,
+            language: null,
+            is_default: false,
+          },
+        ];
+    return {
+      job_id: `job-planned-${this.jobMutation + 10}`,
+      recording_name: recordingName,
+      source_sha256: "e".repeat(64),
+      container_format: "mov,mp4,m4a,3gp,3g2,mj2",
+      duration_seconds: 3_642.5,
+      audio_streams: audioStreams,
+      selected_audio_stream_index: options.audioStreamIndex ?? audioStreams[0]!.index,
+      audio_stream_selection_required: multitrack && options.audioStreamIndex == null,
+      profile: options.profile,
+      provisional: options.profile === "screening",
+      strategy_id: strategy,
+      engine: "faster-whisper",
+      model,
+      model_revision: `mock-${model}-revision`,
+      device: "cpu",
+      compute_type: "int8",
+      cpu_threads: 8,
+      decode_strategy: "ffmpeg_normalize",
+      enhancement_enabled: options.enhance ?? false,
+      estimated_disk_bytes: 612_368_384,
+      estimated_peak_memory_bytes: model === "medium" ? 4_563_402_752 : model === "tiny" ? 1_342_177_280 : 2_415_919_104,
+      memory_budget_bytes: 9_663_676_416,
+      fits_memory_budget: true,
+      warnings: ["paths_are_unreserved"],
+    };
+  }
+}
+
+export function createProcessingClient(): ProcessingClient {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("e2e") === "1" ? new MockProcessingClient() : new TauriProcessingClient();
+}

--- a/frontend/tests/processing.spec.ts
+++ b/frontend/tests/processing.spec.ts
@@ -104,7 +104,9 @@ test("policy enforcement keeps a legacy install visible and offers a trusted rei
 
   await smallModel.getByRole("button", { name: "Reinstall trusted copy" }).click();
   await expect(smallModel.getByRole("button", { name: "Reinstalling…" })).toBeDisabled();
-  await expect(page.getByRole("status")).toContainText("verify it against this build's model policy");
+  await expect(
+    page.getByRole("status").filter({ hasText: "verify it against this build's model policy" }),
+  ).toBeVisible();
 
   await expect(smallModel).toContainText("Trusted by this Scholion build", { timeout: 5_000 });
   await expect(page.getByText("Recommended model ready")).toBeVisible();

--- a/frontend/tests/processing.spec.ts
+++ b/frontend/tests/processing.spec.ts
@@ -95,6 +95,24 @@ test("model downloads show an explicit in-place running state", async ({ page })
   await expect(tinyModel.getByRole("progressbar", { name: "Downloading tiny model" })).toBeVisible();
 });
 
+test("policy enforcement keeps a legacy install visible and offers a trusted reinstall", async ({ page }) => {
+  await openProcessing(page, "&model-policy=1&model-policy-untrusted=1");
+
+  await expect(page.getByText("Recommended model needs trusted reinstall")).toBeVisible();
+  const smallModel = page.locator("article.model-row").filter({ hasText: "small" });
+  await expect(smallModel).toContainText("trusted reinstall required");
+
+  await smallModel.getByRole("button", { name: "Reinstall trusted copy" }).click();
+  await expect(smallModel.getByRole("button", { name: "Reinstalling…" })).toBeDisabled();
+  await expect(page.getByRole("status")).toContainText("verify it against this build's model policy");
+
+  await expect(smallModel).toContainText("Trusted by this Scholion build", { timeout: 5_000 });
+  await expect(page.getByText("Recommended model ready")).toBeVisible();
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations).toEqual([]);
+});
+
 test("speaker labeling is disabled when the backend places the capability on security hold", async ({ page }) => {
   await openProcessing(page, "&speaker-labeling-held=1");
   await page.getByRole("button", { name: "Choose recording" }).click();

--- a/src/scholion/app/app_container.py
+++ b/src/scholion/app/app_container.py
@@ -38,16 +38,17 @@ from scholion.library.transcript_tools import TranscriptToolsService
 from scholion.library.workspace_metadata import SqliteWorkspaceMetadataStore
 from scholion.media.probe import FfprobeMediaProbe
 from scholion.media.selection import AudioStreamSelector
-from scholion.model_management.catalog import faster_whisper_model_catalog
+from scholion.model_management.catalog import ModelCatalog, faster_whisper_model_catalog
 from scholion.model_management.errors import ModelManagementError
 from scholion.model_management.provider import HuggingFaceModelProvider
-from scholion.model_management.service import ModelManager
+from scholion.model_management.service import ModelManager, ModelStorageAdmitter
 from scholion.runner.inspector import RunnerInspector
 from scholion.runner.policy import RunnerPolicyPlanner
 from scholion.runner.topology import (
     HardwareTopologyInspector,
     NvidiaSmiAcceleratorProbe,
 )
+from scholion.supply_chain import ModelTrustCatalog, load_bundled_model_trust_catalog
 from scholion.transcription.adaptive_executor import AdaptiveTranscriptionExecutor
 from scholion.transcription.assembly import TranscriptAssembler
 from scholion.transcription.audio import FfmpegAudioDecoder
@@ -201,6 +202,27 @@ def _restore_embedding_provider(
     return SentenceTransformersE5Provider.from_profile(profile)
 
 
+def _create_model_manager(
+    *,
+    catalog: ModelCatalog,
+    provider: HuggingFaceModelProvider,
+    file_store: FileManagerFacade,
+    model_root: Path,
+    storage_admitter: ModelStorageAdmitter,
+    trust_catalog: ModelTrustCatalog | None,
+) -> ModelManager:
+    """Activate exact model policy automatically when this build bundles a catalog."""
+    return ModelManager(
+        catalog=catalog,
+        provider=provider,
+        file_store=file_store,
+        model_root=model_root,
+        storage_admitter=storage_admitter,
+        trust_catalog=trust_catalog,
+        enforce_policy_trust=trust_catalog is not None,
+    )
+
+
 class _ModelStorageAdmitter:
     """Adapt the shared disk policy without coupling model management to ASR."""
 
@@ -255,13 +277,15 @@ class AppContainer(containers.DeclarativeContainer):
     model_storage_admitter = providers.Singleton(
         _ModelStorageAdmitter, policy=storage_admission
     )
+    model_trust_catalog = providers.Singleton(load_bundled_model_trust_catalog)
     model_manager = providers.Singleton(
-        ModelManager,
+        _create_model_manager,
         catalog=model_catalog,
         provider=model_provider,
         file_store=file_manager,
         model_root=config.provided.MODEL_DIR,
         storage_admitter=model_storage_admitter,
+        trust_catalog=model_trust_catalog,
     )
     media_probe = providers.Singleton(_create_media_probe, config=config)
     audio_stream_selector = providers.Singleton(AudioStreamSelector)

--- a/src/scholion/app/processing_center.py
+++ b/src/scholion/app/processing_center.py
@@ -58,7 +58,6 @@ def _safe_failure_message(error_code: str | None) -> str | None:
 
 def _serialize_model(item: ModelInventoryItem) -> dict[str, object]:
     manifest = item.manifest
-    policy = None if manifest is None else manifest.policy_trust
     return {
         "model_id": item.spec.model_id,
         "engine": item.spec.engine,
@@ -68,16 +67,6 @@ def _serialize_model(item: ModelInventoryItem) -> dict[str, object]:
         "resolved_revision": None if manifest is None else manifest.resolved_revision,
         "installed_size_bytes": None if manifest is None else manifest.size_bytes,
         "verification": None if manifest is None else manifest.verification,
-        "policy_trusted": item.policy_trusted,
-        "policy_trust": None
-        if policy is None
-        else {
-            "catalog_schema_version": policy.catalog_schema_version,
-            "revision": policy.revision,
-            "verification": policy.verification,
-            "verified_files": policy.verified_files,
-            "total_bytes": policy.total_bytes,
-        },
     }
 
 
@@ -220,7 +209,10 @@ class ProcessingCenterService:
             None,
         )
         inventory = self.model_manager.inventory()
-        policy_enforced = self.model_manager.enforce_policy_trust
+        policy_enforced = getattr(self.model_manager, "enforce_policy_trust", False)
+        policy_trust = {
+            item.spec.model_id: item.policy_trusted for item in inventory
+        }
         speaker_labeling = diarization_runtime_status()
         recommended_model: str | None = None
         recommended_installed = False
@@ -281,6 +273,7 @@ class ProcessingCenterService:
             "strategies": [self._serialize_strategy(item) for item in assessments],
             "models": [_serialize_model(item) for item in inventory],
             "model_policy_enforced": policy_enforced,
+            "model_policy_trust": policy_trust,
             "recommended_model": recommended_model,
             "recommended_model_installed": recommended_installed,
             "recommended_model_ready": recommended_ready,
@@ -385,6 +378,4 @@ class ProcessingCenterService:
             "resolved_revision": None
             if manifest is None
             else manifest.resolved_revision,
-            "policy_trusted": item.policy_trusted,
-            "policy_enforced": self.model_manager.enforce_policy_trust,
         }

--- a/src/scholion/app/processing_center.py
+++ b/src/scholion/app/processing_center.py
@@ -58,6 +58,7 @@ def _safe_failure_message(error_code: str | None) -> str | None:
 
 def _serialize_model(item: ModelInventoryItem) -> dict[str, object]:
     manifest = item.manifest
+    policy = None if manifest is None else manifest.policy_trust
     return {
         "model_id": item.spec.model_id,
         "engine": item.spec.engine,
@@ -67,6 +68,16 @@ def _serialize_model(item: ModelInventoryItem) -> dict[str, object]:
         "resolved_revision": None if manifest is None else manifest.resolved_revision,
         "installed_size_bytes": None if manifest is None else manifest.size_bytes,
         "verification": None if manifest is None else manifest.verification,
+        "policy_trusted": item.policy_trusted,
+        "policy_trust": None
+        if policy is None
+        else {
+            "catalog_schema_version": policy.catalog_schema_version,
+            "revision": policy.revision,
+            "verification": policy.verification,
+            "verified_files": policy.verified_files,
+            "total_bytes": policy.total_bytes,
+        },
     }
 
 
@@ -209,16 +220,27 @@ class ProcessingCenterService:
             None,
         )
         inventory = self.model_manager.inventory()
+        policy_enforced = self.model_manager.enforce_policy_trust
         speaker_labeling = diarization_runtime_status()
         recommended_model: str | None = None
         recommended_installed = False
+        recommended_ready = False
         if recommended is not None:
             strategy = cast("dict[str, object]", recommended["strategy"])
             recommended_model = str(strategy["model"])
-            recommended_installed = any(
-                item.spec.model_id == recommended_model and item.installed
-                for item in inventory
+            recommended_item = next(
+                (
+                    item
+                    for item in inventory
+                    if item.spec.model_id == recommended_model
+                ),
+                None,
             )
+            if recommended_item is not None:
+                recommended_installed = recommended_item.installed
+                recommended_ready = recommended_item.installed and (
+                    not policy_enforced or recommended_item.policy_trusted
+                )
         return {
             "health": {
                 "status": health.status.value,
@@ -258,8 +280,10 @@ class ProcessingCenterService:
             },
             "strategies": [self._serialize_strategy(item) for item in assessments],
             "models": [_serialize_model(item) for item in inventory],
+            "model_policy_enforced": policy_enforced,
             "recommended_model": recommended_model,
             "recommended_model_installed": recommended_installed,
+            "recommended_model_ready": recommended_ready,
         }
 
     @staticmethod
@@ -344,9 +368,23 @@ class ProcessingCenterService:
         self.lifecycle_store.discard(job_id)
 
     def verify_model(self, model_id: str) -> dict[str, object]:
-        revision = self.model_manager.resolved_revision(model_id)
+        item = next(
+            (
+                candidate
+                for candidate in self.model_manager.inventory()
+                if candidate.spec.model_id == model_id
+            ),
+            None,
+        )
+        if item is None:
+            raise ValueError(f"unknown model: {model_id}")
+        manifest = item.manifest
         return {
             "model_id": model_id,
-            "installed": revision is not None,
-            "resolved_revision": revision,
+            "installed": item.installed,
+            "resolved_revision": None
+            if manifest is None
+            else manifest.resolved_revision,
+            "policy_trusted": item.policy_trusted,
+            "policy_enforced": self.model_manager.enforce_policy_trust,
         }

--- a/src/scholion/app/processing_center.py
+++ b/src/scholion/app/processing_center.py
@@ -210,9 +210,7 @@ class ProcessingCenterService:
         )
         inventory = self.model_manager.inventory()
         policy_enforced = getattr(self.model_manager, "enforce_policy_trust", False)
-        policy_trust = {
-            item.spec.model_id: item.policy_trusted for item in inventory
-        }
+        policy_trust = {item.spec.model_id: item.policy_trusted for item in inventory}
         speaker_labeling = diarization_runtime_status()
         recommended_model: str | None = None
         recommended_installed = False
@@ -221,11 +219,7 @@ class ProcessingCenterService:
             strategy = cast("dict[str, object]", recommended["strategy"])
             recommended_model = str(strategy["model"])
             recommended_item = next(
-                (
-                    item
-                    for item in inventory
-                    if item.spec.model_id == recommended_model
-                ),
+                (item for item in inventory if item.spec.model_id == recommended_model),
                 None,
             )
             if recommended_item is not None:

--- a/src/scholion/app/tests/test_model_policy_composition.py
+++ b/src/scholion/app/tests/test_model_policy_composition.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 from scholion.app.app_container import _create_model_manager
 from scholion.model_management.catalog import ModelCatalog
 from scholion.model_management.models import ModelSpec
+from scholion.model_management.service import ModelManager
 from scholion.supply_chain import ModelTrustCatalog, TrustedModelFile, TrustedModelSpec
 
 
@@ -45,7 +46,9 @@ def _trust_catalog() -> ModelTrustCatalog:
     )
 
 
-def _manager(tmp_path: Path, trust_catalog: ModelTrustCatalog | None):
+def _manager(
+    tmp_path: Path, trust_catalog: ModelTrustCatalog | None
+) -> ModelManager:
     return _create_model_manager(
         catalog=_catalog(),
         provider=cast(Any, object()),

--- a/src/scholion/app/tests/test_model_policy_composition.py
+++ b/src/scholion/app/tests/test_model_policy_composition.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+from typing import Any, cast
+
+from scholion.app.app_container import _create_model_manager
+from scholion.model_management.catalog import ModelCatalog
+from scholion.model_management.models import ModelSpec
+from scholion.supply_chain import ModelTrustCatalog, TrustedModelFile, TrustedModelSpec
+
+
+def _catalog() -> ModelCatalog:
+    return ModelCatalog(
+        (
+            ModelSpec(
+                model_id="tiny",
+                engine="faster-whisper",
+                repository_id="Systran/faster-whisper-tiny",
+                estimated_cache_bytes=100,
+                quality_rank=1,
+            ),
+        )
+    )
+
+
+def _trust_catalog() -> ModelTrustCatalog:
+    return ModelTrustCatalog(
+        schema_version=1,
+        models=(
+            TrustedModelSpec(
+                model_id="tiny",
+                engine="faster-whisper",
+                repository_id="Systran/faster-whisper-tiny",
+                revision="a" * 40,
+                source_url="https://huggingface.co/Systran/faster-whisper-tiny",
+                license_id="test",
+                license_url="https://example.test/license",
+                files=(
+                    TrustedModelFile(
+                        path="model.bin",
+                        size_bytes=1,
+                        sha256_hex="b" * 64,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def _manager(tmp_path: Path, trust_catalog: ModelTrustCatalog | None):
+    return _create_model_manager(
+        catalog=_catalog(),
+        provider=cast(Any, object()),
+        file_store=cast(Any, object()),
+        model_root=tmp_path / "models",
+        storage_admitter=cast(Any, object()),
+        trust_catalog=trust_catalog,
+    )
+
+
+def test_source_build_without_packaged_policy_keeps_enforcement_off(
+    tmp_path: Path,
+) -> None:
+    manager = _manager(tmp_path, None)
+
+    assert manager.trust_catalog is None
+    assert manager.enforce_policy_trust is False
+
+
+def test_packaged_policy_automatically_enables_enforcement(tmp_path: Path) -> None:
+    trust_catalog = _trust_catalog()
+
+    manager = _manager(tmp_path, trust_catalog)
+
+    assert manager.trust_catalog is trust_catalog
+    assert manager.enforce_policy_trust is True

--- a/src/scholion/app/tests/test_model_policy_composition.py
+++ b/src/scholion/app/tests/test_model_policy_composition.py
@@ -46,9 +46,7 @@ def _trust_catalog() -> ModelTrustCatalog:
     )
 
 
-def _manager(
-    tmp_path: Path, trust_catalog: ModelTrustCatalog | None
-) -> ModelManager:
+def _manager(tmp_path: Path, trust_catalog: ModelTrustCatalog | None) -> ModelManager:
     return _create_model_manager(
         catalog=_catalog(),
         provider=cast(Any, object()),

--- a/src/scholion/app/tests/test_processing_model_policy.py
+++ b/src/scholion/app/tests/test_processing_model_policy.py
@@ -1,0 +1,152 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from scholion.app import processing_center
+from scholion.app.processing_center import ProcessingCenterService
+from scholion.model_management.models import (
+    ManagedModelManifest,
+    ModelInventoryItem,
+    ModelSpec,
+)
+from scholion.runner.models import ProcessingProfile
+
+
+class _Health:
+    def run(self) -> object:
+        return SimpleNamespace(status=SimpleNamespace(value="healthy"), checks=())
+
+
+class _Topology:
+    def inspect(self) -> object:
+        resources = SimpleNamespace(
+            platform="TestOS",
+            machine="test",
+            processor_name="test cpu",
+            effective_cpus=4,
+            memory_total_bytes=8_000,
+            memory_available_bytes=6_000,
+            effective_memory_available_bytes=6_000,
+            constraints=(),
+        )
+        return SimpleNamespace(resources=resources, accelerators=())
+
+
+class _Policy:
+    def plan(self, resources: object, profile: ProcessingProfile) -> object:
+        return SimpleNamespace(
+            profile=profile,
+            provisional=False,
+            cpu_threads=3,
+            memory_budget_bytes=4_000,
+            constraints=(),
+        )
+
+
+class _Planner:
+    def assess_strategies(self, **_: object) -> tuple[dict[str, object], ...]:
+        return (
+            {
+                "strategy": {
+                    "strategy_id": "small-cpu-int8",
+                    "model": "small",
+                    "device": "cpu",
+                    "compute_type": "int8",
+                    "estimated_peak_device_memory_bytes": 0,
+                    "model_cache_bytes": 100,
+                },
+                "effective_peak_memory_bytes": 1_000,
+                "feasible": True,
+                "rejection_reasons": [],
+                "recommended": True,
+            },
+        )
+
+
+class _Models:
+    def __init__(self, *, enforced: bool, trusted: bool) -> None:
+        self.enforce_policy_trust = enforced
+        spec = ModelSpec(
+            model_id="small",
+            engine="faster-whisper",
+            repository_id="Systran/faster-whisper-small",
+            estimated_cache_bytes=100,
+            quality_rank=1,
+        )
+        manifest = ManagedModelManifest(
+            schema_version=1,
+            model_id="small",
+            engine="faster-whisper",
+            repository_id="Systran/faster-whisper-small",
+            requested_revision=None,
+            resolved_revision="legacy-or-trusted",
+            snapshot_path=Path("/models/small"),
+            size_bytes=90,
+            verification="local",
+        )
+        self.item = ModelInventoryItem(
+            spec=spec,
+            manifest=manifest,
+            policy_trusted=trusted,
+        )
+
+    def inventory(self) -> tuple[ModelInventoryItem, ...]:
+        return (self.item,)
+
+
+class _Lifecycle:
+    def list_records(self) -> tuple[object, ...]:
+        return ()
+
+
+def _service(models: _Models) -> ProcessingCenterService:
+    return ProcessingCenterService(
+        health_check=cast(Any, _Health()),
+        topology_inspector=cast(Any, _Topology()),
+        policy_planner=cast(Any, _Policy()),
+        planner=cast(Any, _Planner()),
+        model_manager=cast(Any, models),
+        lifecycle_store=cast(Any, _Lifecycle()),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _speaker_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        processing_center,
+        "diarization_runtime_status",
+        lambda: SimpleNamespace(to_dict=lambda: {"available": False}),
+    )
+
+
+def test_unenforced_build_treats_locally_installed_model_as_ready() -> None:
+    result = _service(_Models(enforced=False, trusted=False)).readiness(
+        ProcessingProfile.BALANCED
+    )
+
+    assert result["model_policy_enforced"] is False
+    assert result["model_policy_trust"] == {"small": False}
+    assert result["recommended_model_installed"] is True
+    assert result["recommended_model_ready"] is True
+
+
+def test_enforced_build_keeps_untrusted_install_visible_but_not_ready() -> None:
+    result = _service(_Models(enforced=True, trusted=False)).readiness(
+        ProcessingProfile.BALANCED
+    )
+
+    assert result["model_policy_enforced"] is True
+    assert result["model_policy_trust"] == {"small": False}
+    assert result["recommended_model_installed"] is True
+    assert result["recommended_model_ready"] is False
+
+
+def test_enforced_build_reports_current_policy_trusted_model_ready() -> None:
+    result = _service(_Models(enforced=True, trusted=True)).readiness(
+        ProcessingProfile.BALANCED
+    )
+
+    assert result["model_policy_trust"] == {"small": True}
+    assert result["recommended_model_ready"] is True

--- a/src/scholion/desktop/processing_worker.py
+++ b/src/scholion/desktop/processing_worker.py
@@ -228,7 +228,19 @@ def _run_model_install(task: _ModelInstall, container: AppContainer) -> None:
 
 def _run_model_remove(task: _ModelRemove, container: AppContainer) -> None:
     manager = container.model_manager()
-    current = manager.resolved_revision(task.model_id)
+    item = next(
+        (
+            candidate
+            for candidate in manager.inventory()
+            if candidate.spec.model_id == task.model_id
+        ),
+        None,
+    )
+    current = (
+        None
+        if item is None or item.manifest is None
+        else item.manifest.resolved_revision
+    )
     if current != task.expected_revision:
         raise ValueError("model state changed; refresh before removing it")
     manager.remove(task.model_id)

--- a/src/scholion/desktop/tests/test_processing_worker.py
+++ b/src/scholion/desktop/tests/test_processing_worker.py
@@ -55,8 +55,14 @@ class _ModelManager:
     def install(self, model_id: str, *, revision: str | None) -> None:
         self.installs.append((model_id, revision))
 
-    def resolved_revision(self, model_id: str) -> str | None:
-        return self.revisions.get(model_id)
+    def inventory(self) -> tuple[SimpleNamespace, ...]:
+        return tuple(
+            SimpleNamespace(
+                spec=SimpleNamespace(model_id=model_id),
+                manifest=SimpleNamespace(resolved_revision=revision),
+            )
+            for model_id, revision in self.revisions.items()
+        )
 
     def remove(self, model_id: str) -> None:
         self.removals.append(model_id)

--- a/src/scholion/model_management/service.py
+++ b/src/scholion/model_management/service.py
@@ -64,9 +64,10 @@ class ModelManager:
         self.enforce_policy_trust = enforce_policy_trust
 
     def inventory(self) -> tuple[ModelInventoryItem, ...]:
+        """Report local custody even when a legacy install is not execution-admissible."""
         inventory: list[ModelInventoryItem] = []
         for spec in self.catalog.specs:
-            manifest = self._manifest(spec.model_id)
+            manifest = self._manifest(spec.model_id, require_policy_trust=False)
             inventory.append(
                 ModelInventoryItem(
                     spec=spec,
@@ -82,7 +83,9 @@ class ModelManager:
         spec = self.catalog.require(model_id)
         if revision is not None and not revision.strip():
             raise ValueError("revision cannot be empty")
-        trusted_spec = self._trusted_spec_for(spec)
+        trusted_spec = self._trusted_spec_for(
+            spec, require_policy_trust=self.enforce_policy_trust
+        )
         requested_revision = revision
         if trusted_spec is not None:
             if revision is not None and revision != trusted_spec.revision:
@@ -136,7 +139,7 @@ class ModelManager:
 
     def remove(self, model_id: str) -> ManagedModelManifest:
         spec = self.catalog.require(model_id)
-        manifest = self._manifest(spec.model_id)
+        manifest = self._manifest(spec.model_id, require_policy_trust=False)
         if manifest is None:
             raise ValueError(f"model is not managed by Scholion: {model_id}")
         snapshot = InstalledSnapshot(
@@ -162,13 +165,16 @@ class ModelManager:
     def is_policy_trusted(self, model_id: str) -> bool:
         """Return whether current bundled policy revalidates the managed snapshot."""
         spec = self.catalog.require(model_id)
-        manifest = self._manifest(model_id)
+        manifest = self._manifest(model_id, require_policy_trust=False)
         return self._has_current_policy_trust(spec, manifest)
 
     def resolved_revision(self, model_id: str) -> str | None:
-        """Return the locally revalidated managed revision without network access or writes."""
+        """Return the execution-admissible managed revision without network access or writes."""
         self.catalog.require(model_id)
-        manifest = self._manifest(model_id)
+        manifest = self._manifest(
+            model_id,
+            require_policy_trust=self.enforce_policy_trust,
+        )
         return None if manifest is None else manifest.resolved_revision
 
     def _prepare_roots(self) -> None:
@@ -176,7 +182,12 @@ class ModelManager:
         self.file_store.ensure_directory_exists(self.cache_root, private=True)
         self.file_store.ensure_directory_exists(self.registry_root, private=True)
 
-    def _manifest(self, model_id: str) -> ManagedModelManifest | None:
+    def _manifest(
+        self,
+        model_id: str,
+        *,
+        require_policy_trust: bool | None = None,
+    ) -> ManagedModelManifest | None:
         path = self._manifest_path(model_id)
         if not self.file_store.file_exists(path):
             return None
@@ -185,14 +196,29 @@ class ModelManager:
             if not isinstance(document, dict):
                 raise ValueError("model manifest must be an object")
             manifest = ManagedModelManifest.from_dict(document)
-            self._validate_manifest(model_id, manifest)
+            self._validate_manifest(
+                model_id,
+                manifest,
+                require_policy_trust=require_policy_trust,
+            )
             return manifest
         except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
             raise ModelManagementError(
                 "The local model registry is invalid", cause=exc
             ) from exc
 
-    def _validate_manifest(self, model_id: str, manifest: ManagedModelManifest) -> None:
+    def _validate_manifest(
+        self,
+        model_id: str,
+        manifest: ManagedModelManifest,
+        *,
+        require_policy_trust: bool | None = None,
+    ) -> None:
+        policy_required = (
+            self.enforce_policy_trust
+            if require_policy_trust is None
+            else require_policy_trust
+        )
         spec = self.catalog.require(model_id)
         if (
             manifest.model_id != spec.model_id
@@ -214,10 +240,13 @@ class ModelManager:
         except Exception as exc:
             raise ValueError("managed model snapshot is no longer valid") from exc
 
-        trusted_spec = self._trusted_spec_for(spec)
+        trusted_spec = self._trusted_spec_for(
+            spec,
+            require_policy_trust=policy_required,
+        )
         if manifest.policy_trust is not None:
             if trusted_spec is None:
-                if self.enforce_policy_trust:
+                if policy_required:
                     raise ValueError(
                         "managed model no longer has a trusted policy entry"
                     )
@@ -227,7 +256,7 @@ class ModelManager:
                 raise ValueError(
                     "managed model policy trust evidence no longer matches"
                 )
-        elif self.enforce_policy_trust:
+        elif policy_required:
             raise ValueError("managed model lacks required policy trust evidence")
 
     def _has_current_policy_trust(
@@ -238,17 +267,27 @@ class ModelManager:
         return (
             manifest is not None
             and manifest.policy_trust is not None
-            and self._trusted_spec_for(spec) is not None
+            and self._trusted_spec_for(spec, require_policy_trust=False) is not None
         )
 
-    def _trusted_spec_for(self, spec: ModelSpec) -> TrustedModelSpec | None:
+    def _trusted_spec_for(
+        self,
+        spec: ModelSpec,
+        *,
+        require_policy_trust: bool | None = None,
+    ) -> TrustedModelSpec | None:
+        policy_required = (
+            self.enforce_policy_trust
+            if require_policy_trust is None
+            else require_policy_trust
+        )
         trust_catalog = self.trust_catalog
         if trust_catalog is None:
             return None
         try:
             trusted_spec = trust_catalog.require(spec.model_id)
         except ValueError:
-            if self.enforce_policy_trust:
+            if policy_required:
                 raise
             return None
         if (

--- a/src/scholion/model_management/tests/test_policy_migration.py
+++ b/src/scholion/model_management/tests/test_policy_migration.py
@@ -1,0 +1,177 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scholion.model_management.catalog import ModelCatalog
+from scholion.model_management.errors import ModelManagementError
+from scholion.model_management.models import InstalledSnapshot, ModelSpec
+from scholion.model_management.service import ModelManager
+from scholion.supply_chain import ModelTrustCatalog, TrustedModelFile, TrustedModelSpec
+
+_REVISION = "a" * 40
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.files: dict[Path, bytes] = {}
+
+    def ensure_directory_exists(
+        self, directory_path: str | Path, *, private: bool = False
+    ) -> None:
+        assert private
+
+    def save_file(
+        self, content: bytes, file_path: str | Path, *, private: bool = False
+    ) -> None:
+        assert private
+        self.files[Path(file_path)] = content
+
+    def read_file(self, file_path: str | Path) -> bytes:
+        return self.files[Path(file_path)]
+
+    def file_exists(self, file_path: str | Path) -> bool:
+        return Path(file_path) in self.files
+
+    def delete_file(self, file_path: str | Path) -> None:
+        self.files.pop(Path(file_path), None)
+
+
+class _Provider:
+    def __init__(self, snapshot_path: Path) -> None:
+        self.snapshot_path = snapshot_path
+        self.removed: list[str] = []
+
+    def install(
+        self,
+        spec: ModelSpec,
+        *,
+        cache_root: Path,
+        revision: str | None,
+    ) -> InstalledSnapshot:
+        return InstalledSnapshot(
+            resolved_revision=revision or "legacy-revision",
+            snapshot_path=self.snapshot_path,
+            size_bytes=10,
+            verification="test-local-validation",
+        )
+
+    def validate(
+        self,
+        spec: ModelSpec,
+        snapshot: InstalledSnapshot,
+        *,
+        cache_root: Path,
+    ) -> None:
+        assert snapshot.snapshot_path.is_relative_to(cache_root)
+
+    def remove(
+        self,
+        snapshot: InstalledSnapshot,
+        *,
+        cache_root: Path,
+    ) -> None:
+        assert snapshot.snapshot_path.is_relative_to(cache_root)
+        self.removed.append(snapshot.resolved_revision)
+
+
+def _catalog() -> ModelCatalog:
+    return ModelCatalog(
+        (
+            ModelSpec(
+                model_id="small",
+                engine="faster-whisper",
+                repository_id="Systran/faster-whisper-small",
+                estimated_cache_bytes=100,
+                quality_rank=1,
+                required_files=("model.bin",),
+            ),
+        )
+    )
+
+
+def _trust_catalog() -> ModelTrustCatalog:
+    return ModelTrustCatalog(
+        schema_version=1,
+        models=(
+            TrustedModelSpec(
+                model_id="small",
+                engine="faster-whisper",
+                repository_id="Systran/faster-whisper-small",
+                revision=_REVISION,
+                source_url="https://huggingface.co/Systran/faster-whisper-small",
+                license_id="test",
+                license_url="https://example.test/license",
+                files=(
+                    TrustedModelFile(
+                        path="model.bin",
+                        size_bytes=1,
+                        sha256_hex="0" * 64,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def _legacy_manifest(manager: ModelManager, store: _Store) -> None:
+    store.files[manager._manifest_path("small")] = json.dumps(
+        {
+            "schema_version": 1,
+            "model_id": "small",
+            "engine": "faster-whisper",
+            "repository_id": "Systran/faster-whisper-small",
+            "requested_revision": None,
+            "resolved_revision": "legacy-revision",
+            "snapshot_path": str(manager.cache_root / "snapshots" / "legacy-revision"),
+            "size_bytes": 10,
+            "verification": "test-local-validation",
+            "policy_trust": None,
+        }
+    ).encode("utf-8")
+
+
+def _enforcing_manager(tmp_path: Path) -> tuple[ModelManager, _Store, _Provider]:
+    root = tmp_path / "models"
+    provider = _Provider(root / "faster-whisper" / "snapshots" / "legacy-revision")
+    store = _Store()
+    manager = ModelManager(
+        catalog=_catalog(),
+        provider=provider,
+        file_store=store,
+        model_root=root,
+        trust_catalog=_trust_catalog(),
+        enforce_policy_trust=True,
+    )
+    _legacy_manifest(manager, store)
+    return manager, store, provider
+
+
+def test_enforcement_keeps_legacy_model_visible_but_not_policy_trusted(
+    tmp_path: Path,
+) -> None:
+    manager, _, _ = _enforcing_manager(tmp_path)
+
+    item = manager.inventory()[0]
+
+    assert item.installed is True
+    assert item.manifest is not None
+    assert item.manifest.resolved_revision == "legacy-revision"
+    assert item.policy_trusted is False
+
+
+def test_enforcement_refuses_legacy_model_for_new_execution(tmp_path: Path) -> None:
+    manager, _, _ = _enforcing_manager(tmp_path)
+
+    with pytest.raises(ModelManagementError, match="registry is invalid"):
+        manager.resolved_revision("small")
+
+
+def test_enforcement_allows_legacy_model_removal_for_replacement(tmp_path: Path) -> None:
+    manager, store, provider = _enforcing_manager(tmp_path)
+
+    removed = manager.remove("small")
+
+    assert removed.resolved_revision == "legacy-revision"
+    assert provider.removed == ["legacy-revision"]
+    assert manager._manifest_path("small") not in store.files

--- a/src/scholion/model_management/tests/test_policy_migration.py
+++ b/src/scholion/model_management/tests/test_policy_migration.py
@@ -167,7 +167,9 @@ def test_enforcement_refuses_legacy_model_for_new_execution(tmp_path: Path) -> N
         manager.resolved_revision("small")
 
 
-def test_enforcement_allows_legacy_model_removal_for_replacement(tmp_path: Path) -> None:
+def test_enforcement_allows_legacy_model_removal_for_replacement(
+    tmp_path: Path,
+) -> None:
     manager, store, provider = _enforcing_manager(tmp_path)
 
     removed = manager.remove("small")

--- a/src/scholion/supply_chain/__init__.py
+++ b/src/scholion/supply_chain/__init__.py
@@ -1,5 +1,10 @@
 """Supply-chain trust primitives for models and application releases."""
 
+from scholion.supply_chain.catalog_loader import (
+    load_bundled_model_trust_catalog,
+    load_model_trust_catalog,
+    parse_model_trust_catalog,
+)
 from scholion.supply_chain.model_trust import (
     ModelTrustCatalog,
     ModelTrustEvidence,
@@ -24,6 +29,9 @@ __all__ = [
     "TrustedModelSpec",
     "UpdateManifestPayload",
     "UpdateTrustError",
+    "load_bundled_model_trust_catalog",
+    "load_model_trust_catalog",
+    "parse_model_trust_catalog",
     "verify_signed_update_manifest",
     "verify_trusted_model_snapshot",
 ]

--- a/src/scholion/supply_chain/catalog_loader.py
+++ b/src/scholion/supply_chain/catalog_loader.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+from pathlib import Path
+
+from scholion.supply_chain.model_trust import ModelTrustCatalog
+
+_BUNDLED_MODEL_TRUST_CATALOG = "model-trust.json"
+
+
+def parse_model_trust_catalog(document_bytes: bytes) -> ModelTrustCatalog:
+    """Parse one strict UTF-8 curated model-trust catalog."""
+    try:
+        document = json.loads(document_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("model trust catalog must be valid UTF-8 JSON") from exc
+    if not isinstance(document, dict):
+        raise ValueError("model trust catalog must be a JSON object")
+    return ModelTrustCatalog.from_dict(document)
+
+
+def load_model_trust_catalog(path: Path) -> ModelTrustCatalog:
+    """Load an explicitly selected catalog without leaking its local path on failure."""
+    try:
+        payload = path.expanduser().resolve(strict=False).read_bytes()
+    except OSError as exc:
+        raise ValueError("model trust catalog is unavailable") from exc
+    return parse_model_trust_catalog(payload)
+
+
+def load_bundled_model_trust_catalog() -> ModelTrustCatalog | None:
+    """Load the catalog shipped inside Scholion, if this build intentionally includes one."""
+    candidate = files("scholion.supply_chain").joinpath(_BUNDLED_MODEL_TRUST_CATALOG)
+    if not candidate.is_file():
+        return None
+    try:
+        payload = candidate.read_bytes()
+    except OSError as exc:
+        raise ValueError("bundled model trust catalog is unavailable") from exc
+    return parse_model_trust_catalog(payload)

--- a/src/scholion/supply_chain/tests/test_catalog_loader.py
+++ b/src/scholion/supply_chain/tests/test_catalog_loader.py
@@ -1,0 +1,94 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scholion.supply_chain import catalog_loader
+
+
+def _catalog_document() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "models": [
+            {
+                "model_id": "tiny",
+                "engine": "faster-whisper",
+                "repository_id": "Systran/faster-whisper-tiny",
+                "revision": "a" * 40,
+                "source_url": "https://huggingface.co/Systran/faster-whisper-tiny",
+                "license_id": "MIT",
+                "license_url": "https://opensource.org/license/mit",
+                "files": [
+                    {
+                        "path": "model.bin",
+                        "size_bytes": 3,
+                        "sha256": "b" * 64,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_parse_model_trust_catalog_accepts_strict_utf8_json() -> None:
+    catalog = catalog_loader.parse_model_trust_catalog(
+        json.dumps(_catalog_document()).encode("utf-8")
+    )
+
+    assert catalog.schema_version == 1
+    assert catalog.require("tiny").revision == "a" * 40
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        (b"\xff", "valid UTF-8 JSON"),
+        (b"{", "valid UTF-8 JSON"),
+        (b"[]", "JSON object"),
+    ],
+)
+def test_parse_model_trust_catalog_rejects_invalid_documents(
+    payload: bytes, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        catalog_loader.parse_model_trust_catalog(payload)
+
+
+def test_load_model_trust_catalog_reads_explicit_file(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.json"
+    path.write_text(json.dumps(_catalog_document()), encoding="utf-8")
+
+    catalog = catalog_loader.load_model_trust_catalog(path)
+
+    assert catalog.require("tiny").repository_id == "Systran/faster-whisper-tiny"
+
+
+def test_load_model_trust_catalog_hides_local_path_on_failure(tmp_path: Path) -> None:
+    path = tmp_path / "private-secret-directory" / "missing.json"
+
+    with pytest.raises(ValueError, match="catalog is unavailable") as caught:
+        catalog_loader.load_model_trust_catalog(path)
+
+    assert "private-secret-directory" not in str(caught.value)
+
+
+def test_bundled_loader_returns_none_when_build_has_no_catalog(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(catalog_loader, "files", lambda _package: tmp_path)
+
+    assert catalog_loader.load_bundled_model_trust_catalog() is None
+
+
+def test_bundled_loader_parses_packaged_catalog(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "model-trust.json").write_text(
+        json.dumps(_catalog_document()), encoding="utf-8"
+    )
+    monkeypatch.setattr(catalog_loader, "files", lambda _package: tmp_path)
+
+    catalog = catalog_loader.load_bundled_model_trust_catalog()
+
+    assert catalog is not None
+    assert catalog.require("tiny").model_id == "tiny"


### PR DESCRIPTION
## Summary

Continues #110 after merged PR #141 by wiring the model-policy seam into real application composition without inventing production trust data.

This PR:

- adds a strict packaged `model-trust.json` loader;
- makes `AppContainer` automatically enable `ModelManager` policy enforcement whenever a reviewed catalog is bundled with the build;
- keeps source/development builds without a production catalog on the existing locally revalidated path;
- keeps legacy locally valid model custody visible/removable after enforcement is introduced while refusing those untrusted bytes for new-transcription admission;
- separates physical installation from policy execution readiness in the Processing Center contract;
- exposes current policy enforcement/trust state to the desktop UI;
- gives an installed-but-untrusted model an explicit trusted-reinstall path rather than treating it as ready;
- adds migration, catalog-loader, backend readiness, and Playwright coverage.

## Trust boundary

No real faster-whisper revision, hash, signing key, or mutable upstream reference is promoted to Scholion policy here. The application activates enforcement only when the build actually contains a deliberately reviewed catalog. The real catalog remains release trust material that must be generated from reviewed immutable upstream snapshots.

## Migration behavior

When policy enforcement first appears in a release, an older managed model can be structurally valid but lack current Scholion policy evidence. In that state Scholion:

1. keeps the model visible in local inventory;
2. reports it as installed but not policy-ready;
3. refuses it for a new transcription;
4. allows removal; and
5. offers a reinstall through the curated policy path.

This avoids both unsafe grandfathering and a migration dead end.

## Remaining #110 work after this PR

- deliberately review real upstream faster-whisper revisions and generate the production catalog;
- validate that release packaging includes that reviewed catalog;
- native/Tauri signed update client, fixed metadata endpoint, anti-rollback state, staged artifact verification and activation;
- production update public key provisioning;
- update UI states and native/offline qualification;
- platform code signing/notarization integration.

Related: #110, #140